### PR TITLE
Enable nullability in benchmarks and core tests

### DIFF
--- a/benchmark/EFCore.Benchmarks/ChangeTracker/DbSetOperationTests.cs
+++ b/benchmark/EFCore.Benchmarks/ChangeTracker/DbSetOperationTests.cs
@@ -14,11 +14,11 @@ public class DbSetOperationTests
 {
     public abstract class DbSetOperationBase
     {
-        private OrdersFixtureBase _fixture;
+        private OrdersFixtureBase _fixture = null!;
 
-        protected List<Customer> _customersWithoutPk;
-        protected List<Customer> _customersWithPk;
-        protected OrdersContextBase _context;
+        protected List<Customer> _customersWithoutPk = null!;
+        protected List<Customer> _customersWithPk = null!;
+        protected OrdersContextBase _context = null!;
 
         public abstract OrdersFixtureBase CreateFixture();
 

--- a/benchmark/EFCore.Benchmarks/ChangeTracker/FixupTests.cs
+++ b/benchmark/EFCore.Benchmarks/ChangeTracker/FixupTests.cs
@@ -16,12 +16,12 @@ public class FixupTests
 {
     public abstract class FixupBase
     {
-        private OrdersFixtureBase _fixture;
+        private OrdersFixtureBase _fixture = null!;
 
-        protected List<Customer> _customers;
-        protected List<Order> _ordersWithoutPk;
-        protected List<Order> _ordersWithPk;
-        protected OrdersContextBase _context;
+        protected List<Customer> _customers = null!;
+        protected List<Order> _ordersWithoutPk = null!;
+        protected List<Order> _ordersWithPk = null!;
+        protected OrdersContextBase _context = null!;
 
         public abstract OrdersFixtureBase CreateFixture();
 

--- a/benchmark/EFCore.Benchmarks/EFCore.Benchmarks.csproj
+++ b/benchmark/EFCore.Benchmarks/EFCore.Benchmarks.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
     <RootNamespace>Microsoft.EntityFrameworkCore.Benchmarks</RootNamespace>
-    <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">

--- a/benchmark/EFCore.Benchmarks/EFCoreBenchmarkRunner.cs
+++ b/benchmark/EFCore.Benchmarks/EFCoreBenchmarkRunner.cs
@@ -11,7 +11,7 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks;
 
 public static class EFCoreBenchmarkRunner
 {
-    public static void Run(string[] args, Assembly assembly, IConfig config = null)
+    public static void Run(string[] args, Assembly assembly, IConfig? config = null)
     {
         config ??= DefaultConfig.Instance;
 

--- a/benchmark/EFCore.Benchmarks/Initialization/InitializationTests.cs
+++ b/benchmark/EFCore.Benchmarks/Initialization/InitializationTests.cs
@@ -13,8 +13,8 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.Initialization;
 [DisplayName("InitializationTests")]
 public abstract class InitializationTests
 {
-    private ServiceProvider _serviceProvider;
-    private ServiceProvider _pooledServiceProvider;
+    private ServiceProvider _serviceProvider = null!;
+    private ServiceProvider _pooledServiceProvider = null!;
 
     protected abstract AdventureWorksContextBase CreateContext();
     protected abstract ConventionSet CreateConventionSet();
@@ -51,7 +51,7 @@ public abstract class InitializationTests
     [Benchmark]
     public virtual void CreateAndDisposeUnusedContextFromDiFactory()
     {
-        var factory = _serviceProvider.GetService<IDbContextFactory<AdventureWorksContextBase>>();
+        var factory = _serviceProvider.GetService<IDbContextFactory<AdventureWorksContextBase>>()!;
         for (var i = 0; i < 10000; i++)
         {
             using var _ = factory.CreateDbContext();
@@ -64,7 +64,7 @@ public abstract class InitializationTests
         for (var i = 0; i < 10000; i++)
         {
             using var scope = _pooledServiceProvider.CreateScope();
-            var context = (AdventureWorksContextBase)scope.ServiceProvider.GetService(typeof(AdventureWorksContextBase));
+            var context = (AdventureWorksContextBase)scope.ServiceProvider.GetService(typeof(AdventureWorksContextBase))!;
             var _ = context.Model;
         }
     }
@@ -72,7 +72,7 @@ public abstract class InitializationTests
     [Benchmark]
     public virtual void CreateAndDisposePooledContextFromDiFactory()
     {
-        var factory = _pooledServiceProvider.GetService<IDbContextFactory<AdventureWorksContextBase>>();
+        var factory = _pooledServiceProvider.GetService<IDbContextFactory<AdventureWorksContextBase>>()!;
         for (var i = 0; i < 10000; i++)
         {
             using var context = factory.CreateDbContext();

--- a/benchmark/EFCore.Benchmarks/Models/AdventureWorks/Address.cs
+++ b/benchmark/EFCore.Benchmarks/Models/AdventureWorks/Address.cs
@@ -16,11 +16,11 @@ public class Address
     }
 
     public int AddressID { get; set; }
-    public string AddressLine1 { get; set; }
-    public string AddressLine2 { get; set; }
-    public string City { get; set; }
+    public string AddressLine1 { get; set; } = null!;
+    public string? AddressLine2 { get; set; }
+    public string City { get; set; } = null!;
     public DateTime ModifiedDate { get; set; }
-    public string PostalCode { get; set; }
+    public string PostalCode { get; set; } = null!;
 #pragma warning disable IDE1006 // Naming Styles
     public Guid rowguid { get; set; }
 #pragma warning restore IDE1006 // Naming Styles
@@ -29,5 +29,5 @@ public class Address
     public virtual ICollection<BusinessEntityAddress> BusinessEntityAddress { get; set; }
     public virtual ICollection<SalesOrderHeader> SalesOrderHeader { get; set; }
     public virtual ICollection<SalesOrderHeader> SalesOrderHeaderNavigation { get; set; }
-    public virtual StateProvince StateProvince { get; set; }
+    public virtual StateProvince StateProvince { get; set; } = null!;
 }

--- a/benchmark/EFCore.Benchmarks/Models/AdventureWorks/AddressType.cs
+++ b/benchmark/EFCore.Benchmarks/Models/AdventureWorks/AddressType.cs
@@ -13,7 +13,7 @@ public class AddressType
 
     public int AddressTypeID { get; set; }
     public DateTime ModifiedDate { get; set; }
-    public string Name { get; set; }
+    public string Name { get; set; } = null!;
 #pragma warning disable IDE1006 // Naming Styles
     public Guid rowguid { get; set; }
 #pragma warning restore IDE1006 // Naming Styles

--- a/benchmark/EFCore.Benchmarks/Models/AdventureWorks/AdventureWorksContextBase.cs
+++ b/benchmark/EFCore.Benchmarks/Models/AdventureWorks/AdventureWorksContextBase.cs
@@ -14,73 +14,73 @@ public abstract class AdventureWorksContextBase : DbContext
     {
     }
 
-    public virtual DbSet<Address> Address { get; set; }
-    public virtual DbSet<AddressType> AddressType { get; set; }
-    public virtual DbSet<BillOfMaterials> BillOfMaterials { get; set; }
-    public virtual DbSet<BusinessEntity> BusinessEntity { get; set; }
-    public virtual DbSet<BusinessEntityAddress> BusinessEntityAddress { get; set; }
-    public virtual DbSet<BusinessEntityContact> BusinessEntityContact { get; set; }
-    public virtual DbSet<ContactType> ContactType { get; set; }
-    public virtual DbSet<CountryRegion> CountryRegion { get; set; }
-    public virtual DbSet<CountryRegionCurrency> CountryRegionCurrency { get; set; }
-    public virtual DbSet<CreditCard> CreditCard { get; set; }
-    public virtual DbSet<Culture> Culture { get; set; }
-    public virtual DbSet<Currency> Currency { get; set; }
-    public virtual DbSet<CurrencyRate> CurrencyRate { get; set; }
-    public virtual DbSet<Customer> Customer { get; set; }
-    public virtual DbSet<Department> Department { get; set; }
-    public virtual DbSet<EmailAddress> EmailAddress { get; set; }
-    public virtual DbSet<Employee> Employee { get; set; }
-    public virtual DbSet<EmployeeDepartmentHistory> EmployeeDepartmentHistory { get; set; }
-    public virtual DbSet<EmployeePayHistory> EmployeePayHistory { get; set; }
-    public virtual DbSet<Illustration> Illustration { get; set; }
-    public virtual DbSet<JobCandidate> JobCandidate { get; set; }
-    public virtual DbSet<Location> Location { get; set; }
-    public virtual DbSet<Password> Password { get; set; }
-    public virtual DbSet<Person> Person { get; set; }
-    public virtual DbSet<PersonCreditCard> PersonCreditCard { get; set; }
-    public virtual DbSet<PersonPhone> PersonPhone { get; set; }
-    public virtual DbSet<PhoneNumberType> PhoneNumberType { get; set; }
-    public virtual DbSet<Product> Product { get; set; }
-    public virtual DbSet<ProductCategory> ProductCategory { get; set; }
-    public virtual DbSet<ProductCostHistory> ProductCostHistory { get; set; }
-    public virtual DbSet<ProductDescription> ProductDescription { get; set; }
-    public virtual DbSet<ProductDocument> ProductDocument { get; set; }
-    public virtual DbSet<ProductInventory> ProductInventory { get; set; }
-    public virtual DbSet<ProductListPriceHistory> ProductListPriceHistory { get; set; }
-    public virtual DbSet<ProductModel> ProductModel { get; set; }
-    public virtual DbSet<ProductModelIllustration> ProductModelIllustration { get; set; }
-    public virtual DbSet<ProductModelProductDescriptionCulture> ProductModelProductDescriptionCulture { get; set; }
-    public virtual DbSet<ProductPhoto> ProductPhoto { get; set; }
-    public virtual DbSet<ProductProductPhoto> ProductProductPhoto { get; set; }
-    public virtual DbSet<ProductReview> ProductReview { get; set; }
-    public virtual DbSet<ProductSubcategory> ProductSubcategory { get; set; }
-    public virtual DbSet<ProductVendor> ProductVendor { get; set; }
-    public virtual DbSet<PurchaseOrderDetail> PurchaseOrderDetail { get; set; }
-    public virtual DbSet<PurchaseOrderHeader> PurchaseOrderHeader { get; set; }
-    public virtual DbSet<SalesOrderDetail> SalesOrderDetail { get; set; }
-    public virtual DbSet<SalesOrderHeader> SalesOrderHeader { get; set; }
-    public virtual DbSet<SalesOrderHeaderSalesReason> SalesOrderHeaderSalesReason { get; set; }
-    public virtual DbSet<SalesPerson> SalesPerson { get; set; }
-    public virtual DbSet<SalesPersonQuotaHistory> SalesPersonQuotaHistory { get; set; }
-    public virtual DbSet<SalesReason> SalesReason { get; set; }
-    public virtual DbSet<SalesTaxRate> SalesTaxRate { get; set; }
-    public virtual DbSet<SalesTerritory> SalesTerritory { get; set; }
-    public virtual DbSet<SalesTerritoryHistory> SalesTerritoryHistory { get; set; }
-    public virtual DbSet<ScrapReason> ScrapReason { get; set; }
-    public virtual DbSet<Shift> Shift { get; set; }
-    public virtual DbSet<ShipMethod> ShipMethod { get; set; }
-    public virtual DbSet<ShoppingCartItem> ShoppingCartItem { get; set; }
-    public virtual DbSet<SpecialOffer> SpecialOffer { get; set; }
-    public virtual DbSet<SpecialOfferProduct> SpecialOfferProduct { get; set; }
-    public virtual DbSet<StateProvince> StateProvince { get; set; }
-    public virtual DbSet<Store> Store { get; set; }
-    public virtual DbSet<TransactionHistory> TransactionHistory { get; set; }
-    public virtual DbSet<TransactionHistoryArchive> TransactionHistoryArchive { get; set; }
-    public virtual DbSet<UnitMeasure> UnitMeasure { get; set; }
-    public virtual DbSet<Vendor> Vendor { get; set; }
-    public virtual DbSet<WorkOrder> WorkOrder { get; set; }
-    public virtual DbSet<WorkOrderRouting> WorkOrderRouting { get; set; }
+    public virtual DbSet<Address> Address { get; set; } = null!;
+    public virtual DbSet<AddressType> AddressType { get; set; } = null!;
+    public virtual DbSet<BillOfMaterials> BillOfMaterials { get; set; } = null!;
+    public virtual DbSet<BusinessEntity> BusinessEntity { get; set; } = null!;
+    public virtual DbSet<BusinessEntityAddress> BusinessEntityAddress { get; set; } = null!;
+    public virtual DbSet<BusinessEntityContact> BusinessEntityContact { get; set; } = null!;
+    public virtual DbSet<ContactType> ContactType { get; set; } = null!;
+    public virtual DbSet<CountryRegion> CountryRegion { get; set; } = null!;
+    public virtual DbSet<CountryRegionCurrency> CountryRegionCurrency { get; set; } = null!;
+    public virtual DbSet<CreditCard> CreditCard { get; set; } = null!;
+    public virtual DbSet<Culture> Culture { get; set; } = null!;
+    public virtual DbSet<Currency> Currency { get; set; } = null!;
+    public virtual DbSet<CurrencyRate> CurrencyRate { get; set; } = null!;
+    public virtual DbSet<Customer> Customer { get; set; } = null!;
+    public virtual DbSet<Department> Department { get; set; } = null!;
+    public virtual DbSet<EmailAddress> EmailAddress { get; set; } = null!;
+    public virtual DbSet<Employee> Employee { get; set; } = null!;
+    public virtual DbSet<EmployeeDepartmentHistory> EmployeeDepartmentHistory { get; set; } = null!;
+    public virtual DbSet<EmployeePayHistory> EmployeePayHistory { get; set; } = null!;
+    public virtual DbSet<Illustration> Illustration { get; set; } = null!;
+    public virtual DbSet<JobCandidate> JobCandidate { get; set; } = null!;
+    public virtual DbSet<Location> Location { get; set; } = null!;
+    public virtual DbSet<Password> Password { get; set; } = null!;
+    public virtual DbSet<Person> Person { get; set; } = null!;
+    public virtual DbSet<PersonCreditCard> PersonCreditCard { get; set; } = null!;
+    public virtual DbSet<PersonPhone> PersonPhone { get; set; } = null!;
+    public virtual DbSet<PhoneNumberType> PhoneNumberType { get; set; } = null!;
+    public virtual DbSet<Product> Product { get; set; } = null!;
+    public virtual DbSet<ProductCategory> ProductCategory { get; set; } = null!;
+    public virtual DbSet<ProductCostHistory> ProductCostHistory { get; set; } = null!;
+    public virtual DbSet<ProductDescription> ProductDescription { get; set; } = null!;
+    public virtual DbSet<ProductDocument> ProductDocument { get; set; } = null!;
+    public virtual DbSet<ProductInventory> ProductInventory { get; set; } = null!;
+    public virtual DbSet<ProductListPriceHistory> ProductListPriceHistory { get; set; } = null!;
+    public virtual DbSet<ProductModel> ProductModel { get; set; } = null!;
+    public virtual DbSet<ProductModelIllustration> ProductModelIllustration { get; set; } = null!;
+    public virtual DbSet<ProductModelProductDescriptionCulture> ProductModelProductDescriptionCulture { get; set; } = null!;
+    public virtual DbSet<ProductPhoto> ProductPhoto { get; set; } = null!;
+    public virtual DbSet<ProductProductPhoto> ProductProductPhoto { get; set; } = null!;
+    public virtual DbSet<ProductReview> ProductReview { get; set; } = null!;
+    public virtual DbSet<ProductSubcategory> ProductSubcategory { get; set; } = null!;
+    public virtual DbSet<ProductVendor> ProductVendor { get; set; } = null!;
+    public virtual DbSet<PurchaseOrderDetail> PurchaseOrderDetail { get; set; } = null!;
+    public virtual DbSet<PurchaseOrderHeader> PurchaseOrderHeader { get; set; } = null!;
+    public virtual DbSet<SalesOrderDetail> SalesOrderDetail { get; set; } = null!;
+    public virtual DbSet<SalesOrderHeader> SalesOrderHeader { get; set; } = null!;
+    public virtual DbSet<SalesOrderHeaderSalesReason> SalesOrderHeaderSalesReason { get; set; } = null!;
+    public virtual DbSet<SalesPerson> SalesPerson { get; set; } = null!;
+    public virtual DbSet<SalesPersonQuotaHistory> SalesPersonQuotaHistory { get; set; } = null!;
+    public virtual DbSet<SalesReason> SalesReason { get; set; } = null!;
+    public virtual DbSet<SalesTaxRate> SalesTaxRate { get; set; } = null!;
+    public virtual DbSet<SalesTerritory> SalesTerritory { get; set; } = null!;
+    public virtual DbSet<SalesTerritoryHistory> SalesTerritoryHistory { get; set; } = null!;
+    public virtual DbSet<ScrapReason> ScrapReason { get; set; } = null!;
+    public virtual DbSet<Shift> Shift { get; set; } = null!;
+    public virtual DbSet<ShipMethod> ShipMethod { get; set; } = null!;
+    public virtual DbSet<ShoppingCartItem> ShoppingCartItem { get; set; } = null!;
+    public virtual DbSet<SpecialOffer> SpecialOffer { get; set; } = null!;
+    public virtual DbSet<SpecialOfferProduct> SpecialOfferProduct { get; set; } = null!;
+    public virtual DbSet<StateProvince> StateProvince { get; set; } = null!;
+    public virtual DbSet<Store> Store { get; set; } = null!;
+    public virtual DbSet<TransactionHistory> TransactionHistory { get; set; } = null!;
+    public virtual DbSet<TransactionHistoryArchive> TransactionHistoryArchive { get; set; } = null!;
+    public virtual DbSet<UnitMeasure> UnitMeasure { get; set; } = null!;
+    public virtual DbSet<Vendor> Vendor { get; set; } = null!;
+    public virtual DbSet<WorkOrder> WorkOrder { get; set; } = null!;
+    public virtual DbSet<WorkOrderRouting> WorkOrderRouting { get; set; } = null!;
 
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         => ConfigureProvider(optionsBuilder);

--- a/benchmark/EFCore.Benchmarks/Models/AdventureWorks/BillOfMaterials.cs
+++ b/benchmark/EFCore.Benchmarks/Models/AdventureWorks/BillOfMaterials.cs
@@ -15,9 +15,9 @@ public class BillOfMaterials
     public decimal PerAssemblyQty { get; set; }
     public int? ProductAssemblyID { get; set; }
     public DateTime StartDate { get; set; }
-    public string UnitMeasureCode { get; set; }
+    public string UnitMeasureCode { get; set; } = null!;
 
-    public virtual Product Component { get; set; }
-    public virtual Product ProductAssembly { get; set; }
-    public virtual UnitMeasure UnitMeasureCodeNavigation { get; set; }
+    public virtual Product Component { get; set; } = null!;
+    public virtual Product? ProductAssembly { get; set; }
+    public virtual UnitMeasure UnitMeasureCodeNavigation { get; set; } = null!;
 }

--- a/benchmark/EFCore.Benchmarks/Models/AdventureWorks/BusinessEntity.cs
+++ b/benchmark/EFCore.Benchmarks/Models/AdventureWorks/BusinessEntity.cs
@@ -22,7 +22,7 @@ public class BusinessEntity
 
     public virtual ICollection<BusinessEntityAddress> BusinessEntityAddress { get; set; }
     public virtual ICollection<BusinessEntityContact> BusinessEntityContact { get; set; }
-    public virtual Person Person { get; set; }
-    public virtual Store Store { get; set; }
-    public virtual Vendor Vendor { get; set; }
+    public virtual Person? Person { get; set; }
+    public virtual Store? Store { get; set; }
+    public virtual Vendor? Vendor { get; set; }
 }

--- a/benchmark/EFCore.Benchmarks/Models/AdventureWorks/BusinessEntityAddress.cs
+++ b/benchmark/EFCore.Benchmarks/Models/AdventureWorks/BusinessEntityAddress.cs
@@ -15,7 +15,7 @@ public class BusinessEntityAddress
     public Guid rowguid { get; set; }
 #pragma warning restore IDE1006 // Naming Styles
 
-    public virtual Address Address { get; set; }
-    public virtual AddressType AddressType { get; set; }
-    public virtual BusinessEntity BusinessEntity { get; set; }
+    public virtual Address Address { get; set; } = null!;
+    public virtual AddressType AddressType { get; set; } = null!;
+    public virtual BusinessEntity BusinessEntity { get; set; } = null!;
 }

--- a/benchmark/EFCore.Benchmarks/Models/AdventureWorks/BusinessEntityContact.cs
+++ b/benchmark/EFCore.Benchmarks/Models/AdventureWorks/BusinessEntityContact.cs
@@ -15,7 +15,7 @@ public class BusinessEntityContact
     public Guid rowguid { get; set; }
 #pragma warning restore IDE1006 // Naming Styles
 
-    public virtual BusinessEntity BusinessEntity { get; set; }
-    public virtual ContactType ContactType { get; set; }
-    public virtual Person Person { get; set; }
+    public virtual BusinessEntity BusinessEntity { get; set; } = null!;
+    public virtual ContactType ContactType { get; set; } = null!;
+    public virtual Person Person { get; set; } = null!;
 }

--- a/benchmark/EFCore.Benchmarks/Models/AdventureWorks/ContactType.cs
+++ b/benchmark/EFCore.Benchmarks/Models/AdventureWorks/ContactType.cs
@@ -13,7 +13,7 @@ public class ContactType
 
     public int ContactTypeID { get; set; }
     public DateTime ModifiedDate { get; set; }
-    public string Name { get; set; }
+    public string Name { get; set; } = null!;
 
     public virtual ICollection<BusinessEntityContact> BusinessEntityContact { get; set; }
 }

--- a/benchmark/EFCore.Benchmarks/Models/AdventureWorks/CountryRegion.cs
+++ b/benchmark/EFCore.Benchmarks/Models/AdventureWorks/CountryRegion.cs
@@ -15,9 +15,9 @@ public class CountryRegion
         StateProvince = new HashSet<StateProvince>();
     }
 
-    public string CountryRegionCode { get; set; }
+    public string CountryRegionCode { get; set; } = null!;
     public DateTime ModifiedDate { get; set; }
-    public string Name { get; set; }
+    public string Name { get; set; } = null!;
 
     public virtual ICollection<CountryRegionCurrency> CountryRegionCurrency { get; set; }
     public virtual ICollection<SalesTerritory> SalesTerritory { get; set; }

--- a/benchmark/EFCore.Benchmarks/Models/AdventureWorks/CountryRegionCurrency.cs
+++ b/benchmark/EFCore.Benchmarks/Models/AdventureWorks/CountryRegionCurrency.cs
@@ -7,10 +7,10 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.Models.AdventureWorks;
 
 public class CountryRegionCurrency
 {
-    public string CountryRegionCode { get; set; }
-    public string CurrencyCode { get; set; }
+    public string CountryRegionCode { get; set; } = null!;
+    public string CurrencyCode { get; set; } = null!;
     public DateTime ModifiedDate { get; set; }
 
-    public virtual CountryRegion CountryRegionCodeNavigation { get; set; }
-    public virtual Currency CurrencyCodeNavigation { get; set; }
+    public virtual CountryRegion CountryRegionCodeNavigation { get; set; } = null!;
+    public virtual Currency CurrencyCodeNavigation { get; set; } = null!;
 }

--- a/benchmark/EFCore.Benchmarks/Models/AdventureWorks/CreditCard.cs
+++ b/benchmark/EFCore.Benchmarks/Models/AdventureWorks/CreditCard.cs
@@ -15,8 +15,8 @@ public class CreditCard
     }
 
     public int CreditCardID { get; set; }
-    public string CardNumber { get; set; }
-    public string CardType { get; set; }
+    public string CardNumber { get; set; } = null!;
+    public string CardType { get; set; } = null!;
     public byte ExpMonth { get; set; }
     public short ExpYear { get; set; }
     public DateTime ModifiedDate { get; set; }

--- a/benchmark/EFCore.Benchmarks/Models/AdventureWorks/Culture.cs
+++ b/benchmark/EFCore.Benchmarks/Models/AdventureWorks/Culture.cs
@@ -11,9 +11,9 @@ public class Culture
     public Culture()
         => ProductModelProductDescriptionCulture = new HashSet<ProductModelProductDescriptionCulture>();
 
-    public string CultureID { get; set; }
+    public string CultureID { get; set; } = null!;
     public DateTime ModifiedDate { get; set; }
-    public string Name { get; set; }
+    public string Name { get; set; } = null!;
 
     public virtual ICollection<ProductModelProductDescriptionCulture> ProductModelProductDescriptionCulture { get; set; }
 }

--- a/benchmark/EFCore.Benchmarks/Models/AdventureWorks/Currency.cs
+++ b/benchmark/EFCore.Benchmarks/Models/AdventureWorks/Currency.cs
@@ -15,9 +15,9 @@ public class Currency
         CurrencyRateNavigation = new HashSet<CurrencyRate>();
     }
 
-    public string CurrencyCode { get; set; }
+    public string CurrencyCode { get; set; } = null!;
     public DateTime ModifiedDate { get; set; }
-    public string Name { get; set; }
+    public string Name { get; set; } = null!;
 
     public virtual ICollection<CountryRegionCurrency> CountryRegionCurrency { get; set; }
     public virtual ICollection<CurrencyRate> CurrencyRate { get; set; }

--- a/benchmark/EFCore.Benchmarks/Models/AdventureWorks/CurrencyRate.cs
+++ b/benchmark/EFCore.Benchmarks/Models/AdventureWorks/CurrencyRate.cs
@@ -15,11 +15,11 @@ public class CurrencyRate
     public decimal AverageRate { get; set; }
     public DateTime CurrencyRateDate { get; set; }
     public decimal EndOfDayRate { get; set; }
-    public string FromCurrencyCode { get; set; }
+    public string FromCurrencyCode { get; set; } = null!;
     public DateTime ModifiedDate { get; set; }
-    public string ToCurrencyCode { get; set; }
+    public string ToCurrencyCode { get; set; } = null!;
 
     public virtual ICollection<SalesOrderHeader> SalesOrderHeader { get; set; }
-    public virtual Currency FromCurrencyCodeNavigation { get; set; }
-    public virtual Currency ToCurrencyCodeNavigation { get; set; }
+    public virtual Currency FromCurrencyCodeNavigation { get; set; } = null!;
+    public virtual Currency ToCurrencyCodeNavigation { get; set; } = null!;
 }

--- a/benchmark/EFCore.Benchmarks/Models/AdventureWorks/Customer.cs
+++ b/benchmark/EFCore.Benchmarks/Models/AdventureWorks/Customer.cs
@@ -12,7 +12,7 @@ public class Customer
         => SalesOrderHeader = new HashSet<SalesOrderHeader>();
 
     public int CustomerID { get; set; }
-    public string AccountNumber { get; set; }
+    public string AccountNumber { get; set; } = null!;
     public DateTime ModifiedDate { get; set; }
     public int? PersonID { get; set; }
 #pragma warning disable IDE1006 // Naming Styles
@@ -22,7 +22,7 @@ public class Customer
     public int? TerritoryID { get; set; }
 
     public virtual ICollection<SalesOrderHeader> SalesOrderHeader { get; set; }
-    public virtual Person Person { get; set; }
-    public virtual Store Store { get; set; }
-    public virtual SalesTerritory Territory { get; set; }
+    public virtual Person? Person { get; set; }
+    public virtual Store? Store { get; set; }
+    public virtual SalesTerritory? Territory { get; set; }
 }

--- a/benchmark/EFCore.Benchmarks/Models/AdventureWorks/Department.cs
+++ b/benchmark/EFCore.Benchmarks/Models/AdventureWorks/Department.cs
@@ -12,9 +12,9 @@ public class Department
         => EmployeeDepartmentHistory = new HashSet<EmployeeDepartmentHistory>();
 
     public short DepartmentID { get; set; }
-    public string GroupName { get; set; }
+    public string GroupName { get; set; } = null!;
     public DateTime ModifiedDate { get; set; }
-    public string Name { get; set; }
+    public string Name { get; set; } = null!;
 
     public virtual ICollection<EmployeeDepartmentHistory> EmployeeDepartmentHistory { get; set; }
 }

--- a/benchmark/EFCore.Benchmarks/Models/AdventureWorks/EmailAddress.cs
+++ b/benchmark/EFCore.Benchmarks/Models/AdventureWorks/EmailAddress.cs
@@ -9,11 +9,11 @@ public class EmailAddress
 {
     public int BusinessEntityID { get; set; }
     public int EmailAddressID { get; set; }
-    public string EmailAddress1 { get; set; }
+    public string? EmailAddress1 { get; set; }
     public DateTime ModifiedDate { get; set; }
 #pragma warning disable IDE1006 // Naming Styles
     public Guid rowguid { get; set; }
 #pragma warning restore IDE1006 // Naming Styles
 
-    public virtual Person BusinessEntity { get; set; }
+    public virtual Person BusinessEntity { get; set; } = null!;
 }

--- a/benchmark/EFCore.Benchmarks/Models/AdventureWorks/Employee.cs
+++ b/benchmark/EFCore.Benchmarks/Models/AdventureWorks/Employee.cs
@@ -19,13 +19,13 @@ public class Employee
     public int BusinessEntityID { get; set; }
     public DateTime BirthDate { get; set; }
     public bool CurrentFlag { get; set; }
-    public string Gender { get; set; }
+    public string Gender { get; set; } = null!;
     public DateTime HireDate { get; set; }
-    public string JobTitle { get; set; }
-    public string LoginID { get; set; }
-    public string MaritalStatus { get; set; }
+    public string JobTitle { get; set; } = null!;
+    public string LoginID { get; set; } = null!;
+    public string MaritalStatus { get; set; } = null!;
     public DateTime ModifiedDate { get; set; }
-    public string NationalIDNumber { get; set; }
+    public string NationalIDNumber { get; set; } = null!;
     public short? OrganizationLevel { get; set; }
 #pragma warning disable IDE1006 // Naming Styles
     public Guid rowguid { get; set; }
@@ -38,6 +38,6 @@ public class Employee
     public virtual ICollection<EmployeePayHistory> EmployeePayHistory { get; set; }
     public virtual ICollection<JobCandidate> JobCandidate { get; set; }
     public virtual ICollection<PurchaseOrderHeader> PurchaseOrderHeader { get; set; }
-    public virtual SalesPerson SalesPerson { get; set; }
-    public virtual Person BusinessEntity { get; set; }
+    public virtual SalesPerson? SalesPerson { get; set; }
+    public virtual Person BusinessEntity { get; set; } = null!;
 }

--- a/benchmark/EFCore.Benchmarks/Models/AdventureWorks/EmployeeDepartmentHistory.cs
+++ b/benchmark/EFCore.Benchmarks/Models/AdventureWorks/EmployeeDepartmentHistory.cs
@@ -14,7 +14,7 @@ public class EmployeeDepartmentHistory
     public DateTime? EndDate { get; set; }
     public DateTime ModifiedDate { get; set; }
 
-    public virtual Employee BusinessEntity { get; set; }
-    public virtual Department Department { get; set; }
-    public virtual Shift Shift { get; set; }
+    public virtual Employee BusinessEntity { get; set; } = null!;
+    public virtual Department Department { get; set; } = null!;
+    public virtual Shift Shift { get; set; } = null!;
 }

--- a/benchmark/EFCore.Benchmarks/Models/AdventureWorks/EmployeePayHistory.cs
+++ b/benchmark/EFCore.Benchmarks/Models/AdventureWorks/EmployeePayHistory.cs
@@ -13,5 +13,5 @@ public class EmployeePayHistory
     public byte PayFrequency { get; set; }
     public decimal Rate { get; set; }
 
-    public virtual Employee BusinessEntity { get; set; }
+    public virtual Employee BusinessEntity { get; set; } = null!;
 }

--- a/benchmark/EFCore.Benchmarks/Models/AdventureWorks/Illustration.cs
+++ b/benchmark/EFCore.Benchmarks/Models/AdventureWorks/Illustration.cs
@@ -13,7 +13,7 @@ public class Illustration
 
     public int IllustrationID { get; set; }
     public DateTime ModifiedDate { get; set; }
-    public string Diagram { get; set; }
+    public string? Diagram { get; set; }
 
     public virtual ICollection<ProductModelIllustration> ProductModelIllustration { get; set; }
 }

--- a/benchmark/EFCore.Benchmarks/Models/AdventureWorks/JobCandidate.cs
+++ b/benchmark/EFCore.Benchmarks/Models/AdventureWorks/JobCandidate.cs
@@ -10,7 +10,7 @@ public class JobCandidate
     public int JobCandidateID { get; set; }
     public int? BusinessEntityID { get; set; }
     public DateTime ModifiedDate { get; set; }
-    public string Resume { get; set; }
+    public string? Resume { get; set; }
 
-    public virtual Employee BusinessEntity { get; set; }
+    public virtual Employee? BusinessEntity { get; set; }
 }

--- a/benchmark/EFCore.Benchmarks/Models/AdventureWorks/Location.cs
+++ b/benchmark/EFCore.Benchmarks/Models/AdventureWorks/Location.cs
@@ -18,7 +18,7 @@ public class Location
     public decimal Availability { get; set; }
     public decimal CostRate { get; set; }
     public DateTime ModifiedDate { get; set; }
-    public string Name { get; set; }
+    public string Name { get; set; } = null!;
 
     public virtual ICollection<ProductInventory> ProductInventory { get; set; }
     public virtual ICollection<WorkOrderRouting> WorkOrderRouting { get; set; }

--- a/benchmark/EFCore.Benchmarks/Models/AdventureWorks/Password.cs
+++ b/benchmark/EFCore.Benchmarks/Models/AdventureWorks/Password.cs
@@ -9,11 +9,11 @@ public class Password
 {
     public int BusinessEntityID { get; set; }
     public DateTime ModifiedDate { get; set; }
-    public string PasswordHash { get; set; }
-    public string PasswordSalt { get; set; }
+    public string PasswordHash { get; set; } = null!;
+    public string PasswordSalt { get; set; } = null!;
 #pragma warning disable IDE1006 // Naming Styles
     public Guid rowguid { get; set; }
 #pragma warning restore IDE1006 // Naming Styles
 
-    public virtual Person BusinessEntity { get; set; }
+    public virtual Person BusinessEntity { get; set; } = null!;
 }

--- a/benchmark/EFCore.Benchmarks/Models/AdventureWorks/Person.cs
+++ b/benchmark/EFCore.Benchmarks/Models/AdventureWorks/Person.cs
@@ -19,26 +19,26 @@ public class Person
 
     public int BusinessEntityID { get; set; }
     public int EmailPromotion { get; set; }
-    public string FirstName { get; set; }
-    public string LastName { get; set; }
-    public string MiddleName { get; set; }
+    public string FirstName { get; set; } = null!;
+    public string LastName { get; set; } = null!;
+    public string? MiddleName { get; set; }
     public DateTime ModifiedDate { get; set; }
     public bool NameStyle { get; set; }
-    public string PersonType { get; set; }
+    public string PersonType { get; set; } = null!;
 #pragma warning disable IDE1006 // Naming Styles
     public Guid rowguid { get; set; }
 #pragma warning restore IDE1006 // Naming Styles
-    public string Suffix { get; set; }
-    public string Title { get; set; }
-    public string AdditionalContactInfo { get; set; }
-    public string Demographics { get; set; }
+    public string? Suffix { get; set; }
+    public string? Title { get; set; }
+    public string? AdditionalContactInfo { get; set; }
+    public string? Demographics { get; set; }
 
     public virtual ICollection<BusinessEntityContact> BusinessEntityContact { get; set; }
     public virtual ICollection<Customer> Customer { get; set; }
     public virtual ICollection<EmailAddress> EmailAddress { get; set; }
-    public virtual Employee Employee { get; set; }
-    public virtual Password Password { get; set; }
+    public virtual Employee? Employee { get; set; }
+    public virtual Password? Password { get; set; }
     public virtual ICollection<PersonCreditCard> PersonCreditCard { get; set; }
     public virtual ICollection<PersonPhone> PersonPhone { get; set; }
-    public virtual BusinessEntity BusinessEntity { get; set; }
+    public virtual BusinessEntity BusinessEntity { get; set; } = null!;
 }

--- a/benchmark/EFCore.Benchmarks/Models/AdventureWorks/PersonCreditCard.cs
+++ b/benchmark/EFCore.Benchmarks/Models/AdventureWorks/PersonCreditCard.cs
@@ -11,6 +11,6 @@ public class PersonCreditCard
     public int CreditCardID { get; set; }
     public DateTime ModifiedDate { get; set; }
 
-    public virtual Person BusinessEntity { get; set; }
-    public virtual CreditCard CreditCard { get; set; }
+    public virtual Person BusinessEntity { get; set; } = null!;
+    public virtual CreditCard CreditCard { get; set; } = null!;
 }

--- a/benchmark/EFCore.Benchmarks/Models/AdventureWorks/PersonPhone.cs
+++ b/benchmark/EFCore.Benchmarks/Models/AdventureWorks/PersonPhone.cs
@@ -8,10 +8,10 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.Models.AdventureWorks;
 public class PersonPhone
 {
     public int BusinessEntityID { get; set; }
-    public string PhoneNumber { get; set; }
+    public string PhoneNumber { get; set; } = null!;
     public int PhoneNumberTypeID { get; set; }
     public DateTime ModifiedDate { get; set; }
 
-    public virtual Person BusinessEntity { get; set; }
-    public virtual PhoneNumberType PhoneNumberType { get; set; }
+    public virtual Person BusinessEntity { get; set; } = null!;
+    public virtual PhoneNumberType PhoneNumberType { get; set; } = null!;
 }

--- a/benchmark/EFCore.Benchmarks/Models/AdventureWorks/PhoneNumberType.cs
+++ b/benchmark/EFCore.Benchmarks/Models/AdventureWorks/PhoneNumberType.cs
@@ -13,7 +13,7 @@ public class PhoneNumberType
 
     public int PhoneNumberTypeID { get; set; }
     public DateTime ModifiedDate { get; set; }
-    public string Name { get; set; }
+    public string Name { get; set; } = null!;
 
     public virtual ICollection<PersonPhone> PersonPhone { get; set; }
 }

--- a/benchmark/EFCore.Benchmarks/Models/AdventureWorks/Product.cs
+++ b/benchmark/EFCore.Benchmarks/Models/AdventureWorks/Product.cs
@@ -27,18 +27,18 @@ public class Product
     }
 
     public int ProductID { get; set; }
-    public string Class { get; set; }
-    public string Color { get; set; }
+    public string? Class { get; set; }
+    public string? Color { get; set; }
     public int DaysToManufacture { get; set; }
     public DateTime? DiscontinuedDate { get; set; }
     public bool FinishedGoodsFlag { get; set; }
     public decimal ListPrice { get; set; }
     public bool MakeFlag { get; set; }
     public DateTime ModifiedDate { get; set; }
-    public string Name { get; set; }
-    public string ProductLine { get; set; }
+    public string Name { get; set; } = null!;
+    public string? ProductLine { get; set; }
     public int? ProductModelID { get; set; }
-    public string ProductNumber { get; set; }
+    public string ProductNumber { get; set; } = null!;
     public int? ProductSubcategoryID { get; set; }
     public short ReorderPoint { get; set; }
 #pragma warning disable IDE1006 // Naming Styles
@@ -47,12 +47,12 @@ public class Product
     public short SafetyStockLevel { get; set; }
     public DateTime? SellEndDate { get; set; }
     public DateTime SellStartDate { get; set; }
-    public string Size { get; set; }
-    public string SizeUnitMeasureCode { get; set; }
+    public string? Size { get; set; }
+    public string? SizeUnitMeasureCode { get; set; }
     public decimal StandardCost { get; set; }
-    public string Style { get; set; }
+    public string? Style { get; set; }
     public decimal? Weight { get; set; }
-    public string WeightUnitMeasureCode { get; set; }
+    public string? WeightUnitMeasureCode { get; set; }
 
     public virtual ICollection<BillOfMaterials> BillOfMaterials { get; set; }
     public virtual ICollection<BillOfMaterials> BillOfMaterialsNavigation { get; set; }
@@ -68,8 +68,8 @@ public class Product
     public virtual ICollection<SpecialOfferProduct> SpecialOfferProduct { get; set; }
     public virtual ICollection<TransactionHistory> TransactionHistory { get; set; }
     public virtual ICollection<WorkOrder> WorkOrder { get; set; }
-    public virtual ProductModel ProductModel { get; set; }
-    public virtual ProductSubcategory ProductSubcategory { get; set; }
-    public virtual UnitMeasure SizeUnitMeasureCodeNavigation { get; set; }
-    public virtual UnitMeasure WeightUnitMeasureCodeNavigation { get; set; }
+    public virtual ProductModel? ProductModel { get; set; }
+    public virtual ProductSubcategory? ProductSubcategory { get; set; }
+    public virtual UnitMeasure? SizeUnitMeasureCodeNavigation { get; set; }
+    public virtual UnitMeasure? WeightUnitMeasureCodeNavigation { get; set; }
 }

--- a/benchmark/EFCore.Benchmarks/Models/AdventureWorks/ProductCategory.cs
+++ b/benchmark/EFCore.Benchmarks/Models/AdventureWorks/ProductCategory.cs
@@ -13,7 +13,7 @@ public class ProductCategory
 
     public int ProductCategoryID { get; set; }
     public DateTime ModifiedDate { get; set; }
-    public string Name { get; set; }
+    public string Name { get; set; } = null!;
 #pragma warning disable IDE1006 // Naming Styles
     public Guid rowguid { get; set; }
 #pragma warning restore IDE1006 // Naming Styles

--- a/benchmark/EFCore.Benchmarks/Models/AdventureWorks/ProductCostHistory.cs
+++ b/benchmark/EFCore.Benchmarks/Models/AdventureWorks/ProductCostHistory.cs
@@ -13,5 +13,5 @@ public class ProductCostHistory
     public DateTime ModifiedDate { get; set; }
     public decimal StandardCost { get; set; }
 
-    public virtual Product Product { get; set; }
+    public virtual Product Product { get; set; } = null!;
 }

--- a/benchmark/EFCore.Benchmarks/Models/AdventureWorks/ProductDescription.cs
+++ b/benchmark/EFCore.Benchmarks/Models/AdventureWorks/ProductDescription.cs
@@ -12,7 +12,7 @@ public class ProductDescription
         => ProductModelProductDescriptionCulture = new HashSet<ProductModelProductDescriptionCulture>();
 
     public int ProductDescriptionID { get; set; }
-    public string Description { get; set; }
+    public string Description { get; set; } = null!;
     public DateTime ModifiedDate { get; set; }
 #pragma warning disable IDE1006 // Naming Styles
     public Guid rowguid { get; set; }

--- a/benchmark/EFCore.Benchmarks/Models/AdventureWorks/ProductDocument.cs
+++ b/benchmark/EFCore.Benchmarks/Models/AdventureWorks/ProductDocument.cs
@@ -11,5 +11,5 @@ public class ProductDocument
     public int DocumentNode { get; set; }
     public DateTime ModifiedDate { get; set; }
 
-    public virtual Product Product { get; set; }
+    public virtual Product Product { get; set; } = null!;
 }

--- a/benchmark/EFCore.Benchmarks/Models/AdventureWorks/ProductInventory.cs
+++ b/benchmark/EFCore.Benchmarks/Models/AdventureWorks/ProductInventory.cs
@@ -15,8 +15,8 @@ public class ProductInventory
 #pragma warning disable IDE1006 // Naming Styles
     public Guid rowguid { get; set; }
 #pragma warning restore IDE1006 // Naming Styles
-    public string Shelf { get; set; }
+    public string Shelf { get; set; } = null!;
 
-    public virtual Location Location { get; set; }
-    public virtual Product Product { get; set; }
+    public virtual Location Location { get; set; } = null!;
+    public virtual Product Product { get; set; } = null!;
 }

--- a/benchmark/EFCore.Benchmarks/Models/AdventureWorks/ProductListPriceHistory.cs
+++ b/benchmark/EFCore.Benchmarks/Models/AdventureWorks/ProductListPriceHistory.cs
@@ -13,5 +13,5 @@ public class ProductListPriceHistory
     public decimal ListPrice { get; set; }
     public DateTime ModifiedDate { get; set; }
 
-    public virtual Product Product { get; set; }
+    public virtual Product Product { get; set; } = null!;
 }

--- a/benchmark/EFCore.Benchmarks/Models/AdventureWorks/ProductModel.cs
+++ b/benchmark/EFCore.Benchmarks/Models/AdventureWorks/ProductModel.cs
@@ -17,12 +17,12 @@ public class ProductModel
 
     public int ProductModelID { get; set; }
     public DateTime ModifiedDate { get; set; }
-    public string Name { get; set; }
+    public string Name { get; set; } = null!;
 #pragma warning disable IDE1006 // Naming Styles
     public Guid rowguid { get; set; }
 #pragma warning restore IDE1006 // Naming Styles
-    public string CatalogDescription { get; set; }
-    public string Instructions { get; set; }
+    public string? CatalogDescription { get; set; }
+    public string? Instructions { get; set; }
 
     public virtual ICollection<Product> Product { get; set; }
     public virtual ICollection<ProductModelIllustration> ProductModelIllustration { get; set; }

--- a/benchmark/EFCore.Benchmarks/Models/AdventureWorks/ProductModelIllustration.cs
+++ b/benchmark/EFCore.Benchmarks/Models/AdventureWorks/ProductModelIllustration.cs
@@ -11,6 +11,6 @@ public class ProductModelIllustration
     public int IllustrationID { get; set; }
     public DateTime ModifiedDate { get; set; }
 
-    public virtual Illustration Illustration { get; set; }
-    public virtual ProductModel ProductModel { get; set; }
+    public virtual Illustration Illustration { get; set; } = null!;
+    public virtual ProductModel ProductModel { get; set; } = null!;
 }

--- a/benchmark/EFCore.Benchmarks/Models/AdventureWorks/ProductModelProductDescriptionCulture.cs
+++ b/benchmark/EFCore.Benchmarks/Models/AdventureWorks/ProductModelProductDescriptionCulture.cs
@@ -9,10 +9,10 @@ public class ProductModelProductDescriptionCulture
 {
     public int ProductModelID { get; set; }
     public int ProductDescriptionID { get; set; }
-    public string CultureID { get; set; }
+    public string CultureID { get; set; } = null!;
     public DateTime ModifiedDate { get; set; }
 
-    public virtual Culture Culture { get; set; }
-    public virtual ProductDescription ProductDescription { get; set; }
-    public virtual ProductModel ProductModel { get; set; }
+    public virtual Culture Culture { get; set; } = null!;
+    public virtual ProductDescription ProductDescription { get; set; } = null!;
+    public virtual ProductModel ProductModel { get; set; } = null!;
 }

--- a/benchmark/EFCore.Benchmarks/Models/AdventureWorks/ProductPhoto.cs
+++ b/benchmark/EFCore.Benchmarks/Models/AdventureWorks/ProductPhoto.cs
@@ -13,14 +13,14 @@ public class ProductPhoto
 
     public int ProductPhotoID { get; set; }
 #pragma warning disable CA1819 // Properties should not return arrays
-    public byte[] LargePhoto { get; set; }
+    public byte[]? LargePhoto { get; set; }
 #pragma warning restore CA1819 // Properties should not return arrays
-    public string LargePhotoFileName { get; set; }
+    public string? LargePhotoFileName { get; set; }
     public DateTime ModifiedDate { get; set; }
 #pragma warning disable CA1819 // Properties should not return arrays
-    public byte[] ThumbNailPhoto { get; set; }
+    public byte[]? ThumbNailPhoto { get; set; }
 #pragma warning restore CA1819 // Properties should not return arrays
-    public string ThumbnailPhotoFileName { get; set; }
+    public string? ThumbnailPhotoFileName { get; set; }
 
     public virtual ICollection<ProductProductPhoto> ProductProductPhoto { get; set; }
 }

--- a/benchmark/EFCore.Benchmarks/Models/AdventureWorks/ProductProductPhoto.cs
+++ b/benchmark/EFCore.Benchmarks/Models/AdventureWorks/ProductProductPhoto.cs
@@ -12,6 +12,6 @@ public class ProductProductPhoto
     public DateTime ModifiedDate { get; set; }
     public bool Primary { get; set; }
 
-    public virtual Product Product { get; set; }
-    public virtual ProductPhoto ProductPhoto { get; set; }
+    public virtual Product Product { get; set; } = null!;
+    public virtual ProductPhoto ProductPhoto { get; set; } = null!;
 }

--- a/benchmark/EFCore.Benchmarks/Models/AdventureWorks/ProductReview.cs
+++ b/benchmark/EFCore.Benchmarks/Models/AdventureWorks/ProductReview.cs
@@ -8,13 +8,13 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.Models.AdventureWorks;
 public class ProductReview
 {
     public int ProductReviewID { get; set; }
-    public string Comments { get; set; }
-    public string EmailAddress { get; set; }
+    public string? Comments { get; set; }
+    public string EmailAddress { get; set; } = null!;
     public DateTime ModifiedDate { get; set; }
     public int ProductID { get; set; }
     public int Rating { get; set; }
     public DateTime ReviewDate { get; set; }
-    public string ReviewerName { get; set; }
+    public string ReviewerName { get; set; } = null!;
 
-    public virtual Product Product { get; set; }
+    public virtual Product Product { get; set; } = null!;
 }

--- a/benchmark/EFCore.Benchmarks/Models/AdventureWorks/ProductSubcategory.cs
+++ b/benchmark/EFCore.Benchmarks/Models/AdventureWorks/ProductSubcategory.cs
@@ -13,12 +13,12 @@ public class ProductSubcategory
 
     public int ProductSubcategoryID { get; set; }
     public DateTime ModifiedDate { get; set; }
-    public string Name { get; set; }
+    public string Name { get; set; } = null!;
     public int ProductCategoryID { get; set; }
 #pragma warning disable IDE1006 // Naming Styles
     public Guid rowguid { get; set; }
 #pragma warning restore IDE1006 // Naming Styles
 
     public virtual ICollection<Product> Product { get; set; }
-    public virtual ProductCategory ProductCategory { get; set; }
+    public virtual ProductCategory ProductCategory { get; set; } = null!;
 }

--- a/benchmark/EFCore.Benchmarks/Models/AdventureWorks/ProductVendor.cs
+++ b/benchmark/EFCore.Benchmarks/Models/AdventureWorks/ProductVendor.cs
@@ -17,9 +17,9 @@ public class ProductVendor
     public DateTime ModifiedDate { get; set; }
     public int? OnOrderQty { get; set; }
     public decimal StandardPrice { get; set; }
-    public string UnitMeasureCode { get; set; }
+    public string UnitMeasureCode { get; set; } = null!;
 
-    public virtual Vendor BusinessEntity { get; set; }
-    public virtual Product Product { get; set; }
-    public virtual UnitMeasure UnitMeasureCodeNavigation { get; set; }
+    public virtual Vendor BusinessEntity { get; set; } = null!;
+    public virtual Product Product { get; set; } = null!;
+    public virtual UnitMeasure UnitMeasureCodeNavigation { get; set; } = null!;
 }

--- a/benchmark/EFCore.Benchmarks/Models/AdventureWorks/PurchaseOrderDetail.cs
+++ b/benchmark/EFCore.Benchmarks/Models/AdventureWorks/PurchaseOrderDetail.cs
@@ -19,6 +19,6 @@ public class PurchaseOrderDetail
     public decimal StockedQty { get; set; }
     public decimal UnitPrice { get; set; }
 
-    public virtual Product Product { get; set; }
-    public virtual PurchaseOrderHeader PurchaseOrder { get; set; }
+    public virtual Product Product { get; set; } = null!;
+    public virtual PurchaseOrderHeader PurchaseOrder { get; set; } = null!;
 }

--- a/benchmark/EFCore.Benchmarks/Models/AdventureWorks/PurchaseOrderHeader.cs
+++ b/benchmark/EFCore.Benchmarks/Models/AdventureWorks/PurchaseOrderHeader.cs
@@ -26,7 +26,7 @@ public class PurchaseOrderHeader
     public int VendorID { get; set; }
 
     public virtual ICollection<PurchaseOrderDetail> PurchaseOrderDetail { get; set; }
-    public virtual Employee Employee { get; set; }
-    public virtual ShipMethod ShipMethod { get; set; }
-    public virtual Vendor Vendor { get; set; }
+    public virtual Employee Employee { get; set; } = null!;
+    public virtual ShipMethod ShipMethod { get; set; } = null!;
+    public virtual Vendor Vendor { get; set; } = null!;
 }

--- a/benchmark/EFCore.Benchmarks/Models/AdventureWorks/SalesOrderDetail.cs
+++ b/benchmark/EFCore.Benchmarks/Models/AdventureWorks/SalesOrderDetail.cs
@@ -9,7 +9,7 @@ public class SalesOrderDetail
 {
     public int SalesOrderID { get; set; }
     public int SalesOrderDetailID { get; set; }
-    public string CarrierTrackingNumber { get; set; }
+    public string? CarrierTrackingNumber { get; set; }
     public decimal LineTotal { get; set; }
     public DateTime ModifiedDate { get; set; }
     public short OrderQty { get; set; }
@@ -21,6 +21,6 @@ public class SalesOrderDetail
     public decimal UnitPrice { get; set; }
     public decimal UnitPriceDiscount { get; set; }
 
-    public virtual SalesOrderHeader SalesOrder { get; set; }
-    public virtual SpecialOfferProduct SpecialOfferProduct { get; set; }
+    public virtual SalesOrderHeader SalesOrder { get; set; } = null!;
+    public virtual SpecialOfferProduct SpecialOfferProduct { get; set; } = null!;
 }

--- a/benchmark/EFCore.Benchmarks/Models/AdventureWorks/SalesOrderHeader.cs
+++ b/benchmark/EFCore.Benchmarks/Models/AdventureWorks/SalesOrderHeader.cs
@@ -15,10 +15,10 @@ public class SalesOrderHeader
     }
 
     public int SalesOrderID { get; set; }
-    public string AccountNumber { get; set; }
+    public string? AccountNumber { get; set; }
     public int BillToAddressID { get; set; }
-    public string Comment { get; set; }
-    public string CreditCardApprovalCode { get; set; }
+    public string? Comment { get; set; }
+    public string? CreditCardApprovalCode { get; set; }
     public int? CreditCardID { get; set; }
     public int? CurrencyRateID { get; set; }
     public int CustomerID { get; set; }
@@ -27,12 +27,12 @@ public class SalesOrderHeader
     public DateTime ModifiedDate { get; set; }
     public bool OnlineOrderFlag { get; set; }
     public DateTime OrderDate { get; set; }
-    public string PurchaseOrderNumber { get; set; }
+    public string? PurchaseOrderNumber { get; set; }
     public byte RevisionNumber { get; set; }
 #pragma warning disable IDE1006 // Naming Styles
     public Guid rowguid { get; set; }
 #pragma warning restore IDE1006 // Naming Styles
-    public string SalesOrderNumber { get; set; }
+    public string SalesOrderNumber { get; set; } = null!;
     public int? SalesPersonID { get; set; }
     public DateTime? ShipDate { get; set; }
     public int ShipMethodID { get; set; }
@@ -45,12 +45,12 @@ public class SalesOrderHeader
 
     public virtual ICollection<SalesOrderDetail> SalesOrderDetail { get; set; }
     public virtual ICollection<SalesOrderHeaderSalesReason> SalesOrderHeaderSalesReason { get; set; }
-    public virtual Address BillToAddress { get; set; }
-    public virtual CreditCard CreditCard { get; set; }
-    public virtual CurrencyRate CurrencyRate { get; set; }
-    public virtual Customer Customer { get; set; }
-    public virtual SalesPerson SalesPerson { get; set; }
-    public virtual ShipMethod ShipMethod { get; set; }
-    public virtual Address ShipToAddress { get; set; }
-    public virtual SalesTerritory Territory { get; set; }
+    public virtual Address BillToAddress { get; set; } = null!;
+    public virtual CreditCard? CreditCard { get; set; }
+    public virtual CurrencyRate? CurrencyRate { get; set; }
+    public virtual Customer Customer { get; set; } = null!;
+    public virtual SalesPerson? SalesPerson { get; set; }
+    public virtual ShipMethod ShipMethod { get; set; } = null!;
+    public virtual Address ShipToAddress { get; set; } = null!;
+    public virtual SalesTerritory? Territory { get; set; }
 }

--- a/benchmark/EFCore.Benchmarks/Models/AdventureWorks/SalesOrderHeaderSalesReason.cs
+++ b/benchmark/EFCore.Benchmarks/Models/AdventureWorks/SalesOrderHeaderSalesReason.cs
@@ -11,6 +11,6 @@ public class SalesOrderHeaderSalesReason
     public int SalesReasonID { get; set; }
     public DateTime ModifiedDate { get; set; }
 
-    public virtual SalesOrderHeader SalesOrder { get; set; }
-    public virtual SalesReason SalesReason { get; set; }
+    public virtual SalesOrderHeader SalesOrder { get; set; } = null!;
+    public virtual SalesReason SalesReason { get; set; } = null!;
 }

--- a/benchmark/EFCore.Benchmarks/Models/AdventureWorks/SalesPerson.cs
+++ b/benchmark/EFCore.Benchmarks/Models/AdventureWorks/SalesPerson.cs
@@ -32,6 +32,6 @@ public class SalesPerson
     public virtual ICollection<SalesPersonQuotaHistory> SalesPersonQuotaHistory { get; set; }
     public virtual ICollection<SalesTerritoryHistory> SalesTerritoryHistory { get; set; }
     public virtual ICollection<Store> Store { get; set; }
-    public virtual Employee BusinessEntity { get; set; }
-    public virtual SalesTerritory Territory { get; set; }
+    public virtual Employee BusinessEntity { get; set; } = null!;
+    public virtual SalesTerritory? Territory { get; set; }
 }

--- a/benchmark/EFCore.Benchmarks/Models/AdventureWorks/SalesPersonQuotaHistory.cs
+++ b/benchmark/EFCore.Benchmarks/Models/AdventureWorks/SalesPersonQuotaHistory.cs
@@ -15,5 +15,5 @@ public class SalesPersonQuotaHistory
 #pragma warning restore IDE1006 // Naming Styles
     public decimal SalesQuota { get; set; }
 
-    public virtual SalesPerson BusinessEntity { get; set; }
+    public virtual SalesPerson BusinessEntity { get; set; } = null!;
 }

--- a/benchmark/EFCore.Benchmarks/Models/AdventureWorks/SalesReason.cs
+++ b/benchmark/EFCore.Benchmarks/Models/AdventureWorks/SalesReason.cs
@@ -13,8 +13,8 @@ public class SalesReason
 
     public int SalesReasonID { get; set; }
     public DateTime ModifiedDate { get; set; }
-    public string Name { get; set; }
-    public string ReasonType { get; set; }
+    public string Name { get; set; } = null!;
+    public string ReasonType { get; set; } = null!;
 
     public virtual ICollection<SalesOrderHeaderSalesReason> SalesOrderHeaderSalesReason { get; set; }
 }

--- a/benchmark/EFCore.Benchmarks/Models/AdventureWorks/SalesTaxRate.cs
+++ b/benchmark/EFCore.Benchmarks/Models/AdventureWorks/SalesTaxRate.cs
@@ -9,7 +9,7 @@ public class SalesTaxRate
 {
     public int SalesTaxRateID { get; set; }
     public DateTime ModifiedDate { get; set; }
-    public string Name { get; set; }
+    public string Name { get; set; } = null!;
 #pragma warning disable IDE1006 // Naming Styles
     public Guid rowguid { get; set; }
 #pragma warning restore IDE1006 // Naming Styles
@@ -17,5 +17,5 @@ public class SalesTaxRate
     public decimal TaxRate { get; set; }
     public byte TaxType { get; set; }
 
-    public virtual StateProvince StateProvince { get; set; }
+    public virtual StateProvince StateProvince { get; set; } = null!;
 }

--- a/benchmark/EFCore.Benchmarks/Models/AdventureWorks/SalesTerritory.cs
+++ b/benchmark/EFCore.Benchmarks/Models/AdventureWorks/SalesTerritory.cs
@@ -20,10 +20,10 @@ public class SalesTerritory
     public int TerritoryID { get; set; }
     public decimal CostLastYear { get; set; }
     public decimal CostYTD { get; set; }
-    public string CountryRegionCode { get; set; }
-    public string Group { get; set; }
+    public string CountryRegionCode { get; set; } = null!;
+    public string Group { get; set; } = null!;
     public DateTime ModifiedDate { get; set; }
-    public string Name { get; set; }
+    public string Name { get; set; } = null!;
 #pragma warning disable IDE1006 // Naming Styles
     public Guid rowguid { get; set; }
 #pragma warning restore IDE1006 // Naming Styles
@@ -35,5 +35,5 @@ public class SalesTerritory
     public virtual ICollection<SalesPerson> SalesPerson { get; set; }
     public virtual ICollection<SalesTerritoryHistory> SalesTerritoryHistory { get; set; }
     public virtual ICollection<StateProvince> StateProvince { get; set; }
-    public virtual CountryRegion CountryRegionCodeNavigation { get; set; }
+    public virtual CountryRegion CountryRegionCodeNavigation { get; set; } = null!;
 }

--- a/benchmark/EFCore.Benchmarks/Models/AdventureWorks/SalesTerritoryHistory.cs
+++ b/benchmark/EFCore.Benchmarks/Models/AdventureWorks/SalesTerritoryHistory.cs
@@ -16,6 +16,6 @@ public class SalesTerritoryHistory
     public Guid rowguid { get; set; }
 #pragma warning restore IDE1006 // Naming Styles
 
-    public virtual SalesPerson BusinessEntity { get; set; }
-    public virtual SalesTerritory Territory { get; set; }
+    public virtual SalesPerson BusinessEntity { get; set; } = null!;
+    public virtual SalesTerritory Territory { get; set; } = null!;
 }

--- a/benchmark/EFCore.Benchmarks/Models/AdventureWorks/ScrapReason.cs
+++ b/benchmark/EFCore.Benchmarks/Models/AdventureWorks/ScrapReason.cs
@@ -13,7 +13,7 @@ public class ScrapReason
 
     public short ScrapReasonID { get; set; }
     public DateTime ModifiedDate { get; set; }
-    public string Name { get; set; }
+    public string Name { get; set; } = null!;
 
     public virtual ICollection<WorkOrder> WorkOrder { get; set; }
 }

--- a/benchmark/EFCore.Benchmarks/Models/AdventureWorks/Shift.cs
+++ b/benchmark/EFCore.Benchmarks/Models/AdventureWorks/Shift.cs
@@ -14,7 +14,7 @@ public class Shift
     public byte ShiftID { get; set; }
     public DateTime EndTime { get; set; }
     public DateTime ModifiedDate { get; set; }
-    public string Name { get; set; }
+    public string Name { get; set; } = null!;
     public DateTime StartTime { get; set; }
 
     public virtual ICollection<EmployeeDepartmentHistory> EmployeeDepartmentHistory { get; set; }

--- a/benchmark/EFCore.Benchmarks/Models/AdventureWorks/ShipMethod.cs
+++ b/benchmark/EFCore.Benchmarks/Models/AdventureWorks/ShipMethod.cs
@@ -16,7 +16,7 @@ public class ShipMethod
 
     public int ShipMethodID { get; set; }
     public DateTime ModifiedDate { get; set; }
-    public string Name { get; set; }
+    public string Name { get; set; } = null!;
 #pragma warning disable IDE1006 // Naming Styles
     public Guid rowguid { get; set; }
 #pragma warning restore IDE1006 // Naming Styles

--- a/benchmark/EFCore.Benchmarks/Models/AdventureWorks/ShoppingCartItem.cs
+++ b/benchmark/EFCore.Benchmarks/Models/AdventureWorks/ShoppingCartItem.cs
@@ -12,7 +12,7 @@ public class ShoppingCartItem
     public DateTime ModifiedDate { get; set; }
     public int ProductID { get; set; }
     public int Quantity { get; set; }
-    public string ShoppingCartID { get; set; }
+    public string ShoppingCartID { get; set; } = null!;
 
-    public virtual Product Product { get; set; }
+    public virtual Product Product { get; set; } = null!;
 }

--- a/benchmark/EFCore.Benchmarks/Models/AdventureWorks/SpecialOffer.cs
+++ b/benchmark/EFCore.Benchmarks/Models/AdventureWorks/SpecialOffer.cs
@@ -12,8 +12,8 @@ public class SpecialOffer
         => SpecialOfferProduct = new HashSet<SpecialOfferProduct>();
 
     public int SpecialOfferID { get; set; }
-    public string Category { get; set; }
-    public string Description { get; set; }
+    public string Category { get; set; } = null!;
+    public string Description { get; set; } = null!;
     public decimal DiscountPct { get; set; }
     public DateTime EndDate { get; set; }
     public int? MaxQty { get; set; }
@@ -23,7 +23,7 @@ public class SpecialOffer
     public Guid rowguid { get; set; }
 #pragma warning restore IDE1006 // Naming Styles
     public DateTime StartDate { get; set; }
-    public string Type { get; set; }
+    public string Type { get; set; } = null!;
 
     public virtual ICollection<SpecialOfferProduct> SpecialOfferProduct { get; set; }
 }

--- a/benchmark/EFCore.Benchmarks/Models/AdventureWorks/SpecialOfferProduct.cs
+++ b/benchmark/EFCore.Benchmarks/Models/AdventureWorks/SpecialOfferProduct.cs
@@ -19,6 +19,6 @@ public class SpecialOfferProduct
 #pragma warning restore IDE1006 // Naming Styles
 
     public virtual ICollection<SalesOrderDetail> SalesOrderDetail { get; set; }
-    public virtual Product Product { get; set; }
-    public virtual SpecialOffer SpecialOffer { get; set; }
+    public virtual Product Product { get; set; } = null!;
+    public virtual SpecialOffer SpecialOffer { get; set; } = null!;
 }

--- a/benchmark/EFCore.Benchmarks/Models/AdventureWorks/StateProvince.cs
+++ b/benchmark/EFCore.Benchmarks/Models/AdventureWorks/StateProvince.cs
@@ -15,18 +15,18 @@ public class StateProvince
     }
 
     public int StateProvinceID { get; set; }
-    public string CountryRegionCode { get; set; }
+    public string CountryRegionCode { get; set; } = null!;
     public bool IsOnlyStateProvinceFlag { get; set; }
     public DateTime ModifiedDate { get; set; }
-    public string Name { get; set; }
+    public string Name { get; set; } = null!;
 #pragma warning disable IDE1006 // Naming Styles
     public Guid rowguid { get; set; }
 #pragma warning restore IDE1006 // Naming Styles
-    public string StateProvinceCode { get; set; }
+    public string StateProvinceCode { get; set; } = null!;
     public int TerritoryID { get; set; }
 
     public virtual ICollection<Address> Address { get; set; }
     public virtual ICollection<SalesTaxRate> SalesTaxRate { get; set; }
-    public virtual CountryRegion CountryRegionCodeNavigation { get; set; }
-    public virtual SalesTerritory Territory { get; set; }
+    public virtual CountryRegion CountryRegionCodeNavigation { get; set; } = null!;
+    public virtual SalesTerritory Territory { get; set; } = null!;
 }

--- a/benchmark/EFCore.Benchmarks/Models/AdventureWorks/Store.cs
+++ b/benchmark/EFCore.Benchmarks/Models/AdventureWorks/Store.cs
@@ -13,14 +13,14 @@ public class Store
 
     public int BusinessEntityID { get; set; }
     public DateTime ModifiedDate { get; set; }
-    public string Name { get; set; }
+    public string Name { get; set; } = null!;
 #pragma warning disable IDE1006 // Naming Styles
     public Guid rowguid { get; set; }
 #pragma warning restore IDE1006 // Naming Styles
     public int? SalesPersonID { get; set; }
-    public string Demographics { get; set; }
+    public string? Demographics { get; set; }
 
     public virtual ICollection<Customer> Customer { get; set; }
-    public virtual BusinessEntity BusinessEntity { get; set; }
-    public virtual SalesPerson SalesPerson { get; set; }
+    public virtual BusinessEntity BusinessEntity { get; set; } = null!;
+    public virtual SalesPerson? SalesPerson { get; set; }
 }

--- a/benchmark/EFCore.Benchmarks/Models/AdventureWorks/TransactionHistory.cs
+++ b/benchmark/EFCore.Benchmarks/Models/AdventureWorks/TransactionHistory.cs
@@ -15,7 +15,7 @@ public class TransactionHistory
     public int ReferenceOrderID { get; set; }
     public int ReferenceOrderLineID { get; set; }
     public DateTime TransactionDate { get; set; }
-    public string TransactionType { get; set; }
+    public string TransactionType { get; set; } = null!;
 
-    public virtual Product Product { get; set; }
+    public virtual Product Product { get; set; } = null!;
 }

--- a/benchmark/EFCore.Benchmarks/Models/AdventureWorks/TransactionHistoryArchive.cs
+++ b/benchmark/EFCore.Benchmarks/Models/AdventureWorks/TransactionHistoryArchive.cs
@@ -15,5 +15,5 @@ public class TransactionHistoryArchive
     public int ReferenceOrderID { get; set; }
     public int ReferenceOrderLineID { get; set; }
     public DateTime TransactionDate { get; set; }
-    public string TransactionType { get; set; }
+    public string TransactionType { get; set; } = null!;
 }

--- a/benchmark/EFCore.Benchmarks/Models/AdventureWorks/UnitMeasure.cs
+++ b/benchmark/EFCore.Benchmarks/Models/AdventureWorks/UnitMeasure.cs
@@ -16,9 +16,9 @@ public class UnitMeasure
         ProductVendor = new HashSet<ProductVendor>();
     }
 
-    public string UnitMeasureCode { get; set; }
+    public string UnitMeasureCode { get; set; } = null!;
     public DateTime ModifiedDate { get; set; }
-    public string Name { get; set; }
+    public string Name { get; set; } = null!;
 
     public virtual ICollection<BillOfMaterials> BillOfMaterials { get; set; }
     public virtual ICollection<Product> Product { get; set; }

--- a/benchmark/EFCore.Benchmarks/Models/AdventureWorks/Vendor.cs
+++ b/benchmark/EFCore.Benchmarks/Models/AdventureWorks/Vendor.cs
@@ -15,15 +15,15 @@ public class Vendor
     }
 
     public int BusinessEntityID { get; set; }
-    public string AccountNumber { get; set; }
+    public string AccountNumber { get; set; } = null!;
     public bool ActiveFlag { get; set; }
     public byte CreditRating { get; set; }
     public DateTime ModifiedDate { get; set; }
-    public string Name { get; set; }
+    public string Name { get; set; } = null!;
     public bool PreferredVendorStatus { get; set; }
-    public string PurchasingWebServiceURL { get; set; }
+    public string? PurchasingWebServiceURL { get; set; }
 
     public virtual ICollection<ProductVendor> ProductVendor { get; set; }
     public virtual ICollection<PurchaseOrderHeader> PurchaseOrderHeader { get; set; }
-    public virtual BusinessEntity BusinessEntity { get; set; }
+    public virtual BusinessEntity BusinessEntity { get; set; } = null!;
 }

--- a/benchmark/EFCore.Benchmarks/Models/AdventureWorks/WorkOrder.cs
+++ b/benchmark/EFCore.Benchmarks/Models/AdventureWorks/WorkOrder.cs
@@ -23,6 +23,6 @@ public class WorkOrder
     public int StockedQty { get; set; }
 
     public virtual ICollection<WorkOrderRouting> WorkOrderRouting { get; set; }
-    public virtual Product Product { get; set; }
-    public virtual ScrapReason ScrapReason { get; set; }
+    public virtual Product Product { get; set; } = null!;
+    public virtual ScrapReason? ScrapReason { get; set; }
 }

--- a/benchmark/EFCore.Benchmarks/Models/AdventureWorks/WorkOrderRouting.cs
+++ b/benchmark/EFCore.Benchmarks/Models/AdventureWorks/WorkOrderRouting.cs
@@ -20,6 +20,6 @@ public class WorkOrderRouting
     public DateTime ScheduledEndDate { get; set; }
     public DateTime ScheduledStartDate { get; set; }
 
-    public virtual Location Location { get; set; }
-    public virtual WorkOrder WorkOrder { get; set; }
+    public virtual Location Location { get; set; } = null!;
+    public virtual WorkOrder WorkOrder { get; set; } = null!;
 }

--- a/benchmark/EFCore.Benchmarks/Models/Orders/Customer.cs
+++ b/benchmark/EFCore.Benchmarks/Models/Orders/Customer.cs
@@ -9,22 +9,22 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.Models.Orders;
 public class Customer
 {
     public int CustomerId { get; set; }
-    public string Title { get; set; }
-    public string FirstName { get; set; }
-    public string LastName { get; set; }
+    public string? Title { get; set; }
+    public string? FirstName { get; set; }
+    public string? LastName { get; set; }
     public DateTime? DateOfBirth { get; set; }
     public bool IsLoyaltyMember { get; set; }
     public DateTime Joined { get; set; }
     public bool OptedOutOfMarketing { get; set; }
-    public string Phone { get; set; }
-    public string Email { get; set; }
+    public string? Phone { get; set; }
+    public string? Email { get; set; }
 
-    public string AddressLineOne { get; set; }
-    public string AddressLineTwo { get; set; }
-    public string City { get; set; }
-    public string StateOrProvince { get; set; }
-    public string ZipOrPostalCode { get; set; }
-    public string County { get; set; }
+    public string? AddressLineOne { get; set; }
+    public string? AddressLineTwo { get; set; }
+    public string? City { get; set; }
+    public string? StateOrProvince { get; set; }
+    public string? ZipOrPostalCode { get; set; }
+    public string? County { get; set; }
 
-    public ICollection<Order> Orders { get; set; }
+    public ICollection<Order> Orders { get; set; } = null!;
 }

--- a/benchmark/EFCore.Benchmarks/Models/Orders/Order.cs
+++ b/benchmark/EFCore.Benchmarks/Models/Orders/Order.cs
@@ -10,21 +10,21 @@ public class Order
 {
     public int OrderId { get; set; }
     public DateTime Date { get; set; }
-    public string SpecialRequests { get; set; }
+    public string? SpecialRequests { get; set; }
     public decimal OrderDiscount { get; set; }
-    public string DiscountReason { get; set; }
+    public string? DiscountReason { get; set; }
     public decimal Tax { get; set; }
 
-    public string Addressee { get; set; }
-    public string AddressLineOne { get; set; }
-    public string AddressLineTwo { get; set; }
-    public string City { get; set; }
-    public string StateOrProvince { get; set; }
-    public string ZipOrPostalCode { get; set; }
-    public string County { get; set; }
+    public string? Addressee { get; set; }
+    public string? AddressLineOne { get; set; }
+    public string? AddressLineTwo { get; set; }
+    public string? City { get; set; }
+    public string? StateOrProvince { get; set; }
+    public string? ZipOrPostalCode { get; set; }
+    public string? County { get; set; }
 
     public int CustomerId { get; set; }
-    public Customer Customer { get; set; }
+    public Customer Customer { get; set; } = null!;
 
-    public ICollection<OrderLine> OrderLines { get; set; }
+    public ICollection<OrderLine> OrderLines { get; set; } = null!;
 }

--- a/benchmark/EFCore.Benchmarks/Models/Orders/OrderLine.cs
+++ b/benchmark/EFCore.Benchmarks/Models/Orders/OrderLine.cs
@@ -9,12 +9,12 @@ public class OrderLine
     public int Quantity { get; set; }
     public double Price { get; set; }
     public bool IsSubjectToTax { get; set; }
-    public string SpecialRequests { get; set; }
+    public string? SpecialRequests { get; set; }
     public bool IsShipped { get; set; }
 
     public int OrderId { get; set; }
-    public Order Order { get; set; }
+    public Order Order { get; set; } = null!;
 
     public int ProductId { get; set; }
-    public Product Product { get; set; }
+    public Product Product { get; set; } = null!;
 }

--- a/benchmark/EFCore.Benchmarks/Models/Orders/OrdersContextBase.cs
+++ b/benchmark/EFCore.Benchmarks/Models/Orders/OrdersContextBase.cs
@@ -5,12 +5,12 @@ using System;
 
 namespace Microsoft.EntityFrameworkCore.Benchmarks.Models.Orders;
 
-public abstract class OrdersContextBase(IServiceProvider serviceProvider) : DbContext
+public abstract class OrdersContextBase(IServiceProvider? serviceProvider) : DbContext
 {
-    public DbSet<Customer> Customers { get; set; }
-    public DbSet<Order> Orders { get; set; }
-    public DbSet<OrderLine> OrderLines { get; set; }
-    public DbSet<Product> Products { get; set; }
+    public DbSet<Customer> Customers { get; set; } = null!;
+    public DbSet<Order> Orders { get; set; } = null!;
+    public DbSet<OrderLine> OrderLines { get; set; } = null!;
+    public DbSet<Product> Products { get; set; } = null!;
 
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         => ConfigureProvider(optionsBuilder.UseInternalServiceProvider(serviceProvider));

--- a/benchmark/EFCore.Benchmarks/Models/Orders/OrdersFixtureBase.cs
+++ b/benchmark/EFCore.Benchmarks/Models/Orders/OrdersFixtureBase.cs
@@ -12,7 +12,7 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.Models.Orders;
 
 public abstract class OrdersFixtureBase : OrdersFixtureSeedBase
 {
-    private IServiceProvider _serviceProvider;
+    private IServiceProvider? _serviceProvider;
     private int _productCount;
     private int _customerCount;
     private int _ordersPerCustomer;
@@ -23,7 +23,7 @@ public abstract class OrdersFixtureBase : OrdersFixtureSeedBase
         int customerCount,
         int ordersPerCustomer,
         int linesPerOrder,
-        Action<DbContext> seedAction = null)
+        Action<DbContext>? seedAction = null)
     {
         _productCount = productCount;
         _customerCount = customerCount;
@@ -36,9 +36,9 @@ public abstract class OrdersFixtureBase : OrdersFixtureSeedBase
     public void SetServiceProvider(IServiceProvider serviceProvider)
         => _serviceProvider = serviceProvider;
 
-    public abstract OrdersContextBase CreateContext(IServiceProvider serviceProvider = null, bool disableBatching = false);
+    public abstract OrdersContextBase CreateContext(IServiceProvider? serviceProvider = null, bool disableBatching = false);
 
-    private void EnsureDatabaseCreated(Action<DbContext> seedAction)
+    private void EnsureDatabaseCreated(Action<DbContext>? seedAction)
     {
         using (var context = CreateContext())
         {

--- a/benchmark/EFCore.Benchmarks/Models/Orders/Product.cs
+++ b/benchmark/EFCore.Benchmarks/Models/Orders/Product.cs
@@ -9,9 +9,9 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.Models.Orders;
 public class Product
 {
     public int ProductId { get; set; }
-    public string Name { get; set; }
-    public string Description { get; set; }
-    public string SKU { get; set; }
+    public string? Name { get; set; }
+    public string? Description { get; set; }
+    public string? SKU { get; set; }
     public double Retail { get; set; }
     public double CurrentPrice { get; set; }
     public int TargetStockLevel { get; set; }
@@ -21,5 +21,5 @@ public class Product
     public DateTime? NextShipmentExpected { get; set; }
     public bool IsDiscontinued { get; set; }
 
-    public ICollection<OrderLine> OrderLines { get; set; }
+    public ICollection<OrderLine> OrderLines { get; set; } = null!;
 }

--- a/benchmark/EFCore.Benchmarks/Query/FuncletizationTests.cs
+++ b/benchmark/EFCore.Benchmarks/Query/FuncletizationTests.cs
@@ -14,7 +14,7 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.Query;
 [DisplayName(nameof(FuncletizationTests))]
 public abstract class FuncletizationTests
 {
-    private OrdersContextBase _context;
+    private OrdersContextBase _context = null!;
 
     protected virtual int FuncletizationIterationCount
         => 100;

--- a/benchmark/EFCore.Benchmarks/Query/NavigationsQueryTests.cs
+++ b/benchmark/EFCore.Benchmarks/Query/NavigationsQueryTests.cs
@@ -13,8 +13,8 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.Query;
 [DisplayName(nameof(NavigationsQueryTests))]
 public abstract class NavigationsQueryTests
 {
-    private AdventureWorksContextBase _context;
-    private IQueryable<Store> _query;
+    private AdventureWorksContextBase _context = null!;
+    private IQueryable<Store> _query = null!;
 
     protected virtual int QueriesPerIteration
         => 10;
@@ -35,8 +35,8 @@ public abstract class NavigationsQueryTests
     {
         _context = CreateContext();
         _query = Filter
-            ? _context.Store.Where(s => s.SalesPerson.Bonus > 3000)
-            : _context.Store.Where(s => s.SalesPerson.Bonus >= 0);
+            ? _context.Store.Where(s => s.SalesPerson!.Bonus > 3000)
+            : _context.Store.Where(s => s.SalesPerson!.Bonus >= 0);
     }
 
     [GlobalCleanup]

--- a/benchmark/EFCore.Benchmarks/Query/QueryCompilationTests.cs
+++ b/benchmark/EFCore.Benchmarks/Query/QueryCompilationTests.cs
@@ -19,10 +19,10 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.Query;
 [DisplayName(nameof(QueryCompilationTests))]
 public abstract class QueryCompilationTests
 {
-    private OrdersContextBase _context;
-    private IQueryable<Product> _simpleQuery;
-    private IQueryable<DTO> _complexQuery;
-    private IQueryable<Customer> _multipleJoinQuery;
+    private OrdersContextBase _context = null!;
+    private IQueryable<Product> _simpleQuery = null!;
+    private IQueryable<DTO> _complexQuery = null!;
+    private IQueryable<Customer> _multipleJoinQuery = null!;
 
     public abstract OrdersFixtureBase CreateFixture();
     public abstract IServiceCollection AddProviderServices(IServiceCollection services);
@@ -97,17 +97,17 @@ public abstract class QueryCompilationTests
     private class DTO
     {
         public int ProductId { get; set; }
-        public string Name { get; set; }
-        public string Description { get; set; }
+        public string? Name { get; set; }
+        public string? Description { get; set; }
         public int ActualStockLevel { get; set; }
-        public string SKU { get; set; }
+        public string? SKU { get; set; }
         public double Savings { get; set; }
         public int Surplus { get; set; }
     }
 
     private class NonCachingMemoryCache : IMemoryCache
     {
-        public bool TryGetValue(object key, out object value)
+        public bool TryGetValue(object key, out object? value)
         {
             value = null;
             return false;
@@ -122,13 +122,13 @@ public abstract class QueryCompilationTests
             {
             }
 
-            public object Key { get; }
-            public object Value { get; set; }
+            public object Key { get; } = null!;
+            public object? Value { get; set; }
             public DateTimeOffset? AbsoluteExpiration { get; set; }
             public TimeSpan? AbsoluteExpirationRelativeToNow { get; set; }
             public TimeSpan? SlidingExpiration { get; set; }
-            public IList<IChangeToken> ExpirationTokens { get; }
-            public IList<PostEvictionCallbackRegistration> PostEvictionCallbacks { get; }
+            public IList<IChangeToken> ExpirationTokens { get; } = null!;
+            public IList<PostEvictionCallbackRegistration> PostEvictionCallbacks { get; } = null!;
             public CacheItemPriority Priority { get; set; }
             public long? Size { get; set; }
         }

--- a/benchmark/EFCore.Benchmarks/Query/RawSqlQueryTests.cs
+++ b/benchmark/EFCore.Benchmarks/Query/RawSqlQueryTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.Query;
 [DisplayName(nameof(RawSqlQueryTests))]
 public abstract class RawSqlQueryTests
 {
-    private OrdersContextBase _context;
+    private OrdersContextBase _context = null!;
 
     protected abstract OrdersFixtureBase CreateFixture();
     protected abstract string StoredProcedureCreationScript { get; }

--- a/benchmark/EFCore.Benchmarks/Query/SimpleQueryTests.cs
+++ b/benchmark/EFCore.Benchmarks/Query/SimpleQueryTests.cs
@@ -15,7 +15,7 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.Query;
 [DisplayName(nameof(SimpleQueryTests))]
 public abstract class SimpleQueryTests
 {
-    private OrdersContextBase _context;
+    private OrdersContextBase _context = null!;
 
     protected abstract OrdersFixtureBase CreateFixture();
 

--- a/benchmark/EFCore.Benchmarks/UpdatePipeline/SimpleUpdatePipelineTests.cs
+++ b/benchmark/EFCore.Benchmarks/UpdatePipeline/SimpleUpdatePipelineTests.cs
@@ -17,9 +17,9 @@ public class SimpleUpdatePipelineTests
 {
     public abstract class UpdatePipelineBase
     {
-        protected OrdersFixtureBase _fixture;
-        protected OrdersContextBase _context;
-        private IDbContextTransaction _transaction;
+        protected OrdersFixtureBase _fixture = null!;
+        protected OrdersContextBase _context = null!;
+        private IDbContextTransaction _transaction = null!;
         private int _recordsAffected = -1;
 
         public abstract OrdersFixtureBase CreateFixture();

--- a/benchmark/EFCore.SqlServer.Benchmarks/EFCore.SqlServer.Benchmarks.csproj
+++ b/benchmark/EFCore.SqlServer.Benchmarks/EFCore.SqlServer.Benchmarks.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
     <RootNamespace>Microsoft.EntityFrameworkCore.Benchmarks</RootNamespace>
     <OutputType>Exe</OutputType>
-    <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">

--- a/benchmark/EFCore.SqlServer.Benchmarks/Models/Orders/OrdersSqlServerContext.cs
+++ b/benchmark/EFCore.SqlServer.Benchmarks/Models/Orders/OrdersSqlServerContext.cs
@@ -5,7 +5,7 @@ using System;
 
 namespace Microsoft.EntityFrameworkCore.Benchmarks.Models.Orders;
 
-public class OrdersSqlServerContext(string connectionString, IServiceProvider serviceProvider = null, bool disableBatching = false)
+public class OrdersSqlServerContext(string connectionString, IServiceProvider? serviceProvider = null, bool disableBatching = false)
     : OrdersContextBase(serviceProvider)
 {
     private readonly string _connectionString = connectionString;

--- a/benchmark/EFCore.SqlServer.Benchmarks/Models/Orders/OrdersSqlServerFixture.cs
+++ b/benchmark/EFCore.SqlServer.Benchmarks/Models/Orders/OrdersSqlServerFixture.cs
@@ -9,6 +9,6 @@ public class OrdersSqlServerFixture(string databaseName) : OrdersFixtureBase
 {
     private readonly string _connectionString = SqlServerBenchmarkEnvironment.CreateConnectionString(databaseName);
 
-    public override OrdersContextBase CreateContext(IServiceProvider serviceProvider = null, bool disableBatching = false)
+    public override OrdersContextBase CreateContext(IServiceProvider? serviceProvider = null, bool disableBatching = false)
         => new OrdersSqlServerContext(_connectionString, serviceProvider, disableBatching);
 }

--- a/benchmark/EFCore.SqlServer.Benchmarks/Support/SqlServerBenchmarkEnvironment.cs
+++ b/benchmark/EFCore.SqlServer.Benchmarks/Support/SqlServerBenchmarkEnvironment.cs
@@ -33,6 +33,6 @@ public static class SqlServerBenchmarkEnvironment
     public static string DefaultConnection
         => Config["DefaultConnection"] ?? DefaultConnectionString;
 
-    public static string CreateConnectionString(string name, string fileName = null, bool? multipleActiveResultSets = null)
+    public static string CreateConnectionString(string name, string? fileName = null, bool? multipleActiveResultSets = null)
         => new SqlConnectionStringBuilder(DefaultConnection) { InitialCatalog = name }.ToString();
 }

--- a/benchmark/EFCore.Sqlite.Benchmarks/EFCore.Sqlite.Benchmarks.csproj
+++ b/benchmark/EFCore.Sqlite.Benchmarks/EFCore.Sqlite.Benchmarks.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
     <RootNamespace>Microsoft.EntityFrameworkCore.Benchmarks</RootNamespace>
     <OutputType>Exe</OutputType>
-    <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">

--- a/benchmark/EFCore.Sqlite.Benchmarks/Models/AdventureWorks/AdventureWorksSqliteFixture.cs
+++ b/benchmark/EFCore.Sqlite.Benchmarks/Models/AdventureWorks/AdventureWorksSqliteFixture.cs
@@ -8,7 +8,7 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.Models.AdventureWorks;
 public static class AdventureWorksSqliteFixture
 {
     private static readonly string _baseDirectory
-        = Path.GetDirectoryName(typeof(AdventureWorksSqliteFixture).Assembly.Location);
+        = Path.GetDirectoryName(typeof(AdventureWorksSqliteFixture).Assembly.Location)!;
 
     public static string ConnectionString { get; } = $"Data Source={Path.Combine(_baseDirectory, "AdventureWorks2014.db")}";
 

--- a/benchmark/EFCore.Sqlite.Benchmarks/Models/Orders/OrdersSqliteContext.cs
+++ b/benchmark/EFCore.Sqlite.Benchmarks/Models/Orders/OrdersSqliteContext.cs
@@ -5,7 +5,7 @@ using System;
 
 namespace Microsoft.EntityFrameworkCore.Benchmarks.Models.Orders;
 
-public class OrdersSqliteContext(string connectionString, IServiceProvider serviceProvider = null, bool disableBatching = false)
+public class OrdersSqliteContext(string connectionString, IServiceProvider? serviceProvider = null, bool disableBatching = false)
     : OrdersContextBase(serviceProvider)
 {
     private readonly string _connectionString = connectionString;

--- a/benchmark/EFCore.Sqlite.Benchmarks/Models/Orders/OrdersSqliteFixture.cs
+++ b/benchmark/EFCore.Sqlite.Benchmarks/Models/Orders/OrdersSqliteFixture.cs
@@ -9,10 +9,10 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.Models.Orders;
 public class OrdersSqliteFixture(string databaseName) : OrdersFixtureBase
 {
     private static readonly string _baseDirectory
-        = Path.GetDirectoryName(typeof(OrdersSqliteFixture).Assembly.Location);
+        = Path.GetDirectoryName(typeof(OrdersSqliteFixture).Assembly.Location)!;
 
     private readonly string _connectionString = $"Data Source={Path.Combine(_baseDirectory, databaseName + ".db")}";
 
-    public override OrdersContextBase CreateContext(IServiceProvider serviceProvider = null, bool disableBatching = false)
+    public override OrdersContextBase CreateContext(IServiceProvider? serviceProvider = null, bool disableBatching = false)
         => new OrdersSqliteContext(_connectionString, serviceProvider, disableBatching);
 }

--- a/test/EFCore.InMemory.Tests/EFCore.InMemory.Tests.csproj
+++ b/test/EFCore.InMemory.Tests/EFCore.InMemory.Tests.csproj
@@ -5,7 +5,6 @@
     <AssemblyName>Microsoft.EntityFrameworkCore.InMemory.Tests</AssemblyName>
     <RootNamespace>Microsoft.EntityFrameworkCore</RootNamespace>
     <ImplicitUsings>true</ImplicitUsings>
-    <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/EFCore.InMemory.Tests/Storage/InMemoryDatabaseCreatorTest.cs
+++ b/test/EFCore.InMemory.Tests/Storage/InMemoryDatabaseCreatorTest.cs
@@ -126,7 +126,7 @@ public class InMemoryDatabaseCreatorTest
     private class FraggleContext(bool seed = false, bool asyncSeed = false) : DbContext
     {
         // ReSharper disable once UnusedAutoPropertyAccessor.Local
-        public DbSet<Fraggle> Fraggles { get; set; }
+        public DbSet<Fraggle> Fraggles { get; set; } = null!;
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         {
@@ -149,6 +149,6 @@ public class InMemoryDatabaseCreatorTest
     private class Fraggle
     {
         public int Id { get; set; }
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
     }
 }

--- a/test/EFCore.InMemory.Tests/Storage/InMemoryDatabaseTest.cs
+++ b/test/EFCore.InMemory.Tests/Storage/InMemoryDatabaseTest.cs
@@ -183,6 +183,6 @@ public class InMemoryDatabaseTest
     private class Customer
     {
         public int Id { get; set; }
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
     }
 }

--- a/test/EFCore.InMemory.Tests/ValueGeneration/InMemoryIntegerValueGeneratorTest.cs
+++ b/test/EFCore.InMemory.Tests/ValueGeneration/InMemoryIntegerValueGeneratorTest.cs
@@ -15,30 +15,30 @@ public class InMemoryIntegerValueGeneratorTest
     {
         var generator = new InMemoryIntegerValueGenerator<int>(0);
 
-        Assert.Equal(1, generator.Next(null));
-        Assert.Equal(2, generator.Next(null));
-        Assert.Equal(3, generator.Next(null));
-        Assert.Equal(4, generator.Next(null));
-        Assert.Equal(5, generator.Next(null));
-        Assert.Equal(6, generator.Next(null));
+        Assert.Equal(1, generator.Next(null!));
+        Assert.Equal(2, generator.Next(null!));
+        Assert.Equal(3, generator.Next(null!));
+        Assert.Equal(4, generator.Next(null!));
+        Assert.Equal(5, generator.Next(null!));
+        Assert.Equal(6, generator.Next(null!));
 
         generator = new InMemoryIntegerValueGenerator<int>(0);
 
-        Assert.Equal(1, generator.Next(null));
-        Assert.Equal(2, generator.Next(null));
+        Assert.Equal(1, generator.Next(null!));
+        Assert.Equal(2, generator.Next(null!));
     }
 
     [Fact]
     public void Can_create_values_for_all_integer_types()
     {
-        Assert.Equal(1, new InMemoryIntegerValueGenerator<int>(0).Next(null));
-        Assert.Equal(1L, new InMemoryIntegerValueGenerator<long>(0).Next(null));
-        Assert.Equal((short)1, new InMemoryIntegerValueGenerator<short>(0).Next(null));
-        Assert.Equal((byte)1, new InMemoryIntegerValueGenerator<byte>(0).Next(null));
-        Assert.Equal((uint)1, new InMemoryIntegerValueGenerator<uint>(0).Next(null));
-        Assert.Equal((ulong)1, new InMemoryIntegerValueGenerator<ulong>(0).Next(null));
-        Assert.Equal((ushort)1, new InMemoryIntegerValueGenerator<ushort>(0).Next(null));
-        Assert.Equal((sbyte)1, new InMemoryIntegerValueGenerator<sbyte>(0).Next(null));
+        Assert.Equal(1, new InMemoryIntegerValueGenerator<int>(0).Next(null!));
+        Assert.Equal(1L, new InMemoryIntegerValueGenerator<long>(0).Next(null!));
+        Assert.Equal((short)1, new InMemoryIntegerValueGenerator<short>(0).Next(null!));
+        Assert.Equal((byte)1, new InMemoryIntegerValueGenerator<byte>(0).Next(null!));
+        Assert.Equal((uint)1, new InMemoryIntegerValueGenerator<uint>(0).Next(null!));
+        Assert.Equal((ulong)1, new InMemoryIntegerValueGenerator<ulong>(0).Next(null!));
+        Assert.Equal((ushort)1, new InMemoryIntegerValueGenerator<ushort>(0).Next(null!));
+        Assert.Equal((sbyte)1, new InMemoryIntegerValueGenerator<sbyte>(0).Next(null!));
     }
 
     [Fact]
@@ -48,10 +48,10 @@ public class InMemoryIntegerValueGeneratorTest
 
         for (var i = 1; i < 256; i++)
         {
-            generator.Next(null);
+            generator.Next(null!);
         }
 
-        Assert.Throws<OverflowException>(() => generator.Next(null));
+        Assert.Throws<OverflowException>(() => generator.Next(null!));
     }
 
     [Fact]

--- a/test/EFCore.InMemory.Tests/ValueGeneration/InMemoryValueGeneratorSelectorTest.cs
+++ b/test/EFCore.InMemory.Tests/ValueGeneration/InMemoryValueGeneratorSelectorTest.cs
@@ -65,22 +65,22 @@ public class InMemoryValueGeneratorSelectorTest
         var model = BuildModel();
         var entityType = model.FindEntityType(typeof(AnEntity))!;
 
-        Assert.Equal(1, CreateAndUseFactory(entityType.FindProperty("Id")));
-        Assert.Equal(1L, CreateAndUseFactory(entityType.FindProperty("Long")));
-        Assert.Equal((short)1, CreateAndUseFactory(entityType.FindProperty("Short")));
-        Assert.Equal((byte)1, CreateAndUseFactory(entityType.FindProperty("Byte")));
-        Assert.Equal((int?)1, CreateAndUseFactory(entityType.FindProperty("NullableInt")));
-        Assert.Equal((long?)1, CreateAndUseFactory(entityType.FindProperty("NullableLong")));
-        Assert.Equal((short?)1, CreateAndUseFactory(entityType.FindProperty("NullableShort")));
-        Assert.Equal((byte?)1, CreateAndUseFactory(entityType.FindProperty("NullableByte")));
-        Assert.Equal((uint)1, CreateAndUseFactory(entityType.FindProperty("UInt")));
-        Assert.Equal((ulong)1, CreateAndUseFactory(entityType.FindProperty("ULong")));
-        Assert.Equal((ushort)1, CreateAndUseFactory(entityType.FindProperty("UShort")));
-        Assert.Equal((sbyte)1, CreateAndUseFactory(entityType.FindProperty("SByte")));
-        Assert.Equal((uint?)1, CreateAndUseFactory(entityType.FindProperty("NullableUInt")));
-        Assert.Equal((ulong?)1, CreateAndUseFactory(entityType.FindProperty("NullableULong")));
-        Assert.Equal((ushort?)1, CreateAndUseFactory(entityType.FindProperty("NullableUShort")));
-        Assert.Equal((sbyte?)1, CreateAndUseFactory(entityType.FindProperty("NullableSByte")));
+        Assert.Equal(1, CreateAndUseFactory(entityType.FindProperty("Id")!));
+        Assert.Equal(1L, CreateAndUseFactory(entityType.FindProperty("Long")!));
+        Assert.Equal((short)1, CreateAndUseFactory(entityType.FindProperty("Short")!));
+        Assert.Equal((byte)1, CreateAndUseFactory(entityType.FindProperty("Byte")!));
+        Assert.Equal((int?)1, CreateAndUseFactory(entityType.FindProperty("NullableInt")!));
+        Assert.Equal((long?)1, CreateAndUseFactory(entityType.FindProperty("NullableLong")!));
+        Assert.Equal((short?)1, CreateAndUseFactory(entityType.FindProperty("NullableShort")!));
+        Assert.Equal((byte?)1, CreateAndUseFactory(entityType.FindProperty("NullableByte")!));
+        Assert.Equal((uint)1, CreateAndUseFactory(entityType.FindProperty("UInt")!));
+        Assert.Equal((ulong)1, CreateAndUseFactory(entityType.FindProperty("ULong")!));
+        Assert.Equal((ushort)1, CreateAndUseFactory(entityType.FindProperty("UShort")!));
+        Assert.Equal((sbyte)1, CreateAndUseFactory(entityType.FindProperty("SByte")!));
+        Assert.Equal((uint?)1, CreateAndUseFactory(entityType.FindProperty("NullableUInt")!));
+        Assert.Equal((ulong?)1, CreateAndUseFactory(entityType.FindProperty("NullableULong")!));
+        Assert.Equal((ushort?)1, CreateAndUseFactory(entityType.FindProperty("NullableUShort")!));
+        Assert.Equal((sbyte?)1, CreateAndUseFactory(entityType.FindProperty("NullableSByte")!));
     }
 
     private static object CreateAndUseFactory(IProperty property)
@@ -91,7 +91,7 @@ public class InMemoryValueGeneratorSelectorTest
 
         selector.TrySelect(property, property.DeclaringType, out var generator);
 
-        return generator!.Next(null!);
+        return generator!.Next(null!)!;
     }
 
     [Fact]
@@ -111,7 +111,7 @@ public class InMemoryValueGeneratorSelectorTest
         var builder = InMemoryTestHelpers.Instance.CreateConventionBuilder();
         builder.Entity<AnEntity>().Property(e => e.Custom).HasValueGenerator<CustomValueGenerator>();
         var model = builder.Model;
-        var entityType = model.FindEntityType(typeof(AnEntity));
+        var entityType = model.FindEntityType(typeof(AnEntity))!;
 
         foreach (var property in entityType.GetProperties())
         {
@@ -140,9 +140,9 @@ public class InMemoryValueGeneratorSelectorTest
         public ulong? NullableULong { get; set; }
         public ushort? NullableUShort { get; set; }
         public sbyte? NullableSByte { get; set; }
-        public string String { get; set; }
+        public string String { get; set; } = null!;
         public Guid Guid { get; set; }
-        public byte[] Binary { get; set; }
+        public byte[] Binary { get; set; } = null!;
         public float Float { get; set; }
     }
 

--- a/test/EFCore.Proxies.Tests/ChangeDetectionProxyTests.cs
+++ b/test/EFCore.Proxies.Tests/ChangeDetectionProxyTests.cs
@@ -41,7 +41,7 @@ public class ChangeDetectionProxyTests
         using var context = new ChangeContext<ChangeNonVirtualIndexerNotUsed>();
 
         Assert.DoesNotContain(
-            context.Model.FindEntityType(typeof(ChangeNonVirtualIndexerNotUsed)).GetProperties(), e => e.IsIndexerProperty());
+            context.Model.FindEntityType(typeof(ChangeNonVirtualIndexerNotUsed))!.GetProperties(), e => e.IsIndexerProperty());
     }
 
     [Fact]
@@ -88,7 +88,7 @@ public class ChangeDetectionProxyTests
     {
         using var context = new ChangingAndChangedNotificationsWithOriginalValuesContext();
 
-        var entityType = context.Model.FindEntityType(typeof(ChangeValueEntity));
+        var entityType = context.Model.FindEntityType(typeof(ChangeValueEntity))!;
 
         Assert.Equal(ChangeTrackingStrategy.ChangingAndChangedNotificationsWithOriginalValues, entityType.GetChangeTrackingStrategy());
     }
@@ -177,7 +177,7 @@ public class ChangeDetectionProxyTests
 
             Assert.Equal(
                 10,
-                ((ChangeValueEntity)s).Value);
+                ((ChangeValueEntity)s!).Value);
         };
 
         proxy.Value = 10;
@@ -207,7 +207,7 @@ public class ChangeDetectionProxyTests
 
             Assert.Equal(
                 5,
-                ((ChangeValueEntity)s).Value);
+                ((ChangeValueEntity)s!).Value);
         };
 
         proxy.Value = 10;
@@ -285,12 +285,12 @@ public class ChangeDetectionProxyTests
     private class ChangeContext<TEntity>(
         bool useLazyLoading = false,
         bool checkEquality = true,
-        Action<EntityTypeBuilder<TEntity>> entityBuilderAction = null) : TestContext<TEntity>(
+        Action<EntityTypeBuilder<TEntity>>? entityBuilderAction = null) : TestContext<TEntity>(
         dbName: "ChangeDetectionContext", useLazyLoading: useLazyLoading, useChangeDetection: true,
         checkEquality: checkEquality)
         where TEntity : class
     {
-        private readonly Action<EntityTypeBuilder<TEntity>> _entityBuilderAction = entityBuilderAction;
+        private readonly Action<EntityTypeBuilder<TEntity>>? _entityBuilderAction = entityBuilderAction;
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
@@ -301,10 +301,10 @@ public class ChangeDetectionProxyTests
         }
     }
 
-    private class SharedChangeContext<TEntity>(Action<EntityTypeBuilder<TEntity>> entityBuilderAction = null) : DbContext
+    private class SharedChangeContext<TEntity>(Action<EntityTypeBuilder<TEntity>>? entityBuilderAction = null) : DbContext
         where TEntity : class
     {
-        private readonly Action<EntityTypeBuilder<TEntity>> _entityBuilderAction = entityBuilderAction;
+        private readonly Action<EntityTypeBuilder<TEntity>>? _entityBuilderAction = entityBuilderAction;
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
             => optionsBuilder
@@ -329,14 +329,14 @@ public class ChangeDetectionProxyTests
     {
         public int Id { get; set; }
 
-        public virtual ChangeNonVirtualPropEntity SelfRef { get; set; }
+        public virtual ChangeNonVirtualPropEntity? SelfRef { get; set; }
     }
 
     public class ChangeNonVirtualNavEntity
     {
         public virtual int Id { get; set; }
 
-        public ChangeNonVirtualNavEntity SelfRef { get; set; }
+        public ChangeNonVirtualNavEntity? SelfRef { get; set; }
     }
 
     public class ChangeValueEntity
@@ -350,7 +350,7 @@ public class ChangeDetectionProxyTests
     {
         public virtual int Id { get; set; }
 
-        public virtual ChangeSelfRefEntity SelfRef { get; set; }
+        public virtual ChangeSelfRefEntity? SelfRef { get; set; }
     }
 
     public class ChangeNonVirtualIndexer

--- a/test/EFCore.Proxies.Tests/EFCore.Proxies.Tests.csproj
+++ b/test/EFCore.Proxies.Tests/EFCore.Proxies.Tests.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
     <AssemblyName>Microsoft.EntityFrameworkCore.Proxies.Tests</AssemblyName>
     <RootNamespace>Microsoft.EntityFrameworkCore</RootNamespace>
-    <Nullable>disable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
   </PropertyGroup>
 

--- a/test/EFCore.Proxies.Tests/LazyLoadingProxyTests.cs
+++ b/test/EFCore.Proxies.Tests/LazyLoadingProxyTests.cs
@@ -99,7 +99,7 @@ public class LazyLoadingProxyTests
 
         using (var scope = serviceProvider.CreateScope())
         {
-            var context = scope.ServiceProvider.GetService<JammieDodgerContext>();
+            var context = scope.ServiceProvider.GetService<JammieDodgerContext>()!;
             context.Add(new Phone());
             context.SaveChanges();
         }
@@ -107,7 +107,7 @@ public class LazyLoadingProxyTests
         Phone phone;
         using (var scope = serviceProvider.CreateScope())
         {
-            var context = scope.ServiceProvider.GetService<JammieDodgerContext>();
+            var context = scope.ServiceProvider.GetService<JammieDodgerContext>()!;
             phone = context.Set<Phone>().Single();
         }
 
@@ -182,21 +182,21 @@ public class LazyLoadingProxyTests
     {
         public int Id { get; set; }
 
-        public LazyNonVirtualNavEntity SelfRef { get; set; }
+        public LazyNonVirtualNavEntity? SelfRef { get; set; }
     }
 
     public class LazyFieldNavEntity
     {
         public int Id { get; set; }
 
-        public LazyFieldNavEntity SelfRef;
+        public LazyFieldNavEntity? SelfRef;
     }
 
     public class LazyNonVirtualOwnedNavEntity
     {
         public int Id { get; set; }
 
-        public OwnedNavEntity NavigationToOwned { get; set; }
+        public OwnedNavEntity? NavigationToOwned { get; set; }
     }
 
     [Owned]
@@ -204,16 +204,16 @@ public class LazyLoadingProxyTests
     {
         public int Id { get; set; }
 
-        public string Name { get; set; }
+        public string? Name { get; set; }
 
-        public LazyNonVirtualOwnedNavEntity Owner { get; set; }
+        public LazyNonVirtualOwnedNavEntity? Owner { get; set; }
     }
 
     public class LazyFieldOwnedNavEntity
     {
         public int Id { get; set; }
 
-        public OwnedFieldNavEntity NavigationToOwned;
+        public OwnedFieldNavEntity? NavigationToOwned;
     }
 
     [Owned]
@@ -221,19 +221,19 @@ public class LazyLoadingProxyTests
     {
         public int Id { get; set; }
 
-        public string Name { get; set; }
+        public string? Name { get; set; }
 
-        public LazyFieldOwnedNavEntity Owner;
+        public LazyFieldOwnedNavEntity? Owner;
     }
 
     public class LazyHiddenFieldEntity
     {
-        private LazyHiddenFieldEntity _hiddenBackingField;
+        private LazyHiddenFieldEntity? _hiddenBackingField;
 
         public int Id { get; set; }
 
         // ReSharper disable once ConvertToAutoProperty
-        public virtual LazyHiddenFieldEntity SelfRef
+        public virtual LazyHiddenFieldEntity? SelfRef
         {
             get => _hiddenBackingField;
             set => _hiddenBackingField = value;
@@ -249,7 +249,7 @@ public class LazyLoadingProxyTests
     public class Phone
     {
         public int Id { get; set; }
-        public virtual ICollection<Text> Texts { get; set; }
+        public virtual ICollection<Text> Texts { get; set; } = null!;
     }
 
     public class Text

--- a/test/EFCore.Proxies.Tests/ProxyTests.cs
+++ b/test/EFCore.Proxies.Tests/ProxyTests.cs
@@ -309,10 +309,10 @@ public class ProxyTests
     {
         public virtual int Id { get; set; }
 
-        public virtual IsOwnedButNotWeak Owned { get; set; }
+        public virtual IsOwnedButNotWeak? Owned { get; set; }
 
-        public virtual IsWeak Weak1 { get; set; }
-        public virtual IsWeak Weak2 { get; set; }
+        public virtual IsWeak? Weak1 { get; set; }
+        public virtual IsWeak? Weak2 { get; set; }
     }
 
     [Owned]
@@ -328,7 +328,7 @@ public class ProxyTests
 
     public record IndyCar;
 
-    private class NeweyContext(string dbName = null, bool useLazyLoading = true, bool useChangeDetection = false) : DbContext
+    private class NeweyContext(string? dbName = null, bool useLazyLoading = true, bool useChangeDetection = false) : DbContext
     {
         private readonly IServiceProvider _internalServiceProvider
             = new ServiceCollection()
@@ -339,11 +339,11 @@ public class ProxyTests
         private static readonly InMemoryDatabaseRoot _dbRoot = new();
         private readonly bool _useLazyLoadingProxies = useLazyLoading;
         private readonly bool _useChangeDetectionProxies = useChangeDetection;
-        private readonly string _dbName = dbName;
+        private readonly string? _dbName = dbName;
 
         public NeweyContext(
             IServiceProvider internalServiceProvider,
-            string dbName = null,
+            string? dbName = null,
             bool useLazyLoading = true,
             bool useChangeDetection = false)
             : this(dbName, useLazyLoading, useChangeDetection)
@@ -471,7 +471,7 @@ public class ProxyTests
 
     private class CannotAddProxyTypeToModel : DbContext
     {
-        public DbSet<ClassToBeProxied> _entityToBeProxied { get; set; }
+        public DbSet<ClassToBeProxied> _entityToBeProxied { get; set; } = null!;
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
             => optionsBuilder

--- a/test/EFCore.Proxies.Tests/TestUtilities/TestContext.cs
+++ b/test/EFCore.Proxies.Tests/TestUtilities/TestContext.cs
@@ -4,7 +4,7 @@
 namespace Microsoft.EntityFrameworkCore.TestUtilities;
 
 internal abstract class TestContext<TEntity>(
-    string dbName = null,
+    string? dbName = null,
     bool useLazyLoading = false,
     bool useChangeDetection = false,
     bool checkEquality = true,

--- a/test/EFCore.Tests/ApiConsistencyTest.cs
+++ b/test/EFCore.Tests/ApiConsistencyTest.cs
@@ -22,7 +22,10 @@ public class ApiConsistencyTest(ApiConsistencyTest.ApiConsistencyFixture fixture
     {
         protected override void Initialize()
         {
-            AddInstanceMethods(MetadataTypes);
+            AddInstanceMethods(
+                MetadataTypes.ToDictionary(
+                    type => type.Key,
+                    type => (type.Value.Mutable, type.Value.Convention, type.Value.ConventionBuilder!, type.Value.Runtime!)));
 
             MirrorTypes.Add(typeof(PropertyBuilder), typeof(ComplexTypePropertyBuilder));
 
@@ -81,8 +84,7 @@ public class ApiConsistencyTest(ApiConsistencyTest.ApiConsistencyFixture fixture
             typeof(EntityFrameworkServiceCollectionExtensions)
         ];
 
-        public override HashSet<MethodInfo> VirtualMethodExceptions { get; } =
-        [
+        public override HashSet<MethodInfo> VirtualMethodExceptions { get; } = MethodSet(
             typeof(CompiledQueryCacheKeyGenerator).GetMethod("GenerateCacheKeyCore", AnyInstance),
             typeof(InternalEntityEntry).GetMethod("get_Item"),
             typeof(InternalEntityEntry).GetMethod("set_Item"),
@@ -97,15 +99,12 @@ public class ApiConsistencyTest(ApiConsistencyTest.ApiConsistencyFixture fixture
             typeof(JsonValueReaderWriter<>).GetMethod(nameof(JsonValueReaderWriter.ToJson)),
             typeof(JsonValueReaderWriter<>).GetMethod("get_ValueType"),
             typeof(JsonValueReaderWriter).GetMethod(nameof(JsonValueReaderWriter.FromJsonString)),
-            typeof(JsonValueReaderWriter).GetMethod(nameof(JsonValueReaderWriter.ToJsonString))
-        ];
+            typeof(JsonValueReaderWriter).GetMethod(nameof(JsonValueReaderWriter.ToJsonString)));
 
-        public override HashSet<MethodInfo> NotAnnotatedMethods { get; } =
-        [
+        public override HashSet<MethodInfo> NotAnnotatedMethods { get; } = MethodSet(
             typeof(DbContext).GetMethod(nameof(DbContext.OnConfiguring), AnyInstance),
             typeof(DbContext).GetMethod(nameof(DbContext.OnModelCreating), AnyInstance),
-            typeof(IEntityTypeConfiguration<>).GetMethod(nameof(IEntityTypeConfiguration<Type>.Configure))
-        ];
+            typeof(IEntityTypeConfiguration<>).GetMethod(nameof(IEntityTypeConfiguration<Type>.Configure)));
 
         public override Dictionary<MethodInfo, string> MetadataMethodNameTransformers { get; } = new()
         {
@@ -121,8 +120,7 @@ public class ApiConsistencyTest(ApiConsistencyTest.ApiConsistencyFixture fixture
             }
         };
 
-        public override HashSet<MethodInfo> UnmatchedMetadataMethods { get; } =
-        [
+        public override HashSet<MethodInfo> UnmatchedMetadataMethods { get; } = MethodSet(
             typeof(PropertyBuilder).GetMethod(
                 nameof(PropertyBuilder.HasValueGenerator), 0, [typeof(Func<IProperty, ITypeBase, ValueGenerator>)]),
             typeof(ComplexPropertyBuilder).GetMethod(
@@ -183,11 +181,9 @@ public class ApiConsistencyTest(ApiConsistencyTest.ApiConsistencyFixture fixture
             typeof(IConventionAnnotatableBuilder).GetMethod(nameof(IConventionAnnotatableBuilder.HasNonNullAnnotation)),
             typeof(IConventionEntityTypeBuilder).GetMethod(nameof(IConventionEntityTypeBuilder.RemoveUnusedImplicitProperties)),
             typeof(IConventionTypeBaseBuilder).GetMethod(nameof(IConventionTypeBaseBuilder.RemoveUnusedImplicitProperties)),
-            typeof(IConventionEntityTypeBuilder).GetMethod(nameof(IConventionEntityTypeBuilder.GetTargetEntityTypeBuilder))
-        ];
+            typeof(IConventionEntityTypeBuilder).GetMethod(nameof(IConventionEntityTypeBuilder.GetTargetEntityTypeBuilder)));
 
-        public override HashSet<MethodInfo> MetadataMethodExceptions { get; } =
-        [
+        public override HashSet<MethodInfo> MetadataMethodExceptions { get; } = MethodSet(
             typeof(IConventionAnnotatable).GetMethod(nameof(IConventionAnnotatable.SetAnnotation)),
             typeof(IConventionAnnotatable).GetMethod(nameof(IConventionAnnotatable.SetOrRemoveAnnotation)),
             typeof(IConventionAnnotatable).GetMethod(nameof(IConventionAnnotatable.AddAnnotations)),
@@ -201,6 +197,9 @@ public class ApiConsistencyTest(ApiConsistencyTest.ApiConsistencyFixture fixture
             typeof(IConventionEntityType).GetMethod(nameof(IConventionEntityType.LeastDerivedType)),
             typeof(IConventionEntityType).GetMethod(
                 nameof(IConventionEntityType.SetQueryFilter), [typeof(string), typeof(LambdaExpression), typeof(bool)])
-        ];
+        );
+
+        private static HashSet<MethodInfo> MethodSet(params MethodInfo?[] methods)
+            => [.. methods.Select(method => method!)];
     }
 }

--- a/test/EFCore.Tests/ChangeTracking/ChangeTrackerTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/ChangeTrackerTest.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using Microsoft.EntityFrameworkCore.Diagnostics.Internal;
 
 // ReSharper disable ClassNeverInstantiated.Local

--- a/test/EFCore.Tests/ChangeTracking/CollectionEntryTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/CollectionEntryTest.cs
@@ -67,7 +67,7 @@ public class CollectionEntryTest
         Assert.Same(chunky, cherry.Monkeys.Single());
         Assert.Equal(cherry.Id, chunky.GarciaId);
         Assert.Same(chunky, collection.CurrentValue.Cast<Chunky>().Single());
-        Assert.Same(collection.FindEntry(chunky).GetInfrastructure(), context.Entry(chunky).GetInfrastructure());
+        Assert.Same(collection.FindEntry(chunky)!.GetInfrastructure(), context.Entry(chunky).GetInfrastructure());
 
         collection.CurrentValue = null;
 
@@ -96,7 +96,7 @@ public class CollectionEntryTest
         Assert.Same(chunky, cherry.Monkeys.Single());
         Assert.Equal(cherry.Id, chunky.GarciaId);
         Assert.Same(chunky, collection.CurrentValue.Single());
-        Assert.Same(collection.FindEntry(chunky).GetInfrastructure(), context.Entry(chunky).GetInfrastructure());
+        Assert.Same(collection.FindEntry(chunky)!.GetInfrastructure(), context.Entry(chunky).GetInfrastructure());
 
         collection.CurrentValue = null;
 
@@ -453,7 +453,7 @@ public class CollectionEntryTest
         public int Id { get; set; }
 
         public int? GarciaId { get; set; }
-        public Cherry Garcia { get; set; }
+        public Cherry Garcia { get; set; } = null!;
     }
 
     private class Cherry
@@ -461,7 +461,7 @@ public class CollectionEntryTest
         public int Garcia { get; set; }
         public int Id { get; set; }
 
-        public ICollection<Chunky> Monkeys { get; set; }
+        public ICollection<Chunky> Monkeys { get; set; } = null!;
     }
 
     private class FreezerContext : DbContext
@@ -471,7 +471,7 @@ public class CollectionEntryTest
                 .UseInternalServiceProvider(InMemoryFixture.DefaultServiceProvider)
                 .UseInMemoryDatabase(nameof(FreezerContext));
 
-        public DbSet<Chunky> Icecream { get; set; }
+        public DbSet<Chunky> Icecream { get; set; } = null!;
 
         protected internal override void OnModelCreating(ModelBuilder modelBuilder)
         {

--- a/test/EFCore.Tests/ChangeTracking/ComplexPropertyEntryTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/ComplexPropertyEntryTest.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
 using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 
 namespace Microsoft.EntityFrameworkCore.ChangeTracking;

--- a/test/EFCore.Tests/ChangeTracking/EntityEntryTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/EntityEntryTest.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
 #pragma warning disable CS0649 // Field is never assigned to, and will always have its default value
 #pragma warning disable CS0414 // Field is assigned but its value is never used
 

--- a/test/EFCore.Tests/ChangeTracking/FindEntryTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/FindEntryTest.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System.ComponentModel.DataAnnotations.Schema;
 
 namespace Microsoft.EntityFrameworkCore.ChangeTracking;

--- a/test/EFCore.Tests/ChangeTracking/GraphTrackingTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/GraphTrackingTest.cs
@@ -391,10 +391,10 @@ public class GraphTrackingTest
                 .UseInMemoryDatabase(nameof(AggregateContext))
                 .UseInternalServiceProvider(InMemoryFixture.DefaultServiceProvider);
 
-        public DbSet<Blog> Blogs { get; set; }
-        public DbSet<Post> Posts { get; set; }
-        public DbSet<Comment> Comments { get; set; }
-        public DbSet<Author> Authors { get; set; }
+        public DbSet<Blog> Blogs { get; set; } = null!;
+        public DbSet<Post> Posts { get; set; } = null!;
+        public DbSet<Comment> Comments { get; set; } = null!;
+        public DbSet<Author> Authors { get; set; } = null!;
     }
 
     private class BlogCategoryStatistics
@@ -402,16 +402,16 @@ public class GraphTrackingTest
         public int Id { get; set; }
 
         public int? BlogCategoryId { get; set; }
-        public BlogCategory BlogCategory { get; set; }
+        public BlogCategory BlogCategory { get; set; } = null!;
     }
 
     private class BlogCategory
     {
         public int Id { get; set; }
 
-        public BlogCategoryStatistics Statistics { get; set; }
+        public BlogCategoryStatistics Statistics { get; set; } = null!;
 
-        public ICollection<Blog> Blogs { get; set; }
+        public ICollection<Blog> Blogs { get; set; } = null!;
     }
 
     private class Blog
@@ -419,12 +419,12 @@ public class GraphTrackingTest
         public int Id { get; set; }
 
         public int? BlogCategoryId { get; set; }
-        public BlogCategory BlogCategory { get; set; }
+        public BlogCategory BlogCategory { get; set; } = null!;
 
         public int? AuthorId { get; set; }
-        public Author Author { get; set; }
+        public Author Author { get; set; } = null!;
 
-        public ICollection<Post> Posts { get; set; }
+        public ICollection<Post> Posts { get; set; } = null!;
     }
 
     private class Post
@@ -432,12 +432,12 @@ public class GraphTrackingTest
         public int Id { get; set; }
 
         public int? AuthorId { get; set; }
-        public Author Author { get; set; }
+        public Author Author { get; set; } = null!;
 
         public int BlogId { get; set; }
-        public Blog Blog { get; set; }
+        public Blog Blog { get; set; } = null!;
 
-        public ICollection<Comment> Comments { get; set; }
+        public ICollection<Comment> Comments { get; set; } = null!;
     }
 
     private class Comment
@@ -445,20 +445,20 @@ public class GraphTrackingTest
         public int Id { get; set; }
 
         public int? AuthorId { get; set; }
-        public Author Author { get; set; }
+        public Author Author { get; set; } = null!;
 
         public int PostId { get; set; }
-        public Post Post { get; set; }
+        public Post Post { get; set; } = null!;
     }
 
     private class Author
     {
         public int Id { get; set; }
 
-        public ICollection<Blog> Blogs { get; set; }
-        public ICollection<Post> Posts { get; set; }
-        public ICollection<Comment> Comments { get; set; }
-        public ICollection<Reminder> Reminders { get; set; }
+        public ICollection<Blog> Blogs { get; set; } = null!;
+        public ICollection<Post> Posts { get; set; } = null!;
+        public ICollection<Comment> Comments { get; set; } = null!;
+        public ICollection<Reminder> Reminders { get; set; } = null!;
     }
 
     private class Reminder
@@ -466,6 +466,6 @@ public class GraphTrackingTest
         public int Id { get; set; }
 
         public int AuthorId { get; set; }
-        public Author Author { get; set; }
+        public Author Author { get; set; } = null!;
     }
 }

--- a/test/EFCore.Tests/ChangeTracking/Internal/ChangeDetectorTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/ChangeDetectorTest.cs
@@ -27,7 +27,7 @@ public class ChangeDetectorTest
 
         contextServices
             .GetRequiredService<IChangeDetector>()
-            .PropertyChanging(entry, entry.EntityType.FindProperty("DependentId"));
+            .PropertyChanging(entry, entry.EntityType.FindProperty("DependentId")!);
 
         Assert.False(entry.HasRelationshipSnapshot);
     }
@@ -43,7 +43,7 @@ public class ChangeDetectorTest
         Assert.False(entry.EntityType.UseEagerSnapshots());
         Assert.False(entry.HasRelationshipSnapshot);
 
-        var property = entry.EntityType.FindProperty("DependentId");
+        var property = entry.EntityType.FindProperty("DependentId")!;
 
         contextServices
             .GetRequiredService<IChangeDetector>()
@@ -71,7 +71,7 @@ public class ChangeDetectorTest
 
         Assert.False(entry.EntityType.UseEagerSnapshots());
 
-        var property = entry.EntityType.FindProperty("Name");
+        var property = entry.EntityType.FindProperty("Name")!;
 
         contextServices
             .GetRequiredService<IChangeDetector>()
@@ -98,7 +98,7 @@ public class ChangeDetectorTest
         Assert.False(entry.EntityType.UseEagerSnapshots());
         Assert.False(entry.HasRelationshipSnapshot);
 
-        var navigation = entry.EntityType.FindNavigation("Category");
+        var navigation = entry.EntityType.FindNavigation("Category")!;
 
         contextServices
             .GetRequiredService<IChangeDetector>()
@@ -128,7 +128,7 @@ public class ChangeDetectorTest
         Assert.False(entry.EntityType.UseEagerSnapshots());
         Assert.False(entry.HasRelationshipSnapshot);
 
-        var property = entry.EntityType.FindProperty("Id");
+        var property = entry.EntityType.FindProperty("Id")!;
 
         contextServices
             .GetRequiredService<IChangeDetector>()
@@ -162,7 +162,7 @@ public class ChangeDetectorTest
         changeDetector.DetectChanges(entry);
 
         Assert.Equal(EntityState.Modified, entry.EntityState);
-        Assert.True(entry.IsModified(entry.EntityType.FindProperty("Name")));
+        Assert.True(entry.IsModified(entry.EntityType.FindProperty("Name")!));
     }
 
     [Theory, InlineData(true, true, true), InlineData(false, true, true), InlineData(true, false, true),
@@ -173,7 +173,7 @@ public class ChangeDetectorTest
         using var context = useTypeMapping ? new BaxterWithMappingContext() : new BaxterContext();
         var value = nullValue ? null : new[] { 1, 2, 3, 4 };
 
-        var baxter = new Baxter { Id = Guid.NewGuid(), Demands = value };
+        var baxter = new Baxter { Id = Guid.NewGuid(), Demands = value! };
 
         var entityEntry = context.Entry(baxter);
 
@@ -199,7 +199,7 @@ public class ChangeDetectorTest
         }
         else
         {
-            baxter.Demands[1] = 767;
+            baxter.Demands![1] = 767;
         }
 
         context.ChangeTracker.DetectChanges();
@@ -215,16 +215,18 @@ public class ChangeDetectorTest
         var baxter = context.Attach(
             new Baxter { Id = Guid.NewGuid(), Demands = [1, 2, 3, 4] }).Entity;
 
-        baxter.Demands[2] = 33;
+        baxter.Demands![2] = 33;
 
         var entityEntry = context.Entry(baxter);
+    #pragma warning disable CS8620
         AssertDetected(entityEntry, entityEntry.Property(e => e.Demands));
+    #pragma warning restore CS8620
 
         context.SaveChanges();
 
         Assert.Equal(EntityState.Unchanged, entityEntry.State);
 
-        baxter.Demands[1] = 767;
+        baxter.Demands![1] = 767;
 
         context.ChangeTracker.DetectChanges();
 
@@ -280,7 +282,7 @@ public class ChangeDetectorTest
     private class Baxter
     {
         public Guid Id { get; set; }
-        public int[] Demands { get; set; }
+        public int[]? Demands { get; set; }
     }
 
     private class BaxterWithMappingContext : BaxterContext
@@ -302,11 +304,11 @@ public class ChangeDetectorTest
         }
 
         public override CoreTypeMapping WithComposedConverter(
-            ValueConverter converter,
-            ValueComparer comparer = null,
-            ValueComparer keyComparer = null,
-            CoreTypeMapping elementMapping = null,
-            JsonValueReaderWriter jsonValueReaderWriter = null)
+            ValueConverter? converter,
+            ValueComparer? comparer = null,
+            ValueComparer? keyComparer = null,
+            CoreTypeMapping? elementMapping = null,
+            JsonValueReaderWriter? jsonValueReaderWriter = null)
             => new ConcreteTypeMapping(
                 Parameters.WithComposedConverter(
                     converter, comparer, keyComparer, elementMapping, jsonValueReaderWriter));
@@ -330,7 +332,7 @@ public class ChangeDetectorTest
             var intArrayComparer = new ValueComparer<int[]>(
                 (l, r) => (l == null || r == null) ? (l == r) : l.SequenceEqual(r),
                 v => v == null ? 0 : v.Aggregate(0, (t, e) => (t * 397) ^ e),
-                v => v == null ? null : v.ToArray());
+                v => v == null ? null! : v.ToArray());
 
             var intArrayConverter = new ValueConverter<int[], string>(
                 v => string.Join(",", v.Select(i => i.ToString())),
@@ -380,7 +382,7 @@ public class ChangeDetectorTest
         changeDetector.DetectChanges(stateManager);
 
         Assert.Equal(EntityState.Unchanged, entry.EntityState);
-        Assert.False(entry.IsModified(entry.EntityType.FindProperty("Name")));
+        Assert.False(entry.IsModified(entry.EntityType.FindProperty("Name")!));
     }
 
     [Fact]
@@ -399,7 +401,7 @@ public class ChangeDetectorTest
         changeDetector.DetectChanges(entry);
 
         Assert.Equal(EntityState.Unchanged, entry.EntityState);
-        Assert.False(entry.IsModified(entry.EntityType.FindProperty("Name")));
+        Assert.False(entry.IsModified(entry.EntityType.FindProperty("Name")!));
     }
 
     [Fact]
@@ -418,12 +420,12 @@ public class ChangeDetectorTest
 
         changeDetector.DetectChanges(entry);
 
-        Assert.Equal(78, entry.GetRelationshipSnapshotValue(entry.EntityType.FindProperty("PrincipalId")));
+        Assert.Equal(78, entry.GetRelationshipSnapshotValue(entry.EntityType.FindProperty("PrincipalId")!));
 
         var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
         Assert.Same(entry, testListener.KeyChange.Item1);
-        Assert.Same(entry.EntityType.FindProperty("PrincipalId"), testListener.KeyChange.Item2);
+        Assert.Same(entry.EntityType.FindProperty("PrincipalId")!, testListener.KeyChange.Item2);
         Assert.Single(testListener.KeyChange.Item3);
         Assert.Empty(testListener.KeyChange.Item4);
         Assert.Equal(77, testListener.KeyChange.Item5);
@@ -456,7 +458,7 @@ public class ChangeDetectorTest
         var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
         Assert.Same(entry, testListener.KeyChange.Item1);
-        Assert.Same(entry.EntityType.FindProperty("PrincipalId"), testListener.KeyChange.Item2);
+        Assert.Same(entry.EntityType.FindProperty("PrincipalId")!, testListener.KeyChange.Item2);
         Assert.Single(testListener.KeyChange.Item3);
         Assert.Empty(testListener.KeyChange.Item4);
         Assert.Equal(78, testListener.KeyChange.Item5);
@@ -478,7 +480,7 @@ public class ChangeDetectorTest
         var entry = stateManager.GetOrCreateEntry(category);
         entry.SetEntityState(EntityState.Added);
 
-        var property = entry.EntityType.FindProperty("PrincipalId");
+        var property = entry.EntityType.FindProperty("PrincipalId")!;
         entry.PrepareToSave();
 
         entry[property] = 78;
@@ -522,7 +524,7 @@ public class ChangeDetectorTest
         var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
         Assert.Same(entry, testListener.KeyChange.Item1);
-        Assert.Same(entry.EntityType.FindProperty("Id"), testListener.KeyChange.Item2);
+        Assert.Same(entry.EntityType.FindProperty("Id")!, testListener.KeyChange.Item2);
         Assert.Single(testListener.KeyChange.Item3);
         Assert.Empty(testListener.KeyChange.Item4);
         Assert.Equal(-1, testListener.KeyChange.Item5);
@@ -549,7 +551,7 @@ public class ChangeDetectorTest
         var entry = stateManager.GetOrCreateEntry(category);
         entry.SetEntityState(EntityState.Added);
 
-        var property = entry.EntityType.FindProperty("Id");
+        var property = entry.EntityType.FindProperty("Id")!;
         entry.PrepareToSave();
 
         entry[property] = 78;
@@ -559,7 +561,7 @@ public class ChangeDetectorTest
         var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
         Assert.Same(entry, testListener.KeyChange.Item1);
-        Assert.Same(entry.EntityType.FindProperty("Id"), testListener.KeyChange.Item2);
+        Assert.Same(entry.EntityType.FindProperty("Id")!, testListener.KeyChange.Item2);
         Assert.Single(testListener.KeyChange.Item3);
         Assert.Empty(testListener.KeyChange.Item4);
         Assert.Equal(-1, testListener.KeyChange.Item5);
@@ -605,7 +607,7 @@ public class ChangeDetectorTest
         entry.SetEntityState(EntityState.Added);
         entry.PrepareToSave();
 
-        var property = entry.EntityType.FindProperty("PrincipalId");
+        var property = entry.EntityType.FindProperty("PrincipalId")!;
 
         entry[property] = 77;
 
@@ -637,7 +639,7 @@ public class ChangeDetectorTest
         var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
         Assert.Same(entry, testListener.KeyChange.Item1);
-        Assert.Same(entry.EntityType.FindProperty("DependentId"), testListener.KeyChange.Item2);
+        Assert.Same(entry.EntityType.FindProperty("DependentId")!, testListener.KeyChange.Item2);
         Assert.Empty(testListener.KeyChange.Item3);
         Assert.Single(testListener.KeyChange.Item4);
         Assert.Equal(77, testListener.KeyChange.Item5);
@@ -670,7 +672,7 @@ public class ChangeDetectorTest
         var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
         Assert.Same(entry, testListener.KeyChange.Item1);
-        Assert.Same(entry.EntityType.FindProperty("DependentId"), testListener.KeyChange.Item2);
+        Assert.Same(entry.EntityType.FindProperty("DependentId")!, testListener.KeyChange.Item2);
         Assert.Empty(testListener.KeyChange.Item3);
         Assert.Single(testListener.KeyChange.Item4);
         Assert.Equal(78, testListener.KeyChange.Item5);
@@ -693,7 +695,7 @@ public class ChangeDetectorTest
         entry.SetEntityState(EntityState.Unchanged);
         entry.PrepareToSave();
 
-        var property = entry.EntityType.FindProperty("DependentId");
+        var property = entry.EntityType.FindProperty("DependentId")!;
         entry[property] = 78;
 
         changeDetector.DetectChanges(entry);
@@ -747,7 +749,7 @@ public class ChangeDetectorTest
         entry.SetEntityState(EntityState.Unchanged);
         entry.PrepareToSave();
 
-        var property = entry.EntityType.FindProperty("DependentId");
+        var property = entry.EntityType.FindProperty("DependentId")!;
         entry[property] = 77;
 
         changeDetector.DetectChanges(entry);
@@ -778,14 +780,14 @@ public class ChangeDetectorTest
         entry.SetEntityState(EntityState.Unchanged);
 
         var newCategory = new Category { Id = 1, PrincipalId = 2 };
-        product.Category = newCategory;
+        product.Category = newCategory!;
 
         changeDetector.DetectChanges(entry);
 
         var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
         Assert.Same(entry, testListener.ReferenceChange.Item1);
-        Assert.Same(entry.EntityType.FindNavigation("Category"), testListener.ReferenceChange.Item2);
+        Assert.Same(entry.EntityType.FindNavigation("Category")!, testListener.ReferenceChange.Item2);
         Assert.Equal(originalCategory, testListener.ReferenceChange.Item3);
         Assert.Equal(newCategory, testListener.ReferenceChange.Item4);
 
@@ -827,7 +829,7 @@ public class ChangeDetectorTest
                 PrincipalId = 2,
                 TagId = 778
             };
-        product.Category = newCategory;
+        product.Category = newCategory!;
 
         changeDetector.DetectChanges(entry);
 
@@ -838,7 +840,7 @@ public class ChangeDetectorTest
         var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
         Assert.Same(entry, testListener.ReferenceChange.Item1);
-        Assert.Same(entry.EntityType.FindNavigation("Category"), testListener.ReferenceChange.Item2);
+        Assert.Same(entry.EntityType.FindNavigation("Category")!, testListener.ReferenceChange.Item2);
         Assert.Equal(newCategory, testListener.ReferenceChange.Item3);
         Assert.Equal(originalCategory, testListener.ReferenceChange.Item4);
 
@@ -905,13 +907,13 @@ public class ChangeDetectorTest
         var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
         Assert.Same(entry, testListener.CollectionChange.Item1);
-        Assert.Same(entry.EntityType.FindNavigation("Products"), testListener.CollectionChange.Item2);
+        Assert.Same(entry.EntityType.FindNavigation("Products")!, testListener.CollectionChange.Item2);
         Assert.Equal([product3], testListener.CollectionChange.Item3);
         Assert.Empty(testListener.CollectionChange.Item4);
 
         var productEntry = stateManager.GetOrCreateEntry(product3);
         Assert.Same(productEntry, testListener.ReferenceChange.Item1);
-        Assert.Same(productEntry.EntityType.FindNavigation("Category"), testListener.ReferenceChange.Item2);
+        Assert.Same(productEntry.EntityType.FindNavigation("Category")!, testListener.ReferenceChange.Item2);
         Assert.Null(testListener.ReferenceChange.Item3);
         Assert.Equal(category, testListener.ReferenceChange.Item4);
 
@@ -944,7 +946,7 @@ public class ChangeDetectorTest
         var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
         Assert.Same(entry, testListener.CollectionChange.Item1);
-        Assert.Same(entry.EntityType.FindNavigation("Products"), testListener.CollectionChange.Item2);
+        Assert.Same(entry.EntityType.FindNavigation("Products")!, testListener.CollectionChange.Item2);
         Assert.Empty(testListener.CollectionChange.Item3);
         Assert.Equal([product1], testListener.CollectionChange.Item4);
 
@@ -1077,13 +1079,13 @@ public class ChangeDetectorTest
         var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
         Assert.Same(entry, testListener.CollectionChange.Item1);
-        Assert.Same(entry.EntityType.FindNavigation("Products"), testListener.CollectionChange.Item2);
+        Assert.Same(entry.EntityType.FindNavigation("Products")!, testListener.CollectionChange.Item2);
         Assert.Equal([product3], testListener.CollectionChange.Item3);
         Assert.Empty(testListener.CollectionChange.Item4);
 
         var productEntry = stateManager.GetOrCreateEntry(product3);
         Assert.Same(productEntry, testListener.ReferenceChange.Item1);
-        Assert.Same(productEntry.EntityType.FindNavigation("Category"), testListener.ReferenceChange.Item2);
+        Assert.Same(productEntry.EntityType.FindNavigation("Category")!, testListener.ReferenceChange.Item2);
         Assert.Null(testListener.ReferenceChange.Item3);
         Assert.Equal(category, testListener.ReferenceChange.Item4);
 
@@ -1262,7 +1264,7 @@ public class ChangeDetectorTest
         var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
         Assert.Same(entry, testListener.KeyChange.Item1);
-        Assert.Same(entry.EntityType.FindProperty("PrincipalId"), testListener.KeyChange.Item2);
+        Assert.Same(entry.EntityType.FindProperty("PrincipalId")!, testListener.KeyChange.Item2);
         Assert.Single(testListener.KeyChange.Item3);
         Assert.Empty(testListener.KeyChange.Item4);
         Assert.Equal(77, testListener.KeyChange.Item5);
@@ -1289,7 +1291,7 @@ public class ChangeDetectorTest
         var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
         Assert.Same(entry, testListener.KeyChange.Item1);
-        Assert.Same(entry.EntityType.FindProperty("PrincipalId"), testListener.KeyChange.Item2);
+        Assert.Same(entry.EntityType.FindProperty("PrincipalId")!, testListener.KeyChange.Item2);
         Assert.Single(testListener.KeyChange.Item3);
         Assert.Empty(testListener.KeyChange.Item4);
         Assert.Equal(78, testListener.KeyChange.Item5);
@@ -1320,7 +1322,7 @@ public class ChangeDetectorTest
         var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
         Assert.Same(entry, testListener.KeyChange.Item1);
-        Assert.Same(entry.EntityType.FindProperty("Id"), testListener.KeyChange.Item2);
+        Assert.Same(entry.EntityType.FindProperty("Id")!, testListener.KeyChange.Item2);
         Assert.Single(testListener.KeyChange.Item3);
         Assert.Empty(testListener.KeyChange.Item4);
         Assert.Equal(-1, testListener.KeyChange.Item5);
@@ -1366,7 +1368,7 @@ public class ChangeDetectorTest
         var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
         Assert.Same(entry, testListener.KeyChange.Item1);
-        Assert.Same(entry.EntityType.FindProperty("DependentId"), testListener.KeyChange.Item2);
+        Assert.Same(entry.EntityType.FindProperty("DependentId")!, testListener.KeyChange.Item2);
         Assert.Empty(testListener.KeyChange.Item3);
         Assert.Single(testListener.KeyChange.Item4);
         Assert.Equal(77, testListener.KeyChange.Item5);
@@ -1393,7 +1395,7 @@ public class ChangeDetectorTest
         var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
         Assert.Same(entry, testListener.KeyChange.Item1);
-        Assert.Same(entry.EntityType.FindProperty("DependentId"), testListener.KeyChange.Item2);
+        Assert.Same(entry.EntityType.FindProperty("DependentId")!, testListener.KeyChange.Item2);
         Assert.Empty(testListener.KeyChange.Item3);
         Assert.Single(testListener.KeyChange.Item4);
         Assert.Equal(78, testListener.KeyChange.Item5);
@@ -1446,7 +1448,7 @@ public class ChangeDetectorTest
         var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
         Assert.Same(entry, testListener.ReferenceChange.Item1);
-        Assert.Same(entry.EntityType.FindNavigation("Category"), testListener.ReferenceChange.Item2);
+        Assert.Same(entry.EntityType.FindNavigation("Category")!, testListener.ReferenceChange.Item2);
         Assert.Equal(originalCategory, testListener.ReferenceChange.Item3);
         Assert.Equal(newCategory, testListener.ReferenceChange.Item4);
 
@@ -1486,13 +1488,13 @@ public class ChangeDetectorTest
                 TagId = 778
             };
 
-        product.Category = newCategory;
+        product.Category = newCategory!;
         product.Category = originalCategory;
 
         var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
         Assert.Same(entry, testListener.ReferenceChange.Item1);
-        Assert.Same(entry.EntityType.FindNavigation("Category"), testListener.ReferenceChange.Item2);
+        Assert.Same(entry.EntityType.FindNavigation("Category")!, testListener.ReferenceChange.Item2);
         Assert.Equal(newCategory, testListener.ReferenceChange.Item3);
         Assert.Equal(originalCategory, testListener.ReferenceChange.Item4);
 
@@ -1551,13 +1553,13 @@ public class ChangeDetectorTest
         var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
         Assert.Same(entry, testListener.CollectionChange.Item1);
-        Assert.Same(entry.EntityType.FindNavigation("Products"), testListener.CollectionChange.Item2);
+        Assert.Same(entry.EntityType.FindNavigation("Products")!, testListener.CollectionChange.Item2);
         Assert.Equal([product3], testListener.CollectionChange.Item3);
         Assert.Empty(testListener.CollectionChange.Item4);
 
         var productEntry = stateManager.GetOrCreateEntry(product3);
         Assert.Same(productEntry, testListener.ReferenceChange.Item1);
-        Assert.Same(productEntry.EntityType.FindNavigation("Category"), testListener.ReferenceChange.Item2);
+        Assert.Same(productEntry.EntityType.FindNavigation("Category")!, testListener.ReferenceChange.Item2);
         Assert.Null(testListener.ReferenceChange.Item3);
         Assert.Equal(category, testListener.ReferenceChange.Item4);
 
@@ -1590,7 +1592,7 @@ public class ChangeDetectorTest
         var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
         Assert.Same(entry, testListener.CollectionChange.Item1);
-        Assert.Same(entry.EntityType.FindNavigation("Products"), testListener.CollectionChange.Item2);
+        Assert.Same(entry.EntityType.FindNavigation("Products")!, testListener.CollectionChange.Item2);
         Assert.Empty(testListener.CollectionChange.Item3);
         Assert.Equal([product1], testListener.CollectionChange.Item4);
 
@@ -1740,12 +1742,12 @@ public class ChangeDetectorTest
     {
         public int Id { get; set; }
         public int? PrincipalId { get; set; }
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
 
         public virtual ICollection<Product> Products { get; } = new List<Product>();
 
         public int TagId { get; set; }
-        public CategoryTag Tag { get; set; }
+        public CategoryTag Tag { get; set; } = null!;
     }
 
     private class CategoryTag
@@ -1753,19 +1755,19 @@ public class ChangeDetectorTest
         public int Id { get; set; }
 
         public int CategoryId { get; set; }
-        public Category Category { get; set; }
+        public Category Category { get; set; } = null!;
     }
 
     private class Product
     {
         public Guid Id { get; set; }
         public int? DependentId { get; set; }
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
 
-        public virtual Category Category { get; set; }
+        public virtual Category Category { get; set; } = null!;
 
         public int TagId { get; set; }
-        public ProductTag Tag { get; set; }
+        public ProductTag Tag { get; set; } = null!;
     }
 
     private class ProductTag
@@ -1773,7 +1775,7 @@ public class ChangeDetectorTest
         public int Id { get; set; }
 
         public int ProductId { get; set; }
-        public Product Product { get; set; }
+        public Product Product { get; set; } = null!;
     }
 
     private class Person
@@ -1781,8 +1783,8 @@ public class ChangeDetectorTest
         public int Id { get; set; }
 
         public int HusbandId { get; set; }
-        public Person Husband { get; set; }
-        public Person Wife { get; set; }
+        public Person Husband { get; set; } = null!;
+        public Person Wife { get; set; } = null!;
     }
 
     private static IModel BuildModel()
@@ -1821,9 +1823,9 @@ public class ChangeDetectorTest
     {
         private int _id;
         private int? _principalId;
-        private string _name;
+        private string _name = null!;
         private int _tagId;
-        private NotifyingCategoryTag _tag;
+        private NotifyingCategoryTag _tag = null!;
 
         public int Id
         {
@@ -1862,7 +1864,7 @@ public class ChangeDetectorTest
     {
         private int _id;
         private int _categoryId;
-        private NotifyingCategory _category;
+        private NotifyingCategory _category = null!;
 
         public int Id
         {
@@ -1887,10 +1889,10 @@ public class ChangeDetectorTest
     {
         private Guid _id;
         private int? _dependentId;
-        private string _name;
-        private NotifyingCategory _category;
+        private string _name = null!;
+        private NotifyingCategory _category = null!;
         private int _tagId;
-        private NotifyingProductTag _tag;
+        private NotifyingProductTag _tag = null!;
 
         public Guid Id
         {
@@ -1933,7 +1935,7 @@ public class ChangeDetectorTest
     {
         private int _id;
         private int _productId;
-        private NotifyingProduct _product;
+        private NotifyingProduct _product = null!;
 
         public int Id
         {
@@ -1958,8 +1960,8 @@ public class ChangeDetectorTest
     {
         private int _id;
         private int _husbandId;
-        private NotifyingPerson _husband;
-        private NotifyingPerson _wife;
+        private NotifyingPerson _husband = null!;
+        private NotifyingPerson _wife = null!;
 
         public int Id
         {
@@ -1996,8 +1998,8 @@ public class ChangeDetectorTest
             NotifyChanged(propertyName);
         }
 
-        public event PropertyChangingEventHandler PropertyChanging;
-        public event PropertyChangedEventHandler PropertyChanged;
+        public event PropertyChangingEventHandler? PropertyChanging;
+        public event PropertyChangedEventHandler? PropertyChanged;
 
         private void NotifyChanged(string propertyName)
             => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
@@ -2042,13 +2044,13 @@ public class ChangeDetectorTest
     private class CategoryWithChanged : INotifyPropertyChanged
     {
         public int Id { get; set; }
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
 
         public virtual ICollection<ProductWithChanged> Products { get; set; } = new ObservableCollection<ProductWithChanged>();
 
         // Actual implementation not needed for tests
 #pragma warning disable 67
-        public event PropertyChangedEventHandler PropertyChanged;
+        public event PropertyChangedEventHandler? PropertyChanged;
 #pragma warning restore 67
     }
 
@@ -2056,13 +2058,13 @@ public class ChangeDetectorTest
     {
         public int Id { get; set; }
         public int? DependentId { get; set; }
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
 
-        public virtual CategoryWithChanged Category { get; set; }
+        public virtual CategoryWithChanged Category { get; set; } = null!;
 
         // Actual implementation not needed for tests
 #pragma warning disable 67
-        public event PropertyChangedEventHandler PropertyChanged;
+        public event PropertyChangedEventHandler? PropertyChanged;
 #pragma warning restore 67
     }
 
@@ -2081,14 +2083,14 @@ public class ChangeDetectorTest
 
     private static InternalEntityEntry CreateInternalEntry<TEntity>(
         IServiceProvider contextServices,
-        TEntity entity = null)
+        TEntity? entity = null)
         where TEntity : class, new()
         => contextServices.GetRequiredService<IStateManager>()
             .GetOrCreateEntry(
                 entity ?? new TEntity(),
-                contextServices.GetRequiredService<IModel>().FindEntityType(typeof(TEntity)));
+                contextServices.GetRequiredService<IModel>().FindEntityType(typeof(TEntity))!);
 
-    private static IServiceProvider CreateContextServices(IModel model = null)
+    private static IServiceProvider CreateContextServices(IModel? model = null)
         => InMemoryTestHelpers.Instance.CreateContextServices(
             new ServiceCollection()
                 .AddScoped<TestRelationshipListener>()
@@ -2098,7 +2100,7 @@ public class ChangeDetectorTest
 
     private class TestAttacher(IEntityEntryGraphIterator graphIterator) : EntityGraphAttacher(graphIterator)
     {
-        public Tuple<InternalEntityEntry, EntityState> Attached { get; set; }
+        public Tuple<InternalEntityEntry, EntityState> Attached { get; set; } = null!;
 
         public override void AttachGraph(
             InternalEntityEntry rootEntry,
@@ -2116,20 +2118,20 @@ public class ChangeDetectorTest
         attacher, new StructuralTypeMaterializerSource(
             new StructuralTypeMaterializerSourceDependencies([])))
     {
-        public Tuple<InternalEntityEntry, IProperty, IEnumerable<IKey>, IEnumerable<IForeignKey>, object, object> KeyChange
+        public Tuple<InternalEntityEntry, IProperty, IEnumerable<IKey>, IEnumerable<IForeignKey>, object?, object?> KeyChange
         {
             get;
             set;
-        }
+        } = null!;
 
-        public Tuple<InternalEntityEntry, INavigationBase, object, object> ReferenceChange { get; set; }
-        public Tuple<InternalEntityEntry, INavigationBase, IEnumerable<object>, IEnumerable<object>> CollectionChange { get; set; }
+        public Tuple<InternalEntityEntry, INavigationBase, object?, object?> ReferenceChange { get; set; } = null!;
+        public Tuple<InternalEntityEntry, INavigationBase, IEnumerable<object>, IEnumerable<object>> CollectionChange { get; set; } = null!;
 
         public override void NavigationReferenceChanged(
             InternalEntityEntry entry,
             INavigationBase navigationBase,
-            object oldValue,
-            object newValue)
+            object? oldValue,
+            object? newValue)
         {
             ReferenceChange = Tuple.Create(entry, navigationBase, oldValue, newValue);
 
@@ -2154,8 +2156,8 @@ public class ChangeDetectorTest
             IProperty property,
             IEnumerable<IKey> containingPrincipalKeys,
             IEnumerable<IForeignKey> containingForeignKeys,
-            object oldValue,
-            object newValue)
+            object? oldValue,
+            object? newValue)
         {
             KeyChange = Tuple.Create(entry, property, containingPrincipalKeys, containingForeignKeys, oldValue, newValue);
 

--- a/test/EFCore.Tests/ChangeTracking/Internal/CurrentValueComparerTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/CurrentValueComparerTest.cs
@@ -38,7 +38,7 @@ public class CurrentValueComparerTest
 
         var factory = CurrentValueComparerFactory.Instance;
 
-        Assert.IsType(expectedComparer, factory.Create(context.Model.FindEntityType(typeof(Godzilla)).FindProperty(property)));
+        Assert.IsType(expectedComparer, factory.Create(context.Model.FindEntityType(typeof(Godzilla))!.FindProperty(property)!));
     }
 
     [Fact]
@@ -52,7 +52,7 @@ public class CurrentValueComparerTest
             CoreStrings.NonComparableKeyType(
                 nameof(Godzilla), nameof(Godzilla.NotComparable), nameof(NotComparable)),
             Assert.Throws<InvalidOperationException>(() => factory.Create(
-                context.Model.FindEntityType(typeof(Godzilla)).FindProperty(nameof(Godzilla.NotComparable)))).Message);
+                context.Model.FindEntityType(typeof(Godzilla))!.FindProperty(nameof(Godzilla.NotComparable))!)).Message);
     }
 
     [Fact]
@@ -66,7 +66,7 @@ public class CurrentValueComparerTest
             CoreStrings.NonComparableKeyTypes(
                 nameof(Godzilla), nameof(Godzilla.NotComparableConverted), nameof(NotComparable), nameof(NotComparable)),
             Assert.Throws<InvalidOperationException>(() => factory.Create(
-                context.Model.FindEntityType(typeof(Godzilla)).FindProperty(nameof(Godzilla.NotComparableConverted)))).Message);
+                context.Model.FindEntityType(typeof(Godzilla))!.FindProperty(nameof(Godzilla.NotComparableConverted))!)).Message);
     }
 
     [Fact]
@@ -111,8 +111,8 @@ public class CurrentValueComparerTest
             generator(1), generator(9), generator(7), generator(3));
 
         var comparer = context.Model
-            .FindEntityType(typeof(Godzilla))
-            .FindProperty(propertyName)
+            .FindEntityType(typeof(Godzilla))!
+            .FindProperty(propertyName)!
             .GetCurrentValueComparer();
 
         var entries = context.ChangeTracker.Entries<Godzilla>()
@@ -164,8 +164,8 @@ public class CurrentValueComparerTest
             generator([1, 1]), generator([9]), generator([7]), generator([3, 3]));
 
         var comparer = context.Model
-            .FindEntityType(typeof(Godzilla))
-            .FindProperty(propertyName)
+            .FindEntityType(typeof(Godzilla))!
+            .FindProperty(propertyName)!
             .GetCurrentValueComparer();
 
         var entries = context.ChangeTracker.Entries<Godzilla>()
@@ -221,28 +221,28 @@ public class CurrentValueComparerTest
     public void Can_sort_Strings()
         => CanSortNullable(
             nameof(Godzilla.String),
-            i => new Godzilla { String = i?.ToString() },
+            i => new Godzilla { String = i?.ToString()! },
             g => g.String == null ? null : int.Parse(g.String));
 
     [Fact]
     public void Can_sort_IntClasses()
         => CanSortNullable(
             nameof(Godzilla.IntClass),
-            i => new Godzilla { IntClass = i.HasValue ? new IntClass { Value = i.Value } : null },
+            i => new Godzilla { IntClass = i.HasValue ? new IntClass { Value = i.Value } : null! },
             g => g.IntClass?.Value);
 
     [Fact]
     public void Can_sort_ComparableIntClasses()
         => CanSortNullable(
             nameof(Godzilla.ComparableIntClass),
-            i => new Godzilla { ComparableIntClass = i.HasValue ? new ComparableIntClass { Value = i.Value } : null },
+            i => new Godzilla { ComparableIntClass = i.HasValue ? new ComparableIntClass { Value = i.Value } : null! },
             g => g.ComparableIntClass?.Value);
 
     [Fact]
     public void Can_sort_GenericComparableIntClass()
         => CanSortNullable(
             nameof(Godzilla.GenericComparableIntClass),
-            i => new Godzilla { GenericComparableIntClass = i.HasValue ? new GenericComparableIntClass { Value = i.Value } : null },
+            i => new Godzilla { GenericComparableIntClass = i.HasValue ? new GenericComparableIntClass { Value = i.Value } : null! },
             g => g.GenericComparableIntClass?.Value);
 
     private void CanSortNullable(
@@ -258,8 +258,8 @@ public class CurrentValueComparerTest
             generator(1), generator(9), generator(7), generator(3));
 
         var comparer = context.Model
-            .FindEntityType(typeof(Godzilla))
-            .FindProperty(propertyName)
+            .FindEntityType(typeof(Godzilla))!
+            .FindProperty(propertyName)!
             .GetCurrentValueComparer();
 
         var entries = context.ChangeTracker.Entries<Godzilla>()
@@ -311,13 +311,13 @@ public class CurrentValueComparerTest
     public void Can_sort_Bytes()
         => CanSortNullable(
             nameof(Godzilla.Bytes),
-            i => new Godzilla { Bytes = i },
+            i => new Godzilla { Bytes = i! },
             g => g.Bytes);
 
     private void CanSortNullable(
         string propertyName,
-        Func<byte[], Godzilla> generator,
-        Func<Godzilla, byte[]> selector)
+        Func<byte[]?, Godzilla> generator,
+        Func<Godzilla, byte[]?> selector)
     {
         using var context = new GodzillaContext();
 
@@ -327,8 +327,8 @@ public class CurrentValueComparerTest
             generator([1, 1]), generator([9]), generator([7]), generator([3, 3]));
 
         var comparer = context.Model
-            .FindEntityType(typeof(Godzilla))
-            .FindProperty(propertyName)
+            .FindEntityType(typeof(Godzilla))!
+            .FindProperty(propertyName)!
             .GetCurrentValueComparer();
 
         var entries = context.ChangeTracker.Entries<Godzilla>()
@@ -395,11 +395,11 @@ public class CurrentValueComparerTest
         public StructuralComparableBytesStruct? NullableStructuralComparableBytesStruct { get; set; }
         public int? NullableInt { get; set; }
         public ulong? NullableULong { get; set; }
-        public string String { get; set; }
-        public byte[] Bytes { get; set; }
-        public IntClass IntClass { get; set; }
-        public ComparableIntClass ComparableIntClass { get; set; }
-        public GenericComparableIntClass GenericComparableIntClass { get; set; }
+        public string String { get; set; } = null!;
+        public byte[] Bytes { get; set; } = null!;
+        public IntClass IntClass { get; set; } = null!;
+        public ComparableIntClass ComparableIntClass { get; set; } = null!;
+        public GenericComparableIntClass GenericComparableIntClass { get; set; } = null!;
         public NotComparable NotComparable { get; set; }
         public NotComparable NotComparableConverted { get; set; }
     }
@@ -453,8 +453,8 @@ public class CurrentValueComparerTest
 
         public int Value { get; set; }
 
-        public int CompareTo(object other)
-            => Value - ((ComparableIntStruct)other).Value;
+        public int CompareTo(object? other)
+            => Value - ((ComparableIntStruct)other!).Value;
     }
 
     private struct ComparableBytesStruct : IComparable
@@ -484,9 +484,9 @@ public class CurrentValueComparerTest
             return code.ToHashCode();
         }
 
-        public int CompareTo(object other)
+        public int CompareTo(object? other)
         {
-            var result = Value.Length - ((ComparableBytesStruct)other).Value.Length;
+            var result = Value.Length - ((ComparableBytesStruct)other!).Value.Length;
             if (result != 0)
             {
                 return result;
@@ -573,9 +573,9 @@ public class CurrentValueComparerTest
             return code.ToHashCode();
         }
 
-        public int CompareTo(object other, IComparer comparer)
+        public int CompareTo(object? other, IComparer comparer)
         {
-            var typedOther = ((StructuralComparableBytesStruct)other);
+            var typedOther = ((StructuralComparableBytesStruct)other!);
 
             var i = -1;
             var result = Value.Length - typedOther.Value.Length;
@@ -598,7 +598,7 @@ public class CurrentValueComparerTest
         private bool Equals(IntClass other)
             => other != null && Value == other.Value;
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => obj == this
                 || obj?.GetType() == GetType()
                 && Equals((IntClass)obj);
@@ -619,7 +619,7 @@ public class CurrentValueComparerTest
         private bool Equals(ComparableIntClass other)
             => other != null && Value == other.Value;
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => obj == this
                 || obj?.GetType() == GetType()
                 && Equals((ComparableIntClass)obj);
@@ -627,8 +627,8 @@ public class CurrentValueComparerTest
         public override int GetHashCode()
             => Value;
 
-        public int CompareTo(object other)
-            => Value - ((ComparableIntClass)other).Value;
+        public int CompareTo(object? other)
+            => Value - ((ComparableIntClass)other!).Value;
     }
 
     private class GenericComparableIntClass : IComparable<GenericComparableIntClass>
@@ -641,7 +641,7 @@ public class CurrentValueComparerTest
         private bool Equals(GenericComparableIntClass other)
             => other != null && Value == other.Value;
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => obj == this
                 || obj?.GetType() == GetType()
                 && Equals((GenericComparableIntClass)obj);
@@ -649,7 +649,7 @@ public class CurrentValueComparerTest
         public override int GetHashCode()
             => Value;
 
-        public int CompareTo(GenericComparableIntClass other)
-            => Value - other.Value;
+        public int CompareTo(GenericComparableIntClass? other)
+            => Value - other!.Value;
     }
 }

--- a/test/EFCore.Tests/ChangeTracking/Internal/FixupCompositeTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/FixupCompositeTest.cs
@@ -3454,7 +3454,7 @@ public class FixupCompositeTest
         public int Id1 { get; set; }
         public Guid Id2 { get; set; }
 
-        public Child Child { get; set; }
+        public Child Child { get; set; } = null!;
     }
 
     private class Child
@@ -3465,7 +3465,7 @@ public class FixupCompositeTest
         public int ParentId1 { get; set; }
         public Guid ParentId2 { get; set; }
 
-        public Parent Parent { get; set; }
+        public Parent Parent { get; set; } = null!;
     }
 
     private class ParentPN
@@ -3473,7 +3473,7 @@ public class FixupCompositeTest
         public int Id1 { get; set; }
         public Guid Id2 { get; set; }
 
-        public ChildPN Child { get; set; }
+        public ChildPN Child { get; set; } = null!;
     }
 
     private class ChildPN
@@ -3498,7 +3498,7 @@ public class FixupCompositeTest
 
         public int ParentId1 { get; set; }
         public Guid ParentId2 { get; set; }
-        public ParentDN Parent { get; set; }
+        public ParentDN Parent { get; set; } = null!;
     }
 
     private class ParentNN
@@ -3529,7 +3529,7 @@ public class FixupCompositeTest
 
         public int CategoryId1 { get; set; }
         public Guid CategoryId2 { get; set; }
-        public CategoryDN Category { get; set; }
+        public CategoryDN Category { get; set; } = null!;
     }
 
     private class CategoryPN
@@ -3579,7 +3579,7 @@ public class FixupCompositeTest
 
         public int CategoryId1 { get; set; }
         public Guid CategoryId2 { get; set; }
-        public Category Category { get; set; }
+        public Category Category { get; set; } = null!;
     }
 
     public class ParentShared
@@ -3587,7 +3587,7 @@ public class FixupCompositeTest
         public long ID { get; set; }
         public long? FavoriteChildID { get; set; }
 
-        public virtual ChildShared FavoriteChildShared { get; set; }
+        public virtual ChildShared FavoriteChildShared { get; set; } = null!;
         public virtual List<ChildShared> Children { get; } = [];
     }
 
@@ -3596,7 +3596,7 @@ public class FixupCompositeTest
         public long ParentID { get; set; }
         public long ID { get; set; }
 
-        public virtual ParentShared ParentShared { get; set; }
+        public virtual ParentShared ParentShared { get; set; } = null!;
     }
 
     private class FixupContext : DbContext

--- a/test/EFCore.Tests/ChangeTracking/Internal/FixupTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/FixupTest.cs
@@ -2057,7 +2057,7 @@ public class FixupTest
 
             Assert.Equal(category2.Id, product.CategoryId);
             Assert.Equal(category, category.Products.Single().Category);
-            Assert.Equal(category2, category2.Products.Single().Category); // Throws
+            Assert.Equal(category2, category2.Products!.Single().Category!); // Throws
         }
     }
 
@@ -2100,17 +2100,17 @@ public class FixupTest
     public void Navigation_fixup_happens_when_entities_are_tracked_from_query()
     {
         using var context = new FixupContext();
-        var categoryType = context.Model.FindEntityType(typeof(Category));
-        var productType = context.Model.FindEntityType(typeof(Product));
-        var offerType = context.Model.FindEntityType(typeof(SpecialOffer));
+        var categoryType = context.Model.FindEntityType(typeof(Category))!;
+        var productType = context.Model.FindEntityType(typeof(Product))!;
+        var offerType = context.Model.FindEntityType(typeof(SpecialOffer))!;
 
         var stateManager = context.GetService<IStateManager>();
 
-        stateManager.StartTrackingFromQuery(categoryType, new Category(11), new Snapshot<int>(11));
+        stateManager.StartTrackingFromQuery(categoryType!, new Category(11), new Snapshot<int>(11));
         stateManager.StartTrackingFromQuery(categoryType, new Category(12), new Snapshot<int>(12));
         stateManager.StartTrackingFromQuery(categoryType, new Category(13), new Snapshot<int>(13));
 
-        stateManager.StartTrackingFromQuery(productType, new Product(21, 11), new Snapshot<int, int>(21, 11));
+        stateManager.StartTrackingFromQuery(productType!, new Product(21, 11), new Snapshot<int, int>(21, 11));
         AssertAllFixedUp(context);
         stateManager.StartTrackingFromQuery(productType, new Product(22, 11), new Snapshot<int, int>(22, 11));
         AssertAllFixedUp(context);
@@ -2121,7 +2121,7 @@ public class FixupTest
         stateManager.StartTrackingFromQuery(productType, new Product(25, 12), new Snapshot<int, int>(25, 12));
         AssertAllFixedUp(context);
 
-        stateManager.StartTrackingFromQuery(offerType, new SpecialOffer(31, 22), new Snapshot<int, int>(31, 22));
+        stateManager.StartTrackingFromQuery(offerType!, new SpecialOffer(31, 22), new Snapshot<int, int>(31, 22));
         AssertAllFixedUp(context);
         stateManager.StartTrackingFromQuery(offerType, new SpecialOffer(32, 22), new Snapshot<int, int>(32, 22));
         AssertAllFixedUp(context);
@@ -2979,13 +2979,13 @@ public class FixupTest
     private class Level2 : IComparable<Level2>
     {
         public int Id { get; set; }
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
 
-        public Level1 Level1 { get; set; }
+        public Level1 Level1 { get; set; } = null!;
         public int Level1Id { get; set; }
 
-        public int CompareTo(Level2 other)
-            => StringComparer.InvariantCultureIgnoreCase.Compare(Name, other.Name);
+        public int CompareTo(Level2? other)
+            => StringComparer.InvariantCultureIgnoreCase.Compare(Name, other!.Name);
     }
 
     private class ComparableEntitiesContext(string databaseName) : DbContext
@@ -2995,8 +2995,8 @@ public class FixupTest
         protected internal override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
             => optionsBuilder.UseInMemoryDatabase(_databaseName);
 
-        public DbSet<Level1> Level1s { get; set; }
-        public DbSet<Level2> Level2s { get; set; }
+        public DbSet<Level1> Level1s { get; set; } = null!;
+        public DbSet<Level2> Level2s { get; set; } = null!;
     }
 
     [Fact]
@@ -3036,7 +3036,7 @@ public class FixupTest
 
             context.Attach(attached);
 
-            detachedRoom.Product = null;
+            detachedRoom.Product = null!;
             detachedRoom.ProductId = null;
 
             context.Entry(attachedRoom).CurrentValues.SetValues(detachedRoom);
@@ -3051,7 +3051,7 @@ public class FixupTest
     public class ContainerX
     {
         public int Id { get; set; }
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
         public List<ContainerRoomX> Rooms { get; set; } = [];
     }
 
@@ -3060,15 +3060,15 @@ public class FixupTest
         public int Id { get; set; }
         public int Number { get; set; }
         public int ContainerId { get; set; }
-        public ContainerX Container { get; set; }
+        public ContainerX Container { get; set; } = null!;
         public int? ProductId { get; set; }
-        public ProductX Product { get; set; }
+        public ProductX Product { get; set; } = null!;
     }
 
     public class ProductX
     {
         public int Id { get; set; }
-        public string Description { get; set; }
+        public string Description { get; set; } = null!;
         public List<ContainerRoomX> Rooms { get; set; } = [];
     }
 
@@ -3143,7 +3143,7 @@ public class FixupTest
     protected class ParentX
     {
         public int Id { get; set; }
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
         public virtual IList<ParentChildX> ParentChildren { get; set; } = new List<ParentChildX>();
     }
 
@@ -3152,11 +3152,11 @@ public class FixupTest
         public int ParentId { get; set; }
         public int ChildId { get; set; }
         public int SortOrder { get; set; }
-        public virtual ParentX Parent { get; set; }
-        public virtual ChildX Child { get; set; }
+        public virtual ParentX Parent { get; set; } = null!;
+        public virtual ChildX Child { get; set; } = null!;
 
         // Bad implementation of Equals to test for regression
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (obj == null)
             {
@@ -3191,7 +3191,7 @@ public class FixupTest
     protected class ChildX
     {
         public int Id { get; set; }
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
         public virtual IList<ParentChildX> ParentChildren { get; set; } = new List<ParentChildX>();
     }
 
@@ -3271,15 +3271,15 @@ public class FixupTest
     private class EntityB
     {
         public int EntityBId { get; set; }
-        public string Value { get; set; }
-        public EntityA EntityA { get; set; }
+        public string Value { get; set; } = null!;
+        public EntityA EntityA { get; set; } = null!;
     }
 
     private class EntityA
     {
         public int EntityAId { get; set; }
         public int? EntityBId { get; set; }
-        public EntityB EntityB { get; set; }
+        public EntityB EntityB { get; set; } = null!;
     }
 
     private class BadBeeContext(string databaseName, params IInterceptor[] interceptors) : DbContext
@@ -3292,8 +3292,8 @@ public class FixupTest
                 .AddInterceptors(_interceptors)
                 .UseInMemoryDatabase(_databaseName);
 
-        public DbSet<EntityA> AEntities { get; set; }
-        public DbSet<EntityB> BEntities { get; set; }
+        public DbSet<EntityA> AEntities { get; set; } = null!;
+        public DbSet<EntityB> BEntities { get; set; } = null!;
     }
 
     protected virtual void AssertAllFixedUp(DbContext context)
@@ -3330,7 +3330,7 @@ public class FixupTest
     private class Cat
     {
         public int Id { get; set; }
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
         public int Age { get; set; }
         public ICollection<Human> Humans { get; } = new List<Human>();
     }
@@ -3338,7 +3338,7 @@ public class FixupTest
     private class Human
     {
         public int Id { get; set; }
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
         public int Age { get; set; }
         public ICollection<Cat> Cats { get; } = new List<Cat>();
     }
@@ -3347,14 +3347,14 @@ public class FixupTest
     {
         // ReSharper disable once FieldCanBeMadeReadOnly.Local
         private readonly int _id = id;
-        private Child _child;
+        private Child _child = null!;
 
         // ReSharper disable once ConvertToAutoProperty
         public int Id
             => _id;
 
-        public string Value1 { get; set; }
-        public string Value2 { get; set; }
+        public string? Value1 { get; set; }
+        public string? Value2 { get; set; }
 
         // ReSharper disable once ConvertToAutoPropertyWithPrivateSetter
         public Child Child
@@ -3369,14 +3369,14 @@ public class FixupTest
         // ReSharper disable once FieldCanBeMadeReadOnly.Local
         private readonly int _id = id;
         private int _parentId = parentId;
-        private Parent _parent;
+        private Parent _parent = null!;
 
         // ReSharper disable once ConvertToAutoProperty
         public int Id
             => _id;
 
-        public string Value1 { get; set; }
-        public string Value2 { get; set; }
+        public string? Value1 { get; set; }
+        public string? Value2 { get; set; }
 
         // ReSharper disable once ConvertToAutoPropertyWithPrivateSetter
         public int ParentId
@@ -3397,7 +3397,7 @@ public class FixupTest
     {
         public int Id { get; set; }
 
-        public ChildPN Child { get; set; }
+        public ChildPN Child { get; set; } = null!;
     }
 
     private class ChildPN
@@ -3417,7 +3417,7 @@ public class FixupTest
         public int Id { get; set; }
         public int ParentId { get; set; }
 
-        public ParentDN Parent { get; set; }
+        public ParentDN Parent { get; set; } = null!;
     }
 
     private class ParentNN
@@ -3441,7 +3441,7 @@ public class FixupTest
         public int Id { get; set; }
         public int CategoryId { get; set; }
 
-        public CategoryDN Category { get; set; }
+        public CategoryDN Category { get; set; } = null!;
     }
 
     private class CategoryPN
@@ -3472,7 +3472,7 @@ public class FixupTest
     {
         // ReSharper disable once FieldCanBeMadeReadOnly.Local
         private readonly int _id;
-        private ICollection<Product> _products;
+        private ICollection<Product> _products = null!;
 
         // ReSharper disable once UnusedMember.Local
         public Category()
@@ -3482,8 +3482,8 @@ public class FixupTest
         public Category(int id)
             => _id = id;
 
-        public string Value1 { get; set; }
-        public string Value2 { get; set; }
+        public string? Value1 { get; set; }
+        public string? Value2 { get; set; }
 
         // ReSharper disable once ConvertToAutoProperty
         public int Id
@@ -3502,7 +3502,7 @@ public class FixupTest
         // ReSharper disable once FieldCanBeMadeReadOnly.Local
         private readonly int _id;
         private int _categoryId;
-        private Category _category;
+        private Category _category = null!;
 
         // ReSharper disable once UnusedMember.Local
         public Product()
@@ -3526,8 +3526,8 @@ public class FixupTest
         public void SetCategoryId(int categoryId)
             => _categoryId = categoryId;
 
-        public string Value1 { get; set; }
-        public string Value2 { get; set; }
+        public string? Value1 { get; set; }
+        public string? Value2 { get; set; }
 
         // ReSharper disable once ConvertToAutoPropertyWithPrivateSetter
         public Category Category
@@ -3541,7 +3541,7 @@ public class FixupTest
         {
             get;
             private set;
-        }
+        } = null!;
 
         public void AddSpecialOffer(SpecialOffer specialOffer)
             => (SpecialOffers ??= new List<SpecialOffer>()).Add(specialOffer);
@@ -3552,7 +3552,7 @@ public class FixupTest
         // ReSharper disable once FieldCanBeMadeReadOnly.Local
         private readonly int _id;
         private int _productId;
-        private Product _product;
+        private Product _product = null!;
 
         // ReSharper disable once UnusedMember.Local
         public SpecialOffer()
@@ -3591,7 +3591,7 @@ public class FixupTest
         private readonly string _databaseName;
 
         public FixupContext(params IInterceptor[] interceptors)
-            : this(null, interceptors)
+            : this(null!, interceptors)
         {
         }
 
@@ -3722,7 +3722,7 @@ public class FixupTest
     private class TestAssembly
     {
         [Key]
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
 
         // ReSharper disable once CollectionNeverUpdated.Local
         public ICollection<TestClass> Classes { get; } = new List<TestClass>();
@@ -3730,15 +3730,15 @@ public class FixupTest
 
     private class TestClass
     {
-        public TestAssembly Assembly { get; set; }
-        public string Name { get; set; }
+        public TestAssembly Assembly { get; set; } = null!;
+        public string Name { get; set; } = null!;
     }
 
     private class Context4853 : DbContext
     {
         // ReSharper disable once UnusedMember.Local
-        public DbSet<TestAssembly> Assemblies { get; set; }
-        public DbSet<TestClass> Classes { get; set; }
+        public DbSet<TestAssembly> Assemblies { get; set; } = null!;
+        public DbSet<TestClass> Classes { get; set; } = null!;
 
         protected internal override void OnConfiguring(DbContextOptionsBuilder options)
             => options
@@ -3758,20 +3758,20 @@ public class FixupTest
     private class Dependent
     {
         public int Id { get; set; }
-        public string Url { get; set; }
-        public Principal Principal { get; set; }
+        public string Url { get; set; } = null!;
+        public Principal? Principal { get; set; }
     }
 
     private class Principal
     {
         public int Id { get; set; }
-        public string Title { get; set; }
+        public string Title { get; set; } = null!;
     }
 
     private class DetachingContext : DbContext
     {
-        public DbSet<Principal> Principals { get; set; }
-        public DbSet<Dependent> Dependents { get; set; }
+        public DbSet<Principal> Principals { get; set; } = null!;
+        public DbSet<Dependent> Dependents { get; set; } = null!;
 
         protected internal override void OnConfiguring(DbContextOptionsBuilder options)
             => options
@@ -3817,9 +3817,9 @@ public class FixupTest
     public class FixupBlog
     {
         public int Id { get; set; }
-        public string Name { get; set; }
+        public string? Name { get; set; }
 
-        public FixupSite FixupSite { get; set; }
+        public FixupSite FixupSite { get; set; } = null!;
         public List<FixupPost> Posts { get; } = [];
     }
 
@@ -3828,24 +3828,24 @@ public class FixupTest
         public int Id { get; set; }
 
         public int? FixupBlogId { get; set; }
-        public FixupBlog FixupBlog { get; set; }
+        public FixupBlog FixupBlog { get; set; } = null!;
     }
 
     public class FixupPost
     {
         public int Id { get; set; }
-        public string Title { get; set; }
-        public string Content { get; set; }
+        public string? Title { get; set; }
+        public string? Content { get; set; }
 
         public int? FixupBlogId { get; set; }
-        public FixupBlog FixupBlog { get; set; }
+        public FixupBlog FixupBlog { get; set; } = null!;
         public List<FixupTag> Tags { get; } = [];
     }
 
     public class FixupTag
     {
         public int Id { get; set; }
-        public string Content { get; set; }
+        public string? Content { get; set; }
 
         public List<FixupPost> Posts { get; } = [];
     }

--- a/test/EFCore.Tests/ChangeTracking/Internal/InternalClrEntityEntryTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/InternalClrEntityEntryTest.cs
@@ -76,7 +76,7 @@ public class InternalClrEntityEntryTest : InternalEntityEntryTestBase<
         using var context = new KClrContext();
         var entity = new SomeEntity();
         var entry = context.Add(entity).GetInfrastructure();
-        var keyProperty = entry.EntityType.FindProperty("Id");
+        var keyProperty = entry.EntityType.FindProperty("Id")!;
 
         entry.SetEntityState(EntityState.Added);
         entry.SetTemporaryValue(keyProperty, -1);
@@ -107,7 +107,7 @@ public class InternalClrEntityEntryTest : InternalEntityEntryTestBase<
         ownerEntry.SetEntityState(EntityState.Unchanged);
 
         var entry = context.Entry(((OwnerClass)ownerEntry.Entity).Owned).GetInfrastructure();
-        var valueProperty = entry.EntityType.FindProperty(nameof(OwnedClass.Value));
+        var valueProperty = entry.EntityType.FindProperty(nameof(OwnedClass.Value))!;
 
         entry.SetEntityState(entityState);
 
@@ -144,7 +144,7 @@ public class InternalClrEntityEntryTest : InternalEntityEntryTestBase<
     {
         using var context = new KClrContext();
         var entry = context.Entry(new SomeEntity()).GetInfrastructure();
-        var keyProperty = entry.EntityType.FindProperty("Id");
+        var keyProperty = entry.EntityType.FindProperty("Id")!;
 
         var entity = (SomeEntity)entry.Entity;
 
@@ -161,7 +161,7 @@ public class InternalClrEntityEntryTest : InternalEntityEntryTestBase<
 
         entry.SetEntityState(EntityState.Unchanged); // Does not throw
 
-        var nameProperty = entry.EntityType.FindProperty(nameof(SomeEntity.Name));
+        var nameProperty = entry.EntityType.FindProperty(nameof(SomeEntity.Name))!;
         Assert.False(entry.HasExplicitValue(nameProperty));
 
         entity.Name = "Name";
@@ -189,7 +189,7 @@ public class InternalClrEntityEntryTest : InternalEntityEntryTestBase<
     {
         using var context = new KClrContext();
         var entry = context.Attach(entity).GetInfrastructure();
-        var nameProperty = entry.EntityType.FindProperty("Name");
+        var nameProperty = entry.EntityType.FindProperty("Name")!;
 
         Assert.False(entry.IsModified(nameProperty));
         Assert.Equal(EntityState.Unchanged, entry.EntityState);
@@ -216,7 +216,7 @@ public class InternalClrEntityEntryTest : InternalEntityEntryTestBase<
     public class SomeCompositeEntityBase
     {
         public int Id1 { get; set; }
-        public string Id2 { get; set; }
+        public string Id2 { get; set; } = null!;
     }
 
     public class SomeDependentEntity : SomeCompositeEntityBase
@@ -228,13 +228,13 @@ public class InternalClrEntityEntryTest : InternalEntityEntryTestBase<
     public class SomeMoreDependentEntity : SomeSimpleEntityBase
     {
         public int Fk1 { get; set; }
-        public string Fk2 { get; set; }
+        public string Fk2 { get; set; } = null!;
     }
 
     public class FullNotificationEntity : INotifyPropertyChanging, INotifyPropertyChanged, ISomeEntity
     {
         private int _id;
-        private string _name;
+        private string _name = null!;
 
         public int Id
         {
@@ -264,8 +264,8 @@ public class InternalClrEntityEntryTest : InternalEntityEntryTestBase<
             }
         }
 
-        public event PropertyChangingEventHandler PropertyChanging;
-        public event PropertyChangedEventHandler PropertyChanged;
+        public event PropertyChangingEventHandler? PropertyChanging;
+        public event PropertyChangedEventHandler? PropertyChanged;
 
         private void NotifyChanged([CallerMemberName] string propertyName = "")
             => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
@@ -277,7 +277,7 @@ public class InternalClrEntityEntryTest : InternalEntityEntryTestBase<
     public class ChangedOnlyEntity : INotifyPropertyChanged, ISomeEntity
     {
         private int _id;
-        private string _name;
+        private string _name = null!;
 
         public int Id
         {
@@ -305,7 +305,7 @@ public class InternalClrEntityEntryTest : InternalEntityEntryTestBase<
             }
         }
 
-        public event PropertyChangedEventHandler PropertyChanged;
+        public event PropertyChangedEventHandler? PropertyChanged;
 
         private void NotifyChanged([CallerMemberName] string propertyName = "")
             => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
@@ -315,7 +315,7 @@ public class InternalClrEntityEntryTest : InternalEntityEntryTestBase<
     {
         public int Id { get; set; }
 
-        public FirstDependent First { get; set; }
+        public FirstDependent First { get; set; } = null!;
 
         IFirstDependent IRoot.First
         {
@@ -328,7 +328,7 @@ public class InternalClrEntityEntryTest : InternalEntityEntryTestBase<
     {
         public int Id { get; set; }
 
-        public Root Root { get; set; }
+        public Root Root { get; set; } = null!;
 
         IRoot IFirstDependent.Root
         {
@@ -336,7 +336,7 @@ public class InternalClrEntityEntryTest : InternalEntityEntryTestBase<
             set => Root = (Root)value;
         }
 
-        public SecondDependent Second { get; set; }
+        public SecondDependent Second { get; set; } = null!;
 
         ISecondDependent IFirstDependent.Second
         {
@@ -349,7 +349,7 @@ public class InternalClrEntityEntryTest : InternalEntityEntryTestBase<
     {
         public int Id { get; set; }
 
-        public FirstDependent First { get; set; }
+        public FirstDependent First { get; set; } = null!;
 
         IFirstDependent ISecondDependent.First
         {
@@ -361,20 +361,20 @@ public class InternalClrEntityEntryTest : InternalEntityEntryTestBase<
     public class CompositeRoot : ICompositeRoot
     {
         public int Id1 { get; set; }
-        public string Id2 { get; set; }
+        public string Id2 { get; set; } = null!;
 
-        public ICompositeFirstDependent First { get; set; }
+        public ICompositeFirstDependent First { get; set; } = null!;
     }
 
     public class CompositeFirstDependent : ICompositeFirstDependent
     {
         public int Id1 { get; set; }
-        public string Id2 { get; set; }
+        public string Id2 { get; set; } = null!;
 
         public int RootId1 { get; set; }
-        public string RootId2 { get; set; }
+        public string RootId2 { get; set; } = null!;
 
-        public CompositeRoot Root { get; set; }
+        public CompositeRoot Root { get; set; } = null!;
 
         ICompositeRoot ICompositeFirstDependent.Root
         {
@@ -382,7 +382,7 @@ public class InternalClrEntityEntryTest : InternalEntityEntryTestBase<
             set => Root = (CompositeRoot)value;
         }
 
-        public CompositeSecondDependent Second { get; set; }
+        public CompositeSecondDependent Second { get; set; } = null!;
 
         ICompositeSecondDependent ICompositeFirstDependent.Second
         {
@@ -394,12 +394,12 @@ public class InternalClrEntityEntryTest : InternalEntityEntryTestBase<
     public class CompositeSecondDependent : ICompositeSecondDependent
     {
         public int Id1 { get; set; }
-        public string Id2 { get; set; }
+        public string Id2 { get; set; } = null!;
 
         public int FirstId1 { get; set; }
-        public string FirstId2 { get; set; }
+        public string FirstId2 { get; set; } = null!;
 
-        public CompositeFirstDependent First { get; set; }
+        public CompositeFirstDependent First { get; set; } = null!;
 
         ICompositeFirstDependent ICompositeSecondDependent.First
         {
@@ -411,12 +411,12 @@ public class InternalClrEntityEntryTest : InternalEntityEntryTestBase<
     public class OwnerClass
     {
         public int Id { get; set; }
-        public virtual OwnedClass Owned { get; set; }
+        public virtual OwnedClass Owned { get; set; } = null!;
     }
 
     public class OwnedClass
     {
-        public string Value { get; set; }
+        public string Value { get; set; } = null!;
     }
 
     public interface ISomeEntity
@@ -432,7 +432,7 @@ public class InternalClrEntityEntryTest : InternalEntityEntryTestBase<
 
     public class SomeEntity : SomeSimpleEntityBase, ISomeEntity
     {
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
     }
 
     public class KClrContext : KContext

--- a/test/EFCore.Tests/ChangeTracking/Internal/InternalComplexEntryTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/InternalComplexEntryTest.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 
 public class InternalComplexEntryTest

--- a/test/EFCore.Tests/ChangeTracking/Internal/InternalEntityEntryFactoryTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/InternalEntityEntryFactoryTest.cs
@@ -55,6 +55,6 @@ public class InternalEntityEntryFactoryTest
     {
         public int Id { get; set; }
         public int Long { get; set; }
-        public string Hammer { get; set; }
+        public string Hammer { get; set; } = null!;
     }
 }

--- a/test/EFCore.Tests/ChangeTracking/Internal/InternalEntityEntryTestBase.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/InternalEntityEntryTestBase.cs
@@ -42,7 +42,7 @@ public abstract class InternalEntityEntryTestBase<
     {
         using var context = new TKContext();
         var entry = context.Add(new TSomeEntity()).GetInfrastructure();
-        var keyProperty = entry.EntityType.FindProperty("Id");
+        var keyProperty = entry.EntityType.FindProperty("Id")!;
 
         entry.PrepareToSave();
 
@@ -56,7 +56,7 @@ public abstract class InternalEntityEntryTestBase<
     {
         using var context = new TKContext();
         var entry = context.Entry(new TSomeEntity()).GetInfrastructure();
-        var keyProperty = entry.EntityType.FindProperty("Id");
+        var keyProperty = entry.EntityType.FindProperty("Id")!;
 
         entry[keyProperty] = 1;
 
@@ -71,7 +71,7 @@ public abstract class InternalEntityEntryTestBase<
     {
         using var context = new TKContext();
         var entry1 = context.Entry(new TSomeEntity()).GetInfrastructure();
-        var keyProperty = entry1.EntityType.FindProperty("Id");
+        var keyProperty = entry1.EntityType.FindProperty("Id")!;
 
         if (useTempValue)
         {
@@ -103,7 +103,7 @@ public abstract class InternalEntityEntryTestBase<
     {
         using var context = new TKContext();
         var entry = context.Entry(new TSomeEntity()).GetInfrastructure();
-        var keyProperty = entry.EntityType.FindProperty("Id");
+        var keyProperty = entry.EntityType.FindProperty("Id")!;
 
         entry.SetTemporaryValue(keyProperty, -1, setModified: false);
 
@@ -133,8 +133,8 @@ public abstract class InternalEntityEntryTestBase<
         using var context = new TKContext();
         var entry = context.Add(new TSomeEntity()).GetInfrastructure();
 
-        var keyProperty = entry.EntityType.FindProperty("Id");
-        var nonKeyProperty = entry.EntityType.FindProperty("Name");
+        var keyProperty = entry.EntityType.FindProperty("Id")!;
+        var nonKeyProperty = entry.EntityType.FindProperty("Name")!;
 
         Assert.False(entry.IsModified(keyProperty));
         Assert.False(entry.IsModified(nonKeyProperty));
@@ -161,7 +161,7 @@ public abstract class InternalEntityEntryTestBase<
     {
         using var context = new TKContext();
         var entry = context.Add(new TSomeEntity()).GetInfrastructure();
-        var keyProperty = entry.EntityType.FindProperty("Id");
+        var keyProperty = entry.EntityType.FindProperty("Id")!;
 
         entry.SetEntityState(EntityState.Modified);
 
@@ -191,8 +191,8 @@ public abstract class InternalEntityEntryTestBase<
     {
         using var context = new TKContext();
         var entry = context.Add(new TSomeEntity()).GetInfrastructure();
-        var keyProperty = entry.EntityType.FindProperty("Id");
-        var nonKeyProperty = entry.EntityType.FindProperty("Name");
+        var keyProperty = entry.EntityType.FindProperty("Id")!;
+        var nonKeyProperty = entry.EntityType.FindProperty("Name")!;
 
         entry[keyProperty] = 1;
 
@@ -254,7 +254,7 @@ public abstract class InternalEntityEntryTestBase<
     {
         using var context = new TKContext();
         var entry = context.Add(new TSomeEntity()).GetInfrastructure();
-        var keyProperty = entry.EntityType.FindProperty("Id");
+        var keyProperty = entry.EntityType.FindProperty("Id")!;
 
         entry.SetEntityState(EntityState.Added);
         entry.SetTemporaryValue(keyProperty, -1);
@@ -269,7 +269,7 @@ public abstract class InternalEntityEntryTestBase<
     {
         using var context = new TKContext();
         var entry = context.Add(new TSomeEntity()).GetInfrastructure();
-        var keyProperty = entry.EntityType.FindProperty("Id");
+        var keyProperty = entry.EntityType.FindProperty("Id")!;
 
         entry[keyProperty] = 1;
         entry.SetEntityState(EntityState.Added);
@@ -292,7 +292,7 @@ public abstract class InternalEntityEntryTestBase<
     {
         using var context = new TKContext();
         var entry = context.Add(new TSomeEntity()).GetInfrastructure();
-        var keyProperty = entry.EntityType.FindProperty("Id");
+        var keyProperty = entry.EntityType.FindProperty("Id")!;
 
         entry.SetEntityState(EntityState.Added);
         entry.SetTemporaryValue(keyProperty, -1);
@@ -311,8 +311,8 @@ public abstract class InternalEntityEntryTestBase<
     {
         using var context = new TKContext();
         var entry = context.Add(new TSomeEntity()).GetInfrastructure();
-        var keyProperty = entry.EntityType.FindProperty("Id");
-        var altKeyProperty = entry.EntityType.FindProperty("NonId");
+        var keyProperty = entry.EntityType.FindProperty("Id")!;
+        var altKeyProperty = entry.EntityType.FindProperty("NonId")!;
 
         Assert.NotEqual(0, entry[keyProperty]);
         Assert.Equal(entry[keyProperty], entry[altKeyProperty]);
@@ -331,7 +331,7 @@ public abstract class InternalEntityEntryTestBase<
     {
         using var context = new TKContext();
         var entry = context.Add(new TSomeEntity()).GetInfrastructure();
-        var keyProperty = entry.EntityType.FindProperty("Id");
+        var keyProperty = entry.EntityType.FindProperty("Id")!;
 
         entry[keyProperty] = 31143;
 
@@ -345,9 +345,9 @@ public abstract class InternalEntityEntryTestBase<
     {
         using var context = new TKContext();
         var entry = context.Update(new TSomeEntity()).GetInfrastructure();
-        var property = entry.EntityType.FindProperty("Name");
+        var property = entry.EntityType.FindProperty("Name")!;
 
-        entry[entry.EntityType.FindProperty("Id")] = 1;
+        entry[entry.EntityType.FindProperty("Id")!] = 1;
 
         entry.SetEntityState(EntityState.Modified);
         entry.SetPropertyModified(property);
@@ -364,11 +364,11 @@ public abstract class InternalEntityEntryTestBase<
         var entry = context.Entry(new TSomeDependentEntity()).GetInfrastructure();
 
         var entityType = entry.EntityType;
-        entry[entityType.FindProperty("Id1")] = 77;
-        entry[entityType.FindProperty("Id2")] = "Ready Salted";
+        entry[entityType.FindProperty("Id1")!] = 77;
+        entry[entityType.FindProperty("Id2")!] = "Ready Salted";
         entry.SetEntityState(EntityState.Added);
 
-        var property = entityType.FindProperty("JustAProperty");
+        var property = entityType.FindProperty("JustAProperty")!;
 
         Assert.NotEqual(0, entry[property]);
     }
@@ -380,11 +380,11 @@ public abstract class InternalEntityEntryTestBase<
         var entry = context.Entry(new TSomeDependentEntity()).GetInfrastructure();
 
         var entityType = entry.EntityType;
-        entry[entityType.FindProperty("Id1")] = 77;
-        entry[entityType.FindProperty("Id2")] = "Ready Salted";
+        entry[entityType.FindProperty("Id1")!] = 77;
+        entry[entityType.FindProperty("Id2")!] = "Ready Salted";
         entry.SetEntityState(EntityState.Added);
 
-        var fkProperty = entityType.FindProperty("SomeEntityId");
+        var fkProperty = entityType.FindProperty("SomeEntityId")!;
 
         entry[fkProperty] = 77;
         entry.SetRelationshipSnapshotValue(fkProperty, 78);
@@ -402,11 +402,11 @@ public abstract class InternalEntityEntryTestBase<
         var entry = context.Entry(new TSomeDependentEntity()).GetInfrastructure();
 
         var entityType = entry.EntityType;
-        entry[entityType.FindProperty("Id1")] = 77;
-        entry[entityType.FindProperty("Id2")] = "Ready Salted";
+        entry[entityType.FindProperty("Id1")!] = 77;
+        entry[entityType.FindProperty("Id2")!] = "Ready Salted";
         entry.SetEntityState(EntityState.Unchanged);
 
-        var fkProperty = entityType.FindProperty("SomeEntityId");
+        var fkProperty = entityType.FindProperty("SomeEntityId")!;
 
         entry[fkProperty] = 77;
         entry.SetRelationshipSnapshotValue(fkProperty, 78);
@@ -422,13 +422,13 @@ public abstract class InternalEntityEntryTestBase<
     {
         using var context = new TKContext();
         var stateManager = context.GetService<IStateManager>();
-        var entityType = context.Model.FindEntityType(typeof(TSomeEntity));
+        var entityType = context.Model.FindEntityType(typeof(TSomeEntity))!;
 
-        var keyProperty = entityType.FindProperty("Id");
-        var property = entityType.FindProperty("Name");
+        var keyProperty = entityType.FindProperty("Id")!;
+        var property = entityType.FindProperty("Name")!;
 
         var entry = stateManager.CreateEntry(
-            new Dictionary<IProperty, object> { { keyProperty, 1 }, { property, "Kool" } },
+            new Dictionary<IProperty, object?> { { keyProperty, 1 }, { property, "Kool" } },
             entityType
         );
 
@@ -441,13 +441,13 @@ public abstract class InternalEntityEntryTestBase<
     {
         using var context = new TKContext();
         var stateManager = context.GetService<IStateManager>();
-        var entityType = context.Model.FindEntityType(typeof(TSomeEntity));
+        var entityType = context.Model.FindEntityType(typeof(TSomeEntity))!;
 
-        var keyProperty = entityType.FindProperty("Id");
-        var nameProperty = entityType.FindProperty("Name");
+        var keyProperty = entityType.FindProperty("Id")!;
+        var nameProperty = entityType.FindProperty("Name")!;
 
         var entry = stateManager.CreateEntry(
-            new Dictionary<IProperty, object> { { keyProperty, 1 }, { nameProperty, "Kool" } },
+            new Dictionary<IProperty, object?> { { keyProperty, 1 }, { nameProperty, "Kool" } },
             entityType
         );
 
@@ -461,13 +461,13 @@ public abstract class InternalEntityEntryTestBase<
     {
         using var context = new TKContext();
         var stateManager = context.GetService<IStateManager>();
-        var entityType = context.Model.FindEntityType(typeof(TSomeEntity));
+        var entityType = context.Model.FindEntityType(typeof(TSomeEntity))!;
 
-        var keyProperty = entityType.FindProperty("Id");
-        var property = entityType.FindProperty("Name");
+        var keyProperty = entityType.FindProperty("Id")!;
+        var property = entityType.FindProperty("Name")!;
 
         var entry = stateManager.CreateEntry(
-            new Dictionary<string, object> { { "Id", 1 }, { "Name", "Kool" } },
+            new Dictionary<string, object?> { { "Id", 1 }, { "Name", "Kool" } },
             entityType
         );
 
@@ -480,12 +480,12 @@ public abstract class InternalEntityEntryTestBase<
     {
         using var context = new TKContext();
         var stateManager = context.GetService<IStateManager>();
-        var entityType = context.Model.FindEntityType(typeof(TSomeEntity));
+        var entityType = context.Model.FindEntityType(typeof(TSomeEntity))!;
 
-        var nameProperty = entityType.FindProperty("Name");
+        var nameProperty = entityType.FindProperty("Name")!;
 
         var entry = stateManager.CreateEntry(
-            new Dictionary<string, object> { { "Id", 1 }, { "Name", "Kool" } },
+            new Dictionary<string, object?> { { "Id", 1 }, { "Name", "Kool" } },
             entityType
         );
 
@@ -499,8 +499,8 @@ public abstract class InternalEntityEntryTestBase<
     {
         using var context = new TKContext();
         var entry = context.Add(new TSomeEntity()).GetInfrastructure();
-        var keyProperty = entry.EntityType.FindProperty("Id");
-        var nonKeyProperty = entry.EntityType.FindProperty("Name");
+        var keyProperty = entry.EntityType.FindProperty("Id")!;
+        var nonKeyProperty = entry.EntityType.FindProperty("Name")!;
 
         entry[keyProperty] = 77;
         entry[nonKeyProperty] = "Magic Tree House";
@@ -510,15 +510,15 @@ public abstract class InternalEntityEntryTestBase<
             CreateValueBuffer(entry));
     }
 
-    private static object[] CreateValueBuffer(IUpdateEntry entry)
+    private static object?[] CreateValueBuffer(IUpdateEntry entry)
         => entry.EntityType.GetProperties().Select(entry.GetCurrentValue).ToArray();
 
     protected void AllOriginalValuesTest(object entity)
     {
         using var context = new TKSnapContext();
         var entry = context.Entry(entity).GetInfrastructure();
-        var idProperty = entry.EntityType.FindProperty("Id");
-        var nameProperty = entry.EntityType.FindProperty("Name");
+        var idProperty = entry.EntityType.FindProperty("Id")!;
+        var nameProperty = entry.EntityType.FindProperty("Name")!;
 
         entry[idProperty] = 1;
         entry[nameProperty] = "Kool";
@@ -552,8 +552,8 @@ public abstract class InternalEntityEntryTestBase<
     {
         using var context = new TKContext();
         var entry = context.Entry(entity).GetInfrastructure();
-        entry[entry.EntityType.FindProperty("Id")] = 1;
-        var nameProperty = entry.EntityType.FindProperty("Name");
+        entry[entry.EntityType.FindProperty("Id")!] = 1;
+        var nameProperty = entry.EntityType.FindProperty("Name")!;
         entry[nameProperty] = "Kool";
         entry.SetEntityState(EntityState.Unchanged);
 
@@ -579,8 +579,8 @@ public abstract class InternalEntityEntryTestBase<
     {
         using var context = new TKContext();
         var entry = context.Entry(entity).GetInfrastructure();
-        var idProperty = entry.EntityType.FindProperty("Id");
-        var nameProperty = entry.EntityType.FindProperty("Name");
+        var idProperty = entry.EntityType.FindProperty("Id")!;
+        var nameProperty = entry.EntityType.FindProperty("Name")!;
 
         entry[idProperty] = 77;
         entry[nameProperty] = "Kool";
@@ -608,8 +608,8 @@ public abstract class InternalEntityEntryTestBase<
     {
         using var context = new TKContext();
         var entry = context.Entry(entity).GetInfrastructure();
-        var idProperty = entry.EntityType.FindProperty("Id");
-        var nameProperty = entry.EntityType.FindProperty("Name");
+        var idProperty = entry.EntityType.FindProperty("Id")!;
+        var nameProperty = entry.EntityType.FindProperty("Name")!;
 
         entry[idProperty] = 77;
         entry.SetEntityState(EntityState.Unchanged);
@@ -641,8 +641,8 @@ public abstract class InternalEntityEntryTestBase<
     {
         using var context = new TKContext();
         var entry = context.Entry(entity).GetInfrastructure();
-        var idProperty = entry.EntityType.FindProperty("Id");
-        var nameProperty = entry.EntityType.FindProperty("Name");
+        var idProperty = entry.EntityType.FindProperty("Id")!;
+        var nameProperty = entry.EntityType.FindProperty("Name")!;
 
         entry[idProperty] = 77;
         entry.SetEntityState(EntityState.Unchanged);
@@ -674,8 +674,8 @@ public abstract class InternalEntityEntryTestBase<
     {
         using var context = new TKContext();
         var entry = context.Entry(entity).GetInfrastructure();
-        var idProperty = entry.EntityType.FindProperty("Id");
-        var nameProperty = entry.EntityType.FindProperty("Name");
+        var idProperty = entry.EntityType.FindProperty("Id")!;
+        var nameProperty = entry.EntityType.FindProperty("Name")!;
 
         entry[idProperty] = 77;
         entry[nameProperty] = "Kool";
@@ -713,8 +713,8 @@ public abstract class InternalEntityEntryTestBase<
         var entity = new TSomeEntity();
         var entry = context.Entry(entity).GetInfrastructure();
         var entityType = entry.EntityType;
-        var keyProperty = entityType.FindProperty("Id");
-        var nonKeyProperty = entityType.FindProperty("Name");
+        var keyProperty = entityType.FindProperty("Id")!;
+        var nonKeyProperty = entityType.FindProperty("Name")!;
 
         entry[keyProperty] = 77;
         entry[nonKeyProperty] = "Magic Tree House";
@@ -747,8 +747,8 @@ public abstract class InternalEntityEntryTestBase<
         using var context = new TKContext();
         var entry = context.Entry(new TSomeEntity()).GetInfrastructure();
         var entityType = entry.EntityType;
-        var keyProperty = entityType.FindProperty("Id");
-        var nonKeyProperty = entityType.FindProperty("Name");
+        var keyProperty = entityType.FindProperty("Id")!;
+        var nonKeyProperty = entityType.FindProperty("Name")!;
         entry[keyProperty] = 1;
         entry[nonKeyProperty] = "Kool";
 
@@ -765,8 +765,8 @@ public abstract class InternalEntityEntryTestBase<
         using var context = new TKContext();
         var entry = context.Entry(new TSomeEntity()).GetInfrastructure();
         var entityType = entry.EntityType;
-        var keyProperty = entityType.FindProperty("Id");
-        var nameProperty = entityType.FindProperty("Name");
+        var keyProperty = entityType.FindProperty("Id")!;
+        var nameProperty = entityType.FindProperty("Name")!;
 
         entry[keyProperty] = 1;
         entry[nameProperty] = "Kool";
@@ -789,8 +789,8 @@ public abstract class InternalEntityEntryTestBase<
         using var context = new TKContext();
         var entry = context.Entry(new TSomeEntity()).GetInfrastructure();
         var entityType = entry.EntityType;
-        var keyProperty = entityType.FindProperty("Id");
-        var nameProperty = entityType.FindProperty("Name");
+        var keyProperty = entityType.FindProperty("Id")!;
+        var nameProperty = entityType.FindProperty("Name")!;
 
         entry[keyProperty] = 1;
         entry[nameProperty] = "Kool";
@@ -812,8 +812,8 @@ public abstract class InternalEntityEntryTestBase<
         using var context = new TKContext();
         var entry = context.Entry(new TSomeEntity()).GetInfrastructure();
         var entityType = entry.EntityType;
-        var keyProperty = entityType.FindProperty("Id");
-        var nameProperty = entityType.FindProperty("Name");
+        var keyProperty = entityType.FindProperty("Id")!;
+        var nameProperty = entityType.FindProperty("Name")!;
 
         entry[keyProperty] = 1;
         entry[nameProperty] = "Kool";
@@ -830,7 +830,7 @@ public abstract class InternalEntityEntryTestBase<
     {
         using var context = new KcContext();
         var entry = context.Entry(new TSecondDependent()).GetInfrastructure();
-        var fkProperty = entry.EntityType.FindProperty("Id");
+        var fkProperty = entry.EntityType.FindProperty("Id")!;
 
         entry[fkProperty] = 77;
         entry.SetEntityState(EntityState.Unchanged);
@@ -846,7 +846,7 @@ public abstract class InternalEntityEntryTestBase<
     {
         using var context = new KcContext();
         var entry = context.Entry(new TSecondDependent()).GetInfrastructure();
-        var fkProperty = entry.EntityType.FindProperty("Id");
+        var fkProperty = entry.EntityType.FindProperty("Id")!;
 
         entry[fkProperty] = 77;
         entry.SetEntityState(EntityState.Added);
@@ -863,11 +863,11 @@ public abstract class InternalEntityEntryTestBase<
         using var context = new KcrContext();
         var entry = context.Entry(new TCompositeSecondDependent()).GetInfrastructure();
         var entityType = entry.EntityType;
-        var fkProperty1 = entityType.FindProperty("FirstId1");
-        var fkProperty2 = entityType.FindProperty("FirstId2");
+        var fkProperty1 = entityType.FindProperty("FirstId1")!;
+        var fkProperty2 = entityType.FindProperty("FirstId2")!;
 
-        entry[entityType.FindProperty("Id1")] = 66;
-        entry[entityType.FindProperty("Id2")] = "Bar";
+        entry[entityType.FindProperty("Id1")!] = 66;
+        entry[entityType.FindProperty("Id2")!] = "Bar";
         entry[fkProperty1] = 77;
         entry[fkProperty2] = "Foo";
         entry.SetEntityState(EntityState.Unchanged);
@@ -884,11 +884,11 @@ public abstract class InternalEntityEntryTestBase<
         using var context = new KcContext();
         var entry = context.Entry(new TCompositeSecondDependent()).GetInfrastructure();
         var entityType = entry.EntityType;
-        var fkProperty1 = entityType.FindProperty("FirstId1");
-        var fkProperty2 = entityType.FindProperty("FirstId2");
+        var fkProperty1 = entityType.FindProperty("FirstId1")!;
+        var fkProperty2 = entityType.FindProperty("FirstId2")!;
 
-        entry[entityType.FindProperty("Id1")] = 66;
-        entry[entityType.FindProperty("Id2")] = "Bar";
+        entry[entityType.FindProperty("Id1")!] = 66;
+        entry[entityType.FindProperty("Id2")!] = "Bar";
         entry[fkProperty1] = 77;
         entry[fkProperty2] = "Foo";
         entry.SetEntityState(EntityState.Unchanged);

--- a/test/EFCore.Tests/ChangeTracking/Internal/InternalEntrySubscriberTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/InternalEntrySubscriberTest.cs
@@ -531,40 +531,40 @@ public class InternalEntrySubscriberTest
         {
         }
 
-        public (EventHandler<DetectChangesEventArgs> DetectingAllChanges,
-            EventHandler<DetectedChangesEventArgs> DetectedAllChanges,
-            EventHandler<DetectEntityChangesEventArgs> DetectingEntityChanges,
-            EventHandler<DetectedEntityChangesEventArgs>
+        public (EventHandler<DetectChangesEventArgs>? DetectingAllChanges,
+            EventHandler<DetectedChangesEventArgs>? DetectedAllChanges,
+            EventHandler<DetectEntityChangesEventArgs>? DetectingEntityChanges,
+            EventHandler<DetectedEntityChangesEventArgs>?
             DetectedEntityChanges) CaptureEvents()
             => (null, null, null, null);
 
         public void SetEvents(
-            EventHandler<DetectChangesEventArgs> detectingAllChanges,
-            EventHandler<DetectedChangesEventArgs> detectedAllChanges,
-            EventHandler<DetectEntityChangesEventArgs> detectingEntityChanges,
-            EventHandler<DetectedEntityChangesEventArgs> detectedEntityChanges)
+            EventHandler<DetectChangesEventArgs>? detectingAllChanges,
+            EventHandler<DetectedChangesEventArgs>? detectedAllChanges,
+            EventHandler<DetectEntityChangesEventArgs>? detectingEntityChanges,
+            EventHandler<DetectedEntityChangesEventArgs>? detectedEntityChanges)
         {
         }
 
-        public event EventHandler<DetectEntityChangesEventArgs> DetectingEntityChanges;
+        public event EventHandler<DetectEntityChangesEventArgs>? DetectingEntityChanges;
 
         public void OnDetectingEntityChanges(InternalEntityEntry internalEntityEntry)
-            => DetectingEntityChanges?.Invoke(null, null);
+            => DetectingEntityChanges?.Invoke(null, null!);
 
-        public event EventHandler<DetectChangesEventArgs> DetectingAllChanges;
+        public event EventHandler<DetectChangesEventArgs>? DetectingAllChanges;
 
         public void OnDetectingAllChanges(IStateManager stateManager)
-            => DetectingAllChanges?.Invoke(null, null);
+            => DetectingAllChanges?.Invoke(null, null!);
 
-        public event EventHandler<DetectedEntityChangesEventArgs> DetectedEntityChanges;
+        public event EventHandler<DetectedEntityChangesEventArgs>? DetectedEntityChanges;
 
         public void OnDetectedEntityChanges(InternalEntityEntry internalEntityEntry, bool changesFound)
-            => DetectedEntityChanges?.Invoke(null, null);
+            => DetectedEntityChanges?.Invoke(null, null!);
 
-        public event EventHandler<DetectedChangesEventArgs> DetectedAllChanges;
+        public event EventHandler<DetectedChangesEventArgs>? DetectedAllChanges;
 
         public void OnDetectedAllChanges(IStateManager stateManager, bool changesFound)
-            => DetectedAllChanges?.Invoke(null, null);
+            => DetectedAllChanges?.Invoke(null, null!);
 
         public void Suspend()
         {
@@ -604,8 +604,8 @@ public class InternalEntrySubscriberTest
         public void NavigationReferenceChanged(
             InternalEntityEntry entry,
             INavigationBase navigationBase,
-            object oldValue,
-            object newValue)
+            object? oldValue,
+            object? newValue)
         {
         }
 
@@ -637,8 +637,8 @@ public class InternalEntrySubscriberTest
             IProperty property,
             IEnumerable<IKey> containingPrincipalKeys,
             IEnumerable<IForeignKey> containingForeignKeys,
-            object oldValue,
-            object newValue)
+            object? oldValue,
+            object? newValue)
         {
         }
     }
@@ -661,9 +661,9 @@ public class InternalEntrySubscriberTest
     private class FullNotificationEntity : INotifyPropertyChanging, INotifyPropertyChanged
     {
         private int _id;
-        private string _name;
-        private string _notMapped;
-        private ICollection<ChangedOnlyNotificationEntity> _relatedCollection;
+        private string _name = null!;
+        private string _notMapped = null!;
+        private ICollection<ChangedOnlyNotificationEntity> _relatedCollection = null!;
 
         public int Id
         {
@@ -699,22 +699,22 @@ public class InternalEntrySubscriberTest
             }
         }
 
-        public event PropertyChangingEventHandler PropertyChanging;
-        public event PropertyChangedEventHandler PropertyChanged;
+        public event PropertyChangingEventHandler? PropertyChanging;
+        public event PropertyChangedEventHandler? PropertyChanged;
 
-        public void NotifyChanged(string propertyName)
+        public void NotifyChanged(string? propertyName)
             => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
 
-        public void NotifyChanging(string propertyName)
+        public void NotifyChanging(string? propertyName)
             => PropertyChanging?.Invoke(this, new PropertyChangingEventArgs(propertyName));
     }
 
     private class ChangedOnlyNotificationEntity : INotifyPropertyChanged
     {
         private int _id;
-        private string _name;
+        private string _name = null!;
         private int _fk;
-        private FullNotificationEntity _related;
+        private FullNotificationEntity _related = null!;
 
         public int Id
         {
@@ -749,7 +749,7 @@ public class InternalEntrySubscriberTest
             }
         }
 
-        public event PropertyChangedEventHandler PropertyChanged;
+        public event PropertyChangedEventHandler? PropertyChanged;
 
         private void NotifyChanged(string propertyName)
             => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));

--- a/test/EFCore.Tests/ChangeTracking/Internal/InternalMixedEntityEntryTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/InternalMixedEntityEntryTest.cs
@@ -26,7 +26,7 @@ public class InternalMixedEntityEntryTest : InternalEntityEntryTestBase<
 
     public class Root : IRoot
     {
-        public FirstDependent First { get; set; }
+        public FirstDependent First { get; set; } = null!;
 
         IFirstDependent IRoot.First
         {
@@ -37,7 +37,7 @@ public class InternalMixedEntityEntryTest : InternalEntityEntryTestBase<
 
     public class FirstDependent : IFirstDependent
     {
-        public Root Root { get; set; }
+        public Root Root { get; set; } = null!;
 
         IRoot IFirstDependent.Root
         {
@@ -45,7 +45,7 @@ public class InternalMixedEntityEntryTest : InternalEntityEntryTestBase<
             set => Root = (Root)value;
         }
 
-        public SecondDependent Second { get; set; }
+        public SecondDependent Second { get; set; } = null!;
 
         ISecondDependent IFirstDependent.Second
         {
@@ -56,7 +56,7 @@ public class InternalMixedEntityEntryTest : InternalEntityEntryTestBase<
 
     public class SecondDependent : ISecondDependent
     {
-        public FirstDependent First { get; set; }
+        public FirstDependent First { get; set; } = null!;
 
         IFirstDependent ISecondDependent.First
         {
@@ -67,12 +67,12 @@ public class InternalMixedEntityEntryTest : InternalEntityEntryTestBase<
 
     public class CompositeRoot : ICompositeRoot
     {
-        public ICompositeFirstDependent First { get; set; }
+        public ICompositeFirstDependent First { get; set; } = null!;
     }
 
     public class CompositeFirstDependent : ICompositeFirstDependent
     {
-        public CompositeRoot Root { get; set; }
+        public CompositeRoot Root { get; set; } = null!;
 
         ICompositeRoot ICompositeFirstDependent.Root
         {
@@ -80,7 +80,7 @@ public class InternalMixedEntityEntryTest : InternalEntityEntryTestBase<
             set => Root = (CompositeRoot)value;
         }
 
-        public CompositeSecondDependent Second { get; set; }
+        public CompositeSecondDependent Second { get; set; } = null!;
 
         ICompositeSecondDependent ICompositeFirstDependent.Second
         {
@@ -91,7 +91,7 @@ public class InternalMixedEntityEntryTest : InternalEntityEntryTestBase<
 
     public class CompositeSecondDependent : ICompositeSecondDependent
     {
-        public CompositeFirstDependent First { get; set; }
+        public CompositeFirstDependent First { get; set; } = null!;
 
         ICompositeFirstDependent ICompositeSecondDependent.First
         {

--- a/test/EFCore.Tests/ChangeTracking/Internal/KeyPropagatorTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/KeyPropagatorTest.cs
@@ -19,7 +19,7 @@ public class KeyPropagatorTest
         var contextServices = CreateContextServices(model);
         model = contextServices.GetRequiredService<IModel>();
         var dependentEntry = contextServices.GetRequiredService<IStateManager>().GetOrCreateEntry(dependent);
-        var property = model.FindEntityType(typeof(Product)).FindProperty("CategoryId");
+        var property = model.FindEntityType(typeof(Product))!.FindProperty("CategoryId")!;
         var keyPropagator = contextServices.GetRequiredService<IKeyPropagator>();
 
         if (async)
@@ -259,9 +259,9 @@ public class KeyPropagatorTest
     {
         public int CategoryId { get; set; }
 
-        public Category Category { get; set; }
+        public Category Category { get; set; } = null!;
 
-        public ProductDetail Detail { get; set; }
+        public ProductDetail Detail { get; set; } = null!;
 
         public ICollection<OrderLine> OrderLines { get; } = new List<OrderLine>();
     }
@@ -269,7 +269,7 @@ public class KeyPropagatorTest
     private class ProductDetail
     {
         public int Id { get; set; }
-        public Product Product { get; set; }
+        public Product Product { get; set; } = null!;
     }
 
     private class Order : BaseType
@@ -282,10 +282,10 @@ public class KeyPropagatorTest
         public int OrderId { get; set; }
         public int ProductId { get; set; }
 
-        public virtual Order Order { get; set; }
-        public virtual Product Product { get; set; }
+        public virtual Order Order { get; set; } = null!;
+        public virtual Product Product { get; set; } = null!;
 
-        public virtual OrderLineDetail Detail { get; set; }
+        public virtual OrderLineDetail Detail { get; set; } = null!;
     }
 
     private class OrderLineDetail
@@ -293,7 +293,7 @@ public class KeyPropagatorTest
         public int OrderId { get; set; }
         public int ProductId { get; set; }
 
-        public virtual OrderLine OrderLine { get; set; }
+        public virtual OrderLine OrderLine { get; set; } = null!;
     }
 
     private static IModel BuildModel(bool generateTemporary = false)

--- a/test/EFCore.Tests/ChangeTracking/Internal/NavigationFixerTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/NavigationFixerTest.cs
@@ -32,13 +32,13 @@ public class NavigationFixerTest
 
     private class FixupContext : DbContext
     {
-        public DbSet<Blog> Blogs { get; set; }
-        public DbSet<Post> Posts { get; set; }
+        public DbSet<Blog> Blogs { get; set; } = null!;
+        public DbSet<Post> Posts { get; set; } = null!;
 
         protected internal override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
             => optionsBuilder
                 .UseInternalServiceProvider(InMemoryFixture.DefaultServiceProvider)
-                .UseInMemoryDatabase(typeof(FixupContext).FullName);
+                .UseInMemoryDatabase(typeof(FixupContext).FullName!);
     }
 
     private class Blog
@@ -49,7 +49,7 @@ public class NavigationFixerTest
 
     private class Post
     {
-        private Blog _blog;
+        private Blog _blog = null!;
         public int Id { get; set; }
         public int BlogId { get; set; }
 
@@ -136,8 +136,8 @@ public class NavigationFixerTest
 
         principal.Id = "TEST";
 
-        var principalType = model.FindEntityType(typeof(CaseInsensitiveCategory));
-        var idProperty = principalType.FindProperty(nameof(CaseInsensitiveCategory.Id));
+        var principalType = model.FindEntityType(typeof(CaseInsensitiveCategory))!;
+        var idProperty = principalType.FindProperty(nameof(CaseInsensitiveCategory.Id))!;
 
         fixer.KeyPropertyChanged(
             principalEntry,
@@ -524,8 +524,8 @@ public class NavigationFixerTest
 
         dependent.CategoryId = 11;
 
-        var productType = model.FindEntityType(typeof(Product));
-        var categoryIdProperty = productType.FindProperty("CategoryId");
+        var productType = model.FindEntityType(typeof(Product))!;
+        var categoryIdProperty = productType.FindProperty("CategoryId")!;
 
         fixer.KeyPropertyChanged(
             dependentEntry,
@@ -566,8 +566,8 @@ public class NavigationFixerTest
 
         dependent.CategoryId = 0;
 
-        var productType = model.FindEntityType(typeof(Product));
-        var categoryIdProperty = productType.FindProperty("CategoryId");
+        var productType = model.FindEntityType(typeof(Product))!;
+        var categoryIdProperty = productType.FindProperty("CategoryId")!;
 
         fixer.KeyPropertyChanged(
             dependentEntry,
@@ -608,8 +608,8 @@ public class NavigationFixerTest
 
         dependent.CategoryId = 11;
 
-        var productType = model.FindEntityType(typeof(Product));
-        var categoryIdProperty = productType.FindProperty("CategoryId");
+        var productType = model.FindEntityType(typeof(Product))!;
+        var categoryIdProperty = productType.FindProperty("CategoryId")!;
 
         fixer.KeyPropertyChanged(
             dependentEntry,
@@ -652,8 +652,8 @@ public class NavigationFixerTest
 
         dependent.Id = 22;
 
-        var productDetailType = model.FindEntityType(typeof(ProductDetail));
-        var idProperty = productDetailType.FindProperty("Id");
+        var productDetailType = model.FindEntityType(typeof(ProductDetail))!;
+        var idProperty = productDetailType.FindProperty("Id")!;
 
         fixer.KeyPropertyChanged(
             dependentEntry,
@@ -692,8 +692,8 @@ public class NavigationFixerTest
 
         dependent.Id = 0;
 
-        var productDetailType = model.FindEntityType(typeof(ProductDetail));
-        var idProperty = productDetailType.FindProperty("Id");
+        var productDetailType = model.FindEntityType(typeof(ProductDetail))!;
+        var idProperty = productDetailType.FindProperty("Id")!;
 
         fixer.KeyPropertyChanged(
             dependentEntry,
@@ -731,8 +731,8 @@ public class NavigationFixerTest
 
         dependent.Id = 21;
 
-        var productDetailType = model.FindEntityType(typeof(ProductDetail));
-        var idProperty = productDetailType.FindProperty("Id");
+        var productDetailType = model.FindEntityType(typeof(ProductDetail))!;
+        var idProperty = productDetailType.FindProperty("Id")!;
 
         fixer.KeyPropertyChanged(
             dependentEntry,
@@ -779,8 +779,8 @@ public class NavigationFixerTest
 
         entity1.AlternateProductId = 23;
 
-        var productType = model.FindEntityType(typeof(Product));
-        var alternateProductId = productType.FindProperty("AlternateProductId");
+        var productType = model.FindEntityType(typeof(Product))!;
+        var alternateProductId = productType.FindProperty("AlternateProductId")!;
 
         fixer.KeyPropertyChanged(
             entry1,
@@ -833,8 +833,8 @@ public class NavigationFixerTest
 
         entity1.AlternateProductId = 23;
 
-        var productType = model.FindEntityType(typeof(Product));
-        var alternateProductId = productType.FindProperty("AlternateProductId");
+        var productType = model.FindEntityType(typeof(Product))!;
+        var alternateProductId = productType.FindProperty("AlternateProductId")!;
 
         fixer.KeyPropertyChanged(
             entry1,
@@ -1001,8 +1001,8 @@ public class NavigationFixerTest
         // Changes both FK relationships
         tag1.ProductId = 2;
 
-        var productTagType = model.FindEntityType(typeof(ProductTag));
-        var productId = productTagType.FindProperty("ProductId");
+        var productTagType = model.FindEntityType(typeof(ProductTag))!;
+        var productId = productTagType.FindProperty("ProductId")!;
 
         fixer.KeyPropertyChanged(
             tagEntry1,
@@ -1268,7 +1268,7 @@ public class NavigationFixerTest
         Assert.Equal(dependent2.AlternateProductId, principal2.Id);
     }
 
-    private static IServiceProvider CreateContextServices(IModel model = null)
+    private static IServiceProvider CreateContextServices(IModel? model = null)
         => InMemoryTestHelpers.Instance.CreateContextServices(model ?? BuildModel());
 
     private class Category
@@ -1280,7 +1280,7 @@ public class NavigationFixerTest
 
     private class CaseInsensitiveCategory
     {
-        public string Id { get; set; }
+        public string Id { get; set; } = null!;
 
         public ICollection<CaseInsensitiveProduct> Products { get; } = new List<CaseInsensitiveProduct>();
     }
@@ -1289,8 +1289,8 @@ public class NavigationFixerTest
     {
         public int Id { get; set; }
 
-        public string CategoryId { get; set; }
-        public CaseInsensitiveCategory Category { get; set; }
+        public string CategoryId { get; set; } = null!;
+        public CaseInsensitiveCategory Category { get; set; } = null!;
     }
 
     private class Product
@@ -1298,20 +1298,20 @@ public class NavigationFixerTest
         public int Id { get; set; }
 
         public int CategoryId { get; set; }
-        public Category Category { get; set; }
+        public Category Category { get; set; } = null!;
 
-        public ProductDetail Detail { get; set; }
+        public ProductDetail Detail { get; set; } = null!;
 
         public int? AlternateProductId { get; set; }
-        public Product AlternateProduct { get; set; }
-        public Product OriginalProduct { get; set; }
+        public Product AlternateProduct { get; set; } = null!;
+        public Product OriginalProduct { get; set; } = null!;
     }
 
     private class ProductDetail : IEnumerable<Product>
     {
         public int Id { get; set; }
 
-        public Product Product { get; set; }
+        public Product Product { get; set; } = null!;
 
         public IEnumerator<Product> GetEnumerator()
             => throw new NotImplementedException();
@@ -1323,7 +1323,7 @@ public class NavigationFixerTest
     private class ProductPhoto
     {
         public int ProductId { get; set; }
-        public string PhotoId { get; set; }
+        public string PhotoId { get; set; } = null!;
 
         public ICollection<ProductTag> ProductTags { get; } = new HashSet<ProductTag>();
     }
@@ -1341,11 +1341,11 @@ public class NavigationFixerTest
         public int Id { get; set; }
 
         public int ProductId { get; set; }
-        public string PhotoId { get; set; }
+        public string PhotoId { get; set; } = null!;
         public Guid ReviewId { get; set; }
 
-        public ProductPhoto Photo { get; set; }
-        public ProductReview Review { get; set; }
+        public ProductPhoto Photo { get; set; } = null!;
+        public ProductReview Review { get; set; } = null!;
     }
 
     private sealed class CaseInsensitiveKeyStringTypeMapping : CoreTypeMapping
@@ -1368,11 +1368,11 @@ public class NavigationFixerTest
         }
 
         public override CoreTypeMapping WithComposedConverter(
-            ValueConverter converter,
-            ValueComparer comparer = null,
-            ValueComparer keyComparer = null,
-            CoreTypeMapping elementMapping = null,
-            JsonValueReaderWriter jsonValueReaderWriter = null)
+            ValueConverter? converter,
+            ValueComparer? comparer = null,
+            ValueComparer? keyComparer = null,
+            CoreTypeMapping? elementMapping = null,
+            JsonValueReaderWriter? jsonValueReaderWriter = null)
             => new CaseInsensitiveKeyStringTypeMapping(
                 Parameters.WithComposedConverter(
                     converter, comparer, keyComparer, elementMapping, jsonValueReaderWriter));

--- a/test/EFCore.Tests/ChangeTracking/Internal/ObservableBackedBindingListTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/ObservableBackedBindingListTest.cs
@@ -547,13 +547,13 @@ public class ObservableBackedBindingListTest
 
         public int Int { get; }
         public int? NullableInt { get; }
-        public string String { get; }
-        public NotXNode XNode { get; }
-        public Random Random { get; }
-        public byte[] ByteArray { get; }
+        public string String { get; } = null!;
+        public NotXNode XNode { get; } = null!;
+        public Random Random { get; } = null!;
+        public byte[] ByteArray { get; } = null!;
 
         public static PropertyDescriptor Property(string name)
-            => TypeDescriptor.GetProperties(typeof(ListElement))[name];
+            => TypeDescriptor.GetProperties(typeof(ListElement))[name]!;
     }
 
     private abstract class NotXNode;

--- a/test/EFCore.Tests/ChangeTracking/Internal/OwnedFixupTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/OwnedFixupTest.cs
@@ -23,7 +23,7 @@ public class OwnedFixupTest
     {
         public Guid OwnedByThingId { get; set; }
         public Guid ThingId { get; set; }
-        public Thing Thing { get; set; }
+        public Thing Thing { get; set; } = null!;
     }
 
     [Theory,
@@ -83,14 +83,14 @@ public class OwnedFixupTest
         Assert.True(context.ChangeTracker.HasChanges());
 
         Assert.Equal(EntityState.Added, context.Entry(owner).State);
-        Assert.Equal(EntityState.Detached, context.Entry(owner).Reference(e => e.Child1).TargetEntry.State);
+        Assert.Equal(EntityState.Detached, context.Entry(owner).Reference(e => e.Child1).TargetEntry!.State);
 
         context.Entry(owner).State = EntityState.Detached;
 
         Assert.False(context.ChangeTracker.HasChanges());
 
         Assert.Equal(EntityState.Detached, context.Entry(owner).State);
-        Assert.Equal(EntityState.Detached, context.Entry(owner).Reference(e => e.Child1).TargetEntry.State);
+        Assert.Equal(EntityState.Detached, context.Entry(owner).Reference(e => e.Child1).TargetEntry!.State);
     }
 
     [Fact]
@@ -110,11 +110,11 @@ public class OwnedFixupTest
                 ".Collection().FindEntry()"),
             Assert.Throws<InvalidOperationException>(() => context.Entry(dependent)).Message);
 
-        var dependentEntry1 = context.Entry(principal).Reference(p => p.Child1).TargetEntry;
+        var dependentEntry1 = context.Entry(principal).Reference(p => p.Child1).TargetEntry!;
 
         Assert.Same(dependentEntry1.GetInfrastructure(), context.Entry(dependent).GetInfrastructure());
 
-        var dependentEntry2 = context.Entry(principal).Reference(p => p.Child2).TargetEntry;
+        var dependentEntry2 = context.Entry(principal).Reference(p => p.Child2).TargetEntry!;
 
         Assert.NotNull(dependentEntry2);
         Assert.Equal(
@@ -134,7 +134,7 @@ public class OwnedFixupTest
         principal.Child1 = dependent;
         principal.Child2 = dependent;
 
-        var dependentEntry1 = context.Entry(principal).Reference(p => p.Child1).TargetEntry;
+        var dependentEntry1 = context.Entry(principal).Reference(p => p.Child1).TargetEntry!;
 
         Assert.Same(dependentEntry1.GetInfrastructure(), context.Entry(dependent).GetInfrastructure());
 
@@ -940,7 +940,7 @@ public class OwnedFixupTest
 
         context.ChangeTracker.TrackGraph(principal, e => e.Entry.State = entityState);
 
-        var dependentEntry1 = context.Entry(principal).Reference(p => p.Child2).TargetEntry;
+        var dependentEntry1 = context.Entry(principal).Reference(p => p.Child2).TargetEntry!;
 
         var dependent2 = new ChildPN { Name = "2" };
         principal.Child2 = dependent2;
@@ -957,7 +957,7 @@ public class OwnedFixupTest
         Assert.Same(dependent2, principal.Child2);
         Assert.Equal(entityState, context.Entry(principal).State);
         Assert.Equal(entityState == EntityState.Added ? EntityState.Detached : EntityState.Deleted, dependentEntry1.State);
-        var dependentEntry2 = context.Entry(principal).Reference(p => p.Child2).TargetEntry;
+        var dependentEntry2 = context.Entry(principal).Reference(p => p.Child2).TargetEntry!;
         Assert.Equal(principal.Id, dependentEntry2.Property("ParentId").CurrentValue);
         Assert.Equal(EntityState.Added, dependentEntry2.State);
         Assert.Equal(
@@ -965,7 +965,7 @@ public class OwnedFixupTest
             dependentEntry2.Metadata.DisplayName());
 
         Assert.Same(subDependent2, dependent2.SubChild);
-        var subDependentEntry = dependentEntry2.Reference(p => p.SubChild).TargetEntry;
+        var subDependentEntry = dependentEntry2.Reference(p => p.SubChild).TargetEntry!;
         Assert.Equal(principal.Id, subDependentEntry.Property("ParentId").CurrentValue);
         Assert.Equal(EntityState.Added, subDependentEntry.State);
         Assert.Equal(
@@ -1016,7 +1016,7 @@ public class OwnedFixupTest
 
         context.ChangeTracker.TrackGraph(principal, e => e.Entry.State = entityState);
 
-        var dependentEntry1 = context.Entry(principal).Reference(p => p.Child1).TargetEntry;
+        var dependentEntry1 = context.Entry(principal).Reference(p => p.Child1).TargetEntry!;
 
         var dependent2 = new Child { Name = "2" };
         principal.Child1 = dependent2;
@@ -1036,7 +1036,7 @@ public class OwnedFixupTest
         Assert.Same(dependent2, principal.Child1);
         Assert.Equal(entityState, context.Entry(principal).State);
         Assert.Equal(entityState == EntityState.Added ? EntityState.Detached : EntityState.Deleted, dependentEntry1.State);
-        var dependentEntry2 = context.Entry(principal).Reference(p => p.Child1).TargetEntry;
+        var dependentEntry2 = context.Entry(principal).Reference(p => p.Child1).TargetEntry!;
         Assert.Equal(principal.Id, dependentEntry2.Property("ParentId").CurrentValue);
         Assert.Equal(EntityState.Added, dependentEntry2.State);
         Assert.Equal(
@@ -1148,11 +1148,11 @@ public class OwnedFixupTest
         dependent2.SubChildCollection = CreateChildCollection(collectionType, subDependent2);
 
         var dependentEntry2 = context.Entry(principal).Collection(p => p.ChildCollection2)
-            .FindEntry(dependent2);
+            .FindEntry(dependent2)!;
         dependentEntry2.Property<int>("Id").CurrentValue = dependentEntry1.Property<int>("Id").CurrentValue;
 
         var subDependentEntry2 = dependentEntry2.Collection(p => p.SubChildCollection)
-            .FindEntry(subDependent2);
+            .FindEntry(subDependent2)!;
         subDependentEntry2.Property<int>("Id").CurrentValue = subDependentEntry1.Property<int>("Id").CurrentValue;
 
         context.ChangeTracker.DetectChanges();
@@ -1255,11 +1255,11 @@ public class OwnedFixupTest
         dependent2.SubChildCollection = CreateChildCollection(collectionType, subDependent2);
 
         var dependentEntry2 = context.Entry(principal).Collection(p => p.ChildCollection1)
-            .FindEntry(dependent2);
+            .FindEntry(dependent2)!;
         dependentEntry2.Property<int>("Id").CurrentValue = dependentEntry1.Property<int>("Id").CurrentValue;
 
         var subDependentEntry2 = dependentEntry2.Collection(p => p.SubChildCollection)
-            .FindEntry(subDependent2);
+            .FindEntry(subDependent2)!;
         subDependentEntry2.Property<int>("Id").CurrentValue = subDependentEntry1.Property<int>("Id").CurrentValue;
 
         context.ChangeTracker.DetectChanges();
@@ -1339,9 +1339,9 @@ public class OwnedFixupTest
                 break;
         }
 
-        var dependentEntry1 = context.Entry(principal).Reference(p => p.Child1).TargetEntry;
+        var dependentEntry1 = context.Entry(principal).Reference(p => p.Child1).TargetEntry!;
 
-        principal.Child1 = null;
+        principal.Child1 = null!;
         principal.Child2 = dependent;
 
         context.ChangeTracker.DetectChanges();
@@ -1353,7 +1353,7 @@ public class OwnedFixupTest
         Assert.Same(dependent, principal.Child2);
         Assert.Equal(entityState, context.Entry(principal).State);
         Assert.Equal(entityState == EntityState.Added ? EntityState.Detached : EntityState.Deleted, dependentEntry1.State);
-        var dependentEntry2 = context.Entry(principal).Reference(p => p.Child2).TargetEntry;
+        var dependentEntry2 = context.Entry(principal).Reference(p => p.Child2).TargetEntry!;
         Assert.Equal(principal.Id, dependentEntry2.Property("ParentId").CurrentValue);
         Assert.Equal(EntityState.Added, dependentEntry2.State);
         Assert.Equal(
@@ -1361,7 +1361,7 @@ public class OwnedFixupTest
             dependentEntry2.Metadata.DisplayName());
 
         Assert.Same(subDependent, dependent.SubChild);
-        var subDependentEntry = dependentEntry2.Reference(p => p.SubChild).TargetEntry;
+        var subDependentEntry = dependentEntry2.Reference(p => p.SubChild).TargetEntry!;
         Assert.Equal(principal.Id, subDependentEntry.Property("ParentId").CurrentValue);
         Assert.Equal(EntityState.Added, subDependentEntry.State);
         Assert.Equal(
@@ -1412,10 +1412,10 @@ public class OwnedFixupTest
 
         context.ChangeTracker.TrackGraph(principal, e => e.Entry.State = entityState);
 
-        var dependentEntry1 = context.Entry(principal).Reference(p => p.Child2).TargetEntry;
+        var dependentEntry1 = context.Entry(principal).Reference(p => p.Child2).TargetEntry!;
 
         principal.Child1 = dependent;
-        principal.Child2 = null;
+        principal.Child2 = null!;
 
         context.ChangeTracker.DetectChanges();
 
@@ -1427,7 +1427,7 @@ public class OwnedFixupTest
         Assert.Same(dependent, principal.Child1);
         Assert.Equal(entityState, context.Entry(principal).State);
         Assert.Equal(entityState == EntityState.Added ? EntityState.Detached : EntityState.Deleted, dependentEntry1.State);
-        var dependentEntry2 = context.Entry(principal).Reference(p => p.Child1).TargetEntry;
+        var dependentEntry2 = context.Entry(principal).Reference(p => p.Child1).TargetEntry!;
         Assert.Equal(principal.Id, dependentEntry2.Property("ParentId").CurrentValue);
         Assert.Equal(EntityState.Added, dependentEntry2.State);
         Assert.Equal(
@@ -1529,10 +1529,10 @@ public class OwnedFixupTest
                 break;
         }
 
-        var dependentEntry1 = context.Entry(principal).Collection(p => p.ChildCollection1).FindEntry(dependent);
+        var dependentEntry1 = context.Entry(principal).Collection(p => p.ChildCollection1).FindEntry(dependent)!;
 
         principal.ChildCollection2 = principal.ChildCollection1;
-        principal.ChildCollection1 = null;
+        principal.ChildCollection1 = null!;
 
         context.ChangeTracker.DetectChanges();
 
@@ -1543,7 +1543,7 @@ public class OwnedFixupTest
         Assert.Contains(principal.ChildCollection2, e => ReferenceEquals(e, dependent));
         Assert.Equal(entityState, context.Entry(principal).State);
         Assert.Equal(entityState == EntityState.Added ? EntityState.Detached : EntityState.Deleted, dependentEntry1.State);
-        var dependentEntry2 = context.Entry(principal).Collection(p => p.ChildCollection2).FindEntry(dependent);
+        var dependentEntry2 = context.Entry(principal).Collection(p => p.ChildCollection2).FindEntry(dependent)!;
         Assert.Equal(principal.Id, dependentEntry2.Property("ParentId").CurrentValue);
         Assert.Equal(EntityState.Added, dependentEntry2.State);
         Assert.Equal(
@@ -1551,7 +1551,7 @@ public class OwnedFixupTest
             dependentEntry2.Metadata.DisplayName());
 
         Assert.Contains(dependent.SubChildCollection, e => ReferenceEquals(e, subDependent));
-        var subDependentEntry = dependentEntry2.Collection(p => p.SubChildCollection).FindEntry(subDependent);
+        var subDependentEntry = dependentEntry2.Collection(p => p.SubChildCollection).FindEntry(subDependent)!;
         Assert.Equal(principal.Id, subDependentEntry.Property("ParentId").CurrentValue);
         Assert.Equal(EntityState.Added, subDependentEntry.State);
         Assert.Equal(
@@ -1626,10 +1626,10 @@ public class OwnedFixupTest
                 break;
         }
 
-        var dependentEntry1 = context.Entry(principal).Collection(p => p.ChildCollection2).FindEntry(dependent);
+        var dependentEntry1 = context.Entry(principal).Collection(p => p.ChildCollection2).FindEntry(dependent)!;
 
         principal.ChildCollection1 = principal.ChildCollection2;
-        principal.ChildCollection2 = null;
+        principal.ChildCollection2 = null!;
 
         context.ChangeTracker.DetectChanges();
 
@@ -1641,7 +1641,7 @@ public class OwnedFixupTest
         Assert.Contains(principal.ChildCollection1, e => ReferenceEquals(e, dependent));
         Assert.Equal(entityState, context.Entry(principal).State);
         Assert.Equal(entityState == EntityState.Added ? EntityState.Detached : EntityState.Deleted, dependentEntry1.State);
-        var dependentEntry2 = context.Entry(principal).Collection(p => p.ChildCollection1).FindEntry(dependent);
+        var dependentEntry2 = context.Entry(principal).Collection(p => p.ChildCollection1).FindEntry(dependent)!;
         Assert.Equal(principal.Id, dependentEntry2.Property("ParentId").CurrentValue);
         Assert.Equal(EntityState.Added, dependentEntry2.State);
         Assert.Equal(
@@ -1650,7 +1650,7 @@ public class OwnedFixupTest
 
         Assert.Contains(dependent.SubChildCollection, e => ReferenceEquals(e, subDependent));
         Assert.Same(dependent, subDependent.Parent);
-        var subDependentEntry = dependentEntry2.Collection(p => p.SubChildCollection).FindEntry(subDependent);
+        var subDependentEntry = dependentEntry2.Collection(p => p.SubChildCollection).FindEntry(subDependent)!;
         Assert.Equal(principal.Id, subDependentEntry.Property("ParentId").CurrentValue);
         Assert.Equal(EntityState.Added, subDependentEntry.State);
         Assert.Equal(
@@ -1719,7 +1719,7 @@ public class OwnedFixupTest
         Assert.Same(dependent2, principal.Child1);
         Assert.Equal(entityState, context.Entry(principal).State);
 
-        var dependent1Entry = context.Entry(principal).Reference(p => p.Child1).TargetEntry;
+        var dependent1Entry = context.Entry(principal).Reference(p => p.Child1).TargetEntry!;
         Assert.Equal(principal.Id, dependent1Entry.Property("ParentId").CurrentValue);
         Assert.Equal(EntityState.Added, dependent1Entry.State);
         Assert.Equal(
@@ -1729,7 +1729,7 @@ public class OwnedFixupTest
             entityState == EntityState.Added ? null : EntityState.Deleted,
             dependent1Entry.GetInfrastructure().SharedIdentityEntry?.EntityState);
 
-        var dependent2Entry = context.Entry(principal).Reference(p => p.Child2).TargetEntry;
+        var dependent2Entry = context.Entry(principal).Reference(p => p.Child2).TargetEntry!;
         Assert.Equal(principal.Id, dependent2Entry.Property("ParentId").CurrentValue);
         Assert.Equal(EntityState.Added, dependent2Entry.State);
         Assert.Equal(
@@ -1740,7 +1740,7 @@ public class OwnedFixupTest
             dependent2Entry.GetInfrastructure().SharedIdentityEntry?.EntityState);
 
         Assert.Same(subDependent1, dependent1.SubChild);
-        var subDependentEntry1 = dependent1Entry.Reference(p => p.SubChild).TargetEntry;
+        var subDependentEntry1 = dependent1Entry.Reference(p => p.SubChild).TargetEntry!;
         Assert.Equal(principal.Id, subDependentEntry1.Property("ParentId").CurrentValue);
         Assert.Equal(EntityState.Added, subDependentEntry1.State);
         Assert.Equal(
@@ -1755,7 +1755,7 @@ public class OwnedFixupTest
             + nameof(SubChildPN), subDependentEntry1.Metadata.DisplayName());
 
         Assert.Same(subDependent2, dependent2.SubChild);
-        var subDependentEntry2 = dependent2Entry.Reference(p => p.SubChild).TargetEntry;
+        var subDependentEntry2 = dependent2Entry.Reference(p => p.SubChild).TargetEntry!;
         Assert.Equal(principal.Id, subDependentEntry2.Property("ParentId").CurrentValue);
         Assert.Equal(EntityState.Added, subDependentEntry2.State);
         Assert.Equal(
@@ -1832,7 +1832,7 @@ public class OwnedFixupTest
         Assert.Same(dependent2, principal.Child1);
         Assert.Equal(entityState, context.Entry(principal).State);
 
-        var dependent1Entry = context.Entry(principal).Reference(p => p.Child1).TargetEntry;
+        var dependent1Entry = context.Entry(principal).Reference(p => p.Child1).TargetEntry!;
         Assert.Equal(principal.Id, dependent1Entry.Property("ParentId").CurrentValue);
         Assert.Equal(EntityState.Added, dependent1Entry.State);
         Assert.Equal(
@@ -1842,7 +1842,7 @@ public class OwnedFixupTest
             entityState == EntityState.Added ? null : EntityState.Deleted,
             dependent1Entry.GetInfrastructure().SharedIdentityEntry?.EntityState);
 
-        var dependent2Entry = context.Entry(principal).Reference(p => p.Child2).TargetEntry;
+        var dependent2Entry = context.Entry(principal).Reference(p => p.Child2).TargetEntry!;
         Assert.Equal(principal.Id, dependent2Entry.Property("ParentId").CurrentValue);
         Assert.Equal(EntityState.Added, dependent2Entry.State);
         Assert.Equal(
@@ -1999,19 +1999,19 @@ public class OwnedFixupTest
         principal.ChildCollection1 = tempCollection;
 
         var newDependentEntry1 = context.Entry(principal).Collection(p => p.ChildCollection1)
-            .FindEntry(dependent2);
+            .FindEntry(dependent2)!;
         newDependentEntry1.Property<int>("Id").CurrentValue = dependentEntry2.Property<int>("Id").CurrentValue;
 
         var newDependentEntry2 = context.Entry(principal).Collection(p => p.ChildCollection2)
-            .FindEntry(dependent1);
+            .FindEntry(dependent1)!;
         newDependentEntry2.Property<int>("Id").CurrentValue = dependentEntry1.Property<int>("Id").CurrentValue;
 
         var newSubDependentEntry1 = newDependentEntry1.Collection(p => p.SubChildCollection)
-            .FindEntry(subDependent2);
+            .FindEntry(subDependent2)!;
         newSubDependentEntry1.Property<int>("Id").CurrentValue = subDependentEntry2.Property<int>("Id").CurrentValue;
 
         var newSubDependentEntry2 = newDependentEntry2.Collection(p => p.SubChildCollection)
-            .FindEntry(subDependent1);
+            .FindEntry(subDependent1)!;
         newSubDependentEntry2.Property<int>("Id").CurrentValue = subDependentEntry1.Property<int>("Id").CurrentValue;
 
         context.ChangeTracker.DetectChanges();
@@ -2150,19 +2150,19 @@ public class OwnedFixupTest
         principal.ChildCollection1 = tempCollection;
 
         var newDependentEntry1 = context.Entry(principal).Collection(p => p.ChildCollection1)
-            .FindEntry(dependent2);
+            .FindEntry(dependent2)!;
         newDependentEntry1.Property<int>("Id").CurrentValue = dependentEntry2.Property<int>("Id").CurrentValue;
 
         var newDependentEntry2 = context.Entry(principal).Collection(p => p.ChildCollection2)
-            .FindEntry(dependent1);
+            .FindEntry(dependent1)!;
         newDependentEntry2.Property<int>("Id").CurrentValue = dependentEntry1.Property<int>("Id").CurrentValue;
 
         var newSubDependentEntry1 = newDependentEntry2.Collection(p => p.SubChildCollection)
-            .FindEntry(subDependent1);
+            .FindEntry(subDependent1)!;
         newSubDependentEntry1.Property<int>("Id").CurrentValue = subDependentEntry1.Property<int>("Id").CurrentValue;
 
         var newSubDependentEntry2 = newDependentEntry1.Collection(p => p.SubChildCollection)
-            .FindEntry(subDependent2);
+            .FindEntry(subDependent2)!;
         newSubDependentEntry2.Property<int>("Id").CurrentValue = subDependentEntry2.Property<int>("Id").CurrentValue;
 
         context.ChangeTracker.DetectChanges();
@@ -2266,10 +2266,10 @@ public class OwnedFixupTest
 
         Assert.Equal(entityState != EntityState.Unchanged, context.ChangeTracker.HasChanges());
 
-        var dependentEntry1 = context.Entry(principal1).Reference(p => p.Child1).TargetEntry;
+        var dependentEntry1 = context.Entry(principal1).Reference(p => p.Child1).TargetEntry!;
 
         principal2.Child1 = dependent;
-        principal1.Child1 = null;
+        principal1.Child1 = null!;
 
         if (entityState != EntityState.Added)
         {
@@ -2292,7 +2292,7 @@ public class OwnedFixupTest
             Assert.Equal(entityState, context.Entry(principal2).State);
             Assert.Equal(EntityState.Detached, dependentEntry1.State);
 
-            var dependentEntry2 = context.Entry(principal2).Reference(p => p.Child1).TargetEntry;
+            var dependentEntry2 = context.Entry(principal2).Reference(p => p.Child1).TargetEntry!;
             Assert.Equal(principal2.Id, dependentEntry2.Property("ParentId").CurrentValue);
             Assert.Equal(EntityState.Added, dependentEntry2.State);
             Assert.Equal(
@@ -2300,7 +2300,7 @@ public class OwnedFixupTest
                 dependentEntry2.Metadata.DisplayName());
 
             Assert.Same(subDependent, dependent.SubChild);
-            var subDependentEntry = dependentEntry2.Reference(p => p.SubChild).TargetEntry;
+            var subDependentEntry = dependentEntry2.Reference(p => p.SubChild).TargetEntry!;
             Assert.Equal(principal2.Id, subDependentEntry.Property("ParentId").CurrentValue);
             Assert.Equal(EntityState.Added, subDependentEntry.State);
             Assert.Equal(
@@ -2359,10 +2359,10 @@ public class OwnedFixupTest
 
         Assert.Equal(entityState != EntityState.Unchanged, context.ChangeTracker.HasChanges());
 
-        var dependentEntry1 = context.Entry(principal1).Reference(p => p.Child1).TargetEntry;
+        var dependentEntry1 = context.Entry(principal1).Reference(p => p.Child1).TargetEntry!;
 
         principal2.Child1 = dependent;
-        principal1.Child1 = null;
+        principal1.Child1 = null!;
 
         if (entityState != EntityState.Added)
         {
@@ -2385,7 +2385,7 @@ public class OwnedFixupTest
             Assert.Equal(entityState, context.Entry(principal1).State);
             Assert.Equal(entityState, context.Entry(principal2).State);
             Assert.Equal(EntityState.Detached, dependentEntry1.State);
-            var dependentEntry2 = context.Entry(principal2).Reference(p => p.Child1).TargetEntry;
+            var dependentEntry2 = context.Entry(principal2).Reference(p => p.Child1).TargetEntry!;
             Assert.Equal(EntityState.Added, dependentEntry2.State);
             Assert.Equal(principal2.Id, dependentEntry2.Property("ParentId").CurrentValue);
             Assert.Equal(
@@ -2503,7 +2503,7 @@ public class OwnedFixupTest
         var subDependentEntry1 = context.Entry(subDependent);
 
         principal2.ChildCollection1 = principal1.ChildCollection1;
-        principal1.ChildCollection1 = null;
+        principal1.ChildCollection1 = null!;
 
         if (entityState != EntityState.Added)
         {
@@ -2527,7 +2527,7 @@ public class OwnedFixupTest
             Assert.Equal(EntityState.Detached, dependentEntry1.State);
 
             var dependentEntry2 = context.Entry(principal2).Collection(p => p.ChildCollection1)
-                .FindEntry(dependent);
+                .FindEntry(dependent)!;
             Assert.Equal(principal2.Id, dependentEntry2.Property("ParentId").CurrentValue);
             Assert.Equal(EntityState.Added, dependentEntry2.State);
             Assert.Equal(
@@ -2536,7 +2536,7 @@ public class OwnedFixupTest
 
             Assert.Contains(dependent.SubChildCollection, e => ReferenceEquals(e, subDependent));
             var subDependentEntry2 = dependentEntry2.Collection(p => p.SubChildCollection)
-                .FindEntry(subDependent);
+                .FindEntry(subDependent)!;
             Assert.Equal(principal2.Id, subDependentEntry2.Property("ParentId").CurrentValue);
             Assert.Equal(EntityState.Added, subDependentEntry2.State);
             Assert.Equal(
@@ -2625,7 +2625,7 @@ public class OwnedFixupTest
         var subDependentEntry1 = context.Entry(subDependent);
 
         principal2.ChildCollection1 = principal1.ChildCollection1;
-        principal1.ChildCollection1 = null;
+        principal1.ChildCollection1 = null!;
 
         if (entityState != EntityState.Added)
         {
@@ -2650,7 +2650,7 @@ public class OwnedFixupTest
             Assert.Equal(EntityState.Detached, dependentEntry1.State);
 
             var dependentEntry2 = context.Entry(principal2).Collection(p => p.ChildCollection1)
-                .FindEntry(dependent);
+                .FindEntry(dependent)!;
             Assert.Equal(EntityState.Added, dependentEntry2.State);
             Assert.Equal(principal2.Id, dependentEntry2.Property("ParentId").CurrentValue);
             Assert.Equal(
@@ -2660,7 +2660,7 @@ public class OwnedFixupTest
             Assert.Contains(dependent.SubChildCollection, e => ReferenceEquals(e, subDependent));
             Assert.Same(dependent, subDependent.Parent);
             var subDependentEntry2 = dependentEntry2.Collection(p => p.SubChildCollection)
-                .FindEntry(subDependent);
+                .FindEntry(subDependent)!;
             Assert.Equal(principal2.Id, subDependentEntry2.Property("ParentId").CurrentValue);
             Assert.Equal(EntityState.Added, subDependentEntry2.State);
             Assert.Equal(
@@ -2748,14 +2748,14 @@ public class OwnedFixupTest
             Assert.Equal(entityState, context.Entry(principal1).State);
             Assert.Equal(entityState, context.Entry(principal2).State);
 
-            var dependent1Entry = context.Entry(principal1).Reference(p => p.Child1).TargetEntry;
+            var dependent1Entry = context.Entry(principal1).Reference(p => p.Child1).TargetEntry!;
             Assert.Equal(principal1.Id, dependent1Entry.Property("ParentId").CurrentValue);
             Assert.Equal(entityState == EntityState.Added ? EntityState.Added : EntityState.Modified, dependent1Entry.State);
             Assert.Equal(
                 typeof(ParentPN).ShortDisplayName() + "." + nameof(ParentPN.Child1) + "#" + nameof(ChildPN),
                 dependent1Entry.Metadata.DisplayName());
 
-            var dependent2Entry = context.Entry(principal2).Reference(p => p.Child1).TargetEntry;
+            var dependent2Entry = context.Entry(principal2).Reference(p => p.Child1).TargetEntry!;
             Assert.Equal(principal2.Id, dependent2Entry.Property("ParentId").CurrentValue);
             Assert.Equal(entityState == EntityState.Added ? EntityState.Added : EntityState.Modified, dependent2Entry.State);
             Assert.Equal(
@@ -2763,7 +2763,7 @@ public class OwnedFixupTest
                 dependent2Entry.Metadata.DisplayName());
 
             Assert.Same(subDependent1, dependent1.SubChild);
-            var subDependentEntry1 = dependent1Entry.Reference(p => p.SubChild).TargetEntry;
+            var subDependentEntry1 = dependent1Entry.Reference(p => p.SubChild).TargetEntry!;
             Assert.Equal(principal1.Id, subDependentEntry1.Property("ParentId").CurrentValue);
             Assert.Equal(EntityState.Added, subDependentEntry1.State);
             Assert.Equal(
@@ -2779,7 +2779,7 @@ public class OwnedFixupTest
                 subDependentEntry1.Metadata.DisplayName());
 
             Assert.Same(subDependent2, dependent2.SubChild);
-            var subDependentEntry2 = dependent2Entry.Reference(p => p.SubChild).TargetEntry;
+            var subDependentEntry2 = dependent2Entry.Reference(p => p.SubChild).TargetEntry!;
             Assert.Equal(principal2.Id, subDependentEntry2.Property("ParentId").CurrentValue);
             Assert.Equal(EntityState.Added, subDependentEntry2.State);
             Assert.Equal(
@@ -2874,14 +2874,14 @@ public class OwnedFixupTest
             Assert.Equal(entityState, context.Entry(principal1).State);
             Assert.Equal(entityState, context.Entry(principal2).State);
 
-            var dependent1Entry = context.Entry(principal1).Reference(p => p.Child1).TargetEntry;
+            var dependent1Entry = context.Entry(principal1).Reference(p => p.Child1).TargetEntry!;
             Assert.Equal(entityState == EntityState.Added ? EntityState.Added : EntityState.Modified, dependent1Entry.State);
             Assert.Equal(principal1.Id, dependent1Entry.Property("ParentId").CurrentValue);
             Assert.Equal(
                 typeof(Parent).ShortDisplayName() + "." + nameof(Parent.Child1) + "#" + nameof(Child),
                 dependent1Entry.Metadata.DisplayName());
 
-            var dependent2Entry = context.Entry(principal2).Reference(p => p.Child1).TargetEntry;
+            var dependent2Entry = context.Entry(principal2).Reference(p => p.Child1).TargetEntry!;
             Assert.Equal(principal2.Id, dependent2Entry.Property("ParentId").CurrentValue);
             Assert.Equal(entityState == EntityState.Added ? EntityState.Added : EntityState.Modified, dependent2Entry.State);
             Assert.Equal(
@@ -3069,7 +3069,7 @@ public class OwnedFixupTest
             Assert.Equal(entityState, context.Entry(principal2).State);
 
             var newDependentEntry2 = context.Entry(principal1).Collection(p => p.ChildCollection1)
-                .FindEntry(dependent2);
+                .FindEntry(dependent2)!;
             Assert.Equal(principal1.Id, newDependentEntry2.Property("ParentId").CurrentValue);
             Assert.Equal(entityState == EntityState.Added ? EntityState.Added : EntityState.Modified, newDependentEntry2.State);
             Assert.Equal(
@@ -3077,7 +3077,7 @@ public class OwnedFixupTest
                 newDependentEntry2.Metadata.DisplayName());
 
             var newDependentEntry1 = context.Entry(principal2).Collection(p => p.ChildCollection1)
-                .FindEntry(dependent1);
+                .FindEntry(dependent1)!;
             Assert.Equal(principal2.Id, newDependentEntry1.Property("ParentId").CurrentValue);
             Assert.Equal(entityState == EntityState.Added ? EntityState.Added : EntityState.Modified, newDependentEntry1.State);
             Assert.Equal(
@@ -3086,7 +3086,7 @@ public class OwnedFixupTest
 
             Assert.Contains(dependent1.SubChildCollection, e => ReferenceEquals(e, subDependent1));
             var newSubDependentEntry1 = newDependentEntry1.Collection(p => p.SubChildCollection)
-                .FindEntry(subDependent1);
+                .FindEntry(subDependent1)!;
             Assert.Equal(principal2.Id, newSubDependentEntry1.Property("ParentId").CurrentValue);
             Assert.Equal(EntityState.Added, newSubDependentEntry1.State);
             Assert.Equal(
@@ -3102,7 +3102,7 @@ public class OwnedFixupTest
 
             Assert.Contains(dependent2.SubChildCollection, e => ReferenceEquals(e, subDependent2));
             var newSubDependentEntry2 = newDependentEntry2.Collection(p => p.SubChildCollection)
-                .FindEntry(subDependent2);
+                .FindEntry(subDependent2)!;
             Assert.Equal(principal1.Id, newSubDependentEntry2.Property("ParentId").CurrentValue);
             Assert.Equal(EntityState.Added, newSubDependentEntry2.State);
             Assert.Equal(
@@ -3225,7 +3225,7 @@ public class OwnedFixupTest
             Assert.Equal(entityState, context.Entry(principal2).State);
 
             var newDependentEntry2 = context.Entry(principal1).Collection(p => p.ChildCollection1)
-                .FindEntry(dependent2);
+                .FindEntry(dependent2)!;
             Assert.Equal(entityState == EntityState.Added ? EntityState.Added : EntityState.Modified, newDependentEntry2.State);
             Assert.Equal(principal1.Id, newDependentEntry2.Property("ParentId").CurrentValue);
             Assert.Equal(
@@ -3233,7 +3233,7 @@ public class OwnedFixupTest
                 newDependentEntry2.Metadata.DisplayName());
 
             var newDependentEntry1 = context.Entry(principal2).Collection(p => p.ChildCollection1)
-                .FindEntry(dependent1);
+                .FindEntry(dependent1)!;
             Assert.Equal(principal2.Id, newDependentEntry1.Property("ParentId").CurrentValue);
             Assert.Equal(entityState == EntityState.Added ? EntityState.Added : EntityState.Modified, newDependentEntry1.State);
             Assert.Equal(
@@ -3243,7 +3243,7 @@ public class OwnedFixupTest
             Assert.Contains(dependent1.SubChildCollection, e => ReferenceEquals(e, subDependent1));
             Assert.Same(dependent1, subDependent1.Parent);
             var newSubDependentEntry1 = newDependentEntry1.Collection(p => p.SubChildCollection)
-                .FindEntry(subDependent1);
+                .FindEntry(subDependent1)!;
             Assert.Equal(principal2.Id, newSubDependentEntry1.Property("ParentId").CurrentValue);
             Assert.Equal(EntityState.Added, newSubDependentEntry1.State);
             Assert.Equal(
@@ -3261,7 +3261,7 @@ public class OwnedFixupTest
             Assert.Contains(dependent2.SubChildCollection, e => ReferenceEquals(e, subDependent2));
             Assert.Same(dependent2, subDependent2.Parent);
             var newSubDependentEntry2 = newDependentEntry2.Collection(p => p.SubChildCollection)
-                .FindEntry(subDependent2);
+                .FindEntry(subDependent2)!;
             Assert.Equal(principal1.Id, newSubDependentEntry2.Property("ParentId").CurrentValue);
             Assert.Equal(EntityState.Added, newSubDependentEntry2.State);
             Assert.Equal(
@@ -3321,10 +3321,10 @@ public class OwnedFixupTest
 
         Assert.Equal(entityState != EntityState.Unchanged, context.ChangeTracker.HasChanges());
 
-        var dependentEntry1 = context.Entry(principal1).Reference(p => p.Child2).TargetEntry;
+        var dependentEntry1 = context.Entry(principal1).Reference(p => p.Child2).TargetEntry!;
 
         principal2.Child1 = dependent;
-        principal1.Child2 = null;
+        principal1.Child2 = null!;
 
         context.ChangeTracker.DetectChanges();
 
@@ -3338,7 +3338,7 @@ public class OwnedFixupTest
         Assert.Equal(entityState, context.Entry(principal1).State);
         Assert.Equal(entityState, context.Entry(principal2).State);
         Assert.Equal(entityState == EntityState.Added ? EntityState.Detached : EntityState.Deleted, dependentEntry1.State);
-        var dependentEntry2 = context.Entry(principal2).Reference(p => p.Child1).TargetEntry;
+        var dependentEntry2 = context.Entry(principal2).Reference(p => p.Child1).TargetEntry!;
         Assert.Equal(principal2.Id, dependentEntry2.Property("ParentId").CurrentValue);
         Assert.Equal(EntityState.Added, dependentEntry2.State);
         Assert.Equal(
@@ -3346,7 +3346,7 @@ public class OwnedFixupTest
             dependentEntry2.Metadata.DisplayName());
 
         Assert.Same(subDependent, dependent.SubChild);
-        var subDependentEntry = dependentEntry2.Reference(p => p.SubChild).TargetEntry;
+        var subDependentEntry = dependentEntry2.Reference(p => p.SubChild).TargetEntry!;
         Assert.Equal(principal2.Id, subDependentEntry.Property("ParentId").CurrentValue);
         Assert.Equal(EntityState.Added, subDependentEntry.State);
         Assert.Equal(
@@ -3405,10 +3405,10 @@ public class OwnedFixupTest
 
         Assert.Equal(entityState != EntityState.Unchanged, context.ChangeTracker.HasChanges());
 
-        var dependentEntry1 = context.Entry(principal1).Reference(p => p.Child2).TargetEntry;
+        var dependentEntry1 = context.Entry(principal1).Reference(p => p.Child2).TargetEntry!;
 
         principal2.Child1 = dependent;
-        principal1.Child2 = null;
+        principal1.Child2 = null!;
 
         if (entityState != EntityState.Added)
         {
@@ -3431,7 +3431,7 @@ public class OwnedFixupTest
         Assert.Equal(entityState, context.Entry(principal1).State);
         Assert.Equal(entityState, context.Entry(principal2).State);
         Assert.Equal(EntityState.Detached, dependentEntry1.State);
-        var dependentEntry2 = context.Entry(principal2).Reference(p => p.Child1).TargetEntry;
+        var dependentEntry2 = context.Entry(principal2).Reference(p => p.Child1).TargetEntry!;
         Assert.Equal(principal2.Id, dependentEntry2.Property("ParentId").CurrentValue);
         Assert.Equal(EntityState.Added, dependentEntry2.State);
         Assert.Equal(
@@ -3544,10 +3544,10 @@ public class OwnedFixupTest
 
         Assert.Equal(entityState != EntityState.Unchanged, context.ChangeTracker.HasChanges());
 
-        var dependentEntry1 = context.Entry(principal1).Collection(p => p.ChildCollection2).FindEntry(dependent);
+        var dependentEntry1 = context.Entry(principal1).Collection(p => p.ChildCollection2).FindEntry(dependent)!;
 
         principal2.ChildCollection1 = principal1.ChildCollection2;
-        principal1.ChildCollection2 = null;
+        principal1.ChildCollection2 = null!;
 
         context.ChangeTracker.DetectChanges();
 
@@ -3561,7 +3561,7 @@ public class OwnedFixupTest
         Assert.Equal(entityState, context.Entry(principal1).State);
         Assert.Equal(entityState, context.Entry(principal2).State);
         Assert.Equal(entityState == EntityState.Added ? EntityState.Detached : EntityState.Deleted, dependentEntry1.State);
-        var dependentEntry2 = context.Entry(principal2).Collection(p => p.ChildCollection1).FindEntry(dependent);
+        var dependentEntry2 = context.Entry(principal2).Collection(p => p.ChildCollection1).FindEntry(dependent)!;
         Assert.Equal(principal2.Id, dependentEntry2.Property("ParentId").CurrentValue);
         Assert.Equal(EntityState.Added, dependentEntry2.State);
         Assert.Equal(
@@ -3569,7 +3569,7 @@ public class OwnedFixupTest
             dependentEntry2.Metadata.DisplayName());
 
         Assert.Contains(dependent.SubChildCollection, e => ReferenceEquals(e, subDependent));
-        var subDependentEntry = dependentEntry2.Collection(p => p.SubChildCollection).FindEntry(subDependent);
+        var subDependentEntry = dependentEntry2.Collection(p => p.SubChildCollection).FindEntry(subDependent)!;
         Assert.Equal(principal2.Id, subDependentEntry.Property("ParentId").CurrentValue);
         Assert.Equal(EntityState.Added, subDependentEntry.State);
         Assert.Equal(
@@ -3653,10 +3653,10 @@ public class OwnedFixupTest
 
         Assert.Equal(entityState != EntityState.Unchanged, context.ChangeTracker.HasChanges());
 
-        var dependentEntry1 = context.Entry(principal1).Collection(p => p.ChildCollection2).FindEntry(dependent);
+        var dependentEntry1 = context.Entry(principal1).Collection(p => p.ChildCollection2).FindEntry(dependent)!;
 
         principal2.ChildCollection1 = principal1.ChildCollection2;
-        principal1.ChildCollection2 = null;
+        principal1.ChildCollection2 = null!;
 
         if (entityState != EntityState.Added)
         {
@@ -3679,7 +3679,7 @@ public class OwnedFixupTest
         Assert.Equal(entityState, context.Entry(principal1).State);
         Assert.Equal(entityState, context.Entry(principal2).State);
         Assert.Equal(entityState == EntityState.Added ? EntityState.Detached : EntityState.Deleted, dependentEntry1.State);
-        var dependentEntry2 = context.Entry(principal2).Collection(p => p.ChildCollection1).FindEntry(dependent);
+        var dependentEntry2 = context.Entry(principal2).Collection(p => p.ChildCollection1).FindEntry(dependent)!;
         Assert.Equal(principal2.Id, dependentEntry2.Property("ParentId").CurrentValue);
         Assert.Equal(EntityState.Added, dependentEntry2.State);
         Assert.Equal(
@@ -3688,7 +3688,7 @@ public class OwnedFixupTest
 
         Assert.Contains(dependent.SubChildCollection, e => ReferenceEquals(e, subDependent));
         Assert.Same(dependent, subDependent.Parent);
-        var subDependentEntry = dependentEntry2.Collection(p => p.SubChildCollection).FindEntry(subDependent);
+        var subDependentEntry = dependentEntry2.Collection(p => p.SubChildCollection).FindEntry(subDependent)!;
         Assert.Equal(principal2.Id, subDependentEntry.Property("ParentId").CurrentValue);
         Assert.Equal(EntityState.Added, subDependentEntry.State);
         Assert.Equal(
@@ -3765,7 +3765,7 @@ public class OwnedFixupTest
         Assert.Equal(entityState, context.Entry(principal1).State);
         Assert.Equal(entityState, context.Entry(principal2).State);
 
-        var dependent1Entry = context.Entry(principal1).Reference(p => p.Child2).TargetEntry;
+        var dependent1Entry = context.Entry(principal1).Reference(p => p.Child2).TargetEntry!;
         Assert.Equal(EntityState.Added, dependent1Entry.State);
         Assert.Equal(principal1.Id, dependent1Entry.Property("ParentId").CurrentValue);
         Assert.Equal(
@@ -3775,7 +3775,7 @@ public class OwnedFixupTest
             entityState == EntityState.Added ? null : EntityState.Deleted,
             dependent1Entry.GetInfrastructure().SharedIdentityEntry?.EntityState);
 
-        var dependent2Entry = context.Entry(principal2).Reference(p => p.Child1).TargetEntry;
+        var dependent2Entry = context.Entry(principal2).Reference(p => p.Child1).TargetEntry!;
         Assert.Equal(principal2.Id, dependent2Entry.Property("ParentId").CurrentValue);
         Assert.Equal(EntityState.Added, dependent2Entry.State);
         Assert.Equal(
@@ -3786,7 +3786,7 @@ public class OwnedFixupTest
             dependent2Entry.GetInfrastructure().SharedIdentityEntry?.EntityState);
 
         Assert.Same(subDependent1, dependent1.SubChild);
-        var subDependentEntry1 = dependent1Entry.Reference(p => p.SubChild).TargetEntry;
+        var subDependentEntry1 = dependent1Entry.Reference(p => p.SubChild).TargetEntry!;
         Assert.Equal(principal1.Id, subDependentEntry1.Property("ParentId").CurrentValue);
         Assert.Equal(EntityState.Added, subDependentEntry1.State);
         Assert.Equal(
@@ -3801,7 +3801,7 @@ public class OwnedFixupTest
             + nameof(SubChildPN), subDependentEntry1.Metadata.DisplayName());
 
         Assert.Same(subDependent2, dependent2.SubChild);
-        var subDependentEntry2 = dependent2Entry.Reference(p => p.SubChild).TargetEntry;
+        var subDependentEntry2 = dependent2Entry.Reference(p => p.SubChild).TargetEntry!;
         Assert.Equal(principal2.Id, subDependentEntry2.Property("ParentId").CurrentValue);
         Assert.Equal(EntityState.Added, subDependentEntry2.State);
         Assert.Equal(
@@ -3882,7 +3882,7 @@ public class OwnedFixupTest
         Assert.Equal(entityState, context.Entry(principal1).State);
         Assert.Equal(entityState, context.Entry(principal2).State);
 
-        var dependent1Entry = context.Entry(principal1).Reference(p => p.Child2).TargetEntry;
+        var dependent1Entry = context.Entry(principal1).Reference(p => p.Child2).TargetEntry!;
         Assert.Equal(EntityState.Added, dependent1Entry.State);
         Assert.Equal(principal1.Id, dependent1Entry.Property("ParentId").CurrentValue);
         Assert.Equal(
@@ -3892,7 +3892,7 @@ public class OwnedFixupTest
             entityState == EntityState.Added ? null : EntityState.Deleted,
             dependent1Entry.GetInfrastructure().SharedIdentityEntry?.EntityState);
 
-        var dependent2Entry = context.Entry(principal2).Reference(p => p.Child1).TargetEntry;
+        var dependent2Entry = context.Entry(principal2).Reference(p => p.Child1).TargetEntry!;
         Assert.Equal(principal2.Id, dependent2Entry.Property("ParentId").CurrentValue);
         Assert.Equal(EntityState.Added, dependent2Entry.State);
         Assert.Equal(
@@ -3904,7 +3904,7 @@ public class OwnedFixupTest
 
         Assert.Same(subDependent1, dependent1.SubChild1);
         Assert.Same(dependent1, subDependent1.Parent);
-        var subDependentEntry1 = dependent1Entry.Reference(p => p.SubChild1).TargetEntry;
+        var subDependentEntry1 = dependent1Entry.Reference(p => p.SubChild1).TargetEntry!;
         Assert.Equal(principal1.Id, subDependentEntry1.Property("ParentId").CurrentValue);
         Assert.Equal(EntityState.Added, subDependentEntry1.State);
         Assert.Equal(
@@ -3920,7 +3920,7 @@ public class OwnedFixupTest
 
         Assert.Same(subDependent2, dependent2.SubChild1);
         Assert.Same(dependent2, subDependent2.Parent);
-        var subDependentEntry2 = dependent2Entry.Reference(p => p.SubChild1).TargetEntry;
+        var subDependentEntry2 = dependent2Entry.Reference(p => p.SubChild1).TargetEntry!;
         Assert.Equal(principal2.Id, subDependentEntry2.Property("ParentId").CurrentValue);
         Assert.Equal(EntityState.Added, subDependentEntry2.State);
         Assert.Equal(
@@ -4024,19 +4024,19 @@ public class OwnedFixupTest
         principal1.ChildCollection2 = tempCollection;
 
         var newDependentEntry1 = context.Entry(principal2).Collection(p => p.ChildCollection1)
-            .FindEntry(dependent1);
+            .FindEntry(dependent1)!;
         newDependentEntry1.Property<int>("Id").CurrentValue = dependentEntry1.Property<int>("Id").CurrentValue;
 
         var newDependentEntry2 = context.Entry(principal1).Collection(p => p.ChildCollection2)
-            .FindEntry(dependent2);
+            .FindEntry(dependent2)!;
         newDependentEntry2.Property<int>("Id").CurrentValue = dependentEntry2.Property<int>("Id").CurrentValue;
 
         var newSubDependentEntry1 = newDependentEntry1.Collection(p => p.SubChildCollection)
-            .FindEntry(subDependent1);
+            .FindEntry(subDependent1)!;
         newSubDependentEntry1.Property<int>("Id").CurrentValue = subDependentEntry1.Property<int>("Id").CurrentValue;
 
         var newSubDependentEntry2 = newDependentEntry2.Collection(p => p.SubChildCollection)
-            .FindEntry(subDependent2);
+            .FindEntry(subDependent2)!;
         newSubDependentEntry2.Property<int>("Id").CurrentValue = subDependentEntry2.Property<int>("Id").CurrentValue;
 
         Assert.Equal(entityState != EntityState.Unchanged, context.ChangeTracker.HasChanges());
@@ -4187,19 +4187,19 @@ public class OwnedFixupTest
         principal1.ChildCollection2 = tempCollection;
 
         var newDependentEntry1 = context.Entry(principal2).Collection(p => p.ChildCollection1)
-            .FindEntry(dependent1);
+            .FindEntry(dependent1)!;
         newDependentEntry1.Property<int>("Id").CurrentValue = dependentEntry1.Property<int>("Id").CurrentValue;
 
         var newDependentEntry2 = context.Entry(principal1).Collection(p => p.ChildCollection2)
-            .FindEntry(dependent2);
+            .FindEntry(dependent2)!;
         newDependentEntry2.Property<int>("Id").CurrentValue = dependentEntry2.Property<int>("Id").CurrentValue;
 
         var newSubDependentEntry1 = newDependentEntry1.Collection(p => p.SubChildCollection)
-            .FindEntry(subDependent1);
+            .FindEntry(subDependent1)!;
         newSubDependentEntry1.Property<int>("Id").CurrentValue = subDependentEntry1.Property<int>("Id").CurrentValue;
 
         var newSubDependentEntry2 = newDependentEntry2.Collection(p => p.SubChildCollection)
-            .FindEntry(subDependent2);
+            .FindEntry(subDependent2)!;
         newSubDependentEntry2.Property<int>("Id").CurrentValue = subDependentEntry2.Property<int>("Id").CurrentValue;
 
         if (entityState != EntityState.Added)
@@ -4353,9 +4353,9 @@ public class OwnedFixupTest
         var newChild = new Child
         {
             Name = "n1",
-            SubChild1 = null1 ? null : newSubChild1,
-            SubChild2 = null2 ? null : newSubChild2,
-            SubChildCollection = nullC ? null : newSubChildCollection
+            SubChild1 = null1 ? null! : newSubChild1,
+            SubChild2 = null2 ? null! : newSubChild2,
+            SubChildCollection = nullC ? null! : newSubChildCollection
         };
 
         principal.Child1 = newChild;
@@ -4450,14 +4450,14 @@ public class OwnedFixupTest
     private class Product
     {
         public int Id { get; set; }
-        public string Name { get; set; }
-        public ProductDetails Details { get; set; }
+        public string Name { get; set; } = null!;
+        public ProductDetails Details { get; set; } = null!;
     }
 
     private class ProductDetails
     {
-        public string Color { get; set; }
-        public string Size { get; set; }
+        public string Color { get; set; } = null!;
+        public string Size { get; set; } = null!;
     }
 
     private class OwnedModifiedContext(string databaseName) : DbContext
@@ -4510,14 +4510,14 @@ public class OwnedFixupTest
 
     private class StreetAddress
     {
-        public string Street { get; set; }
-        public string City { get; set; }
+        public string Street { get; set; } = null!;
+        public string City { get; set; } = null!;
     }
 
     private class Distributor
     {
         public int Id { get; set; }
-        public ICollection<StreetAddress> ShippingCenters { get; set; }
+        public ICollection<StreetAddress> ShippingCenters { get; set; } = null!;
     }
 
     private class StreetContext(string databaseName) : DbContext
@@ -4707,7 +4707,7 @@ public class OwnedFixupTest
     {
         public long BookId { get; set; }
         public int Pages { get; set; }
-        public Info EnglishInfo { get; set; }
+        public Info EnglishInfo { get; set; } = null!;
 
         public static void OnModelCreating(ModelBuilder modelBuilder)
         {
@@ -4721,7 +4721,7 @@ public class OwnedFixupTest
 
     private class Info
     {
-        public string Title { get; set; }
+        public string Title { get; set; } = null!;
 
         public static void OnModelCreating<T>(OwnedNavigationBuilder<T, Info> rob)
             where T : class
@@ -4732,7 +4732,7 @@ public class OwnedFixupTest
     {
         private readonly string _databaseName = databaseName;
 
-        public DbSet<Book> Books { get; set; }
+        public DbSet<Book> Books { get; set; } = null!;
 
         protected internal override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
             => optionsBuilder.UseInMemoryDatabase(_databaseName);
@@ -4777,23 +4777,23 @@ public class OwnedFixupTest
     private class TestOrder
     {
         public int Id { get; set; }
-        public string CustomerName { get; set; }
+        public string CustomerName { get; set; } = null!;
 
-        public IList<TestOrderItem> TestOrderItems { get; set; }
+        public IList<TestOrderItem> TestOrderItems { get; set; } = null!;
     }
 
     private class TestOrderItem
     {
         public int Id { get; set; }
         public int TestOrderId { get; set; }
-        public string ProductName { get; set; }
-        public TestMoney Price { get; set; }
+        public string ProductName { get; set; } = null!;
+        public TestMoney Price { get; set; } = null!;
     }
 
     private class TestMoney
     {
         public double Amount { get; set; }
-        public TestCurrency Currency { get; set; }
+        public TestCurrency Currency { get; set; } = null!;
     }
 
     private class TestCurrency
@@ -4814,8 +4814,8 @@ public class OwnedFixupTest
         }
 
         public int Id { get; }
-        public string Name { get; }
-        public string Code { get; }
+        public string Name { get; } = null!;
+        public string Code { get; } = null!;
         public int NumericCode { get; }
     }
 
@@ -4826,7 +4826,7 @@ public class OwnedFixupTest
         protected internal override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
             => optionsBuilder.UseInMemoryDatabase(_databaseName);
 
-        public DbSet<TestOrder> TestOrders { get; set; }
+        public DbSet<TestOrder> TestOrders { get; set; } = null!;
 
         protected internal override void OnModelCreating(ModelBuilder modelBuilder)
         {
@@ -4911,7 +4911,7 @@ public class OwnedFixupTest
                         ip.Property(p => p.Amount).IsRequired();
                         ip.Property(p => p.Currency).HasConversion(
                             v => v.Code,
-                            v => v == "EUR" ? TestCurrency.EUR : v == "USD" ? TestCurrency.USD : null);
+                            v => v == "EUR" ? TestCurrency.EUR : v == "USD" ? TestCurrency.USD : null!);
                     }).HasKey(oi => oi.Id);
         }
     }
@@ -4919,12 +4919,12 @@ public class OwnedFixupTest
     [Fact]
     public void Equatable_entities_that_comply_are_tracked_correctly()
     {
-        EntityState GetEntryState<TEntity>(EquatableEntitiesContext context, string role = null)
+        EntityState GetEntryState<TEntity>(EquatableEntitiesContext context, string? role = null)
             where TEntity : class
             => context
                 .ChangeTracker
                 .Entries<TEntity>()
-                .Single(e => role == null || e.Property("Value").CurrentValue.Equals(role))
+            .Single(e => role == null || e.Property("Value").CurrentValue!.Equals(role))
                 .State;
 
         using (var context = new EquatableEntitiesContext("EquatableEntities"))
@@ -5121,7 +5121,7 @@ public class OwnedFixupTest
         protected internal override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
             => optionsBuilder.UseInMemoryDatabase(nameof(OneRowContext) + _async);
 
-        public DbSet<Blog> Blogs { get; set; }
+        public DbSet<Blog> Blogs { get; set; } = null!;
     }
 
     public class Blog
@@ -5129,13 +5129,13 @@ public class OwnedFixupTest
         [DatabaseGenerated(DatabaseGeneratedOption.None)]
         public int Id { get; set; }
 
-        public OwnedType Type { get; set; }
+        public OwnedType Type { get; set; } = null!;
     }
 
     [Owned]
     public class OwnedType
     {
-        public string Value { get; set; }
+        public string Value { get; set; } = null!;
     }
 
     private class User
@@ -5163,10 +5163,10 @@ public class OwnedFixupTest
     private class Role : IEquatable<Role>
     {
         private Guid RoleAssignmentId { get; set; }
-        public string Value { get; set; }
+        public string Value { get; set; } = null!;
 
-        public bool Equals(Role other)
-            => Value == other.Value;
+        public bool Equals(Role? other)
+            => Value == other!.Value;
     }
 
     private class EquatableEntitiesContext(string databaseName) : DbContext
@@ -5197,15 +5197,15 @@ public class OwnedFixupTest
     {
         public int Id { get; set; }
 
-        public Child Child1 { get; set; }
-        public Child Child2 { get; set; }
-        public ICollection<Child> ChildCollection1 { get; set; }
-        public ICollection<Child> ChildCollection2 { get; set; }
+        public Child Child1 { get; set; } = null!;
+        public Child Child2 { get; set; } = null!;
+        public ICollection<Child> ChildCollection1 { get; set; } = null!;
+        public ICollection<Child> ChildCollection2 { get; set; } = null!;
 
-        public int CompareTo(Parent other)
-            => Id - other.Id;
+        public int CompareTo(Parent? other)
+            => Id - other!.Id;
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             Assert.False(true);
             return false;
@@ -5232,17 +5232,17 @@ public class OwnedFixupTest
 
     private class Child : IComparable<Child>
     {
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
 
-        public Parent Parent { get; set; }
-        public SubChild SubChild1 { get; set; }
-        public SubChild SubChild2 { get; set; }
-        public ICollection<SubChild> SubChildCollection { get; set; }
+        public Parent Parent { get; set; } = null!;
+        public SubChild SubChild1 { get; set; } = null!;
+        public SubChild SubChild2 { get; set; } = null!;
+        public ICollection<SubChild> SubChildCollection { get; set; } = null!;
 
-        public int CompareTo(Child other)
-            => StringComparer.InvariantCulture.Compare(Name, other.Name);
+        public int CompareTo(Child? other)
+            => StringComparer.InvariantCulture.Compare(Name, other!.Name);
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             Assert.False(true);
             return false;
@@ -5271,14 +5271,14 @@ public class OwnedFixupTest
     private class SubChild : IComparable<SubChild>
     {
         // ReSharper disable once UnusedMember.Local
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
 
-        public Child Parent { get; set; }
+        public Child Parent { get; set; } = null!;
 
-        public int CompareTo(SubChild other)
-            => StringComparer.InvariantCulture.Compare(Name, other.Name);
+        public int CompareTo(SubChild? other)
+            => StringComparer.InvariantCulture.Compare(Name, other!.Name);
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             Assert.False(true);
             return false;
@@ -5307,33 +5307,33 @@ public class OwnedFixupTest
     {
         public int Id { get; set; }
 
-        public ChildPN Child1 { get; set; }
-        public ChildPN Child2 { get; set; }
-        public ICollection<ChildPN> ChildCollection1 { get; set; }
-        public ICollection<ChildPN> ChildCollection2 { get; set; }
+        public ChildPN Child1 { get; set; } = null!;
+        public ChildPN Child2 { get; set; } = null!;
+        public ICollection<ChildPN> ChildCollection1 { get; set; } = null!;
+        public ICollection<ChildPN> ChildCollection2 { get; set; } = null!;
 
-        public int CompareTo(ParentPN other)
-            => Id - other.Id;
+        public int CompareTo(ParentPN? other)
+            => Id - other!.Id;
     }
 
     private class ChildPN : IComparable<ChildPN>
     {
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
 
         // ReSharper disable once MemberHidesStaticFromOuterClass
-        public SubChildPN SubChild { get; set; }
-        public ICollection<SubChildPN> SubChildCollection { get; set; }
+        public SubChildPN SubChild { get; set; } = null!;
+        public ICollection<SubChildPN> SubChildCollection { get; set; } = null!;
 
-        public int CompareTo(ChildPN other)
-            => StringComparer.InvariantCulture.Compare(Name, other.Name);
+        public int CompareTo(ChildPN? other)
+            => StringComparer.InvariantCulture.Compare(Name, other!.Name);
     }
 
     private class SubChildPN : IComparable<SubChildPN>
     {
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
 
-        public int CompareTo(SubChildPN other)
-            => StringComparer.InvariantCulture.Compare(Name, other.Name);
+        public int CompareTo(SubChildPN? other)
+            => StringComparer.InvariantCulture.Compare(Name, other!.Name);
     }
 
     private class FixupContext : DbContext

--- a/test/EFCore.Tests/ChangeTracking/Internal/PropertyValuesTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/PropertyValuesTest.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System.Collections;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 

--- a/test/EFCore.Tests/ChangeTracking/Internal/QueryFixupTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/QueryFixupTest.cs
@@ -781,12 +781,12 @@ public class QueryFixupTest
                 var principalEntry = context.Entry(principal);
                 Assert.Equal(EntityState.Unchanged, principalEntry.State);
 
-                var dependentEntry = principalEntry.Reference(p => p.OrderDetails).TargetEntry;
+                var dependentEntry = principalEntry.Reference(p => p.OrderDetails).TargetEntry!;
                 Assert.Equal(principal.Id, dependentEntry.Property("OrderId").CurrentValue);
                 Assert.Equal(EntityState.Unchanged, dependentEntry.State);
-                Assert.Equal(nameof(OrderDetails), dependentEntry.Metadata.FindOwnership().PrincipalToDependent.Name);
+                Assert.Equal(nameof(OrderDetails), dependentEntry.Metadata.FindOwnership()!.PrincipalToDependent!.Name);
 
-                var subDependent1Entry = dependentEntry.Reference(p => p.BillingAddress).TargetEntry;
+                var subDependent1Entry = dependentEntry.Reference(p => p.BillingAddress).TargetEntry!;
                 Assert.Equal(principal.Id, subDependent1Entry.Property("OrderDetailsId").CurrentValue);
                 Assert.Equal(EntityState.Unchanged, subDependent1Entry.State);
                 Assert.Equal(
@@ -796,7 +796,7 @@ public class QueryFixupTest
                     + "#"
                     + typeof(Address).ShortDisplayName(), subDependent1Entry.Metadata.Name);
 
-                var subDependent2Entry = dependentEntry.Reference(p => p.ShippingAddress).TargetEntry;
+                var subDependent2Entry = dependentEntry.Reference(p => p.ShippingAddress).TargetEntry!;
                 Assert.Equal(principal.Id, subDependent2Entry.Property("OrderDetailsId").CurrentValue);
                 Assert.Equal(EntityState.Unchanged, subDependent2Entry.State);
                 Assert.Equal(
@@ -853,7 +853,7 @@ public class QueryFixupTest
             {
                 var dependentEntry = context.Entry(owned);
                 Assert.Equal(principal.Id, dependentEntry.Property("OrderId").CurrentValue);
-                Assert.Equal(nameof(Order.OrderDetails), dependentEntry.Metadata.FindOwnership().PrincipalToDependent.Name);
+                Assert.Equal(nameof(Order.OrderDetails), dependentEntry.Metadata.FindOwnership()!.PrincipalToDependent!.Name);
             });
     }
 
@@ -952,7 +952,7 @@ public class QueryFixupTest
     {
         public int Id { get; set; }
 
-        public Child Child { get; set; }
+        public Child Child { get; set; } = null!;
     }
 
     private class Child
@@ -960,14 +960,14 @@ public class QueryFixupTest
         public int Id { get; set; }
         public int ParentId { get; set; }
 
-        public Parent Parent { get; set; }
+        public Parent Parent { get; set; } = null!;
     }
 
     private class ParentPN
     {
         public int Id { get; set; }
 
-        public ChildPN Child { get; set; }
+        public ChildPN Child { get; set; } = null!;
     }
 
     private class ChildPN
@@ -987,7 +987,7 @@ public class QueryFixupTest
         public int Id { get; set; }
         public int ParentId { get; set; }
 
-        public ParentDN Parent { get; set; }
+        public ParentDN Parent { get; set; } = null!;
     }
 
     private class CategoryDN
@@ -1000,7 +1000,7 @@ public class QueryFixupTest
         public int Id { get; set; }
         public int CategoryId { get; set; }
 
-        public CategoryDN Category { get; set; }
+        public CategoryDN Category { get; set; } = null!;
     }
 
     private class CategoryPN
@@ -1028,27 +1028,27 @@ public class QueryFixupTest
         public int Id { get; set; }
         public int CategoryId { get; set; }
 
-        public Category Category { get; set; }
+        public Category Category { get; set; } = null!;
     }
 
     private class Order
     {
         public int Id { get; set; }
 
-        public OrderDetails OrderDetails { get; set; }
+        public OrderDetails OrderDetails { get; set; } = null!;
     }
 
     private class OrderDetails
     {
-        public Order Order { get; }
-        public Address BillingAddress { get; set; }
-        public Address ShippingAddress { get; set; }
+        public Order Order { get; } = null!;
+        public Address BillingAddress { get; set; } = null!;
+        public Address ShippingAddress { get; set; } = null!;
     }
 
     private class Address
     {
-        public OrderDetails OrderDetails { get; }
-        public string Street { get; set; }
+        public OrderDetails OrderDetails { get; } = null!;
+        public string Street { get; set; } = null!;
     }
 
     private class Blog
@@ -1058,7 +1058,7 @@ public class QueryFixupTest
         public ICollection<Post> Posts { get; } = new List<Post>();
 
         public int TopPostId { get; set; }
-        public Post TopPost { get; set; }
+        public Post TopPost { get; set; } = null!;
     }
 
     private class Post
@@ -1066,7 +1066,7 @@ public class QueryFixupTest
         public int Id { get; set; }
         public int BlogId { get; set; }
 
-        public Blog Blog { get; set; }
+        public Blog Blog { get; set; } = null!;
     }
 
     public class Widget
@@ -1074,9 +1074,9 @@ public class QueryFixupTest
         public int Id { get; set; }
 
         public int? ParentWidgetId { get; set; }
-        public Widget ParentWidget { get; set; }
+        public Widget ParentWidget { get; set; } = null!;
 
-        public List<Widget> ChildWidgets { get; set; }
+        public List<Widget> ChildWidgets { get; set; } = null!;
     }
 
     public class WidgetPN
@@ -1085,7 +1085,7 @@ public class QueryFixupTest
 
         public int? ParentWidgetId { get; set; }
 
-        public List<WidgetPN> ChildWidgets { get; set; }
+        public List<WidgetPN> ChildWidgets { get; set; } = null!;
     }
 
     public class WidgetDN
@@ -1093,7 +1093,7 @@ public class QueryFixupTest
         public int Id { get; set; }
 
         public int? ParentWidgetId { get; set; }
-        public WidgetDN ParentWidget { get; set; }
+        public WidgetDN ParentWidget { get; set; } = null!;
     }
 
     public class Smidget
@@ -1101,8 +1101,8 @@ public class QueryFixupTest
         public int Id { get; set; }
 
         public int? ParentSmidgetId { get; set; }
-        public Smidget ParentSmidget { get; set; }
-        public Smidget ChildSmidget { get; set; }
+        public Smidget ParentSmidget { get; set; } = null!;
+        public Smidget ChildSmidget { get; set; } = null!;
     }
 
     public class SmidgetPN
@@ -1110,7 +1110,7 @@ public class QueryFixupTest
         public int Id { get; set; }
 
         public int? ParentSmidgetId { get; set; }
-        public SmidgetPN ChildSmidget { get; set; }
+        public SmidgetPN ChildSmidget { get; set; } = null!;
     }
 
     public class SmidgetDN
@@ -1118,7 +1118,7 @@ public class QueryFixupTest
         public int Id { get; set; }
 
         public int? ParentSmidgetId { get; set; }
-        public SmidgetDN ParentSmidget { get; set; }
+        public SmidgetDN ParentSmidget { get; set; } = null!;
     }
 
     private class QueryFixupContext : DbContext

--- a/test/EFCore.Tests/ChangeTracking/Internal/ShadowFixupTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/ShadowFixupTest.cs
@@ -231,7 +231,7 @@ public class ShadowFixupTest
             {
                 var fk = b.Metadata.AddForeignKey(
                     [b.Property<int>("CategoryId").Metadata],
-                    category.FindPrimaryKey(),
+                    category.FindPrimaryKey()!,
                     category);
                 fk.SetDependentToPrincipal("Category");
                 fk.SetPrincipalToDependent("Products");
@@ -243,7 +243,7 @@ public class ShadowFixupTest
             {
                 var fk = b.Metadata.AddForeignKey(
                     [b.Property<int>("ParentId").Metadata],
-                    parent.FindPrimaryKey(),
+                    parent.FindPrimaryKey()!,
                     parent);
                 fk.IsUnique = true;
                 fk.SetDependentToPrincipal("Parent");

--- a/test/EFCore.Tests/ChangeTracking/Internal/ShadowFkFixupTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/ShadowFkFixupTest.cs
@@ -1310,21 +1310,21 @@ public class ShadowFkFixupTest
     {
         public int Id { get; set; }
 
-        public Child Child { get; set; }
+        public Child Child { get; set; } = null!;
     }
 
     private class Child
     {
         public int Id { get; set; }
 
-        public Parent Parent { get; set; }
+        public Parent Parent { get; set; } = null!;
     }
 
     private class ParentPN
     {
         public int Id { get; set; }
 
-        public ChildPN Child { get; set; }
+        public ChildPN Child { get; set; } = null!;
     }
 
     private class ChildPN
@@ -1341,7 +1341,7 @@ public class ShadowFkFixupTest
     {
         public int Id { get; set; }
 
-        public ParentDN Parent { get; set; }
+        public ParentDN Parent { get; set; } = null!;
     }
 
     private class ParentNN
@@ -1363,7 +1363,7 @@ public class ShadowFkFixupTest
     {
         public int Id { get; set; }
 
-        public CategoryDN Category { get; set; }
+        public CategoryDN Category { get; set; } = null!;
     }
 
     private class CategoryPN
@@ -1399,7 +1399,7 @@ public class ShadowFkFixupTest
     {
         public int Id { get; set; }
 
-        public Category Category { get; set; }
+        public Category Category { get; set; } = null!;
 
         // ReSharper disable once CollectionNeverUpdated.Local
         public ICollection<SpecialOffer> SpecialOffers { get; } = new List<SpecialOffer>();
@@ -1409,7 +1409,7 @@ public class ShadowFkFixupTest
     {
         public int Id { get; set; }
 
-        public Product Product { get; set; }
+        public Product Product { get; set; } = null!;
     }
 
     private class FixupContext : DbContext

--- a/test/EFCore.Tests/ChangeTracking/Internal/SortableBindingListTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/SortableBindingListTest.cs
@@ -135,12 +135,12 @@ public class SortableBindingListTest
 
         public int Int { get; }
         public int? NullableInt { get; }
-        public string String { get; }
-        public Random Random { get; }
-        public byte[] ByteArray { get; }
+        public string String { get; } = null!;
+        public Random Random { get; } = null!;
+        public byte[] ByteArray { get; } = null!;
 
         public static PropertyDescriptor Property(string name)
-            => TypeDescriptor.GetProperties(typeof(ListElement))[name];
+            => TypeDescriptor.GetProperties(typeof(ListElement))[name]!;
     }
 
     private class DerivedListElement : ListElement
@@ -157,8 +157,8 @@ public class SortableBindingListTest
 
     private class ListElementComparer : IEqualityComparer<ListElement>
     {
-        public bool Equals(ListElement x, ListElement y)
-            => x.Int == y.Int;
+        public bool Equals(ListElement? x, ListElement? y)
+            => x!.Int == y!.Int;
 
         public int GetHashCode(ListElement obj)
             => obj.Int;

--- a/test/EFCore.Tests/ChangeTracking/Internal/StateManagerTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/StateManagerTest.cs
@@ -536,12 +536,12 @@ public class StateManagerTest
 
     private class SingleKeyOwned
     {
-        public string Value { get; set; }
+        public string Value { get; set; } = null!;
     }
 
     private class CompositeKeyOwned
     {
-        public string Value { get; set; }
+        public string Value { get; set; } = null!;
     }
 
     private class SingleKey
@@ -549,9 +549,9 @@ public class StateManagerTest
         public int? Id { get; set; }
         public int? AlternateId { get; set; }
 
-        public string Value { get; set; }
+        public string Value { get; set; } = null!;
 
-        public SingleKeyOwned Owned { get; set; }
+        public SingleKeyOwned Owned { get; set; } = null!;
     }
 
     private class CompositeKey
@@ -562,14 +562,14 @@ public class StateManagerTest
         public int? AlternateId1 { get; set; }
         public int? AlternateId2 { get; set; }
 
-        public string Value { get; set; }
+        public string Value { get; set; } = null!;
 
-        public CompositeKeyOwned Owned { get; set; }
+        public CompositeKeyOwned Owned { get; set; } = null!;
     }
 
     private class WidgetContext : DbContext
     {
-        public DbSet<Widget> Widgets { get; set; }
+        public DbSet<Widget> Widgets { get; set; } = null!;
 
         protected internal override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
             => optionsBuilder
@@ -587,9 +587,9 @@ public class StateManagerTest
         var category = new Category { Id = 77, PrincipalId = 777 };
         var snapshot = new Snapshot<int, string, int>(77, "Bjork", 777);
 
-        var entry = stateManager.StartTrackingFromQuery(categoryType, category, snapshot);
+        var entry = stateManager.StartTrackingFromQuery(categoryType!, category, snapshot);
 
-        Assert.Same(entry, stateManager.StartTrackingFromQuery(categoryType, category, snapshot));
+        Assert.Same(entry, stateManager.StartTrackingFromQuery(categoryType!, category, snapshot));
     }
 
     [Fact]
@@ -599,7 +599,7 @@ public class StateManagerTest
         var stateManager = CreateStateManager(model);
 
         var entry = stateManager.GetOrCreateEntry(
-            new Dogegory { Id = null });
+            new Dogegory { Id = null! });
 
         Assert.Equal(
             CoreStrings.InvalidKeyValue("Dogegory", "Id"),
@@ -963,8 +963,8 @@ public class StateManagerTest
         public void NavigationReferenceChanged(
             InternalEntityEntry entry,
             INavigationBase navigationBase,
-            object oldValue,
-            object newValue)
+            object? oldValue,
+            object? newValue)
         {
         }
 
@@ -985,8 +985,8 @@ public class StateManagerTest
             IProperty property,
             IEnumerable<IKey> containingPrincipalKeys,
             IEnumerable<IForeignKey> containingForeignKeys,
-            object oldValue,
-            object newValue)
+            object? oldValue,
+            object? newValue)
         {
         }
 
@@ -1126,7 +1126,7 @@ public class StateManagerTest
             stateManager.GetOrCreateEntry(
                 new Product { Id = Guid.NewGuid(), DependentId = null }));
 
-        var fk = model.FindEntityType(typeof(Product)).GetForeignKeys().Single();
+        var fk = model.FindEntityType(typeof(Product))!.GetForeignKeys().Single();
 
         Assert.Equal(
             [productEntry1, productEntry2],
@@ -1173,7 +1173,7 @@ public class StateManagerTest
         var destinationLongitude = destination.ComplexType.FindProperty(nameof(Coordinate.Longitude))!;
 
         var entry = stateManager.CreateEntry(
-            new Dictionary<IProperty, object>
+            new Dictionary<IProperty, object?>
             {
                 { id, 1 },
                 { note, "Somewhere" },
@@ -1213,7 +1213,7 @@ public class StateManagerTest
         // properties must fall back to their sentinel (default) values rather than null, which would
         // otherwise cause an invalid cast during materialization.
         var entry = stateManager.CreateEntry(
-            new Dictionary<IProperty, object> { { id, 1 }, { originLatitude, 11 } },
+            new Dictionary<IProperty, object?> { { id, 1 }, { originLatitude, 11 } },
             entityType);
 
         Assert.Equal(1, entry[id]);
@@ -1242,7 +1242,7 @@ public class StateManagerTest
             CoreStrings.PropertyDoesNotBelong(
                 foreignProperty.Name, otherEntityType.DisplayName(), entityType.DisplayName()),
             Assert.Throws<InvalidOperationException>(() => stateManager.CreateEntry(
-                new Dictionary<IProperty, object> { { id, 1 }, { foreignProperty, "Mars" } },
+                new Dictionary<IProperty, object?> { { id, 1 }, { foreignProperty, "Mars" } },
                 entityType)).Message);
     }
 
@@ -1262,7 +1262,7 @@ public class StateManagerTest
             CoreStrings.PropertyDoesNotBelong(
                 foreignLatitude.Name, otherEntityType.DisplayName(), entityType.DisplayName()),
             Assert.Throws<InvalidOperationException>(() => stateManager.CreateEntry(
-                new Dictionary<IProperty, object> { { id, 1 }, { foreignLatitude, 11 } },
+                new Dictionary<IProperty, object?> { { id, 1 }, { foreignLatitude, 11 } },
                 entityType)).Message);
     }
 
@@ -1271,23 +1271,23 @@ public class StateManagerTest
         public int Id { get; set; }
 
         public int? ParentWidgetId { get; set; }
-        public Widget ParentWidget { get; set; }
+        public Widget ParentWidget { get; set; } = null!;
 
-        public List<Widget> ChildWidgets { get; set; }
+        public List<Widget> ChildWidgets { get; set; } = null!;
     }
 
     private class Category
     {
         public int Id { get; set; }
         public int? PrincipalId { get; set; }
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
     }
 
     private class Product
     {
         public Guid Id { get; set; }
         public int? DependentId { get; set; }
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
         public decimal Price { get; set; }
     }
 
@@ -1295,13 +1295,13 @@ public class StateManagerTest
 
     private class Dogegory
     {
-        public string Id { get; set; }
+        public string Id { get; set; } = null!;
     }
 
     private class Location
     {
         public int Id { get; set; }
-        public string Planet { get; set; }
+        public string Planet { get; set; } = null!;
     }
 
     private class Place

--- a/test/EFCore.Tests/ChangeTracking/MemberEntryTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/MemberEntryTest.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
 #pragma warning disable CS0649 // Field is never assigned to, and will always have its default value
 #pragma warning disable CS0414 // Field is assigned but its value is never used
 

--- a/test/EFCore.Tests/ChangeTracking/NavigationEntryTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/NavigationEntryTest.cs
@@ -162,7 +162,7 @@ public class NavigationEntryTest
         public int Id { get; set; }
 
         public int? GarciaId { get; set; }
-        public Cherry Garcia { get; set; }
+        public Cherry Garcia { get; set; } = null!;
     }
 
     private class Cherry
@@ -172,7 +172,7 @@ public class NavigationEntryTest
         // ReSharper disable once UnusedAutoPropertyAccessor.Local
         public int Id { get; set; }
 
-        public ICollection<Chunky> Monkeys { get; set; }
+        public ICollection<Chunky> Monkeys { get; set; } = null!;
     }
 
     private class FreezerContext : DbContext
@@ -182,6 +182,6 @@ public class NavigationEntryTest
                 .UseInternalServiceProvider(InMemoryFixture.DefaultServiceProvider)
                 .UseInMemoryDatabase(nameof(FreezerContext));
 
-        public DbSet<Chunky> Icecream { get; set; }
+        public DbSet<Chunky> Icecream { get; set; } = null!;
     }
 }

--- a/test/EFCore.Tests/ChangeTracking/ObservableHashSetTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/ObservableHashSetTest.cs
@@ -54,7 +54,7 @@ public class ObservableHashSetTest
         {
             Assert.Equal(NotifyCollectionChangedAction.Add, a.Action);
             Assert.Null(a.OldItems);
-            Assert.Equal(adding, a.NewItems.OfType<string>());
+            Assert.Equal(adding, a.NewItems!.OfType<string>());
             collectionChanged++;
         };
 
@@ -99,8 +99,8 @@ public class ObservableHashSetTest
         hashSet.CollectionChanged += (s, a) =>
         {
             Assert.Equal(NotifyCollectionChangedAction.Replace, a.Action);
-            Assert.Equal(testData.OrderBy(i => i), a.OldItems.OfType<int>().OrderBy(i => i));
-            Assert.Empty(a.NewItems);
+            Assert.Equal(testData.OrderBy(i => i), a.OldItems!.OfType<int>().OrderBy(i => i));
+            Assert.Empty(a.NewItems!);
             collectionChanged++;
         };
 
@@ -182,7 +182,7 @@ public class ObservableHashSetTest
         hashSet.CollectionChanged += (s, a) =>
         {
             Assert.Equal(NotifyCollectionChangedAction.Remove, a.Action);
-            Assert.Equal(removing, a.OldItems.OfType<string>());
+            Assert.Equal(removing, a.OldItems!.OfType<string>());
             Assert.Null(a.NewItems);
             collectionChanged++;
         };
@@ -231,8 +231,8 @@ public class ObservableHashSetTest
         hashSet.CollectionChanged += (s, a) =>
         {
             Assert.Equal(NotifyCollectionChangedAction.Replace, a.Action);
-            Assert.Empty(a.OldItems);
-            Assert.Equal(adding, a.NewItems.OfType<string>().OrderBy(i => i));
+            Assert.Empty(a.OldItems!);
+            Assert.Equal(adding, a.NewItems!.OfType<string>().OrderBy(i => i));
             collectionChanged++;
         };
 
@@ -273,8 +273,8 @@ public class ObservableHashSetTest
         hashSet.CollectionChanged += (s, a) =>
         {
             Assert.Equal(NotifyCollectionChangedAction.Replace, a.Action);
-            Assert.Equal(removing, a.OldItems.OfType<string>().OrderBy(i => i));
-            Assert.Empty(a.NewItems);
+            Assert.Equal(removing, a.OldItems!.OfType<string>().OrderBy(i => i));
+            Assert.Empty(a.NewItems!);
             collectionChanged++;
         };
 
@@ -315,8 +315,8 @@ public class ObservableHashSetTest
         hashSet.CollectionChanged += (s, a) =>
         {
             Assert.Equal(NotifyCollectionChangedAction.Replace, a.Action);
-            Assert.Equal(removing, a.OldItems.OfType<string>().OrderBy(i => i));
-            Assert.Empty(a.NewItems);
+            Assert.Equal(removing, a.OldItems!.OfType<string>().OrderBy(i => i));
+            Assert.Empty(a.NewItems!);
             collectionChanged++;
         };
 
@@ -358,8 +358,8 @@ public class ObservableHashSetTest
         hashSet.CollectionChanged += (s, a) =>
         {
             Assert.Equal(NotifyCollectionChangedAction.Replace, a.Action);
-            Assert.Equal(removing, a.OldItems.OfType<string>().OrderBy(i => i));
-            Assert.Equal(adding, a.NewItems.OfType<string>().OrderBy(i => i));
+            Assert.Equal(removing, a.OldItems!.OfType<string>().OrderBy(i => i));
+            Assert.Equal(adding, a.NewItems!.OfType<string>().OrderBy(i => i));
             collectionChanged++;
         };
 
@@ -481,8 +481,8 @@ public class ObservableHashSetTest
         hashSet.CollectionChanged += (s, a) =>
         {
             Assert.Equal(NotifyCollectionChangedAction.Replace, a.Action);
-            Assert.Equal(removing, a.OldItems.OfType<string>().OrderBy(i => i));
-            Assert.Empty(a.NewItems);
+            Assert.Equal(removing, a.OldItems!.OfType<string>().OrderBy(i => i));
+            Assert.Empty(a.NewItems!);
             collectionChanged++;
         };
 
@@ -516,7 +516,7 @@ public class ObservableHashSetTest
 
     private static void AssertCountChanging<T>(
         ObservableHashSet<T> hashSet,
-        object sender,
+        object? sender,
         PropertyChangingEventArgs eventArgs,
         int expectedCount,
         ref int changingCount)
@@ -529,7 +529,7 @@ public class ObservableHashSetTest
 
     private static void AssertCountChanged<T>(
         ObservableHashSet<T> hashSet,
-        object sender,
+        object? sender,
         PropertyChangedEventArgs eventArgs,
         ref int expectedCount,
         int countDelta,

--- a/test/EFCore.Tests/ChangeTracking/PropertyEntryTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/PropertyEntryTest.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
 #pragma warning disable CS0649 // Field is never assigned to, and will always have its default value
 #pragma warning disable CS0414 // Field is assigned but its value is never used
 

--- a/test/EFCore.Tests/ChangeTracking/ReferenceEntryTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/ReferenceEntryTest.cs
@@ -65,7 +65,7 @@ public class ReferenceEntryTest
         Assert.Same(chunky, cherry.Monkeys.Single());
         Assert.Equal(cherry.Id, chunky.GarciaId);
         Assert.Same(cherry, reference.CurrentValue);
-        Assert.Same(reference.TargetEntry.GetInfrastructure(), context.Entry(cherry).GetInfrastructure());
+        Assert.Same(reference.TargetEntry!.GetInfrastructure(), context.Entry(cherry).GetInfrastructure());
 
         reference.CurrentValue = null;
 
@@ -94,7 +94,7 @@ public class ReferenceEntryTest
         Assert.Same(chunky, cherry.Monkeys.Single());
         Assert.Equal(cherry.Id, chunky.GarciaId);
         Assert.Same(cherry, reference.CurrentValue);
-        Assert.Same(reference.TargetEntry.GetInfrastructure(), context.Entry(cherry).GetInfrastructure());
+        Assert.Same(reference.TargetEntry!.GetInfrastructure(), context.Entry(cherry).GetInfrastructure());
 
         reference.CurrentValue = null;
 
@@ -176,7 +176,7 @@ public class ReferenceEntryTest
         Assert.Equal(cherry.Id, chunky.GarciaId);
         Assert.Same(cherry, reference.CurrentValue);
 
-        Assert.Same(reference.TargetEntry.GetInfrastructure(), context.Entry(cherry).GetInfrastructure());
+        Assert.Same(reference.TargetEntry!.GetInfrastructure(), context.Entry(cherry).GetInfrastructure());
         Assert.Equal(EntityState.Added, context.Entry(cherry).State);
         Assert.Equal(EntityState.Added, context.Entry(chunky).State);
 
@@ -211,7 +211,7 @@ public class ReferenceEntryTest
         Assert.Equal(cherry.Id, chunky.GarciaId);
         Assert.Same(cherry, reference.CurrentValue);
 
-        Assert.Same(reference.TargetEntry.GetInfrastructure(), context.Entry(cherry).GetInfrastructure());
+        Assert.Same(reference.TargetEntry!.GetInfrastructure(), context.Entry(cherry).GetInfrastructure());
         Assert.Equal(EntityState.Added, context.Entry(cherry).State);
         Assert.Equal(EntityState.Added, context.Entry(chunky).State);
 
@@ -502,9 +502,9 @@ public class ReferenceEntryTest
         public int Id { get; set; }
 
         public int? GarciaId { get; set; }
-        public Cherry Garcia { get; set; }
+        public Cherry Garcia { get; set; } = null!;
 
-        public Half Baked { get; set; }
+        public Half Baked { get; set; } = null!;
     }
 
     private class Half
@@ -514,7 +514,7 @@ public class ReferenceEntryTest
 
         // ReSharper disable once UnusedAutoPropertyAccessor.Local
         public int? MonkeyId { get; set; }
-        public Chunky Monkey { get; set; }
+        public Chunky Monkey { get; set; } = null!;
     }
 
     private class Cherry
@@ -522,7 +522,7 @@ public class ReferenceEntryTest
         public int Garcia { get; set; }
         public int Id { get; set; }
 
-        public ICollection<Chunky> Monkeys { get; set; }
+        public ICollection<Chunky> Monkeys { get; set; } = null!;
     }
 
     private class FreezerContext : DbContext
@@ -532,7 +532,7 @@ public class ReferenceEntryTest
                 .UseInternalServiceProvider(InMemoryFixture.DefaultServiceProvider)
                 .UseInMemoryDatabase(nameof(FreezerContext));
 
-        public DbSet<Chunky> Icecream { get; set; }
+        public DbSet<Chunky> Icecream { get; set; } = null!;
 
         protected internal override void OnModelCreating(ModelBuilder modelBuilder)
         {

--- a/test/EFCore.Tests/ChangeTracking/SkipCollectionEntryTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/SkipCollectionEntryTest.cs
@@ -100,15 +100,15 @@ public class SkipCollectionEntryTest
         Assert.Same(chunky, cherry.Chunkies.Single());
         Assert.Same(cherry, chunky.Cherries.Single());
         Assert.Same(chunky, collection.CurrentValue.Cast<Chunky>().Single());
-        Assert.Same(cherry, inverseCollection.CurrentValue.Cast<Cherry>().Single());
-        Assert.Same(collection.FindEntry(chunky).GetInfrastructure(), context.Entry(chunky).GetInfrastructure());
+        Assert.Same(cherry, inverseCollection.CurrentValue!.Cast<Cherry>().Single());
+        Assert.Same(collection.FindEntry(chunky)!.GetInfrastructure(), context.Entry(chunky).GetInfrastructure());
 
         collection.CurrentValue = null;
 
         Assert.Empty(chunky.Cherries);
         Assert.Null(cherry.Chunkies);
         Assert.Null(collection.CurrentValue);
-        Assert.Empty(inverseCollection.CurrentValue);
+        Assert.Empty(inverseCollection.CurrentValue!);
         Assert.Null(collection.FindEntry(chunky));
     }
 
@@ -131,15 +131,15 @@ public class SkipCollectionEntryTest
         Assert.Same(chunky, cherry.Chunkies.Single());
         Assert.Same(cherry, chunky.Cherries.Single());
         Assert.Same(chunky, collection.CurrentValue.Single());
-        Assert.Same(cherry, inverseCollection.CurrentValue.Single());
-        Assert.Same(collection.FindEntry(chunky).GetInfrastructure(), context.Entry(chunky).GetInfrastructure());
+        Assert.Same(cherry, inverseCollection.CurrentValue!.Single());
+        Assert.Same(collection.FindEntry(chunky)!.GetInfrastructure(), context.Entry(chunky).GetInfrastructure());
 
         collection.CurrentValue = null;
 
         Assert.Empty(chunky.Cherries);
         Assert.Null(cherry.Chunkies);
         Assert.Null(collection.CurrentValue);
-        Assert.Empty(inverseCollection.CurrentValue);
+        Assert.Empty(inverseCollection.CurrentValue!);
         Assert.Null(collection.FindEntry(chunky));
     }
 
@@ -218,7 +218,7 @@ public class SkipCollectionEntryTest
         Assert.Same(chunky, cherry.Chunkies.Single());
         Assert.Same(cherry, chunky.Cherries.Single());
         Assert.Same(chunky, collection.CurrentValue.Cast<Chunky>().Single());
-        Assert.Same(cherry, inverseCollection.CurrentValue.Cast<Cherry>().Single());
+        Assert.Same(cherry, inverseCollection.CurrentValue!.Cast<Cherry>().Single());
 
         Assert.Equal(EntityState.Added, context.Entry(cherry).State);
         Assert.Equal(EntityState.Added, context.Entry(chunky).State);
@@ -228,7 +228,7 @@ public class SkipCollectionEntryTest
         Assert.Empty(chunky.Cherries);
         Assert.Null(cherry.Chunkies);
         Assert.Null(collection.CurrentValue);
-        Assert.Empty(inverseCollection.CurrentValue);
+        Assert.Empty(inverseCollection.CurrentValue!);
 
         Assert.Equal(EntityState.Added, context.Entry(cherry).State);
         Assert.Equal(EntityState.Added, context.Entry(chunky).State);
@@ -253,7 +253,7 @@ public class SkipCollectionEntryTest
         Assert.Same(chunky, cherry.Chunkies.Single());
         Assert.Same(cherry, chunky.Cherries.Single());
         Assert.Same(chunky, collection.CurrentValue.Single());
-        Assert.Same(cherry, inverseCollection.CurrentValue.Single());
+        Assert.Same(cherry, inverseCollection.CurrentValue!.Single());
 
         Assert.Equal(EntityState.Added, context.Entry(cherry).State);
         Assert.Equal(EntityState.Added, context.Entry(chunky).State);
@@ -263,7 +263,7 @@ public class SkipCollectionEntryTest
         Assert.Empty(chunky.Cherries);
         Assert.Null(cherry.Chunkies);
         Assert.Null(collection.CurrentValue);
-        Assert.Empty(inverseCollection.CurrentValue);
+        Assert.Empty(inverseCollection.CurrentValue!);
 
         Assert.Equal(EntityState.Added, context.Entry(cherry).State);
         Assert.Equal(EntityState.Added, context.Entry(chunky).State);
@@ -536,13 +536,13 @@ public class SkipCollectionEntryTest
     private class Chunky
     {
         public int Id { get; set; }
-        public ICollection<Cherry> Cherries { get; set; }
+        public ICollection<Cherry> Cherries { get; set; } = null!;
     }
 
     private class Cherry
     {
         public int Id { get; set; }
-        public ICollection<Chunky> Chunkies { get; set; }
+        public ICollection<Chunky> Chunkies { get; set; } = null!;
     }
 
     private class FreezerContext : DbContext
@@ -552,7 +552,7 @@ public class SkipCollectionEntryTest
                 .UseInternalServiceProvider(InMemoryFixture.DefaultServiceProvider)
                 .UseInMemoryDatabase(nameof(FreezerContext));
 
-        public DbSet<Chunky> Icecream { get; set; }
+        public DbSet<Chunky> Icecream { get; set; } = null!;
     }
 
     private class ExplicitFreezerContext : FreezerContext

--- a/test/EFCore.Tests/ChangeTracking/SkipMemberEntryTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/SkipMemberEntryTest.cs
@@ -46,14 +46,14 @@ public class SkipMemberEntryTest
 
         Assert.Same(cherry, chunky.Cherries.Single());
         Assert.Same(chunky, cherry.Chunkies.Single());
-        Assert.Equal(cherry, ((ICollection<Cherry>)inverseCollection.CurrentValue).Single());
+        Assert.Equal(cherry, ((ICollection<Cherry>)inverseCollection.CurrentValue!).Single());
         Assert.Same(chunky, ((ICollection<Chunky>)collection.CurrentValue).Single());
 
         collection.CurrentValue = null;
 
         Assert.Empty(chunky.Cherries);
         Assert.Null(cherry.Chunkies);
-        Assert.Empty((IEnumerable)inverseCollection.CurrentValue);
+        Assert.Empty((IEnumerable)inverseCollection.CurrentValue!);
         Assert.Null(collection.CurrentValue);
     }
 
@@ -122,13 +122,13 @@ public class SkipMemberEntryTest
     private class Chunky
     {
         public int Id { get; set; }
-        public ICollection<Cherry> Cherries { get; set; }
+        public ICollection<Cherry> Cherries { get; set; } = null!;
     }
 
     private class Cherry
     {
         public int Id { get; set; }
-        public ICollection<Chunky> Chunkies { get; }
+        public ICollection<Chunky> Chunkies { get; } = null!;
     }
 
     private class FreezerContext : DbContext
@@ -138,6 +138,6 @@ public class SkipMemberEntryTest
                 .UseInternalServiceProvider(InMemoryFixture.DefaultServiceProvider)
                 .UseInMemoryDatabase(nameof(FreezerContext));
 
-        public DbSet<Chunky> Icecream { get; set; }
+        public DbSet<Chunky> Icecream { get; set; } = null!;
     }
 }

--- a/test/EFCore.Tests/ChangeTracking/SkipNavigationEntryTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/SkipNavigationEntryTest.cs
@@ -49,27 +49,27 @@ public class SkipNavigationEntryTest
 
         Assert.Same(cherry, chunky.Cherries.Single());
         Assert.Same(chunky, cherry.Chunkies.Single());
-        Assert.Equal(cherry, ((ICollection<Cherry>)inverseCollection.CurrentValue).Single());
+        Assert.Equal(cherry, ((ICollection<Cherry>)inverseCollection.CurrentValue!).Single());
         Assert.Same(chunky, ((ICollection<Chunky>)collection.CurrentValue).Single());
 
         collection.CurrentValue = null;
 
         Assert.Empty(chunky.Cherries);
         Assert.Null(cherry.Chunkies);
-        Assert.Empty((IEnumerable)inverseCollection.CurrentValue);
+        Assert.Empty((IEnumerable)inverseCollection.CurrentValue!);
         Assert.Null(collection.CurrentValue);
     }
 
     private class Chunky
     {
         public int Id { get; set; }
-        public ICollection<Cherry> Cherries { get; set; }
+        public ICollection<Cherry> Cherries { get; set; } = null!;
     }
 
     private class Cherry
     {
         public int Id { get; set; }
-        public ICollection<Chunky> Chunkies { get; }
+        public ICollection<Chunky> Chunkies { get; } = null!;
     }
 
     private class FreezerContext : DbContext
@@ -79,6 +79,6 @@ public class SkipNavigationEntryTest
                 .UseInternalServiceProvider(InMemoryFixture.DefaultServiceProvider)
                 .UseInMemoryDatabase(nameof(FreezerContext));
 
-        public DbSet<Chunky> Icecream { get; set; }
+        public DbSet<Chunky> Icecream { get; set; } = null!;
     }
 }

--- a/test/EFCore.Tests/ChangeTracking/TemporaryValuesTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/TemporaryValuesTest.cs
@@ -209,7 +209,7 @@ public class TemporaryValuesTest
 
         public int ValueProperty { get; set; }
         public int? NullableValueProperty { get; set; }
-        public string ReferenceValueProperty { get; set; }
+        public string ReferenceValueProperty { get; set; } = null!;
     }
 
     private class EntityWithIndexerValueProperty
@@ -220,7 +220,7 @@ public class TemporaryValuesTest
 
         public int this[string name]
         {
-            get => _values.TryGetValue(name, out var value) ? value : default;
+            get => _values.TryGetValue(name, out var value) ? value : default!;
             set => _values[name] = value;
         }
     }
@@ -233,7 +233,7 @@ public class TemporaryValuesTest
 
         public int? this[string name]
         {
-            get => _values.TryGetValue(name, out var value) ? value : default;
+            get => _values.TryGetValue(name, out var value) ? value : default!;
             set => _values[name] = value;
         }
     }
@@ -246,7 +246,7 @@ public class TemporaryValuesTest
 
         public string this[string name]
         {
-            get => _values.TryGetValue(name, out var value) ? value : default;
+            get => _values.TryGetValue(name, out var value) ? value : default!;
             set => _values[name] = value;
         }
     }
@@ -259,7 +259,7 @@ public class TemporaryValuesTest
 
         public object this[string name]
         {
-            get => _values.TryGetValue(name, out var value) ? value : default;
+            get => _values.TryGetValue(name, out var value) ? value : default!;
             set => _values[name] = value;
         }
     }

--- a/test/EFCore.Tests/ChangeTracking/TrackGraphTestBase.cs
+++ b/test/EFCore.Tests/ChangeTracking/TrackGraphTestBase.cs
@@ -143,12 +143,12 @@ public abstract class TrackGraphTestBase
             + "--> "
             + EntryString(node.Entry);
 
-    private static string EntryString(EntityEntry entry)
+    private static string EntryString(EntityEntry? entry)
         => entry == null
             ? "<None>"
             : entry.Metadata.DisplayName()
             + ":"
-            + entry.Property(entry.Metadata.FindPrimaryKey().Properties[0].Name).CurrentValue;
+            + entry.Property(entry.Metadata.FindPrimaryKey()!.Properties[0].Name).CurrentValue;
 
     [Theory, InlineData(false, false), InlineData(false, true), InlineData(true, false), InlineData(true, true)]
     public void Can_attach_nullable_PK_parent_with_child_collection(bool useAttach, bool setKeys)
@@ -269,10 +269,10 @@ public abstract class TrackGraphTestBase
 
         if (setDependentKey)
         {
-            var dreamsEntry = context.Entry(sweet).Reference(e => e.Dreams).TargetEntry;
+            var dreamsEntry = context.Entry(sweet).Reference(e => e.Dreams).TargetEntry!;
             dreamsEntry.Property("SweetId").CurrentValue = 1;
-            dreamsEntry.Reference(e => e.Are).TargetEntry.Property("DreamsSweetId").CurrentValue = 1;
-            dreamsEntry.Reference(e => e.Made).TargetEntry.Property("DreamsSweetId").CurrentValue = 1;
+            dreamsEntry.Reference(e => e.Are).TargetEntry!.Property("DreamsSweetId").CurrentValue = 1;
+            dreamsEntry.Reference(e => e.Made).TargetEntry!.Property("DreamsSweetId").CurrentValue = 1;
         }
 
         if (useAttach)
@@ -293,7 +293,7 @@ public abstract class TrackGraphTestBase
                     context,
                     sweet,
                     node => node.Entry.State = node.Entry.Metadata.IsOwned()
-                        ? node.SourceEntry.State
+                        ? node.SourceEntry!.State
                         : node.Entry.IsKeySet
                             ? EntityState.Unchanged
                             : EntityState.Added));
@@ -318,9 +318,9 @@ public abstract class TrackGraphTestBase
         Assert.Equal(expectedDependentState, dependentEntry2b.State);
 
         Assert.Equal(1, sweet.Id);
-        Assert.Equal(1, dependentEntry.Property(dependentEntry.Metadata.FindPrimaryKey().Properties[0]).CurrentValue);
-        Assert.Equal(1, dependentEntry2a.Property(dependentEntry2a.Metadata.FindPrimaryKey().Properties[0]).CurrentValue);
-        Assert.Equal(1, dependentEntry2b.Property(dependentEntry2b.Metadata.FindPrimaryKey().Properties[0]).CurrentValue);
+        Assert.Equal(1, dependentEntry.Property(dependentEntry.Metadata.FindPrimaryKey()!.Properties[0]).CurrentValue);
+        Assert.Equal(1, dependentEntry2a.Property(dependentEntry2a.Metadata.FindPrimaryKey()!.Properties[0]).CurrentValue);
+        Assert.Equal(1, dependentEntry2b.Property(dependentEntry2b.Metadata.FindPrimaryKey()!.Properties[0]).CurrentValue);
     }
 
     [Theory, InlineData(false, false), InlineData(false, true), InlineData(true, false), InlineData(true, true)]
@@ -338,8 +338,8 @@ public abstract class TrackGraphTestBase
         {
             var dreamsEntry = context.Entry(dreams);
             dreamsEntry.Property("SweetId").CurrentValue = 1;
-            dreamsEntry.Reference(e => e.Are).TargetEntry.Property("DreamsSweetId").CurrentValue = 1;
-            dreamsEntry.Reference(e => e.Made).TargetEntry.Property("DreamsSweetId").CurrentValue = 1;
+            dreamsEntry.Reference(e => e.Are).TargetEntry!.Property("DreamsSweetId").CurrentValue = 1;
+            dreamsEntry.Reference(e => e.Made).TargetEntry!.Property("DreamsSweetId").CurrentValue = 1;
         }
 
         if (useAttach)
@@ -379,9 +379,9 @@ public abstract class TrackGraphTestBase
         Assert.Equal(expectedDependentState, dependentEntry2b.State);
 
         Assert.Equal(1, dreams.Sweet.Id);
-        Assert.Equal(1, dependentEntry.Property(dependentEntry.Metadata.FindPrimaryKey().Properties[0]).CurrentValue);
-        Assert.Equal(1, dependentEntry2a.Property(dependentEntry2a.Metadata.FindPrimaryKey().Properties[0]).CurrentValue);
-        Assert.Equal(1, dependentEntry2b.Property(dependentEntry2b.Metadata.FindPrimaryKey().Properties[0]).CurrentValue);
+        Assert.Equal(1, dependentEntry.Property(dependentEntry.Metadata.FindPrimaryKey()!.Properties[0]).CurrentValue);
+        Assert.Equal(1, dependentEntry2a.Property(dependentEntry2a.Metadata.FindPrimaryKey()!.Properties[0]).CurrentValue);
+        Assert.Equal(1, dependentEntry2b.Property(dependentEntry2b.Metadata.FindPrimaryKey()!.Properties[0]).CurrentValue);
     }
 
     [Fact]
@@ -710,8 +710,8 @@ public abstract class TrackGraphTestBase
         {
             var dreamsEntry = context.Entry(dreams);
             dreamsEntry.Property("SweetId").CurrentValue = 1;
-            dreamsEntry.Reference(e => e.Are).TargetEntry.Property("DreamsSweetId").CurrentValue = 1;
-            dreamsEntry.Reference(e => e.Made).TargetEntry.Property("DreamsSweetId").CurrentValue = 1;
+            dreamsEntry.Reference(e => e.Are).TargetEntry!.Property("DreamsSweetId").CurrentValue = 1;
+            dreamsEntry.Reference(e => e.Made).TargetEntry!.Property("DreamsSweetId").CurrentValue = 1;
         }
 
         if (useAdd)
@@ -752,9 +752,9 @@ public abstract class TrackGraphTestBase
         Assert.Equal(expectedDependentState, dependentEntry2b.State);
 
         Assert.Equal(1, dreams.Sweet.Id);
-        Assert.Equal(1, dependentEntry.Property(dependentEntry.Metadata.FindPrimaryKey().Properties[0]).CurrentValue);
-        Assert.Equal(1, dependentEntry2a.Property(dependentEntry2a.Metadata.FindPrimaryKey().Properties[0]).CurrentValue);
-        Assert.Equal(1, dependentEntry2b.Property(dependentEntry2b.Metadata.FindPrimaryKey().Properties[0]).CurrentValue);
+        Assert.Equal(1, dependentEntry.Property(dependentEntry.Metadata.FindPrimaryKey()!.Properties[0]).CurrentValue);
+        Assert.Equal(1, dependentEntry2a.Property(dependentEntry2a.Metadata.FindPrimaryKey()!.Properties[0]).CurrentValue);
+        Assert.Equal(1, dependentEntry2b.Property(dependentEntry2b.Metadata.FindPrimaryKey()!.Properties[0]).CurrentValue);
     }
 
     [Theory, InlineData(false, false), InlineData(false, true), InlineData(true, false), InlineData(true, true)] // Issue #12590
@@ -1105,7 +1105,7 @@ public abstract class TrackGraphTestBase
         {
             if (!entry.IsKeySet)
             {
-                entry.GetInfrastructure()[entry.Metadata.FindPrimaryKey().Properties.Single()] = 777;
+                entry.GetInfrastructure()[entry.Metadata.FindPrimaryKey()!.Properties.Single()] = 777;
                 return EntityState.Added;
             }
 
@@ -1244,7 +1244,7 @@ public abstract class TrackGraphTestBase
     {
         public int Id { get; set; }
 
-        public List<Product> Products { get; set; }
+        public List<Product> Products { get; set; } = null!;
     }
 
     private class Product
@@ -1252,38 +1252,38 @@ public abstract class TrackGraphTestBase
         public int Id { get; set; }
 
         public int CategoryId { get; set; }
-        public Category Category { get; set; }
+        public Category Category { get; set; } = null!;
 
-        public ProductDetails Details { get; set; }
+        public ProductDetails Details { get; set; } = null!;
 
         // ReSharper disable once CollectionNeverUpdated.Local
         // ReSharper disable once MemberHidesStaticFromOuterClass
-        public List<OrderDetails> OrderDetails { get; set; }
+        public List<OrderDetails> OrderDetails { get; set; } = null!;
     }
 
     private class ProductDetails
     {
         public int Id { get; set; }
 
-        public Product Product { get; set; }
+        public Product Product { get; set; } = null!;
 
-        public ProductDetailsTag Tag { get; set; }
+        public ProductDetailsTag Tag { get; set; } = null!;
     }
 
     private class ProductDetailsTag
     {
         public int Id { get; set; }
 
-        public ProductDetails Details { get; set; }
+        public ProductDetails Details { get; set; } = null!;
 
-        public ProductDetailsTagDetails TagDetails { get; set; }
+        public ProductDetailsTagDetails TagDetails { get; set; } = null!;
     }
 
     private class ProductDetailsTagDetails
     {
         public int Id { get; }
 
-        public ProductDetailsTag Tag { get; }
+        public ProductDetailsTag Tag { get; } = null!;
     }
 
     private class Order
@@ -1292,7 +1292,7 @@ public abstract class TrackGraphTestBase
 
         // ReSharper disable once CollectionNeverUpdated.Local
         // ReSharper disable once MemberHidesStaticFromOuterClass
-        public List<OrderDetails> OrderDetails { get; }
+        public List<OrderDetails> OrderDetails { get; } = null!;
     }
 
     private class OrderDetails
@@ -1300,40 +1300,40 @@ public abstract class TrackGraphTestBase
         public int OrderId { get; set; }
         public int ProductId { get; set; }
 
-        public Order Order { get; set; }
-        public Product Product { get; set; }
+        public Order Order { get; set; } = null!;
+        public Product Product { get; set; } = null!;
     }
 
     private class NullbileCategory
     {
-        public List<NullbileProduct> Products { get; set; }
-        public NullbileCategoryInfo Info { get; set; }
+        public List<NullbileProduct> Products { get; set; } = null!;
+        public NullbileCategoryInfo Info { get; set; } = null!;
     }
 
     private class NullbileCategoryInfo
     {
         // ReSharper disable once MemberHidesStaticFromOuterClass
-        public NullbileCategory Category { get; set; }
+        public NullbileCategory Category { get; set; } = null!;
     }
 
     private class NullbileProduct
     {
         // ReSharper disable once MemberHidesStaticFromOuterClass
-        public NullbileCategory Category { get; set; }
+        public NullbileCategory Category { get; set; } = null!;
     }
 
     private class Sweet
     {
         public int? Id { get; set; }
-        public Dreams Dreams { get; set; }
+        public Dreams Dreams { get; set; } = null!;
     }
 
     private class Dreams
     {
-        public Sweet Sweet { get; set; }
-        public AreMade Are { get; set; }
-        public AreMade Made { get; set; }
-        public OfThis OfThis { get; }
+        public Sweet Sweet { get; set; } = null!;
+        public AreMade Are { get; set; } = null!;
+        public AreMade Made { get; set; } = null!;
+        public OfThis OfThis { get; } = null!;
     }
 
     private class AreMade;

--- a/test/EFCore.Tests/ChangeTracking/ValueComparerTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/ValueComparerTest.cs
@@ -48,7 +48,7 @@ public class ValueComparerTest
             => optionsBuilder.UseInMemoryDatabase(Guid.NewGuid().ToString());
 
         protected internal override void OnModelCreating(ModelBuilder modelBuilder)
-            => modelBuilder.Entity<Foo>().Property(e => e.Bar).HasConversion<string>((ValueComparer)null, new FakeValueComparer());
+            => modelBuilder.Entity<Foo>().Property(e => e.Bar).HasConversion<string>((ValueComparer)null!, new FakeValueComparer());
     }
 
     [Theory,
@@ -76,7 +76,7 @@ public class ValueComparerTest
 
     private static ValueComparer CompareTest(Type type, object value1, object value2, int? hashCode, bool toNullable)
     {
-        var comparer = (ValueComparer)Activator.CreateInstance(typeof(ValueComparer<>).MakeGenericType(type), [false]);
+        var comparer = (ValueComparer)Activator.CreateInstance(typeof(ValueComparer<>).MakeGenericType(type), [false])!;
         if (toNullable)
         {
             comparer = ToNonNullNullableComparer(comparer);
@@ -92,7 +92,7 @@ public class ValueComparerTest
 
         Assert.Equal(hashCode ?? value1.GetHashCode(), comparer.GetHashCode(value1));
 
-        var keyComparer = (ValueComparer)Activator.CreateInstance(typeof(ValueComparer<>).MakeGenericType(type), [true]);
+        var keyComparer = (ValueComparer)Activator.CreateInstance(typeof(ValueComparer<>).MakeGenericType(type), [true])!;
         if (toNullable)
         {
             keyComparer = ToNonNullNullableComparer(keyComparer);
@@ -142,7 +142,7 @@ public class ValueComparerTest
         LambdaExpression equalsExpression,
         LambdaExpression hashCodeExpression,
         LambdaExpression snapshotExpression) : ValueComparer<T>(
-        (Expression<Func<T, T, bool>>)equalsExpression,
+        (Expression<Func<T?, T?, bool>>)equalsExpression,
         (Expression<Func<T, int>>)hashCodeExpression,
         (Expression<Func<T, T>>)snapshotExpression);
 
@@ -191,7 +191,7 @@ public class ValueComparerTest
         private bool Equals(JustAStructWithEquality other)
             => A == other.A;
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => obj is JustAStructWithEquality o && Equals(o);
 
         public override int GetHashCode()
@@ -253,7 +253,7 @@ public class ValueComparerTest
         private bool Equals(JustAClassWithEquality other)
             => A == other.A;
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => obj is not null
                 && (ReferenceEquals(this, obj)
                     || obj is JustAClassWithEquality o
@@ -316,8 +316,8 @@ public class ValueComparerTest
         Assert.False(keyEquals(value1, value2));
         Assert.False(keyEquals(value2, value1));
 
-        Assert.Equal(hashCode ?? value1.GetHashCode(), getHashCode(value1));
-        Assert.Equal(hashCode ?? value1.GetHashCode(), getKeyHashCode(value1));
+        Assert.Equal(hashCode ?? value1!.GetHashCode(), getHashCode(value1));
+        Assert.Equal(hashCode ?? value1!.GetHashCode(), getKeyHashCode(value1));
     }
 
     private void GenericCompareTestWithNulls<T>(T value1, T value2, int? hashCode = null)
@@ -534,11 +534,11 @@ public class ValueComparerTest
     public void Can_define_different_custom_equals_for_key_and_non_key()
     {
         var comparer = new ValueComparer<Binary>(
-            (v1, v2) => v1.Equals(v2),
+            (v1, v2) => v1!.Equals(v2),
             v => v.GetHashCode());
 
         var keyComparer = new ValueComparer<Binary>(
-            (v1, v2) => v1.Value0 == v2.Value0 && v1.Value1 == v2.Value1,
+            (v1, v2) => v1!.Value0 == v2!.Value0 && v1.Value1 == v2.Value1,
             v => v.Value0 << 8 | v.Value1);
 
         var equals = comparer.EqualsExpression.Compile();
@@ -569,10 +569,10 @@ public class ValueComparerTest
     }
 
     private static readonly MethodInfo _getValue0Method
-        = typeof(DeepBinary).GetProperty(nameof(DeepBinary.Value0)).GetMethod;
+        = typeof(DeepBinary).GetProperty(nameof(DeepBinary.Value0))!.GetMethod!;
 
     private static readonly MethodInfo _getValue1Method
-        = typeof(DeepBinary).GetProperty(nameof(DeepBinary.Value1)).GetMethod;
+        = typeof(DeepBinary).GetProperty(nameof(DeepBinary.Value1))!.GetMethod!;
 
     [Fact]
     public void Can_create_new_comparer_composing_existing_comparers()
@@ -581,11 +581,11 @@ public class ValueComparerTest
         var bytesKeyComparer = new ValueComparer<byte[]>(true);
 
         var comparer = new ValueComparer<DeepBinary>(
-            (Expression<Func<DeepBinary, DeepBinary, bool>>)CreateAndExpression(bytesComparer),
+            (Expression<Func<DeepBinary?, DeepBinary?, bool>>)CreateAndExpression(bytesComparer),
             (Expression<Func<DeepBinary, int>>)CreateHashCodeExpression(bytesComparer));
 
         var keyComparer = new ValueComparer<DeepBinary>(
-            (Expression<Func<DeepBinary, DeepBinary, bool>>)CreateAndExpression(bytesKeyComparer),
+            (Expression<Func<DeepBinary?, DeepBinary?, bool>>)CreateAndExpression(bytesKeyComparer),
             (Expression<Func<DeepBinary, int>>)CreateHashCodeExpression(bytesKeyComparer));
 
         var equals = comparer.EqualsExpression.Compile();

--- a/test/EFCore.Tests/CollectionComparerTest.cs
+++ b/test/EFCore.Tests/CollectionComparerTest.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System.Collections.ObjectModel;
 
 namespace Microsoft.EntityFrameworkCore;

--- a/test/EFCore.Tests/DbContextFactoryTest.cs
+++ b/test/EFCore.Tests/DbContextFactoryTest.cs
@@ -112,7 +112,7 @@ public class DbContextFactoryTest
             .AddPooledDbContextFactory<WoolacombeContext>(b => b.UseInMemoryDatabase(nameof(WoolacombeContext)))
             .BuildServiceProvider(validateScopes: true);
 
-        var contextFactory = serviceProvider.GetService<IDbContextFactory<WoolacombeContext>>();
+        var contextFactory = serviceProvider.GetRequiredService<IDbContextFactory<WoolacombeContext>>();
 
         var context1 = contextFactory.CreateDbContext();
         var context2 = contextFactory.CreateDbContext();
@@ -144,8 +144,9 @@ public class DbContextFactoryTest
             .BuildServiceProvider(validateScopes: true);
 
         var scope = serviceProvider.CreateScope();
-        var contextFactory = serviceProvider.GetService<IDbContextFactory<WoolacombeContext>>();
+        var contextFactory = serviceProvider.GetRequiredService<IDbContextFactory<WoolacombeContext>>();
         Assert.Same(contextFactory, scope.ServiceProvider.GetService<IDbContextFactory<WoolacombeContext>>());
+        Assert.Same(contextFactory, scope.ServiceProvider.GetRequiredService<IDbContextFactory<WoolacombeContext>>());
 
         var context1 = contextFactory.CreateDbContext();
         var context2 = contextFactory.CreateDbContext();
@@ -154,7 +155,7 @@ public class DbContextFactoryTest
         Assert.Equal(nameof(WoolacombeContext), GetStoreName(context1));
         Assert.Equal(nameof(WoolacombeContext), GetStoreName(context2));
 
-        var context3 = scope.ServiceProvider.GetService<WoolacombeContext>();
+        var context3 = scope.ServiceProvider.GetRequiredService<WoolacombeContext>();
 
         Assert.Same(context3, scope.ServiceProvider.GetService<WoolacombeContext>());
         Assert.NotSame(context1, context3);
@@ -169,7 +170,7 @@ public class DbContextFactoryTest
 
         using var context1b = contextFactory.CreateDbContext();
         using var context2b = contextFactory.CreateDbContext();
-        var context3b = scope1.ServiceProvider.GetService<WoolacombeContext>();
+        var context3b = scope1.ServiceProvider.GetRequiredService<WoolacombeContext>();
 
         Assert.Same(context3b, scope1.ServiceProvider.GetService<WoolacombeContext>());
         Assert.NotSame(context1b, context3b);
@@ -263,7 +264,7 @@ public class DbContextFactoryTest
             .AddDbContextFactory<CroydeContext>(b => b.UseInMemoryDatabase(nameof(CroydeContext)))
             .BuildServiceProvider(validateScopes: true);
 
-        using var context = serviceProvider.GetService<IDbContextFactory<CroydeContext>>().CreateDbContext();
+        using var context = serviceProvider.GetRequiredService<IDbContextFactory<CroydeContext>>().CreateDbContext();
 
         Assert.Equal(nameof(CroydeContext), GetStoreName(context));
     }
@@ -287,7 +288,7 @@ public class DbContextFactoryTest
             .AddDbContextFactory<MortehoeContext>()
             .BuildServiceProvider(validateScopes: true);
 
-        using var context = serviceProvider.GetService<IDbContextFactory<MortehoeContext>>().CreateDbContext();
+        using var context = serviceProvider.GetRequiredService<IDbContextFactory<MortehoeContext>>().CreateDbContext();
 
         Assert.Equal(nameof(MortehoeContext), GetStoreName(context));
     }
@@ -305,7 +306,7 @@ public class DbContextFactoryTest
             .AddDbContextFactory<DbContext>(b => b.UseInMemoryDatabase(nameof(DbContext)))
             .BuildServiceProvider(validateScopes: true);
 
-        using var context = serviceProvider.GetService<IDbContextFactory<DbContext>>().CreateDbContext();
+        using var context = serviceProvider.GetRequiredService<IDbContextFactory<DbContext>>().CreateDbContext();
 
         Assert.Equal(nameof(DbContext), GetStoreName(context));
     }
@@ -326,7 +327,7 @@ public class DbContextFactoryTest
             serviceProvider = serviceProvider.CreateScope().ServiceProvider;
         }
 
-        var contextFactory = serviceProvider.GetService<IDbContextFactory<IlfracombeContext>>();
+        var contextFactory = serviceProvider.GetRequiredService<IDbContextFactory<IlfracombeContext>>();
 
         using var context1 = contextFactory.CreateDbContext();
         using var context2 = contextFactory.CreateDbContext();
@@ -375,7 +376,7 @@ public class DbContextFactoryTest
         var scope = serviceProvider.CreateScope();
         var scopedServiceProvider = scope.ServiceProvider;
 
-        var contextFactory = scopedServiceProvider.GetService<IDbContextFactory<CombeMartinContext>>();
+        var contextFactory = scopedServiceProvider.GetRequiredService<IDbContextFactory<CombeMartinContext>>();
 
         using var context1 = contextFactory.CreateDbContext();
         using var context2 = contextFactory.CreateDbContext();
@@ -402,7 +403,7 @@ public class DbContextFactoryTest
 
         scope = serviceProvider.CreateScope();
         scopedServiceProvider = scope.ServiceProvider;
-        contextFactory = scopedServiceProvider.GetService<IDbContextFactory<CombeMartinContext>>();
+        contextFactory = scopedServiceProvider.GetRequiredService<IDbContextFactory<CombeMartinContext>>();
 
         using var context = contextFactory.CreateDbContext();
 
@@ -462,7 +463,7 @@ public class DbContextFactoryTest
             serviceProvider = serviceProvider.CreateScope().ServiceProvider;
         }
 
-        var contextFactory = serviceProvider.GetService<IDbContextFactory<WoolacombeContext>>();
+        var contextFactory = serviceProvider.GetRequiredService<IDbContextFactory<WoolacombeContext>>();
 
         using var context1 = contextFactory.CreateDbContext();
         using var context2 = contextFactory.CreateDbContext();
@@ -487,7 +488,7 @@ public class DbContextFactoryTest
             })
             .BuildServiceProvider(validateScopes: true);
 
-        var contextFactory = serviceProvider.GetService<IDbContextFactory<WoolacombeContext>>();
+        var contextFactory = serviceProvider.GetRequiredService<IDbContextFactory<WoolacombeContext>>();
 
         using var context1 = contextFactory.CreateDbContext();
         using var context2 = contextFactory.CreateDbContext();
@@ -504,10 +505,10 @@ public class DbContextFactoryTest
             .AddDbContextFactory<WestwardHoContext>(b => b.UseInMemoryDatabase(nameof(WestwardHoContext)))
             .BuildServiceProvider(validateScopes: true);
 
-        var factory = serviceProvider.GetService<IDbContextFactory<WestwardHoContext>>();
+        var factory = serviceProvider.GetRequiredService<IDbContextFactory<WestwardHoContext>>();
 
         Assert.Contains(
-            typeof(Random).FullName,
+            typeof(Random).FullName!,
             Assert.Throws<InvalidOperationException>(() => factory.CreateDbContext()).Message);
     }
 
@@ -523,8 +524,8 @@ public class DbContextFactoryTest
             .AddDbContextFactory<ClovellyContext>(b => b.UseInMemoryDatabase(nameof(ClovellyContext)))
             .BuildServiceProvider(validateScopes: true);
 
-        using var context1 = serviceProvider.GetService<IDbContextFactory<CroydeContext>>().CreateDbContext();
-        using var context2 = serviceProvider.GetService<IDbContextFactory<ClovellyContext>>().CreateDbContext();
+        using var context1 = serviceProvider.GetRequiredService<IDbContextFactory<CroydeContext>>().CreateDbContext();
+        using var context2 = serviceProvider.GetRequiredService<IDbContextFactory<ClovellyContext>>().CreateDbContext();
 
         Assert.Equal(nameof(CroydeContext), GetStoreName(context1));
         Assert.Equal(nameof(ClovellyContext), GetStoreName(context2));
@@ -540,8 +541,8 @@ public class DbContextFactoryTest
             .AddDbContextFactory<WoolacombeContext>(b => b.UseInMemoryDatabase(nameof(WoolacombeContext)))
             .BuildServiceProvider(validateScopes: true);
 
-        using var context1 = serviceProvider.GetService<IDbContextFactory<WidemouthBayContext>>().CreateDbContext();
-        using var context2 = serviceProvider.GetService<IDbContextFactory<WoolacombeContext>>().CreateDbContext();
+        using var context1 = serviceProvider.GetRequiredService<IDbContextFactory<WidemouthBayContext>>().CreateDbContext();
+        using var context2 = serviceProvider.GetRequiredService<IDbContextFactory<WoolacombeContext>>().CreateDbContext();
 
         Assert.Equal(nameof(WidemouthBayContext), GetStoreName(context1));
         Assert.Equal(nameof(WoolacombeContext), GetStoreName(context2));
@@ -557,7 +558,7 @@ public class DbContextFactoryTest
             .AddDbContextFactory<WoolacombeContext>(b => b.UseInMemoryDatabase(nameof(WoolacombeContext)))
             .BuildServiceProvider(validateScopes: true);
 
-        var contextFactory = serviceProvider.GetService<IDbContextFactory<WoolacombeContext>>();
+        var contextFactory = serviceProvider.GetRequiredService<IDbContextFactory<WoolacombeContext>>();
 
         Assert.IsType<WoolacombeContextFactory>(contextFactory);
 
@@ -576,7 +577,7 @@ public class DbContextFactoryTest
             .AddDbContextFactory<WoolacombeContext, WoolacombeContextFactory>(b => b.UseInMemoryDatabase(nameof(WoolacombeContext)))
             .BuildServiceProvider(validateScopes: true);
 
-        var contextFactory = serviceProvider.GetService<IDbContextFactory<WoolacombeContext>>();
+        var contextFactory = serviceProvider.GetRequiredService<IDbContextFactory<WoolacombeContext>>();
 
         Assert.IsType<WoolacombeContextFactory>(contextFactory);
 
@@ -890,5 +891,5 @@ public class DbContextFactoryTest
     }
 
     private static string GetStoreName(DbContext context1)
-        => context1.GetService<IDbContextOptions>().FindExtension<InMemoryOptionsExtension>().StoreName;
+        => context1.GetService<IDbContextOptions>().FindExtension<InMemoryOptionsExtension>()!.StoreName;
 }

--- a/test/EFCore.Tests/DbContextLoggerTests.cs
+++ b/test/EFCore.Tests/DbContextLoggerTests.cs
@@ -368,10 +368,10 @@ public class DbContextLoggerTests
         {
             Assert.Equal(0, async ? await context.SaveChangesAsync() : context.SaveChanges());
 
-            productVersion = context.Model.GetProductVersion();
+            productVersion = context.Model.GetProductVersion()!;
         }
 
-        var lines = writer.ToString()
+        var lines = writer.ToString()!
             .Replace(productVersion, "X.X.X-any")
             .Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
 

--- a/test/EFCore.Tests/DbContextOptionsTest.cs
+++ b/test/EFCore.Tests/DbContextOptionsTest.cs
@@ -15,7 +15,7 @@ public class DbContextOptionsTest
         var optionsBuilder = new DbContextOptionsBuilder()
             .ConfigureWarnings(c => c.Default(WarningBehavior.Throw));
 
-        var warningConfiguration = optionsBuilder.Options.FindExtension<CoreOptionsExtension>().WarningsConfiguration;
+        var warningConfiguration = optionsBuilder.Options.FindExtension<CoreOptionsExtension>()!.WarningsConfiguration;
 
         Assert.Equal(WarningBehavior.Throw, warningConfiguration.DefaultBehavior);
     }
@@ -27,7 +27,7 @@ public class DbContextOptionsTest
 
         var optionsBuilder = new DbContextOptionsBuilder().UseModel(model.FinalizeModel());
 
-        Assert.Same(model, optionsBuilder.Options.FindExtension<CoreOptionsExtension>().Model);
+        Assert.Same(model, optionsBuilder.Options.FindExtension<CoreOptionsExtension>()!.Model);
     }
 
     [Fact]
@@ -37,8 +37,8 @@ public class DbContextOptionsTest
 
         var optionsBuilder = new DbContextOptionsBuilder().UseModel(model.FinalizeModel()).EnableSensitiveDataLogging();
 
-        Assert.Same(model, optionsBuilder.Options.FindExtension<CoreOptionsExtension>().Model);
-        Assert.True(optionsBuilder.Options.FindExtension<CoreOptionsExtension>().IsSensitiveDataLoggingEnabled);
+        Assert.Same(model, optionsBuilder.Options.FindExtension<CoreOptionsExtension>()!.Model);
+        Assert.True(optionsBuilder.Options.FindExtension<CoreOptionsExtension>()!.IsSensitiveDataLoggingEnabled);
     }
 
     [Fact]
@@ -197,9 +197,9 @@ public class DbContextOptionsTest
 
     private class FakeDbContextOptionsExtension1 : IDbContextOptionsExtension
     {
-        private DbContextOptionsExtensionInfo _info;
+        private DbContextOptionsExtensionInfo? _info;
 
-        public string Something { get; set; }
+        public string Something { get; set; } = null!;
 
         public DbContextOptionsExtensionInfo Info
             => _info ??= new ExtensionInfo(this);
@@ -235,7 +235,7 @@ public class DbContextOptionsTest
 
     private class FakeDbContextOptionsExtension2 : IDbContextOptionsExtension
     {
-        private DbContextOptionsExtensionInfo _info;
+        private DbContextOptionsExtensionInfo? _info;
 
         public DbContextOptionsExtensionInfo Info
             => _info ??= new ExtensionInfo(this);
@@ -271,7 +271,7 @@ public class DbContextOptionsTest
 
     private class FakeDbContextOptionsExtension3 : IDbContextOptionsExtension
     {
-        private DbContextOptionsExtensionInfo _info;
+        private DbContextOptionsExtensionInfo? _info;
 
         public DbContextOptionsExtensionInfo Info
             => _info ??= new ExtensionInfo(this);
@@ -312,7 +312,7 @@ public class DbContextOptionsTest
 
         var optionsBuilder = GenericCheck(new DbContextOptionsBuilder<UnkoolContext>().UseModel(model));
 
-        Assert.Same(model, optionsBuilder.Options.FindExtension<CoreOptionsExtension>().Model);
+        Assert.Same(model, optionsBuilder.Options.FindExtension<CoreOptionsExtension>()!.Model);
     }
 
     [Fact]
@@ -322,7 +322,7 @@ public class DbContextOptionsTest
 
         var optionsBuilder = GenericCheck(new DbContextOptionsBuilder<UnkoolContext>().UseLoggerFactory(loggerFactory));
 
-        Assert.Same(loggerFactory, optionsBuilder.Options.FindExtension<CoreOptionsExtension>().LoggerFactory);
+        Assert.Same(loggerFactory, optionsBuilder.Options.FindExtension<CoreOptionsExtension>()!.LoggerFactory);
     }
 
     [Fact]
@@ -332,7 +332,7 @@ public class DbContextOptionsTest
 
         var optionsBuilder = GenericCheck(new DbContextOptionsBuilder<UnkoolContext>().UseMemoryCache(memoryCache));
 
-        Assert.Same(memoryCache, optionsBuilder.Options.FindExtension<CoreOptionsExtension>().MemoryCache);
+        Assert.Same(memoryCache, optionsBuilder.Options.FindExtension<CoreOptionsExtension>()!.MemoryCache);
     }
 
     private class FakeMemoryCache : IMemoryCache
@@ -357,7 +357,7 @@ public class DbContextOptionsTest
 
         var optionsBuilder = GenericCheck(new DbContextOptionsBuilder<UnkoolContext>().UseInternalServiceProvider(serviceProvider));
 
-        Assert.Same(serviceProvider, optionsBuilder.Options.FindExtension<CoreOptionsExtension>().InternalServiceProvider);
+        Assert.Same(serviceProvider, optionsBuilder.Options.FindExtension<CoreOptionsExtension>()!.InternalServiceProvider);
     }
 
     private class FakeServiceProvider : IServiceProvider
@@ -381,7 +381,7 @@ public class DbContextOptionsTest
             new DbContextOptionsBuilder<UnkoolContext>().UseQueryTrackingBehavior(QueryTrackingBehavior.NoTracking));
 
         Assert.Equal(
-            QueryTrackingBehavior.NoTracking, optionsBuilder.Options.FindExtension<CoreOptionsExtension>().QueryTrackingBehavior);
+            QueryTrackingBehavior.NoTracking, optionsBuilder.Options.FindExtension<CoreOptionsExtension>()!.QueryTrackingBehavior);
     }
 
     [Fact]
@@ -390,7 +390,7 @@ public class DbContextOptionsTest
         var optionsBuilder = GenericCheck(
             new DbContextOptionsBuilder<UnkoolContext>().ConfigureWarnings(c => c.Default(WarningBehavior.Throw)));
 
-        var warningConfiguration = optionsBuilder.Options.FindExtension<CoreOptionsExtension>().WarningsConfiguration;
+        var warningConfiguration = optionsBuilder.Options.FindExtension<CoreOptionsExtension>()!.WarningsConfiguration;
 
         Assert.Equal(WarningBehavior.Throw, warningConfiguration.DefaultBehavior);
     }

--- a/test/EFCore.Tests/DbContextTest.Services.cs
+++ b/test/EFCore.Tests/DbContextTest.Services.cs
@@ -69,7 +69,7 @@ namespace Microsoft.EntityFrameworkCore
 
             protected internal override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
             {
-                optionsBuilder.UseInMemoryDatabase(typeof(InfoLogContext).FullName)
+                optionsBuilder.UseInMemoryDatabase(typeof(InfoLogContext).FullName!)
                     .ConfigureWarnings(w => w.Default(WarningBehavior.Log));
 
                 if (_useLoggerFactory)
@@ -85,7 +85,7 @@ namespace Microsoft.EntityFrameworkCore
 
                     optionsBuilder
                         .EnableServiceProviderCaching(false)
-                        .UseLoggerFactory(externalProvider.GetService<ILoggerFactory>());
+                        .UseLoggerFactory(externalProvider.GetRequiredService<ILoggerFactory>());
                 }
                 else
                 {
@@ -123,8 +123,8 @@ namespace Microsoft.EntityFrameworkCore
                     LogLevel logLevel,
                     EventId eventId,
                     TState state,
-                    Exception exception,
-                    Func<TState, Exception, string> formatter)
+                    Exception? exception,
+                    Func<TState, Exception?, string> formatter)
                 {
                     var message = new StringBuilder();
                     if (formatter != null)
@@ -151,7 +151,8 @@ namespace Microsoft.EntityFrameworkCore
                 public IDisposable BeginScope(object state)
                     => throw new NotImplementedException();
 
-                public IDisposable BeginScope<TState>(TState state)
+                public IDisposable? BeginScope<TState>(TState state)
+                    where TState : notnull
                     => null;
             }
         }
@@ -187,7 +188,7 @@ namespace Microsoft.EntityFrameworkCore
 
                 using (appServiceProvider)
                 {
-                    loggerFactory = appServiceProvider.GetService<ILoggerFactory>();
+                    loggerFactory = appServiceProvider.GetRequiredService<ILoggerFactory>();
                     Random scopedExternalService;
                     Random scopedExternalServiceFromContext;
 
@@ -200,7 +201,7 @@ namespace Microsoft.EntityFrameworkCore
 
                         Assert.Same(loggerFactory, scope.ServiceProvider.GetService<ILoggerFactory>());
 
-                        scopedExternalService = scope.ServiceProvider.GetService<Random>();
+                        scopedExternalService = scope.ServiceProvider.GetRequiredService<Random>();
                         Assert.NotNull(scopedExternalService);
 
                         scopedExternalServiceFromContext = context.GetService<Random>();
@@ -397,7 +398,7 @@ namespace Microsoft.EntityFrameworkCore
                     }
                     else
                     {
-                        b.UseRootApplicationServiceProvider(p.GetService<ServiceProviderAccessor>().RootServiceProvider);
+                        b.UseRootApplicationServiceProvider(p.GetRequiredService<ServiceProviderAccessor>().RootServiceProvider);
                     }
                 });
 
@@ -406,7 +407,7 @@ namespace Microsoft.EntityFrameworkCore
             private readonly ICoreSingletonOptions _singletonOptions = singletonOptions;
 
             public ApplicationService ApplicationService
-                => _singletonOptions.RootApplicationServiceProvider!.GetService<ApplicationService>();
+                => _singletonOptions.RootApplicationServiceProvider!.GetRequiredService<ApplicationService>();
         }
 
         private class TestScopedService(ICurrentDbContext currentContext, IEntityEntryGraphIterator graphIterator)
@@ -663,8 +664,8 @@ namespace Microsoft.EntityFrameworkCore
             public void NavigationReferenceChanged(
                 InternalEntityEntry entry,
                 INavigationBase navigationBase,
-                object oldValue,
-                object newValue)
+                object? oldValue,
+                object? newValue)
                 => throw new NotImplementedException();
 
             public void NavigationCollectionChanged(
@@ -679,8 +680,8 @@ namespace Microsoft.EntityFrameworkCore
                 IProperty property,
                 IEnumerable<IKey> containingPrincipalKeys,
                 IEnumerable<IForeignKey> containingForeignKeys,
-                object oldValue,
-                object newValue)
+                object? oldValue,
+                object? newValue)
                 => throw new NotImplementedException();
 
             public void TrackedFromQuery(InternalEntityEntry entry)
@@ -828,12 +829,12 @@ namespace Microsoft.EntityFrameworkCore
         [ComplexType]
         private class Tag
         {
-            public string Name { get; set; }
+            public string Name { get; set; } = null!;
 
             [Required]
-            public Stamp Stamp { get; set; }
+            public Stamp Stamp { get; set; } = null!;
 
-            public string[] Notes { get; set; }
+            public string[] Notes { get; set; } = null!;
         }
 
         [ComplexType]
@@ -845,66 +846,66 @@ namespace Microsoft.EntityFrameworkCore
         private class Category
         {
             public int Id { get; set; }
-            public string Name { get; set; }
+            public string Name { get; set; } = null!;
 
             [Required]
-            public Tag Tag { get; set; }
+            public Tag Tag { get; set; } = null!;
 
             [Required]
-            public Stamp Stamp { get; set; }
+            public Stamp Stamp { get; set; } = null!;
 
-            public List<Product> Products { get; set; }
+            public List<Product> Products { get; set; } = [];
         }
 
         private class Product
         {
             public int Id { get; set; }
-            public string Name { get; set; }
+            public string Name { get; set; } = null!;
             public decimal Price { get; set; }
 
             [Required]
-            public Tag Tag { get; set; }
+            public Tag Tag { get; set; } = null!;
 
             [Required]
-            public Stamp Stamp { get; set; }
+            public Stamp Stamp { get; set; } = null!;
 
             public int CategoryId { get; set; }
-            public Category Category { get; set; }
+            public Category Category { get; set; } = null!;
         }
 
         private class TheGu
         {
             public Guid Id { get; set; }
-            public string ShirtColor { get; set; }
+            public string ShirtColor { get; set; } = null!;
         }
 
         private class CategoryWithSentinel
         {
             public int Id { get; set; }
-            public string Name { get; set; }
+            public string Name { get; set; } = null!;
 
-            public List<ProductWithSentinel> Products { get; set; }
+            public List<ProductWithSentinel> Products { get; set; } = [];
         }
 
         private class ProductWithSentinel
         {
             public int Id { get; set; }
-            public string Name { get; set; }
+            public string Name { get; set; } = null!;
             public decimal Price { get; set; }
 
             public int CategoryId { get; set; }
-            public CategoryWithSentinel Category { get; set; }
+            public CategoryWithSentinel Category { get; set; } = null!;
         }
 
         private class TheGuWithSentinel
         {
             public Guid Id { get; set; }
-            public string ShirtColor { get; set; }
+            public string ShirtColor { get; set; } = null!;
         }
 
         private class EarlyLearningCenter : DbContext
         {
-            private readonly IServiceProvider _serviceProvider;
+            private readonly IServiceProvider? _serviceProvider;
 
             public EarlyLearningCenter()
             {
@@ -917,12 +918,12 @@ namespace Microsoft.EntityFrameworkCore
                 : base(options)
                 => _serviceProvider = serviceProvider;
 
-            public DbSet<Product> Products { get; set; }
-            public DbSet<Category> Categories { get; set; }
-            public DbSet<TheGu> Gus { get; set; }
-            public DbSet<ProductWithSentinel> ProductWithSentinels { get; set; }
-            public DbSet<CategoryWithSentinel> CategoryWithSentinels { get; set; }
-            public DbSet<TheGuWithSentinel> GuWithSentinels { get; set; }
+            public DbSet<Product> Products { get; set; } = null!;
+            public DbSet<Category> Categories { get; set; } = null!;
+            public DbSet<TheGu> Gus { get; set; } = null!;
+            public DbSet<ProductWithSentinel> ProductWithSentinels { get; set; } = null!;
+            public DbSet<CategoryWithSentinel> CategoryWithSentinels { get; set; } = null!;
+            public DbSet<TheGuWithSentinel> GuWithSentinels { get; set; } = null!;
 
             protected internal override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
                 => optionsBuilder
@@ -993,8 +994,8 @@ namespace Microsoft.EntityFrameworkCore
                 .AddMemoryCache()
                 .BuildServiceProvider(validateScopes: true);
 
-            var loggerFactory = new WrappingLoggerFactory(appServiceProvider.GetService<ILoggerFactory>());
-            var memoryCache = appServiceProvider.GetService<IMemoryCache>();
+            var loggerFactory = new WrappingLoggerFactory(appServiceProvider.GetRequiredService<ILoggerFactory>());
+            var memoryCache = appServiceProvider.GetRequiredService<IMemoryCache>();
 
             IInMemoryDatabaseRootCache singleton;
 
@@ -1055,8 +1056,8 @@ namespace Microsoft.EntityFrameworkCore
                 .AddMemoryCache()
                 .BuildServiceProvider(validateScopes: true);
 
-            var loggerFactory = new WrappingLoggerFactory(appServiceProvider.GetService<ILoggerFactory>());
-            var memoryCache = appServiceProvider.GetService<IMemoryCache>();
+            var loggerFactory = new WrappingLoggerFactory(appServiceProvider.GetRequiredService<ILoggerFactory>());
+            var memoryCache = appServiceProvider.GetRequiredService<IMemoryCache>();
 
             var options = new DbContextOptionsBuilder<ConstructorTestContextWithOC3A>()
                 .UseInMemoryDatabase(Guid.NewGuid().ToString())
@@ -1188,8 +1189,8 @@ namespace Microsoft.EntityFrameworkCore
                 .AddMemoryCache()
                 .BuildServiceProvider(validateScopes: true);
 
-            var loggerFactory = new WrappingLoggerFactory(appServiceProvider.GetService<ILoggerFactory>());
-            var memoryCache = appServiceProvider.GetService<IMemoryCache>();
+            var loggerFactory = new WrappingLoggerFactory(appServiceProvider.GetRequiredService<ILoggerFactory>());
+            var memoryCache = appServiceProvider.GetRequiredService<IMemoryCache>();
 
             var options = new DbContextOptionsBuilder<ConstructorTestContext1A>()
                 .UseInMemoryDatabase(Guid.NewGuid().ToString())
@@ -1291,8 +1292,8 @@ namespace Microsoft.EntityFrameworkCore
                 .AddMemoryCache()
                 .BuildServiceProvider(validateScopes: true);
 
-            var loggerFactory = new WrappingLoggerFactory(appServiceProvider.GetService<ILoggerFactory>());
-            var memoryCache = appServiceProvider.GetService<IMemoryCache>();
+            var loggerFactory = new WrappingLoggerFactory(appServiceProvider.GetRequiredService<ILoggerFactory>());
+            var memoryCache = appServiceProvider.GetRequiredService<IMemoryCache>();
 
             var options = new DbContextOptionsBuilder()
                 .UseInternalServiceProvider(
@@ -1386,8 +1387,8 @@ namespace Microsoft.EntityFrameworkCore
                        .CreateScope())
             {
                 context1 = useInterface
-                    ? (ConstructorTestContextWithOC1A)serviceScope.ServiceProvider.GetService<IConstructorTestContextWithOC1A>()
-                    : serviceScope.ServiceProvider.GetService<ConstructorTestContextWithOC1A>();
+                    ? (ConstructorTestContextWithOC1A)serviceScope.ServiceProvider.GetRequiredService<IConstructorTestContextWithOC1A>()
+                    : serviceScope.ServiceProvider.GetRequiredService<ConstructorTestContextWithOC1A>();
 
                 if (useInterface)
                 {
@@ -1408,8 +1409,8 @@ namespace Microsoft.EntityFrameworkCore
                        .CreateScope())
             {
                 context2 = useInterface
-                    ? (ConstructorTestContextWithOC1A)serviceScope.ServiceProvider.GetService<IConstructorTestContextWithOC1A>()
-                    : serviceScope.ServiceProvider.GetService<ConstructorTestContextWithOC1A>();
+                    ? (ConstructorTestContextWithOC1A)serviceScope.ServiceProvider.GetRequiredService<IConstructorTestContextWithOC1A>()
+                    : serviceScope.ServiceProvider.GetRequiredService<ConstructorTestContextWithOC1A>();
 
                 // Singleton services not the same because service provider caching is off
                 Assert.NotSame(singleton[0], context2.GetService<IInMemoryDatabaseRootCache>());
@@ -1438,7 +1439,7 @@ namespace Microsoft.EntityFrameworkCore
                        .GetRequiredService<IServiceScopeFactory>()
                        .CreateScope())
             {
-                var context = serviceScope.ServiceProvider.GetService<ConstructorTestContextWithOC1B>();
+                var context = serviceScope.ServiceProvider.GetRequiredService<ConstructorTestContextWithOC1B>();
 
                 Assert.NotNull(singleton = context.GetService<IInMemoryDatabaseRootCache>());
                 Assert.Same(memoryCache, context.GetService<IMemoryCache>());
@@ -1450,7 +1451,7 @@ namespace Microsoft.EntityFrameworkCore
                        .GetRequiredService<IServiceScopeFactory>()
                        .CreateScope())
             {
-                var context = serviceScope.ServiceProvider.GetService<ConstructorTestContextWithOC1B>();
+                var context = serviceScope.ServiceProvider.GetRequiredService<ConstructorTestContextWithOC1B>();
 
                 // Singleton internal services not the same because service provider caching is off
                 Assert.NotSame(singleton, context.GetService<IInMemoryDatabaseRootCache>());
@@ -1481,7 +1482,7 @@ namespace Microsoft.EntityFrameworkCore
                        .GetRequiredService<IServiceScopeFactory>()
                        .CreateScope())
             {
-                var context = serviceScope.ServiceProvider.GetService<ConstructorTestContextWithOC3A>();
+                var context = serviceScope.ServiceProvider.GetRequiredService<ConstructorTestContextWithOC3A>();
 
                 Assert.NotNull(singleton[0] = context.GetService<IInMemoryDatabaseRootCache>());
                 Assert.NotNull(singleton[1] = context.GetService<IMemoryCache>());
@@ -1502,7 +1503,7 @@ namespace Microsoft.EntityFrameworkCore
                        .GetRequiredService<IServiceScopeFactory>()
                        .CreateScope())
             {
-                var context = serviceScope.ServiceProvider.GetService<ConstructorTestContextWithOC3A>();
+                var context = serviceScope.ServiceProvider.GetRequiredService<ConstructorTestContextWithOC3A>();
 
                 Assert.NotSame(singleton[0], context.GetService<IInMemoryDatabaseRootCache>());
                 Assert.NotSame(singleton[1], context.GetService<IMemoryCache>());
@@ -1536,7 +1537,7 @@ namespace Microsoft.EntityFrameworkCore
                        .GetRequiredService<IServiceScopeFactory>()
                        .CreateScope())
             {
-                var context = serviceScope.ServiceProvider.GetService<ConstructorTestContextWithOC3A>();
+                var context = serviceScope.ServiceProvider.GetRequiredService<ConstructorTestContextWithOC3A>();
 
                 Assert.NotNull(singleton = context.GetService<IInMemoryDatabaseRootCache>());
                 Assert.NotNull(loggerFactory = context.GetService<ILoggerFactory>());
@@ -1550,7 +1551,7 @@ namespace Microsoft.EntityFrameworkCore
                        .GetRequiredService<IServiceScopeFactory>()
                        .CreateScope())
             {
-                var context = serviceScope.ServiceProvider.GetService<ConstructorTestContextWithOC3A>();
+                var context = serviceScope.ServiceProvider.GetRequiredService<ConstructorTestContextWithOC3A>();
 
                 // Singleton services not the same because service provider caching is off
                 Assert.NotSame(singleton, context.GetService<IInMemoryDatabaseRootCache>());
@@ -1575,7 +1576,7 @@ namespace Microsoft.EntityFrameworkCore
                        .GetRequiredService<IServiceScopeFactory>()
                        .CreateScope())
             {
-                var context = serviceScope.ServiceProvider.GetService<ConstructorTestContextWithOC2A>();
+                var context = serviceScope.ServiceProvider.GetRequiredService<ConstructorTestContextWithOC2A>();
 
                 Assert.NotNull(singleton[0] = context.GetService<IInMemoryDatabaseRootCache>());
                 Assert.NotNull(singleton[2] = context.GetService<IMemoryCache>());
@@ -1587,7 +1588,7 @@ namespace Microsoft.EntityFrameworkCore
                        .GetRequiredService<IServiceScopeFactory>()
                        .CreateScope())
             {
-                var context = serviceScope.ServiceProvider.GetService<ConstructorTestContextWithOC2A>();
+                var context = serviceScope.ServiceProvider.GetRequiredService<ConstructorTestContextWithOC2A>();
 
                 Assert.Same(singleton[0], context.GetService<IInMemoryDatabaseRootCache>());
                 Assert.Same(singleton[2], context.GetService<IMemoryCache>());
@@ -1614,7 +1615,7 @@ namespace Microsoft.EntityFrameworkCore
                        .GetRequiredService<IServiceScopeFactory>()
                        .CreateScope())
             {
-                var context = serviceScope.ServiceProvider.GetService<ConstructorTestContextWithOC3A>();
+                var context = serviceScope.ServiceProvider.GetRequiredService<ConstructorTestContextWithOC3A>();
 
                 Assert.NotNull(singleton[0] = context.GetService<IInMemoryDatabaseRootCache>());
                 Assert.NotNull(singleton[1] = context.GetService<IMemoryCache>());
@@ -1627,7 +1628,7 @@ namespace Microsoft.EntityFrameworkCore
                        .GetRequiredService<IServiceScopeFactory>()
                        .CreateScope())
             {
-                var context = serviceScope.ServiceProvider.GetService<ConstructorTestContextWithOC3A>();
+                var context = serviceScope.ServiceProvider.GetRequiredService<ConstructorTestContextWithOC3A>();
 
                 Assert.Same(singleton[0], context.GetService<IInMemoryDatabaseRootCache>());
                 Assert.Same(singleton[1], context.GetService<IMemoryCache>());
@@ -1664,8 +1665,8 @@ namespace Microsoft.EntityFrameworkCore
                        .CreateScope())
             {
                 var context = useInterface
-                    ? (ConstructorTestContextWithOC3A)serviceScope.ServiceProvider.GetService<IConstructorTestContextWithOC3A>()
-                    : serviceScope.ServiceProvider.GetService<ConstructorTestContextWithOC3A>();
+                    ? (ConstructorTestContextWithOC3A)serviceScope.ServiceProvider.GetRequiredService<IConstructorTestContextWithOC3A>()
+                    : serviceScope.ServiceProvider.GetRequiredService<ConstructorTestContextWithOC3A>();
 
                 Assert.NotNull(singleton[0] = context.GetService<IInMemoryDatabaseRootCache>());
                 Assert.NotNull(singleton[1] = context.GetService<IMemoryCache>());
@@ -1679,8 +1680,8 @@ namespace Microsoft.EntityFrameworkCore
                        .CreateScope())
             {
                 var context = useInterface
-                    ? (ConstructorTestContextWithOC3A)serviceScope.ServiceProvider.GetService<IConstructorTestContextWithOC3A>()
-                    : serviceScope.ServiceProvider.GetService<ConstructorTestContextWithOC3A>();
+                    ? (ConstructorTestContextWithOC3A)serviceScope.ServiceProvider.GetRequiredService<IConstructorTestContextWithOC3A>()
+                    : serviceScope.ServiceProvider.GetRequiredService<ConstructorTestContextWithOC3A>();
 
                 Assert.Same(singleton[0], context.GetService<IInMemoryDatabaseRootCache>());
                 Assert.Same(singleton[1], context.GetService<IMemoryCache>());
@@ -1711,7 +1712,7 @@ namespace Microsoft.EntityFrameworkCore
                        .GetRequiredService<IServiceScopeFactory>()
                        .CreateScope())
             {
-                var context = serviceScope.ServiceProvider.GetService<ConstructorTestContextWithOC3A>();
+                var context = serviceScope.ServiceProvider.GetRequiredService<ConstructorTestContextWithOC3A>();
 
                 Assert.NotNull(singleton = context.GetService<IInMemoryDatabaseRootCache>());
                 Assert.Same(memoryCache, context.GetService<IMemoryCache>());
@@ -1724,7 +1725,7 @@ namespace Microsoft.EntityFrameworkCore
                        .GetRequiredService<IServiceScopeFactory>()
                        .CreateScope())
             {
-                var context = serviceScope.ServiceProvider.GetService<ConstructorTestContextWithOC3A>();
+                var context = serviceScope.ServiceProvider.GetRequiredService<ConstructorTestContextWithOC3A>();
 
                 Assert.Same(singleton, context.GetService<IInMemoryDatabaseRootCache>());
                 Assert.Same(memoryCache, context.GetService<IMemoryCache>());
@@ -1754,7 +1755,7 @@ namespace Microsoft.EntityFrameworkCore
                        .GetRequiredService<IServiceScopeFactory>()
                        .CreateScope())
             {
-                var context = serviceScope.ServiceProvider.GetService<ConstructorTestContext1A>();
+                var context = serviceScope.ServiceProvider.GetRequiredService<ConstructorTestContext1A>();
 
                 Assert.NotNull(singleton[0] = context.GetService<IInMemoryDatabaseRootCache>());
                 Assert.NotNull(singleton[1] = context.GetService<IMemoryCache>());
@@ -1767,7 +1768,7 @@ namespace Microsoft.EntityFrameworkCore
                        .GetRequiredService<IServiceScopeFactory>()
                        .CreateScope())
             {
-                var context = serviceScope.ServiceProvider.GetService<ConstructorTestContext1A>();
+                var context = serviceScope.ServiceProvider.GetRequiredService<ConstructorTestContext1A>();
 
                 Assert.NotSame(singleton[0], context.GetService<IInMemoryDatabaseRootCache>());
                 Assert.NotSame(singleton[1], context.GetService<IMemoryCache>());
@@ -1793,7 +1794,7 @@ namespace Microsoft.EntityFrameworkCore
                        .GetRequiredService<IServiceScopeFactory>()
                        .CreateScope())
             {
-                var context = serviceScope.ServiceProvider.GetService<ConstructorTestContext1A>();
+                var context = serviceScope.ServiceProvider.GetRequiredService<ConstructorTestContext1A>();
 
                 Assert.NotNull(singleton = context.GetService<IInMemoryDatabaseRootCache>());
                 Assert.NotNull(loggerFactory = context.GetService<ILoggerFactory>());
@@ -1807,7 +1808,7 @@ namespace Microsoft.EntityFrameworkCore
                        .GetRequiredService<IServiceScopeFactory>()
                        .CreateScope())
             {
-                var context = serviceScope.ServiceProvider.GetService<ConstructorTestContext1A>();
+                var context = serviceScope.ServiceProvider.GetRequiredService<ConstructorTestContext1A>();
 
                 Assert.NotSame(singleton, context.GetService<IInMemoryDatabaseRootCache>());
                 Assert.NotSame(loggerFactory, context.GetService<ILoggerFactory>());
@@ -1835,7 +1836,7 @@ namespace Microsoft.EntityFrameworkCore
                        .GetRequiredService<IServiceScopeFactory>()
                        .CreateScope())
             {
-                var context = serviceScope.ServiceProvider.GetService<ConstructorTestContext1A>();
+                var context = serviceScope.ServiceProvider.GetRequiredService<ConstructorTestContext1A>();
 
                 Assert.NotNull(singleton[0] = context.GetService<IInMemoryDatabaseRootCache>());
                 Assert.NotNull(singleton[1] = context.GetService<IMemoryCache>());
@@ -1848,7 +1849,7 @@ namespace Microsoft.EntityFrameworkCore
                        .GetRequiredService<IServiceScopeFactory>()
                        .CreateScope())
             {
-                var context = serviceScope.ServiceProvider.GetService<ConstructorTestContext1A>();
+                var context = serviceScope.ServiceProvider.GetRequiredService<ConstructorTestContext1A>();
 
                 Assert.Same(singleton[0], context.GetService<IInMemoryDatabaseRootCache>());
                 Assert.Same(singleton[1], context.GetService<IMemoryCache>());
@@ -1873,7 +1874,7 @@ namespace Microsoft.EntityFrameworkCore
                        .GetRequiredService<IServiceScopeFactory>()
                        .CreateScope())
             {
-                var context = serviceScope.ServiceProvider.GetService<ConstructorTestContext1A>();
+                var context = serviceScope.ServiceProvider.GetRequiredService<ConstructorTestContext1A>();
 
                 Assert.NotNull(singleton[0] = context.GetService<IInMemoryDatabaseRootCache>());
                 Assert.NotNull(singleton[1] = context.GetService<IMemoryCache>());
@@ -1886,7 +1887,7 @@ namespace Microsoft.EntityFrameworkCore
                        .GetRequiredService<IServiceScopeFactory>()
                        .CreateScope())
             {
-                var context = serviceScope.ServiceProvider.GetService<ConstructorTestContext1A>();
+                var context = serviceScope.ServiceProvider.GetRequiredService<ConstructorTestContext1A>();
 
                 Assert.Same(singleton[0], context.GetService<IInMemoryDatabaseRootCache>());
                 Assert.Same(singleton[1], context.GetService<IMemoryCache>());
@@ -1914,7 +1915,7 @@ namespace Microsoft.EntityFrameworkCore
                        .GetRequiredService<IServiceScopeFactory>()
                        .CreateScope())
             {
-                var context = serviceScope.ServiceProvider.GetService<ConstructorTestContext1A>();
+                var context = serviceScope.ServiceProvider.GetRequiredService<ConstructorTestContext1A>();
 
                 Assert.NotNull(singleton = context.GetService<IInMemoryDatabaseRootCache>());
                 Assert.Same(memoryCache, context.GetService<IMemoryCache>());
@@ -1927,7 +1928,7 @@ namespace Microsoft.EntityFrameworkCore
                        .GetRequiredService<IServiceScopeFactory>()
                        .CreateScope())
             {
-                var context = serviceScope.ServiceProvider.GetService<ConstructorTestContext1A>();
+                var context = serviceScope.ServiceProvider.GetRequiredService<ConstructorTestContext1A>();
 
                 Assert.Same(singleton, context.GetService<IInMemoryDatabaseRootCache>());
                 Assert.Same(memoryCache, context.GetService<IMemoryCache>());
@@ -1949,7 +1950,7 @@ namespace Microsoft.EntityFrameworkCore
                        .GetRequiredService<IServiceScopeFactory>()
                        .CreateScope())
             {
-                var context = serviceScope.ServiceProvider.GetService<DbContext>();
+                var context = serviceScope.ServiceProvider.GetRequiredService<DbContext>();
 
                 Assert.NotNull(singleton[0] = context.GetService<IInMemoryDatabaseRootCache>());
                 Assert.NotNull(singleton[1] = context.GetService<IMemoryCache>());
@@ -1962,7 +1963,7 @@ namespace Microsoft.EntityFrameworkCore
                        .GetRequiredService<IServiceScopeFactory>()
                        .CreateScope())
             {
-                var context = serviceScope.ServiceProvider.GetService<DbContext>();
+                var context = serviceScope.ServiceProvider.GetRequiredService<DbContext>();
 
                 Assert.NotSame(singleton[0], context.GetService<IInMemoryDatabaseRootCache>());
                 Assert.NotSame(singleton[1], context.GetService<IMemoryCache>());
@@ -1992,7 +1993,7 @@ namespace Microsoft.EntityFrameworkCore
                        .GetRequiredService<IServiceScopeFactory>()
                        .CreateScope())
             {
-                var context = serviceScope.ServiceProvider.GetService<DbContext>();
+                var context = serviceScope.ServiceProvider.GetRequiredService<DbContext>();
 
                 Assert.NotNull(singleton = context.GetService<IInMemoryDatabaseRootCache>());
                 Assert.Same(memoryCache, context.GetService<IMemoryCache>());
@@ -2005,7 +2006,7 @@ namespace Microsoft.EntityFrameworkCore
                        .GetRequiredService<IServiceScopeFactory>()
                        .CreateScope())
             {
-                var context = serviceScope.ServiceProvider.GetService<DbContext>();
+                var context = serviceScope.ServiceProvider.GetRequiredService<DbContext>();
 
                 Assert.NotSame(singleton, context.GetService<IInMemoryDatabaseRootCache>());
                 Assert.Same(memoryCache, context.GetService<IMemoryCache>());
@@ -2030,7 +2031,7 @@ namespace Microsoft.EntityFrameworkCore
                        .GetRequiredService<IServiceScopeFactory>()
                        .CreateScope())
             {
-                var context = serviceScope.ServiceProvider.GetService<DbContext>();
+                var context = serviceScope.ServiceProvider.GetRequiredService<DbContext>();
 
                 Assert.NotNull(singleton[0] = context.GetService<IInMemoryDatabaseRootCache>());
                 Assert.NotNull(singleton[1] = context.GetService<IMemoryCache>());
@@ -2043,7 +2044,7 @@ namespace Microsoft.EntityFrameworkCore
                        .GetRequiredService<IServiceScopeFactory>()
                        .CreateScope())
             {
-                var context = serviceScope.ServiceProvider.GetService<DbContext>();
+                var context = serviceScope.ServiceProvider.GetRequiredService<DbContext>();
 
                 Assert.Same(singleton[0], context.GetService<IInMemoryDatabaseRootCache>());
                 Assert.Same(singleton[1], context.GetService<IMemoryCache>());
@@ -2076,7 +2077,7 @@ namespace Microsoft.EntityFrameworkCore
                        .GetRequiredService<IServiceScopeFactory>()
                        .CreateScope())
             {
-                context1 = serviceScope.ServiceProvider.GetService<ConstructorTestContextWithOC1A>();
+                context1 = serviceScope.ServiceProvider.GetRequiredService<ConstructorTestContextWithOC1A>();
 
                 Assert.NotNull(singleton[0] = context1.GetService<IInMemoryDatabaseRootCache>());
                 Assert.NotNull(singleton[1] = context1.GetService<ILoggerFactory>());
@@ -2091,7 +2092,7 @@ namespace Microsoft.EntityFrameworkCore
                        .GetRequiredService<IServiceScopeFactory>()
                        .CreateScope())
             {
-                context2 = serviceScope.ServiceProvider.GetService<ConstructorTestContextWithOC1A>();
+                context2 = serviceScope.ServiceProvider.GetRequiredService<ConstructorTestContextWithOC1A>();
 
                 Assert.Same(singleton[0], context2.GetService<IInMemoryDatabaseRootCache>());
                 Assert.Same(singleton[1], context2.GetService<ILoggerFactory>());
@@ -2156,7 +2157,7 @@ namespace Microsoft.EntityFrameworkCore
                        .GetRequiredService<IServiceScopeFactory>()
                        .CreateScope())
             {
-                context1 = serviceScope.ServiceProvider.GetService<ConstructorTestContextWithOC3A>();
+                context1 = serviceScope.ServiceProvider.GetRequiredService<ConstructorTestContextWithOC3A>();
 
                 Assert.NotNull(singleton[0] = context1.GetService<IInMemoryDatabaseRootCache>());
                 Assert.NotNull(singleton[1] = context1.GetService<ILoggerFactory>());
@@ -2171,7 +2172,7 @@ namespace Microsoft.EntityFrameworkCore
                        .GetRequiredService<IServiceScopeFactory>()
                        .CreateScope())
             {
-                context2 = serviceScope.ServiceProvider.GetService<ConstructorTestContextWithOC3A>();
+                context2 = serviceScope.ServiceProvider.GetRequiredService<ConstructorTestContextWithOC3A>();
 
                 Assert.Same(singleton[0], context2.GetService<IInMemoryDatabaseRootCache>());
                 Assert.Same(singleton[1], context2.GetService<ILoggerFactory>());
@@ -2202,14 +2203,14 @@ namespace Microsoft.EntityFrameworkCore
                         .BuildServiceProvider(validateScopes: true));
 
             var singleton = new object[3];
-            DbContextOptions options = null;
+            DbContextOptions options = null!;
 
             using (var serviceScope = appServiceProvider
                        .GetRequiredService<IServiceScopeFactory>()
                        .CreateScope())
             {
-                var context1 = serviceScope.ServiceProvider.GetService<ConstructorTestContextWithOC1A>();
-                var context2 = serviceScope.ServiceProvider.GetService<ConstructorTestContextWithOC1A>();
+                var context1 = serviceScope.ServiceProvider.GetRequiredService<ConstructorTestContextWithOC1A>();
+                var context2 = serviceScope.ServiceProvider.GetRequiredService<ConstructorTestContextWithOC1A>();
 
                 Assert.NotSame(context1, context2);
 
@@ -2221,7 +2222,7 @@ namespace Microsoft.EntityFrameworkCore
 
                 if (useDbContext)
                 {
-                    options = serviceScope.ServiceProvider.GetService<DbContextOptions>();
+                    options = serviceScope.ServiceProvider.GetRequiredService<DbContextOptions>();
 
                     if (optionsLifetime != ServiceLifetime.Transient)
                     {
@@ -2245,7 +2246,7 @@ namespace Microsoft.EntityFrameworkCore
                        .GetRequiredService<IServiceScopeFactory>()
                        .CreateScope())
             {
-                var context = serviceScope.ServiceProvider.GetService<ConstructorTestContextWithOC1A>();
+                var context = serviceScope.ServiceProvider.GetRequiredService<ConstructorTestContextWithOC1A>();
 
                 // Singleton services not the same because service provider caching is off
                 Assert.NotSame(singleton[0], context.GetService<IInMemoryDatabaseRootCache>());
@@ -2306,8 +2307,8 @@ namespace Microsoft.EntityFrameworkCore
                        .GetRequiredService<IServiceScopeFactory>()
                        .CreateScope())
             {
-                var context1 = serviceScope.ServiceProvider.GetService<ConstructorTestContextWithOC3A>();
-                var context2 = serviceScope.ServiceProvider.GetService<ConstructorTestContextWithOC3A>();
+                var context1 = serviceScope.ServiceProvider.GetRequiredService<ConstructorTestContextWithOC3A>();
+                var context2 = serviceScope.ServiceProvider.GetRequiredService<ConstructorTestContextWithOC3A>();
 
                 Assert.NotSame(context1, context2);
 
@@ -2328,7 +2329,7 @@ namespace Microsoft.EntityFrameworkCore
                        .GetRequiredService<IServiceScopeFactory>()
                        .CreateScope())
             {
-                var context = serviceScope.ServiceProvider.GetService<ConstructorTestContextWithOC3A>();
+                var context = serviceScope.ServiceProvider.GetRequiredService<ConstructorTestContextWithOC3A>();
 
                 Assert.Same(singleton[0], context.GetService<IInMemoryDatabaseRootCache>());
                 Assert.Same(singleton[1], context.GetService<IMemoryCache>());
@@ -2363,7 +2364,7 @@ namespace Microsoft.EntityFrameworkCore
                        .GetRequiredService<IServiceScopeFactory>()
                        .CreateScope())
             {
-                context1 = serviceScope.ServiceProvider.GetService<DbContext>();
+                context1 = serviceScope.ServiceProvider.GetRequiredService<DbContext>();
 
                 Assert.NotNull(singleton[0] = context1.GetService<IInMemoryDatabaseRootCache>());
                 Assert.NotNull(singleton[1] = context1.GetService<ILoggerFactory>());
@@ -2378,7 +2379,7 @@ namespace Microsoft.EntityFrameworkCore
                        .GetRequiredService<IServiceScopeFactory>()
                        .CreateScope())
             {
-                context2 = serviceScope.ServiceProvider.GetService<DbContext>();
+                context2 = serviceScope.ServiceProvider.GetRequiredService<DbContext>();
 
                 Assert.Same(singleton[0], context2.GetService<IInMemoryDatabaseRootCache>());
                 Assert.Same(singleton[1], context2.GetService<ILoggerFactory>());
@@ -2433,7 +2434,7 @@ namespace Microsoft.EntityFrameworkCore
                        .GetRequiredService<IServiceScopeFactory>()
                        .CreateScope())
             {
-                context1 = serviceScope.ServiceProvider.GetService<DbContext>();
+                context1 = serviceScope.ServiceProvider.GetRequiredService<DbContext>();
 
                 Assert.NotNull(singleton[0] = context1.GetService<IInMemoryDatabaseRootCache>());
                 Assert.NotNull(singleton[1] = context1.GetService<ILoggerFactory>());
@@ -2448,7 +2449,7 @@ namespace Microsoft.EntityFrameworkCore
                        .GetRequiredService<IServiceScopeFactory>()
                        .CreateScope())
             {
-                context2 = serviceScope.ServiceProvider.GetService<DbContext>();
+                context2 = serviceScope.ServiceProvider.GetRequiredService<DbContext>();
 
                 Assert.Same(singleton[0], context2.GetService<IInMemoryDatabaseRootCache>());
                 Assert.Same(singleton[1], context2.GetService<ILoggerFactory>());
@@ -2482,8 +2483,8 @@ namespace Microsoft.EntityFrameworkCore
                        .GetRequiredService<IServiceScopeFactory>()
                        .CreateScope())
             {
-                var context1 = serviceScope.ServiceProvider.GetService<DbContext>();
-                var context2 = serviceScope.ServiceProvider.GetService<DbContext>();
+                var context1 = serviceScope.ServiceProvider.GetRequiredService<DbContext>();
+                var context2 = serviceScope.ServiceProvider.GetRequiredService<DbContext>();
 
                 Assert.NotSame(context1, context2);
 
@@ -2504,7 +2505,7 @@ namespace Microsoft.EntityFrameworkCore
                        .GetRequiredService<IServiceScopeFactory>()
                        .CreateScope())
             {
-                var context = serviceScope.ServiceProvider.GetService<DbContext>();
+                var context = serviceScope.ServiceProvider.GetRequiredService<DbContext>();
 
                 Assert.NotSame(singleton[0], context.GetService<IInMemoryDatabaseRootCache>());
                 Assert.NotSame(singleton[1], context.GetService<IMemoryCache>());
@@ -2556,8 +2557,8 @@ namespace Microsoft.EntityFrameworkCore
                        .GetRequiredService<IServiceScopeFactory>()
                        .CreateScope())
             {
-                var context1 = serviceScope.ServiceProvider.GetService<DbContext>();
-                var context2 = serviceScope.ServiceProvider.GetService<DbContext>();
+                var context1 = serviceScope.ServiceProvider.GetRequiredService<DbContext>();
+                var context2 = serviceScope.ServiceProvider.GetRequiredService<DbContext>();
 
                 Assert.NotSame(context1, context2);
 
@@ -2578,7 +2579,7 @@ namespace Microsoft.EntityFrameworkCore
                        .GetRequiredService<IServiceScopeFactory>()
                        .CreateScope())
             {
-                var context = serviceScope.ServiceProvider.GetService<DbContext>();
+                var context = serviceScope.ServiceProvider.GetRequiredService<DbContext>();
 
                 Assert.Same(singleton[0], context.GetService<IInMemoryDatabaseRootCache>());
                 Assert.Same(singleton[1], context.GetService<IMemoryCache>());
@@ -2605,7 +2606,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 Assert.NotNull(serviceScope.ServiceProvider.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
 
-                var context = serviceScope.ServiceProvider.GetService<DbContext>();
+                var context = serviceScope.ServiceProvider.GetRequiredService<DbContext>();
 
                 Assert.NotNull(context.Model);
                 Assert.NotNull(context.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
@@ -2615,7 +2616,7 @@ namespace Microsoft.EntityFrameworkCore
         [Fact]
         public void Can_use_logger_before_context_exists_and_after_disposed_when_logger_factory_replaced()
         {
-            WrappingLoggerFactory loggerFactory = null;
+            WrappingLoggerFactory loggerFactory = null!;
             Log.Clear();
 
             var appServiceProvider = new ServiceCollection()
@@ -2624,7 +2625,7 @@ namespace Microsoft.EntityFrameworkCore
                 .AddDbContext<DbContext>((p, b) =>
                     b.UseInMemoryDatabase(Guid.NewGuid().ToString())
                         .EnableServiceProviderCaching(false)
-                        .UseLoggerFactory(loggerFactory = new WrappingLoggerFactory(p.GetService<ILoggerFactory>())))
+                        .UseLoggerFactory(loggerFactory = new WrappingLoggerFactory(p.GetRequiredService<ILoggerFactory>())))
                 .BuildServiceProvider(validateScopes: true);
 
             Assert.Null(loggerFactory);
@@ -2633,7 +2634,7 @@ namespace Microsoft.EntityFrameworkCore
                        .GetRequiredService<IServiceScopeFactory>()
                        .CreateScope())
             {
-                var context = serviceScope.ServiceProvider.GetService<DbContext>();
+                var context = serviceScope.ServiceProvider.GetRequiredService<DbContext>();
 
                 Assert.NotNull(serviceScope.ServiceProvider.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
 
@@ -2644,11 +2645,11 @@ namespace Microsoft.EntityFrameworkCore
                 Assert.NotNull(context.GetService<IDiagnosticsLogger<DbLoggerCategory.Infrastructure>>());
 
                 // ReSharper disable once PossibleNullReferenceException
-                Assert.Equal(3, loggerFactory.CreatedLoggers.Count(n => n == DbLoggerCategory.Infrastructure.Name));
+                Assert.Equal(3, loggerFactory!.CreatedLoggers.Count(n => n == DbLoggerCategory.Infrastructure.Name));
             }
 
             // ReSharper disable once PossibleNullReferenceException
-            Assert.Equal(3, loggerFactory.CreatedLoggers.Count(n => n == DbLoggerCategory.Infrastructure.Name));
+            Assert.Equal(3, loggerFactory!.CreatedLoggers.Count(n => n == DbLoggerCategory.Infrastructure.Name));
         }
 
         [Fact]
@@ -2669,7 +2670,7 @@ namespace Microsoft.EntityFrameworkCore
                        .GetRequiredService<IServiceScopeFactory>()
                        .CreateScope())
             {
-                var context = serviceScope.ServiceProvider.GetService<DbContext>();
+                var context = serviceScope.ServiceProvider.GetRequiredService<DbContext>();
 
                 Assert.NotNull(context.Model);
                 Assert.Same(memoryCache, context.GetService<IMemoryCache>());
@@ -2697,7 +2698,7 @@ namespace Microsoft.EntityFrameworkCore
                        .GetRequiredService<IServiceScopeFactory>()
                        .CreateScope())
             {
-                var context = serviceScope.ServiceProvider.GetService<DbContext>();
+                var context = serviceScope.ServiceProvider.GetRequiredService<DbContext>();
 
                 Assert.NotNull(context.Model);
                 Assert.Same(replacecMemoryCache, context.GetService<IMemoryCache>());
@@ -2792,7 +2793,7 @@ namespace Microsoft.EntityFrameworkCore
             using var serviceScope = appServiceProvider
                 .GetRequiredService<IServiceScopeFactory>()
                 .CreateScope();
-            var context = serviceScope.ServiceProvider.GetService<ConstructorTestContextWithSets>();
+            var context = serviceScope.ServiceProvider.GetRequiredService<ConstructorTestContextWithSets>();
 
             Assert.Equal(
                 CoreStrings.NoProviderConfigured,
@@ -2829,7 +2830,7 @@ namespace Microsoft.EntityFrameworkCore
             using var serviceScope = appServiceProvider
                 .GetRequiredService<IServiceScopeFactory>()
                 .CreateScope();
-            var context = serviceScope.ServiceProvider.GetService<ConstructorTestContext1A>();
+            var context = serviceScope.ServiceProvider.GetRequiredService<ConstructorTestContext1A>();
 
             Assert.Equal(
                 CoreStrings.NoProviderConfigured,
@@ -2855,7 +2856,7 @@ namespace Microsoft.EntityFrameworkCore
             using var serviceScope = appServiceProvider
                 .GetRequiredService<IServiceScopeFactory>()
                 .CreateScope();
-            var context = serviceScope.ServiceProvider.GetService<ConstructorTestContextNoConfigurationWithSets>();
+            var context = serviceScope.ServiceProvider.GetRequiredService<ConstructorTestContextNoConfigurationWithSets>();
 
             Assert.Equal(
                 CoreStrings.NoProviderConfigured,
@@ -2881,7 +2882,7 @@ namespace Microsoft.EntityFrameworkCore
             using var serviceScope = appServiceProvider
                 .GetRequiredService<IServiceScopeFactory>()
                 .CreateScope();
-            var context = serviceScope.ServiceProvider.GetService<ConstructorTestContextNoConfiguration>();
+            var context = serviceScope.ServiceProvider.GetRequiredService<ConstructorTestContextNoConfiguration>();
 
             Assert.Equal(
                 CoreStrings.NoProviderConfigured,
@@ -3026,7 +3027,7 @@ namespace Microsoft.EntityFrameworkCore
                        .GetRequiredService<IServiceScopeFactory>()
                        .CreateScope())
             {
-                var context = serviceScope.ServiceProvider.GetService<ConstructorTestContextWithOC3A>();
+                var context = serviceScope.ServiceProvider.GetRequiredService<ConstructorTestContextWithOC3A>();
 
                 Assert.NotNull(replacedSingleton = context.GetService<IModelCustomizer>());
                 Assert.IsType<CustomModelCustomizer>(replacedSingleton);
@@ -3045,7 +3046,7 @@ namespace Microsoft.EntityFrameworkCore
                        .GetRequiredService<IServiceScopeFactory>()
                        .CreateScope())
             {
-                var context = serviceScope.ServiceProvider.GetService<ConstructorTestContextWithOC3A>();
+                var context = serviceScope.ServiceProvider.GetRequiredService<ConstructorTestContextWithOC3A>();
 
                 // Singleton services not the same because service provider caching is off
                 Assert.NotSame(replacedSingleton, context.GetService<IModelCustomizer>());
@@ -3452,7 +3453,7 @@ namespace Microsoft.EntityFrameworkCore
                        .GetRequiredService<IServiceScopeFactory>()
                        .CreateScope())
             {
-                var context = serviceScope.ServiceProvider.GetService<ConstructorTestContextWithOC3A>();
+                var context = serviceScope.ServiceProvider.GetRequiredService<ConstructorTestContextWithOC3A>();
 
                 Assert.NotNull(context.Model);
             }
@@ -3465,7 +3466,7 @@ namespace Microsoft.EntityFrameworkCore
                        .GetRequiredService<IServiceScopeFactory>()
                        .CreateScope())
             {
-                var context = serviceScope.ServiceProvider.GetService<ConstructorTestContextWithOC3A>();
+                var context = serviceScope.ServiceProvider.GetRequiredService<ConstructorTestContextWithOC3A>();
 
                 Assert.Equal(
                     CoreStrings.SingletonOptionChanged(
@@ -3580,7 +3581,7 @@ namespace Microsoft.EntityFrameworkCore
                        .GetRequiredService<IServiceScopeFactory>()
                        .CreateScope())
             {
-                var context = serviceScope.ServiceProvider.GetService<ConstructorTestContextWithOC3A>();
+                var context = serviceScope.ServiceProvider.GetRequiredService<ConstructorTestContextWithOC3A>();
 
                 Assert.NotNull(context.Model);
             }
@@ -3593,7 +3594,7 @@ namespace Microsoft.EntityFrameworkCore
                        .GetRequiredService<IServiceScopeFactory>()
                        .CreateScope())
             {
-                var context = serviceScope.ServiceProvider.GetService<ConstructorTestContextWithOC3A>();
+                var context = serviceScope.ServiceProvider.GetRequiredService<ConstructorTestContextWithOC3A>();
 
                 Assert.Equal(
                     CoreStrings.SingletonOptionChanged(
@@ -3627,26 +3628,26 @@ namespace Microsoft.EntityFrameworkCore
 
         private class ConstructorTestContextWithSets(DbContextOptions options) : DbContext(options)
         {
-            public DbSet<Product> Products { get; set; }
+            public DbSet<Product> Products { get; set; } = null!;
         }
 
         private class ConstructorTestContextNoConfiguration : DbContext;
 
         private class ConstructorTestContextNoConfigurationWithSets : DbContext
         {
-            public DbSet<Product> Products { get; set; }
+            public DbSet<Product> Products { get; set; } = null!;
         }
 
         private class ConstructorTestContextWithOCBase : DbContext
         {
-            private readonly IServiceProvider _internalServicesProvider;
-            private readonly ILoggerFactory _loggerFactory;
-            private readonly IMemoryCache _memoryCache;
+            private readonly IServiceProvider? _internalServicesProvider;
+            private readonly ILoggerFactory? _loggerFactory;
+            private readonly IMemoryCache? _memoryCache;
             private readonly bool _isConfigured;
 
             protected ConstructorTestContextWithOCBase(
-                ILoggerFactory loggerFactory = null,
-                IMemoryCache memoryCache = null)
+                ILoggerFactory? loggerFactory = null,
+                IMemoryCache? memoryCache = null)
             {
                 _loggerFactory = loggerFactory;
                 _memoryCache = memoryCache;
@@ -3654,8 +3655,8 @@ namespace Microsoft.EntityFrameworkCore
 
             protected ConstructorTestContextWithOCBase(
                 IServiceProvider internalServicesProvider,
-                ILoggerFactory loggerFactory = null,
-                IMemoryCache memoryCache = null)
+                ILoggerFactory? loggerFactory = null,
+                IMemoryCache? memoryCache = null)
             {
                 _internalServicesProvider = internalServicesProvider;
                 _loggerFactory = loggerFactory;
@@ -3664,8 +3665,8 @@ namespace Microsoft.EntityFrameworkCore
 
             protected ConstructorTestContextWithOCBase(
                 DbContextOptions options,
-                ILoggerFactory loggerFactory = null,
-                IMemoryCache memoryCache = null)
+                ILoggerFactory? loggerFactory = null,
+                IMemoryCache? memoryCache = null)
                 : base(options)
             {
                 _loggerFactory = loggerFactory;
@@ -3755,7 +3756,7 @@ namespace Microsoft.EntityFrameworkCore
                        .GetRequiredService<IServiceScopeFactory>()
                        .CreateScope())
             {
-                var context = serviceScope.ServiceProvider.GetService<DbContext>();
+                var context = serviceScope.ServiceProvider.GetRequiredService<DbContext>();
 
                 Assert.IsType<CustomModelCustomizer2>(context.GetService<IModelCustomizer>());
                 Assert.Single(context.GetService<IEnumerable<IModelCustomizer>>());
@@ -3794,7 +3795,7 @@ namespace Microsoft.EntityFrameworkCore
                        .GetRequiredService<IServiceScopeFactory>()
                        .CreateScope())
             {
-                var context = serviceScope.ServiceProvider.GetService<DerivedContext1>();
+                var context = serviceScope.ServiceProvider.GetRequiredService<DerivedContext1>();
 
                 Assert.IsType<CustomModelCustomizer2>(context.GetService<IModelCustomizer>());
                 Assert.Single(context.GetService<IEnumerable<IModelCustomizer>>());
@@ -3868,7 +3869,8 @@ namespace Microsoft.EntityFrameworkCore
                 .AddDbContext<NonGenericOptions2>(optionsLifetime: ServiceLifetime.Singleton)
                 .BuildServiceProvider(validateScopes: true);
 
-            Assert.Equal(typeof(NonGenericOptions2), services.GetService<DbContextOptions>().ContextType);
+            Assert.Equal(typeof(NonGenericOptions2), services.GetService<DbContextOptions>()!.ContextType);
+            Assert.Equal(typeof(NonGenericOptions2), services.GetRequiredService<DbContextOptions>().ContextType);
         }
 
         [Fact]
@@ -3884,17 +3886,17 @@ namespace Microsoft.EntityFrameworkCore
                 .BuildServiceProvider(validateScopes: true);
 
             using var scope = services.CreateScope();
-            var context1 = scope.ServiceProvider.GetService<DerivedContext1>();
+            var context1 = scope.ServiceProvider.GetRequiredService<DerivedContext1>();
             Assert.IsType<DerivedContext1>(context1);
             Assert.Equal(
                 nameof(DerivedContext1),
-                context1.GetService<IDbContextOptions>().FindExtension<InMemoryOptionsExtension>().StoreName);
+                context1.GetService<IDbContextOptions>().FindExtension<InMemoryOptionsExtension>()!.StoreName);
 
-            var context2 = scope.ServiceProvider.GetService<DerivedContext2>();
+            var context2 = scope.ServiceProvider.GetRequiredService<DerivedContext2>();
             Assert.IsType<DerivedContext2>(context2);
             Assert.Equal(
                 nameof(DerivedContext2),
-                context2.GetService<IDbContextOptions>().FindExtension<InMemoryOptionsExtension>().StoreName);
+                context2.GetService<IDbContextOptions>().FindExtension<InMemoryOptionsExtension>()!.StoreName);
         }
 
         private class DerivedContext1 : DbContext
@@ -3995,11 +3997,11 @@ namespace Microsoft.EntityFrameworkCore
             using var serviceScope = appServiceProvider
                 .GetRequiredService<IServiceScopeFactory>()
                 .CreateScope();
-            var context = serviceScope.ServiceProvider.GetService<ConstructorTestContext1A>();
+            var context = serviceScope.ServiceProvider.GetRequiredService<ConstructorTestContext1A>();
             Assert.NotNull(context);
             Assert.Equal(
                 "ReplacementDb",
-                context.GetService<IDbContextOptions>().FindExtension<InMemoryOptionsExtension>().StoreName);
+                context.GetService<IDbContextOptions>().FindExtension<InMemoryOptionsExtension>()!.StoreName);
         }
 
         [Fact]
@@ -4057,18 +4059,18 @@ namespace Microsoft.EntityFrameworkCore.DifferentNamespace
     internal class Category
     {
         public int Id { get; set; }
-        public string Name { get; set; }
+            public string Name { get; set; } = null!;
 
-        public List<Product> Products { get; set; }
+            public List<Product> Products { get; set; } = [];
     }
 
     internal class Product
     {
         public int Id { get; set; }
-        public string Name { get; set; }
+            public string Name { get; set; } = null!;
         public decimal Price { get; set; }
 
         public int CategoryId { get; set; }
-        public Category Category { get; set; }
+            public Category Category { get; set; } = null!;
     }
 }

--- a/test/EFCore.Tests/DbContextTest.Tracking.cs
+++ b/test/EFCore.Tests/DbContextTest.Tracking.cs
@@ -2545,7 +2545,7 @@ public partial class DbContextTest
         public int Id { get; set; }
 
         public int? Parent77Id { get; set; }
-        public Parent77 Parent77 { get; set; }
+        public Parent77 Parent77 { get; set; } = null!;
     }
 
     private class Required77
@@ -2553,6 +2553,6 @@ public partial class DbContextTest
         public int Id { get; set; }
 
         public int Parent77Id { get; set; }
-        public Parent77 Parent77 { get; set; }
+        public Parent77 Parent77 { get; set; } = null!;
     }
 }

--- a/test/EFCore.Tests/DbContextTest.cs
+++ b/test/EFCore.Tests/DbContextTest.cs
@@ -200,11 +200,11 @@ public partial class DbContextTest
         Assert.Equal(
             "entity",
             // ReSharper disable once AssignNullToNotNullAttribute
-            Assert.Throws<ArgumentNullException>(() => context.Entry(null)).ParamName);
+            Assert.Throws<ArgumentNullException>(() => context.Entry(null!)).ParamName);
         Assert.Equal(
             "entity",
             // ReSharper disable once AssignNullToNotNullAttribute
-            Assert.Throws<ArgumentNullException>(() => context.Entry<Random>(null)).ParamName);
+            Assert.Throws<ArgumentNullException>(() => context.Entry<Random>(null!)).ParamName);
     }
 
     private class FakeChangeDetector : IChangeDetector
@@ -234,40 +234,40 @@ public partial class DbContextTest
         {
         }
 
-        public (EventHandler<DetectChangesEventArgs> DetectingAllChanges,
-            EventHandler<DetectedChangesEventArgs> DetectedAllChanges,
-            EventHandler<DetectEntityChangesEventArgs> DetectingEntityChanges,
-            EventHandler<DetectedEntityChangesEventArgs>
+        public (EventHandler<DetectChangesEventArgs>? DetectingAllChanges,
+            EventHandler<DetectedChangesEventArgs>? DetectedAllChanges,
+            EventHandler<DetectEntityChangesEventArgs>? DetectingEntityChanges,
+            EventHandler<DetectedEntityChangesEventArgs>?
             DetectedEntityChanges) CaptureEvents()
             => (null, null, null, null);
 
         public void SetEvents(
-            EventHandler<DetectChangesEventArgs> detectingAllChanges,
-            EventHandler<DetectedChangesEventArgs> detectedAllChanges,
-            EventHandler<DetectEntityChangesEventArgs> detectingEntityChanges,
-            EventHandler<DetectedEntityChangesEventArgs> detectedEntityChanges)
+            EventHandler<DetectChangesEventArgs>? detectingAllChanges,
+            EventHandler<DetectedChangesEventArgs>? detectedAllChanges,
+            EventHandler<DetectEntityChangesEventArgs>? detectingEntityChanges,
+            EventHandler<DetectedEntityChangesEventArgs>? detectedEntityChanges)
         {
         }
 
-        public event EventHandler<DetectEntityChangesEventArgs> DetectingEntityChanges;
+        public event EventHandler<DetectEntityChangesEventArgs>? DetectingEntityChanges;
 
         public void OnDetectingEntityChanges(InternalEntityEntry internalEntityEntry)
-            => DetectingEntityChanges?.Invoke(null, null);
+            => DetectingEntityChanges?.Invoke(null, null!);
 
-        public event EventHandler<DetectChangesEventArgs> DetectingAllChanges;
+        public event EventHandler<DetectChangesEventArgs>? DetectingAllChanges;
 
         public void OnDetectingAllChanges(IStateManager stateManager)
-            => DetectingAllChanges?.Invoke(null, null);
+            => DetectingAllChanges?.Invoke(null, null!);
 
-        public event EventHandler<DetectedEntityChangesEventArgs> DetectedEntityChanges;
+        public event EventHandler<DetectedEntityChangesEventArgs>? DetectedEntityChanges;
 
         public void OnDetectedEntityChanges(InternalEntityEntry internalEntityEntry, bool changesFound)
-            => DetectedEntityChanges?.Invoke(null, null);
+            => DetectedEntityChanges?.Invoke(null, null!);
 
-        public event EventHandler<DetectedChangesEventArgs> DetectedAllChanges;
+        public event EventHandler<DetectedChangesEventArgs>? DetectedAllChanges;
 
         public void OnDetectedAllChanges(IStateManager stateManager, bool changesFound)
-            => DetectedAllChanges?.Invoke(null, null);
+            => DetectedAllChanges?.Invoke(null, null!);
 
         public void ResetState()
         {
@@ -314,8 +314,8 @@ public partial class DbContextTest
     {
         public int Id { get; set; }
         public int AuthorId { get; set; }
-        public virtual User Author { get; set; }
-        public virtual ICollection<Answer> Answers { get; set; }
+        public virtual User Author { get; set; } = null!;
+        public virtual ICollection<Answer> Answers { get; set; } = [];
     }
 
     public class Answer
@@ -323,8 +323,8 @@ public partial class DbContextTest
         public int Id { get; set; }
         public int QuestionId { get; set; }
         public int AuthorId { get; set; }
-        public virtual Question Question { get; set; }
-        public virtual User Author { get; set; }
+        public virtual Question Question { get; set; } = null!;
+        public virtual User Author { get; set; } = null!;
     }
 
     public class User
@@ -336,9 +336,9 @@ public partial class DbContextTest
 
     public class ActiveAddContext : DbContext
     {
-        public DbSet<User> Users { get; set; }
-        public DbSet<Answer> Answers { get; set; }
-        public DbSet<Question> Questions { get; set; }
+        public DbSet<User> Users { get; set; } = null!;
+        public DbSet<Answer> Answers { get; set; } = null!;
+        public DbSet<Question> Questions { get; set; } = null!;
 
         protected internal override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
             => optionsBuilder
@@ -418,11 +418,11 @@ public partial class DbContextTest
 
     private class ContextWithSets : DbContext
     {
-        public DbSet<Product> Products { get; set; }
-        public DbSet<Category> Categories { get; private set; }
-        private DbSet<TheGu> Gus { get; set; }
+        public DbSet<Product> Products { get; set; } = null!;
+        public DbSet<Category> Categories { get; private set; } = null!;
+        private DbSet<TheGu> Gus { get; set; } = null!;
 
-        public DbSet<Random> NoSetter { get; } = null;
+        public DbSet<Random> NoSetter { get; } = null!;
 
         public DbSet<TheGu> GetGus()
             => Gus;
@@ -445,7 +445,7 @@ public partial class DbContextTest
     {
         private readonly IServiceProvider _serviceProvider = serviceProvider;
 
-        public DbSet<Product> Products { get; set; }
+        public DbSet<Product> Products { get; set; } = null!;
 
         protected internal override void OnModelCreating(ModelBuilder modelBuilder)
             // ReSharper disable once AssignmentIsFullyDiscarded
@@ -474,7 +474,7 @@ public partial class DbContextTest
     {
         private readonly IServiceProvider _serviceProvider = serviceProvider;
 
-        public DbSet<Product> Products { get; set; }
+        public DbSet<Product> Products { get; set; } = null!;
 
         protected internal override void OnModelCreating(ModelBuilder modelBuilder)
             // ReSharper disable once ReturnValueOfPureMethodIsNotUsed
@@ -503,7 +503,7 @@ public partial class DbContextTest
     {
         private readonly IServiceProvider _serviceProvider = serviceProvider;
 
-        public DbSet<Product> Products { get; set; }
+        public DbSet<Product> Products { get; set; } = null!;
 
         protected internal override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         {
@@ -611,7 +611,7 @@ public partial class DbContextTest
     {
         private readonly IServiceProvider _serviceProvider = serviceProvider;
 
-        public DbSet<Product> Products { get; set; }
+        public DbSet<Product> Products { get; set; } = null!;
 
         protected internal override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
             => optionsBuilder
@@ -1334,7 +1334,7 @@ public partial class DbContextTest
         public void Dispose()
             => Disposed = true;
 
-        public object GetService(Type serviceType)
+        public object? GetService(Type serviceType)
         {
             if (serviceType == typeof(IServiceProvider))
             {
@@ -1410,29 +1410,29 @@ public partial class DbContextTest
     private class TestAssembly
     {
         [Key, DatabaseGenerated(DatabaseGeneratedOption.Identity)]
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
 
         public ICollection<TestClass> Classes { get; } = new List<TestClass>();
     }
 
     private class TestClass
     {
-        public TestAssembly Assembly { get; set; }
-        public string Name { get; set; }
+        public TestAssembly Assembly { get; set; } = null!;
+        public string Name { get; set; } = null!;
         public ICollection<Test> Tests { get; } = new List<Test>();
     }
 
     private class Test
     {
-        public TestClass Class { get; set; }
-        public string Name { get; set; }
+        public TestClass Class { get; set; } = null!;
+        public string Name { get; set; } = null!;
     }
 
     private class NullShadowKeyContext : DbContext
     {
-        public DbSet<TestAssembly> Assemblies { get; set; }
-        public DbSet<TestClass> Classes { get; set; }
-        public DbSet<Test> Tests { get; set; }
+        public DbSet<TestAssembly> Assemblies { get; set; } = null!;
+        public DbSet<TestClass> Classes { get; set; } = null!;
+        public DbSet<Test> Tests { get; set; } = null!;
 
         protected internal override void OnConfiguring(DbContextOptionsBuilder options)
             => options

--- a/test/EFCore.Tests/DbSetInitializerTest.cs
+++ b/test/EFCore.Tests/DbSetInitializerTest.cs
@@ -36,9 +36,9 @@ public class DbSetInitializerTest
 
             return
             [
-                new DbSetProperty("One", typeof(string), setterFactory.Create(typeof(JustAContext).GetAnyProperty("One"))),
-                new DbSetProperty("Two", typeof(object), setterFactory.Create(typeof(JustAContext).GetAnyProperty("Two"))),
-                new DbSetProperty("Three", typeof(string), setterFactory.Create(typeof(JustAContext).GetAnyProperty("Three"))),
+                new DbSetProperty("One", typeof(string), setterFactory.Create(typeof(JustAContext).GetAnyProperty("One")!)),
+                new DbSetProperty("Two", typeof(object), setterFactory.Create(typeof(JustAContext).GetAnyProperty("Two")!)),
+                new DbSetProperty("Three", typeof(string), setterFactory.Create(typeof(JustAContext).GetAnyProperty("Three")!)),
                 new DbSetProperty("Four", typeof(string), null)
             ];
         }
@@ -47,16 +47,16 @@ public class DbSetInitializerTest
     private class JustAContext(DbContextOptions options) : DbContext(options)
     {
         // ReSharper disable once UnusedAutoPropertyAccessor.Local
-        public DbSet<string> One { get; set; }
+        public DbSet<string> One { get; set; } = null!;
 
         // ReSharper disable once UnusedAutoPropertyAccessor.Local
-        private DbSet<object> Two { get; set; }
+        private DbSet<object> Two { get; set; } = null!;
 
         // ReSharper disable once UnusedAutoPropertyAccessor.Local
-        public DbSet<string> Three { get; private set; }
+        public DbSet<string> Three { get; private set; } = null!;
 
         public DbSet<string> Four
-            => null;
+            => null!;
 
         public DbSet<object> GetTwo()
             => Two;

--- a/test/EFCore.Tests/DbSetTest.cs
+++ b/test/EFCore.Tests/DbSetTest.cs
@@ -180,7 +180,7 @@ public class DbSetTest
 
     private class IgnoredCntext : DbContext
     {
-        public DbSet<IgnoredEntity> Ignored { get; set; }
+        public DbSet<IgnoredEntity> Ignored { get; set; } = null!;
 
         protected internal override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
             => optionsBuilder
@@ -705,27 +705,27 @@ public class DbSetTest
     private class Category
     {
         public int Id { get; set; }
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
     }
 
     private class Product
     {
         public int Id { get; set; }
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
         public decimal Price { get; set; }
     }
 
     private class TheGu
     {
         public Guid Id { get; set; }
-        public string ShirtColor { get; set; }
+        public string ShirtColor { get; set; } = null!;
     }
 
     private class EarlyLearningCenter : DbContext
     {
-        public DbSet<Product> Products { get; set; }
-        public DbSet<Category> Categories { get; set; }
-        public DbSet<TheGu> Gus { get; set; }
+        public DbSet<Product> Products { get; set; } = null!;
+        public DbSet<Category> Categories { get; set; } = null!;
+        public DbSet<TheGu> Gus { get; set; } = null!;
 
         protected internal override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
             => optionsBuilder

--- a/test/EFCore.Tests/Diagnostics/CoreEventIdTest.cs
+++ b/test/EFCore.Tests/Diagnostics/CoreEventIdTest.cs
@@ -12,21 +12,21 @@ public class CoreEventIdTest : EventIdTestBase
     [Fact]
     public void Every_eventId_has_a_logger_method_and_logs_when_level_enabled()
     {
-        var propertyInfo = typeof(DateTime).GetTypeInfo().GetDeclaredProperty(nameof(DateTime.Now));
+        var propertyInfo = typeof(DateTime).GetTypeInfo().GetDeclaredProperty(nameof(DateTime.Now))!;
         var model = new Model();
-        var entityType = model.AddEntityType(typeof(object), owned: false, ConfigurationSource.Convention);
-        var property = entityType.AddProperty("A", typeof(int), ConfigurationSource.Convention, ConfigurationSource.Convention);
+        var entityType = model.AddEntityType(typeof(object), owned: false, ConfigurationSource.Convention)!;
+        var property = entityType.AddProperty("A", typeof(int), ConfigurationSource.Convention, ConfigurationSource.Convention)!;
         var otherEntityType = new EntityType(typeof(object), entityType.Model, owned: false, ConfigurationSource.Convention);
         var otherProperty = otherEntityType.AddProperty(
             "A", typeof(int), ConfigurationSource.Convention, ConfigurationSource.Convention);
-        var otherKey = otherEntityType.AddKey(otherProperty, ConfigurationSource.Convention);
+        var otherKey = otherEntityType.AddKey(otherProperty!, ConfigurationSource.Convention)!;
         var foreignKey = new ForeignKey([property], otherKey, entityType, otherEntityType, ConfigurationSource.Convention);
         var navigation = new Navigation("N", propertyInfo, null, foreignKey);
         var skipNavigation = new SkipNavigation(
             "SN", null, propertyInfo, null, entityType, otherEntityType, true, false, ConfigurationSource.Convention);
         var navigationBase = new FakeNavigationBase("FNB", ConfigurationSource.Convention, entityType);
         var complexProperty = entityType.AddComplexProperty(
-            "C", typeof(object), typeof(object), true, ConfigurationSource.Convention);
+            "C", typeof(object), typeof(object), true, ConfigurationSource.Convention)!;
 
         entityType.Model.FinalizeModel();
         var options = new DbContextOptionsBuilder()
@@ -56,7 +56,7 @@ public class CoreEventIdTest : EventIdTestBase
             {
                 typeof(Func<DbContext, DbUpdateConcurrencyException, IReadOnlyList<IUpdateEntry>, EventDefinition<Exception>,
                     ConcurrencyExceptionEventData>),
-                () => null
+                () => null!
             },
             { typeof(IReadOnlyList<IReadOnlyPropertyBase>), () => new[] { property } },
             { typeof(IEnumerable<Tuple<MemberInfo, Type>>), () => new[] { new Tuple<MemberInfo, Type>(propertyInfo, typeof(object)) } },
@@ -93,7 +93,7 @@ public class CoreEventIdTest : EventIdTestBase
 
     private class FakeServiceProvider : IServiceProvider
     {
-        public object GetService(Type serviceType)
+        public object? GetService(Type serviceType)
             => null;
     }
 

--- a/test/EFCore.Tests/EFCore.Tests.csproj
+++ b/test/EFCore.Tests/EFCore.Tests.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
     <AssemblyName>Microsoft.EntityFrameworkCore.Tests</AssemblyName>
     <RootNamespace>Microsoft.EntityFrameworkCore</RootNamespace>
-    <Nullable>disable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
     <NoWarn>$(NoWarn);EF9100</NoWarn> <!-- Precompiled query is experimental -->
     <NoWarn>$(NoWarn);EF9101</NoWarn> <!-- Metrics is experimental -->

--- a/test/EFCore.Tests/ExceptionTest.cs
+++ b/test/EFCore.Tests/ExceptionTest.cs
@@ -102,15 +102,15 @@ public class ExceptionTest
         public DbContext Context
             => throw new NotImplementedException();
 
-        public void SetOriginalValue(IProperty property, object value)
+        public void SetOriginalValue(IProperty property, object? value)
             => throw new NotImplementedException();
 
         public void SetPropertyModified(IProperty property)
             => throw new NotImplementedException();
 
-        public IEntityType EntityType { get; }
+        public IEntityType EntityType { get; } = null!;
         public EntityState EntityState { get; set; }
-        public IUpdateEntry SharedIdentityEntry { get; }
+        public IUpdateEntry? SharedIdentityEntry { get; }
 
         public bool IsModified(IProperty property)
             => throw new NotImplementedException();
@@ -145,7 +145,7 @@ public class ExceptionTest
         public TProperty GetOriginalValue<TProperty>(IProperty property)
             => throw new NotImplementedException();
 
-        public void SetStoreGeneratedValue(IProperty property, object value, bool setModified = true)
+        public void SetStoreGeneratedValue(IProperty property, object? value, bool setModified = true)
             => throw new NotImplementedException();
 
         public EntityEntry ToEntityEntry()
@@ -168,6 +168,6 @@ public class ExceptionTest
     {
         var model = new Model();
         model.AddEntityType(typeof(object), owned: false, ConfigurationSource.Convention);
-        return model.FinalizeModel().FindEntityType(typeof(object));
+        return model.FinalizeModel().FindEntityType(typeof(object))!;
     }
 }

--- a/test/EFCore.Tests/Extensions/ExpressionExtensionsTest.cs
+++ b/test/EFCore.Tests/Extensions/ExpressionExtensionsTest.cs
@@ -213,20 +213,20 @@ public class ExpressionExtensionsTest
 
     private sealed class ComplexBlog
     {
-        public string Title { get; set; }
+        public string Title { get; set; } = null!;
         public List<ComplexPost> Posts { get; } = [];
         public ComplexPost[] PostArray { get; } = [];
     }
 
     private sealed class ComplexPost
     {
-        public string Title { get; set; }
+        public string Title { get; set; } = null!;
         public List<ComplexComment> Comments { get; } = [];
     }
 
     private sealed class ComplexComment
     {
-        public string Text { get; set; }
+        public string Text { get; set; } = null!;
     }
 
     [Fact]

--- a/test/EFCore.Tests/Extensions/PropertyExtensionsTest.cs
+++ b/test/EFCore.Tests/Extensions/PropertyExtensionsTest.cs
@@ -52,7 +52,7 @@ public class PropertyExtensionsTest
         property.SetValueConverter(converter);
         Assert.Same(converter, property.GetValueConverter());
 
-        property.SetValueConverter((ValueConverter)null);
+        property.SetValueConverter((ValueConverter?)null);
         Assert.Null(property.GetValueConverter());
     }
 
@@ -188,22 +188,22 @@ public class PropertyExtensionsTest
         var model = BuildModel();
 
         Assert.Equal(
-            (IProperty)model.FindEntityType(typeof(Product)).FindProperty("Id"),
-            ((IProperty)model.FindEntityType(typeof(ProductDetails)).GetForeignKeys().Single().Properties[0]).FindGenerationProperty());
+            (IProperty)model.FindEntityType(typeof(Product))!.FindProperty("Id")!,
+            ((IProperty)model.FindEntityType(typeof(ProductDetails))!.GetForeignKeys().Single().Properties[0]).FindGenerationProperty());
 
         Assert.Equal(
-            (IProperty)model.FindEntityType(typeof(Product)).FindProperty("Id"),
-            ((IProperty)model.FindEntityType(typeof(ProductDetailsTag)).GetForeignKeys().Single().Properties[0])
+            (IProperty)model.FindEntityType(typeof(Product))!.FindProperty("Id")!,
+            ((IProperty)model.FindEntityType(typeof(ProductDetailsTag))!.GetForeignKeys().Single().Properties[0])
             .FindGenerationProperty());
 
         Assert.Equal(
-            (IProperty)model.FindEntityType(typeof(ProductDetails)).FindProperty("Id2"),
-            ((IProperty)model.FindEntityType(typeof(ProductDetailsTag)).GetForeignKeys().Single().Properties[1])
+            (IProperty)model.FindEntityType(typeof(ProductDetails))!.FindProperty("Id2")!,
+            ((IProperty)model.FindEntityType(typeof(ProductDetailsTag))!.GetForeignKeys().Single().Properties[1])
             .FindGenerationProperty());
 
         Assert.Equal(
-            (IProperty)model.FindEntityType(typeof(ProductDetails)).FindProperty("Id2"),
-            ((IProperty)model.FindEntityType(typeof(ProductDetailsTagDetails)).GetForeignKeys().Single().Properties[0])
+            (IProperty)model.FindEntityType(typeof(ProductDetails))!.FindProperty("Id2")!,
+            ((IProperty)model.FindEntityType(typeof(ProductDetailsTagDetails))!.GetForeignKeys().Single().Properties[0])
             .FindGenerationProperty());
     }
 
@@ -213,13 +213,13 @@ public class PropertyExtensionsTest
         var model = BuildModel();
 
         Assert.Equal(
-            (IProperty)model.FindEntityType(typeof(Order)).FindProperty("Id"),
-            ((IProperty)model.FindEntityType(typeof(OrderDetails)).GetForeignKeys().Single(k => k.Properties.First().Name == "OrderId")
+            (IProperty)model.FindEntityType(typeof(Order))!.FindProperty("Id")!,
+            ((IProperty)model.FindEntityType(typeof(OrderDetails))!.GetForeignKeys().Single(k => k.Properties.First().Name == "OrderId")
                 .Properties[0]).FindGenerationProperty());
 
         Assert.Equal(
-            (IProperty)model.FindEntityType(typeof(Product)).FindProperty("Id"),
-            ((IProperty)model.FindEntityType(typeof(OrderDetails)).GetForeignKeys()
+            (IProperty)model.FindEntityType(typeof(Product))!.FindProperty("Id")!,
+            ((IProperty)model.FindEntityType(typeof(OrderDetails))!.GetForeignKeys()
                 .Single(k => k.Properties.First().Name == "ProductId")
                 .Properties[0]).FindGenerationProperty());
     }
@@ -228,7 +228,7 @@ public class PropertyExtensionsTest
     {
         public int Id { get; set; }
 
-        public List<Product> Products { get; set; }
+        public List<Product> Products { get; set; } = [];
     }
 
     private class Product
@@ -236,11 +236,11 @@ public class PropertyExtensionsTest
         public int Id { get; set; }
 
         public int CategoryId { get; set; }
-        public Category Category { get; set; }
+        public Category Category { get; set; } = null!;
 
-        public ProductDetails Details { get; set; }
+        public ProductDetails Details { get; set; } = null!;
 
-        public List<OrderDetails> OrderDetails { get; set; }
+        public List<OrderDetails> OrderDetails { get; set; } = [];
     }
 
     private class ProductDetails
@@ -248,9 +248,9 @@ public class PropertyExtensionsTest
         public int Id1 { get; set; }
         public int Id2 { get; set; }
 
-        public Product Product { get; set; }
+        public Product Product { get; set; } = null!;
 
-        public ProductDetailsTag Tag { get; set; }
+        public ProductDetailsTag Tag { get; set; } = null!;
     }
 
     private class ProductDetailsTag
@@ -258,23 +258,23 @@ public class PropertyExtensionsTest
         public int Id1 { get; set; }
         public int Id2 { get; set; }
 
-        public ProductDetails Details { get; set; }
+        public ProductDetails Details { get; set; } = null!;
 
-        public ProductDetailsTagDetails TagDetails { get; set; }
+        public ProductDetailsTagDetails TagDetails { get; set; } = null!;
     }
 
     private class ProductDetailsTagDetails
     {
         public int Id { get; }
 
-        public ProductDetailsTag Tag { get; }
+        public ProductDetailsTag Tag { get; } = null!;
     }
 
     private class Order
     {
         public int Id { get; set; }
 
-        public List<OrderDetails> OrderDetails { get; }
+        public List<OrderDetails> OrderDetails { get; } = [];
     }
 
     private class OrderDetails
@@ -282,8 +282,8 @@ public class PropertyExtensionsTest
         public int OrderId { get; set; }
         public int ProductId { get; set; }
 
-        public Order Order { get; set; }
-        public Product Product { get; set; }
+        public Order Order { get; set; } = null!;
+        public Product Product { get; set; } = null!;
     }
 
     private static IMutableModel CreateModel()

--- a/test/EFCore.Tests/Extensions/PropertyInfoExtensionsTest.cs
+++ b/test/EFCore.Tests/Extensions/PropertyInfoExtensionsTest.cs
@@ -10,21 +10,21 @@ public class PropertyInfoExtensionsTest
     [Fact]
     public void IsStatic_identifies_static_properties()
     {
-        Assert.True(typeof(KitKat).GetAnyProperty("Yummy").IsStatic());
-        Assert.True(typeof(KitKat).GetAnyProperty("Wafers").IsStatic());
-        Assert.True(typeof(KitKat).GetAnyProperty("And").IsStatic());
-        Assert.True(typeof(KitKat).GetAnyProperty("Chocolate").IsStatic());
-        Assert.True(typeof(KitKat).GetAnyProperty("With").IsStatic());
-        Assert.True(typeof(KitKat).GetAnyProperty("No").IsStatic());
-        Assert.False(typeof(KitKat).GetAnyProperty("Nuts").IsStatic());
-        Assert.False(typeof(KitKat).GetAnyProperty("But").IsStatic());
-        Assert.False(typeof(KitKat).GetAnyProperty("May").IsStatic());
-        Assert.False(typeof(KitKat).GetAnyProperty("Contain").IsStatic());
-        Assert.False(typeof(KitKat).GetAnyProperty("TreeNuts").IsStatic());
-        Assert.False(typeof(KitKat).GetAnyProperty("Just").IsStatic());
-        Assert.True(typeof(KitKat).GetAnyProperty("Like").IsStatic());
-        Assert.False(typeof(KitKat).GetAnyProperty("A").IsStatic());
-        Assert.True(typeof(KitKat).GetAnyProperty("Twix").IsStatic());
+        Assert.True(typeof(KitKat).GetAnyProperty("Yummy")!.IsStatic());
+        Assert.True(typeof(KitKat).GetAnyProperty("Wafers")!.IsStatic());
+        Assert.True(typeof(KitKat).GetAnyProperty("And")!.IsStatic());
+        Assert.True(typeof(KitKat).GetAnyProperty("Chocolate")!.IsStatic());
+        Assert.True(typeof(KitKat).GetAnyProperty("With")!.IsStatic());
+        Assert.True(typeof(KitKat).GetAnyProperty("No")!.IsStatic());
+        Assert.False(typeof(KitKat).GetAnyProperty("Nuts")!.IsStatic());
+        Assert.False(typeof(KitKat).GetAnyProperty("But")!.IsStatic());
+        Assert.False(typeof(KitKat).GetAnyProperty("May")!.IsStatic());
+        Assert.False(typeof(KitKat).GetAnyProperty("Contain")!.IsStatic());
+        Assert.False(typeof(KitKat).GetAnyProperty("TreeNuts")!.IsStatic());
+        Assert.False(typeof(KitKat).GetAnyProperty("Just")!.IsStatic());
+        Assert.True(typeof(KitKat).GetAnyProperty("Like")!.IsStatic());
+        Assert.False(typeof(KitKat).GetAnyProperty("A")!.IsStatic());
+        Assert.True(typeof(KitKat).GetAnyProperty("Twix")!.IsStatic());
     }
 
     public class KitKat

--- a/test/EFCore.Tests/Extensions/QueryableExtensionsTest.cs
+++ b/test/EFCore.Tests/Extensions/QueryableExtensionsTest.cs
@@ -159,7 +159,7 @@ public class QueryableExtensionsTest
                 Assert.Equal(expectedArgument.ToString(), actualArgument.ToString());
             }
 
-            return default;
+            return default!;
         }
 
         public IQueryable CreateQuery(Expression expression)
@@ -175,14 +175,14 @@ public class QueryableExtensionsTest
             => throw new NotImplementedException();
     }
 
-    private class FakeQueryable<TElement>(IQueryProvider provider = null) : IQueryable<TElement>
+    private class FakeQueryable<TElement>(IQueryProvider? provider = null) : IQueryable<TElement>
     {
         public Type ElementType
             => typeof(TElement);
 
-        public Expression Expression { get; set; }
+        public Expression Expression { get; set; } = null!;
 
-        public IQueryProvider Provider { get; } = provider;
+        public IQueryProvider Provider { get; } = provider!;
 
         public IEnumerator<TElement> GetEnumerator()
             => throw new NotImplementedException();
@@ -292,11 +292,11 @@ public class QueryableExtensionsTest
         await SourceNonAsyncQueryableTest(() => Source<decimal?>().SumAsync(e => e));
         await SourceNonAsyncEnumerableTest<int>(() => Source().ToDictionaryAsync(e => e));
         await SourceNonAsyncEnumerableTest<int>(() => Source().ToDictionaryAsync(e => e, e => e));
-        await SourceNonAsyncEnumerableTest<int>(() => Source().ToDictionaryAsync(e => e, ReferenceEqualityComparer.Instance));
-        await SourceNonAsyncEnumerableTest<int>(() => Source().ToDictionaryAsync(e => e, ReferenceEqualityComparer.Instance));
-        await SourceNonAsyncEnumerableTest<int>(() => Source().ToDictionaryAsync(e => e, e => e, ReferenceEqualityComparer.Instance));
+        await SourceNonAsyncEnumerableTest<int>(() => Source().ToDictionaryAsync(e => e, EqualityComparer<int>.Default));
+        await SourceNonAsyncEnumerableTest<int>(() => Source().ToDictionaryAsync(e => e, EqualityComparer<int>.Default));
+        await SourceNonAsyncEnumerableTest<int>(() => Source().ToDictionaryAsync(e => e, e => e, EqualityComparer<int>.Default));
         await SourceNonAsyncEnumerableTest<int>(() => Source().ToDictionaryAsync(
-            e => e, e => e, ReferenceEqualityComparer.Instance, new CancellationToken()));
+            e => e, e => e, EqualityComparer<int>.Default, new CancellationToken()));
         await SourceNonAsyncEnumerableTest<int>(() => Source().ToHashSetAsync());
         await SourceNonAsyncEnumerableTest<int>(() => Source().ToHashSetAsync(EqualityComparer<int>.Default));
         await SourceNonAsyncEnumerableTest<int>(() => Source().ToHashSetAsync(EqualityComparer<int>.Default, new CancellationToken()));
@@ -328,50 +328,50 @@ public class QueryableExtensionsTest
     {
         // ReSharper disable AssignNullToNotNullAttribute
 
-        await ArgumentNullTest("predicate", () => Source().FirstAsync(null));
-        await ArgumentNullTest("predicate", () => Source().FirstOrDefaultAsync(null));
-        await ArgumentNullTest("predicate", () => Source().SingleAsync(null));
-        await ArgumentNullTest("predicate", () => Source().SingleOrDefaultAsync(null));
-        await ArgumentNullTest("predicate", () => Source().AnyAsync(null));
-        await ArgumentNullTest("predicate", () => Source().AllAsync(null));
-        await ArgumentNullTest("predicate", () => Source().AllAsync(null, new CancellationToken()));
-        await ArgumentNullTest("predicate", () => Source().CountAsync(null));
-        await ArgumentNullTest("predicate", () => Source().LongCountAsync(null));
-        await ArgumentNullTest("predicate", () => Source().LongCountAsync(null, new CancellationToken()));
-        await ArgumentNullTest("selector", () => Source().MinAsync<int, bool>(null));
-        await ArgumentNullTest("selector", () => Source().MinAsync<int, bool>(null, new CancellationToken()));
-        await ArgumentNullTest("selector", () => Source().MaxAsync<int, bool>(null));
-        await ArgumentNullTest("selector", () => Source().MaxAsync<int, bool>(null, new CancellationToken()));
-        await ArgumentNullTest("selector", () => Source<int>().SumAsync(null));
-        await ArgumentNullTest("selector", () => Source<int?>().SumAsync(null));
-        await ArgumentNullTest("selector", () => Source<long>().SumAsync(null));
-        await ArgumentNullTest("selector", () => Source<long?>().SumAsync(null));
-        await ArgumentNullTest("selector", () => Source<float>().SumAsync(null));
-        await ArgumentNullTest("selector", () => Source<float?>().SumAsync(null));
-        await ArgumentNullTest("selector", () => Source<double>().SumAsync(null));
-        await ArgumentNullTest("selector", () => Source<double?>().SumAsync(null));
-        await ArgumentNullTest("selector", () => Source<decimal>().SumAsync(null));
-        await ArgumentNullTest("selector", () => Source<decimal?>().SumAsync(null));
-        await ArgumentNullTest("selector", () => Source<int>().AverageAsync(null));
-        await ArgumentNullTest("selector", () => Source<int>().AverageAsync(null, new CancellationToken()));
-        await ArgumentNullTest("selector", () => Source<int?>().AverageAsync(null));
-        await ArgumentNullTest("selector", () => Source<int?>().AverageAsync(null, new CancellationToken()));
-        await ArgumentNullTest("selector", () => Source<long>().AverageAsync(null));
-        await ArgumentNullTest("selector", () => Source<long>().AverageAsync(null, new CancellationToken()));
-        await ArgumentNullTest("selector", () => Source<long?>().AverageAsync(null));
-        await ArgumentNullTest("selector", () => Source<long?>().AverageAsync(null, new CancellationToken()));
-        await ArgumentNullTest("selector", () => Source<float>().AverageAsync(null));
-        await ArgumentNullTest("selector", () => Source<float>().AverageAsync(null, new CancellationToken()));
-        await ArgumentNullTest("selector", () => Source<float?>().AverageAsync(null));
-        await ArgumentNullTest("selector", () => Source<float?>().AverageAsync(null, new CancellationToken()));
-        await ArgumentNullTest("selector", () => Source<double>().AverageAsync(null));
-        await ArgumentNullTest("selector", () => Source<double>().AverageAsync(null, new CancellationToken()));
-        await ArgumentNullTest("selector", () => Source<double?>().AverageAsync(null));
-        await ArgumentNullTest("selector", () => Source<double?>().AverageAsync(null, new CancellationToken()));
-        await ArgumentNullTest("selector", () => Source<decimal>().AverageAsync(null));
-        await ArgumentNullTest("selector", () => Source<decimal>().AverageAsync(null, new CancellationToken()));
-        await ArgumentNullTest("selector", () => Source<decimal?>().AverageAsync(null));
-        await ArgumentNullTest("selector", () => Source<decimal?>().AverageAsync(null, new CancellationToken()));
+        await ArgumentNullTest("predicate", () => Source().FirstAsync(null!));
+        await ArgumentNullTest("predicate", () => Source().FirstOrDefaultAsync(null!));
+        await ArgumentNullTest("predicate", () => Source().SingleAsync(null!));
+        await ArgumentNullTest("predicate", () => Source().SingleOrDefaultAsync(null!));
+        await ArgumentNullTest("predicate", () => Source().AnyAsync(null!));
+        await ArgumentNullTest("predicate", () => Source().AllAsync(null!));
+        await ArgumentNullTest("predicate", () => Source().AllAsync(null!, new CancellationToken()));
+        await ArgumentNullTest("predicate", () => Source().CountAsync(null!));
+        await ArgumentNullTest("predicate", () => Source().LongCountAsync(null!));
+        await ArgumentNullTest("predicate", () => Source().LongCountAsync(null!, new CancellationToken()));
+        await ArgumentNullTest("selector", () => Source().MinAsync<int, bool>(null!));
+        await ArgumentNullTest("selector", () => Source().MinAsync<int, bool>(null!, new CancellationToken()));
+        await ArgumentNullTest("selector", () => Source().MaxAsync<int, bool>(null!));
+        await ArgumentNullTest("selector", () => Source().MaxAsync<int, bool>(null!, new CancellationToken()));
+        await ArgumentNullTest("selector", () => Source<int>().SumAsync(null!));
+        await ArgumentNullTest("selector", () => Source<int?>().SumAsync(null!));
+        await ArgumentNullTest("selector", () => Source<long>().SumAsync(null!));
+        await ArgumentNullTest("selector", () => Source<long?>().SumAsync(null!));
+        await ArgumentNullTest("selector", () => Source<float>().SumAsync(null!));
+        await ArgumentNullTest("selector", () => Source<float?>().SumAsync(null!));
+        await ArgumentNullTest("selector", () => Source<double>().SumAsync(null!));
+        await ArgumentNullTest("selector", () => Source<double?>().SumAsync(null!));
+        await ArgumentNullTest("selector", () => Source<decimal>().SumAsync(null!));
+        await ArgumentNullTest("selector", () => Source<decimal?>().SumAsync(null!));
+        await ArgumentNullTest("selector", () => Source<int>().AverageAsync(null!));
+        await ArgumentNullTest("selector", () => Source<int>().AverageAsync(null!, new CancellationToken()));
+        await ArgumentNullTest("selector", () => Source<int?>().AverageAsync(null!));
+        await ArgumentNullTest("selector", () => Source<int?>().AverageAsync(null!, new CancellationToken()));
+        await ArgumentNullTest("selector", () => Source<long>().AverageAsync(null!));
+        await ArgumentNullTest("selector", () => Source<long>().AverageAsync(null!, new CancellationToken()));
+        await ArgumentNullTest("selector", () => Source<long?>().AverageAsync(null!));
+        await ArgumentNullTest("selector", () => Source<long?>().AverageAsync(null!, new CancellationToken()));
+        await ArgumentNullTest("selector", () => Source<float>().AverageAsync(null!));
+        await ArgumentNullTest("selector", () => Source<float>().AverageAsync(null!, new CancellationToken()));
+        await ArgumentNullTest("selector", () => Source<float?>().AverageAsync(null!));
+        await ArgumentNullTest("selector", () => Source<float?>().AverageAsync(null!, new CancellationToken()));
+        await ArgumentNullTest("selector", () => Source<double>().AverageAsync(null!));
+        await ArgumentNullTest("selector", () => Source<double>().AverageAsync(null!, new CancellationToken()));
+        await ArgumentNullTest("selector", () => Source<double?>().AverageAsync(null!));
+        await ArgumentNullTest("selector", () => Source<double?>().AverageAsync(null!, new CancellationToken()));
+        await ArgumentNullTest("selector", () => Source<decimal>().AverageAsync(null!));
+        await ArgumentNullTest("selector", () => Source<decimal>().AverageAsync(null!, new CancellationToken()));
+        await ArgumentNullTest("selector", () => Source<decimal?>().AverageAsync(null!));
+        await ArgumentNullTest("selector", () => Source<decimal?>().AverageAsync(null!, new CancellationToken()));
 
         // ReSharper restore AssignNullToNotNullAttribute
     }

--- a/test/EFCore.Tests/Extensions/TypeExtensionsTest.cs
+++ b/test/EFCore.Tests/Extensions/TypeExtensionsTest.cs
@@ -95,54 +95,54 @@ public class TypeExtensionsTest
     [Fact]
     public void Get_any_property_returns_any_property()
     {
-        Assert.Same(typeof(TindersticksII), typeof(TindersticksII).GetAnyProperty("ElDiabloEnElOjo").DeclaringType);
-        Assert.Same(typeof(TindersticksII), typeof(TindersticksII).GetAnyProperty("ANightIn").DeclaringType);
-        Assert.Same(typeof(TindersticksII), typeof(TindersticksII).GetAnyProperty("MySister").DeclaringType);
-        Assert.Same(typeof(TindersticksII), typeof(TindersticksII).GetAnyProperty("TinyTears").DeclaringType);
-        Assert.Same(typeof(TindersticksII), typeof(TindersticksII).GetAnyProperty("SnowyInFSharpMinor").DeclaringType);
-        Assert.Same(typeof(TindersticksII), typeof(TindersticksII).GetAnyProperty("Seaweed").DeclaringType);
-        Assert.Same(typeof(TindersticksII), typeof(TindersticksII).GetAnyProperty("VertrauenII").DeclaringType);
-        Assert.Same(typeof(TindersticksII), typeof(TindersticksII).GetAnyProperty("TalkToMe").DeclaringType);
-        Assert.Same(typeof(TindersticksII), typeof(TindersticksII).GetAnyProperty("NoMoreAffairs").DeclaringType);
-        Assert.Same(typeof(TindersticksII), typeof(TindersticksII).GetAnyProperty("Singing").DeclaringType);
-        Assert.Same(typeof(TindersticksII), typeof(TindersticksII).GetAnyProperty("TravellingLight").DeclaringType);
-        Assert.Same(typeof(TindersticksII), typeof(TindersticksII).GetAnyProperty("CherryBlossoms").DeclaringType);
-        Assert.Same(typeof(TindersticksII), typeof(TindersticksII).GetAnyProperty("ShesGone").DeclaringType);
-        Assert.Same(typeof(TindersticksII), typeof(TindersticksII).GetAnyProperty("Mistakes").DeclaringType);
+        Assert.Same(typeof(TindersticksII), typeof(TindersticksII).GetAnyProperty("ElDiabloEnElOjo")!.DeclaringType);
+        Assert.Same(typeof(TindersticksII), typeof(TindersticksII).GetAnyProperty("ANightIn")!.DeclaringType);
+        Assert.Same(typeof(TindersticksII), typeof(TindersticksII).GetAnyProperty("MySister")!.DeclaringType);
+        Assert.Same(typeof(TindersticksII), typeof(TindersticksII).GetAnyProperty("TinyTears")!.DeclaringType);
+        Assert.Same(typeof(TindersticksII), typeof(TindersticksII).GetAnyProperty("SnowyInFSharpMinor")!.DeclaringType);
+        Assert.Same(typeof(TindersticksII), typeof(TindersticksII).GetAnyProperty("Seaweed")!.DeclaringType);
+        Assert.Same(typeof(TindersticksII), typeof(TindersticksII).GetAnyProperty("VertrauenII")!.DeclaringType);
+        Assert.Same(typeof(TindersticksII), typeof(TindersticksII).GetAnyProperty("TalkToMe")!.DeclaringType);
+        Assert.Same(typeof(TindersticksII), typeof(TindersticksII).GetAnyProperty("NoMoreAffairs")!.DeclaringType);
+        Assert.Same(typeof(TindersticksII), typeof(TindersticksII).GetAnyProperty("Singing")!.DeclaringType);
+        Assert.Same(typeof(TindersticksII), typeof(TindersticksII).GetAnyProperty("TravellingLight")!.DeclaringType);
+        Assert.Same(typeof(TindersticksII), typeof(TindersticksII).GetAnyProperty("CherryBlossoms")!.DeclaringType);
+        Assert.Same(typeof(TindersticksII), typeof(TindersticksII).GetAnyProperty("ShesGone")!.DeclaringType);
+        Assert.Same(typeof(TindersticksII), typeof(TindersticksII).GetAnyProperty("Mistakes")!.DeclaringType);
         Assert.Null(typeof(TindersticksII).GetAnyProperty("VertrauenIII"));
-        Assert.Same(typeof(TindersticksII), typeof(TindersticksII).GetAnyProperty("SleepySong").DeclaringType);
+        Assert.Same(typeof(TindersticksII), typeof(TindersticksII).GetAnyProperty("SleepySong")!.DeclaringType);
 
-        Assert.Same(typeof(TindersticksIIVinyl), typeof(TindersticksIIVinyl).GetAnyProperty("ElDiabloEnElOjo").DeclaringType);
-        Assert.Same(typeof(TindersticksIIVinyl), typeof(TindersticksIIVinyl).GetAnyProperty("ANightIn").DeclaringType);
-        Assert.Same(typeof(TindersticksIIVinyl), typeof(TindersticksIIVinyl).GetAnyProperty("MySister").DeclaringType);
-        Assert.Same(typeof(TindersticksIIVinyl), typeof(TindersticksIIVinyl).GetAnyProperty("TinyTears").DeclaringType);
-        Assert.Same(typeof(TindersticksIIVinyl), typeof(TindersticksIIVinyl).GetAnyProperty("SnowyInFSharpMinor").DeclaringType);
-        Assert.Same(typeof(TindersticksIIVinyl), typeof(TindersticksIIVinyl).GetAnyProperty("Seaweed").DeclaringType);
-        Assert.Same(typeof(TindersticksIIVinyl), typeof(TindersticksIIVinyl).GetAnyProperty("VertrauenII").DeclaringType);
-        Assert.Same(typeof(TindersticksIIVinyl), typeof(TindersticksIIVinyl).GetAnyProperty("TalkToMe").DeclaringType);
-        Assert.Same(typeof(TindersticksIIVinyl), typeof(TindersticksIIVinyl).GetAnyProperty("NoMoreAffairs").DeclaringType);
-        Assert.Same(typeof(TindersticksIIVinyl), typeof(TindersticksIIVinyl).GetAnyProperty("Singing").DeclaringType);
-        Assert.Same(typeof(TindersticksIIVinyl), typeof(TindersticksIIVinyl).GetAnyProperty("TravellingLight").DeclaringType);
-        Assert.Same(typeof(TindersticksIIVinyl), typeof(TindersticksIIVinyl).GetAnyProperty("CherryBlossoms").DeclaringType);
-        Assert.Same(typeof(TindersticksIIVinyl), typeof(TindersticksIIVinyl).GetAnyProperty("ShesGone").DeclaringType);
-        Assert.Same(typeof(TindersticksII), typeof(TindersticksIIVinyl).GetAnyProperty("Mistakes").DeclaringType);
-        Assert.Same(typeof(TindersticksIIVinyl), typeof(TindersticksIIVinyl).GetAnyProperty("VertrauenIII").DeclaringType);
+        Assert.Same(typeof(TindersticksIIVinyl), typeof(TindersticksIIVinyl).GetAnyProperty("ElDiabloEnElOjo")!.DeclaringType);
+        Assert.Same(typeof(TindersticksIIVinyl), typeof(TindersticksIIVinyl).GetAnyProperty("ANightIn")!.DeclaringType);
+        Assert.Same(typeof(TindersticksIIVinyl), typeof(TindersticksIIVinyl).GetAnyProperty("MySister")!.DeclaringType);
+        Assert.Same(typeof(TindersticksIIVinyl), typeof(TindersticksIIVinyl).GetAnyProperty("TinyTears")!.DeclaringType);
+        Assert.Same(typeof(TindersticksIIVinyl), typeof(TindersticksIIVinyl).GetAnyProperty("SnowyInFSharpMinor")!.DeclaringType);
+        Assert.Same(typeof(TindersticksIIVinyl), typeof(TindersticksIIVinyl).GetAnyProperty("Seaweed")!.DeclaringType);
+        Assert.Same(typeof(TindersticksIIVinyl), typeof(TindersticksIIVinyl).GetAnyProperty("VertrauenII")!.DeclaringType);
+        Assert.Same(typeof(TindersticksIIVinyl), typeof(TindersticksIIVinyl).GetAnyProperty("TalkToMe")!.DeclaringType);
+        Assert.Same(typeof(TindersticksIIVinyl), typeof(TindersticksIIVinyl).GetAnyProperty("NoMoreAffairs")!.DeclaringType);
+        Assert.Same(typeof(TindersticksIIVinyl), typeof(TindersticksIIVinyl).GetAnyProperty("Singing")!.DeclaringType);
+        Assert.Same(typeof(TindersticksIIVinyl), typeof(TindersticksIIVinyl).GetAnyProperty("TravellingLight")!.DeclaringType);
+        Assert.Same(typeof(TindersticksIIVinyl), typeof(TindersticksIIVinyl).GetAnyProperty("CherryBlossoms")!.DeclaringType);
+        Assert.Same(typeof(TindersticksIIVinyl), typeof(TindersticksIIVinyl).GetAnyProperty("ShesGone")!.DeclaringType);
+        Assert.Same(typeof(TindersticksII), typeof(TindersticksIIVinyl).GetAnyProperty("Mistakes")!.DeclaringType);
+        Assert.Same(typeof(TindersticksIIVinyl), typeof(TindersticksIIVinyl).GetAnyProperty("VertrauenIII")!.DeclaringType);
         Assert.Throws<AmbiguousMatchException>(() => typeof(TindersticksIICd).GetAnyProperty("SleepySong"));
 
-        Assert.Same(typeof(TindersticksIICd), typeof(TindersticksIICd).GetAnyProperty("ANightIn").DeclaringType);
-        Assert.Same(typeof(TindersticksIICd), typeof(TindersticksIICd).GetAnyProperty("MySister").DeclaringType);
-        Assert.Same(typeof(TindersticksIICd), typeof(TindersticksIICd).GetAnyProperty("TinyTears").DeclaringType);
-        Assert.Same(typeof(TindersticksIICd), typeof(TindersticksIICd).GetAnyProperty("SnowyInFSharpMinor").DeclaringType);
-        Assert.Same(typeof(TindersticksIICd), typeof(TindersticksIICd).GetAnyProperty("Seaweed").DeclaringType);
-        Assert.Same(typeof(TindersticksIICd), typeof(TindersticksIICd).GetAnyProperty("VertrauenII").DeclaringType);
-        Assert.Same(typeof(TindersticksIICd), typeof(TindersticksIICd).GetAnyProperty("TalkToMe").DeclaringType);
-        Assert.Same(typeof(TindersticksIICd), typeof(TindersticksIICd).GetAnyProperty("NoMoreAffairs").DeclaringType);
-        Assert.Same(typeof(TindersticksIICd), typeof(TindersticksIICd).GetAnyProperty("Singing").DeclaringType);
-        Assert.Same(typeof(TindersticksIICd), typeof(TindersticksIICd).GetAnyProperty("TravellingLight").DeclaringType);
-        Assert.Same(typeof(TindersticksIICd), typeof(TindersticksIICd).GetAnyProperty("CherryBlossoms").DeclaringType);
-        Assert.Same(typeof(TindersticksIIVinyl), typeof(TindersticksIICd).GetAnyProperty("ShesGone").DeclaringType);
-        Assert.Same(typeof(TindersticksIICd), typeof(TindersticksIICd).GetAnyProperty("Mistakes").DeclaringType);
-        Assert.Same(typeof(TindersticksIICd), typeof(TindersticksIICd).GetAnyProperty("VertrauenIII").DeclaringType);
+        Assert.Same(typeof(TindersticksIICd), typeof(TindersticksIICd).GetAnyProperty("ANightIn")!.DeclaringType);
+        Assert.Same(typeof(TindersticksIICd), typeof(TindersticksIICd).GetAnyProperty("MySister")!.DeclaringType);
+        Assert.Same(typeof(TindersticksIICd), typeof(TindersticksIICd).GetAnyProperty("TinyTears")!.DeclaringType);
+        Assert.Same(typeof(TindersticksIICd), typeof(TindersticksIICd).GetAnyProperty("SnowyInFSharpMinor")!.DeclaringType);
+        Assert.Same(typeof(TindersticksIICd), typeof(TindersticksIICd).GetAnyProperty("Seaweed")!.DeclaringType);
+        Assert.Same(typeof(TindersticksIICd), typeof(TindersticksIICd).GetAnyProperty("VertrauenII")!.DeclaringType);
+        Assert.Same(typeof(TindersticksIICd), typeof(TindersticksIICd).GetAnyProperty("TalkToMe")!.DeclaringType);
+        Assert.Same(typeof(TindersticksIICd), typeof(TindersticksIICd).GetAnyProperty("NoMoreAffairs")!.DeclaringType);
+        Assert.Same(typeof(TindersticksIICd), typeof(TindersticksIICd).GetAnyProperty("Singing")!.DeclaringType);
+        Assert.Same(typeof(TindersticksIICd), typeof(TindersticksIICd).GetAnyProperty("TravellingLight")!.DeclaringType);
+        Assert.Same(typeof(TindersticksIICd), typeof(TindersticksIICd).GetAnyProperty("CherryBlossoms")!.DeclaringType);
+        Assert.Same(typeof(TindersticksIIVinyl), typeof(TindersticksIICd).GetAnyProperty("ShesGone")!.DeclaringType);
+        Assert.Same(typeof(TindersticksIICd), typeof(TindersticksIICd).GetAnyProperty("Mistakes")!.DeclaringType);
+        Assert.Same(typeof(TindersticksIICd), typeof(TindersticksIICd).GetAnyProperty("VertrauenIII")!.DeclaringType);
         Assert.Throws<AmbiguousMatchException>(() => typeof(TindersticksIICd).GetAnyProperty("SleepySong"));
     }
 
@@ -327,7 +327,7 @@ public class TypeExtensionsTest
     private class Role2014 : IRole2014
     {
         public int RoleId { get; set; }
-        public string Permissions { get; set; }
+        public string Permissions { get; set; } = null!;
     }
 
     [Fact]
@@ -354,7 +354,7 @@ public class TypeExtensionsTest
     [Fact]
     public void Can_get_default_value_for_type()
     {
-        Assert.False((bool)typeof(bool).GetDefaultValue());
+        Assert.False((bool)typeof(bool).GetDefaultValue()!);
         Assert.Equal((sbyte)0, typeof(sbyte).GetDefaultValue());
         Assert.Equal((short)0, typeof(short).GetDefaultValue());
         Assert.Equal(0, typeof(int).GetDefaultValue());
@@ -543,7 +543,7 @@ public class TypeExtensionsTest
             { typeof(List<>), true, "System.Collections.Generic.List<>" },
             { typeof(Dictionary<,>), true, "System.Collections.Generic.Dictionary<,>" },
             { typeof(Level1<>.Level2<>.Level3<>), true, "Microsoft.EntityFrameworkCore.TypeExtensionsTest+Level1<>+Level2<>+Level3<>" },
-            { typeof(PartiallyClosedGeneric<>).BaseType, true, "Microsoft.EntityFrameworkCore.TypeExtensionsTest+C<, int>" },
+            { typeof(PartiallyClosedGeneric<>).BaseType!, true, "Microsoft.EntityFrameworkCore.TypeExtensionsTest+C<, int>" },
             {
                 typeof(OuterGeneric<>.InnerNonGeneric.InnerGeneric<,>.InnerGenericLeafNode<>), true,
                 "Microsoft.EntityFrameworkCore.TypeExtensionsTest+OuterGeneric<>+InnerNonGeneric+InnerGeneric<,>+InnerGenericLeafNode<>"

--- a/test/EFCore.Tests/IEntityTypeConfigurationTest.cs
+++ b/test/EFCore.Tests/IEntityTypeConfigurationTest.cs
@@ -12,7 +12,7 @@ public class IEntityTypeConfigurationTest
 
         builder.ApplyConfiguration(new CustomerConfiguration());
 
-        var entityType = builder.Model.FindEntityType(typeof(Customer));
+        var entityType = builder.Model.FindEntityType(typeof(Customer))!;
         Assert.NotNull(entityType);
         Assert.Equal(nameof(Customer.AlternateKey), entityType.GetKeys().Single().Properties.Single().Name);
     }
@@ -25,7 +25,7 @@ public class IEntityTypeConfigurationTest
         builder.Entity<Customer>();
         builder.ApplyConfiguration(new CustomerConfiguration());
 
-        var entityType = builder.Model.FindEntityType(typeof(Customer));
+        var entityType = builder.Model.FindEntityType(typeof(Customer))!;
         Assert.Equal(nameof(Customer.AlternateKey), entityType.GetKeys().Single().Properties.Single().Name);
     }
 
@@ -37,8 +37,8 @@ public class IEntityTypeConfigurationTest
         builder.Entity<Customer>().Property(c => c.Name).HasMaxLength(500);
         builder.ApplyConfiguration(new CustomerConfiguration());
 
-        var entityType = builder.Model.FindEntityType(typeof(Customer));
-        Assert.Equal(200, entityType.FindProperty(nameof(Customer.Name)).GetMaxLength());
+        var entityType = builder.Model.FindEntityType(typeof(Customer))!;
+        Assert.Equal(200, entityType.FindProperty(nameof(Customer.Name))!.GetMaxLength());
     }
 
     [Fact]
@@ -49,8 +49,8 @@ public class IEntityTypeConfigurationTest
         builder.ApplyConfiguration(new CustomerConfiguration());
         builder.Entity<Customer>().Property(c => c.Name).HasMaxLength(500);
 
-        var entityType = builder.Model.FindEntityType(typeof(Customer));
-        Assert.Equal(500, entityType.FindProperty(nameof(Customer.Name)).GetMaxLength());
+        var entityType = builder.Model.FindEntityType(typeof(Customer))!;
+        Assert.Equal(500, entityType.FindProperty(nameof(Customer.Name))!.GetMaxLength());
     }
 
     [Fact]
@@ -61,9 +61,9 @@ public class IEntityTypeConfigurationTest
         builder.ApplyConfiguration(new CustomerConfiguration());
         builder.ApplyConfiguration(new CustomerConfiguration2());
 
-        var entityType = builder.Model.FindEntityType(typeof(Customer));
+        var entityType = builder.Model.FindEntityType(typeof(Customer))!;
         Assert.Equal(nameof(Customer.AlternateKey), entityType.GetKeys().Single().Properties.Single().Name);
-        Assert.Equal(1000, entityType.FindProperty(nameof(Customer.Name)).GetMaxLength());
+        Assert.Equal(1000, entityType.FindProperty(nameof(Customer.Name))!.GetMaxLength());
     }
 
     private class CustomerConfiguration : IEntityTypeConfiguration<Customer>
@@ -88,15 +88,15 @@ public class IEntityTypeConfigurationTest
 
         public int? CustomerId { get; set; }
         public Guid AnotherCustomerId { get; set; }
-        public Customer Customer { get; set; }
+        public Customer Customer { get; set; } = null!;
     }
 
     protected class Customer
     {
         public int Id { get; set; }
         public Guid AlternateKey { get; set; }
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
 
-        public IEnumerable<Order> Orders { get; set; }
+        public IEnumerable<Order> Orders { get; set; } = [];
     }
 }

--- a/test/EFCore.Tests/Infrastructure/AnnotatableTest.cs
+++ b/test/EFCore.Tests/Infrastructure/AnnotatableTest.cs
@@ -38,13 +38,13 @@ public class AnnotatableTest
 
         annotatable.AddAnnotations([new ConventionAnnotation("Foo", "Bar", ConfigurationSource.Convention)]);
 
-        Assert.Equal(typeof(Annotation), annotatable.FindAnnotation("Foo").GetType());
+        Assert.Equal(typeof(Annotation), annotatable.FindAnnotation("Foo")!.GetType());
 
         var conventionAnnotatable = new Model();
 
         conventionAnnotatable.AddAnnotations([new Annotation("Foo", "Bar")]);
 
-        Assert.Equal(typeof(ConventionAnnotation), conventionAnnotatable.FindAnnotation("Foo").GetType());
+        Assert.Equal(typeof(ConventionAnnotation), conventionAnnotatable.FindAnnotation("Foo")!.GetType());
     }
 
     [Fact]

--- a/test/EFCore.Tests/Infrastructure/DatabaseFacadeTest.cs
+++ b/test/EFCore.Tests/Infrastructure/DatabaseFacadeTest.cs
@@ -199,9 +199,9 @@ public class DatabaseFacadeTest
         public IDbContextTransaction CurrentTransaction
             => _transaction;
 
-        public Transaction EnlistedTransaction { get; }
+        public Transaction? EnlistedTransaction { get; }
 
-        public void EnlistTransaction(Transaction transaction)
+        public void EnlistTransaction(Transaction? transaction)
             => throw new NotImplementedException();
 
         public void ResetState()

--- a/test/EFCore.Tests/Infrastructure/DbSetFinderTest.cs
+++ b/test/EFCore.Tests/Infrastructure/DbSetFinderTest.cs
@@ -31,22 +31,22 @@ public class DbSetFinderTest
 
     public class Streets : DbContext
     {
-        public DbSet<You> Yous { get; set; }
-        protected DbSet<Better> Betters { get; set; }
+        public DbSet<You> Yous { get; set; } = null!;
+        protected DbSet<Better> Betters { get; set; } = null!;
 
         internal DbSet<Stop> Stops
-            => null;
+            => null!;
     }
 
     public class The : Streets
     {
-        public DbSet<Drinking> Drinkings { get; set; }
-        private DbSet<Brandy> Brandies { get; set; }
+        public DbSet<Drinking> Drinkings { get; set; } = null!;
+        private DbSet<Brandy> Brandies { get; set; } = null!;
 
-        public static DbSet<Random> NotMe1 { get; set; }
-        public Random NotMe2 { get; set; }
-        public List<Random> NotMe3 { get; set; }
-        public NotANormalSet<Random> NotMe4 { get; set; }
+        public static DbSet<Random> NotMe1 { get; set; } = null!;
+        public Random NotMe2 { get; set; } = null!;
+        public List<Random> NotMe3 { get; set; } = null!;
+        public NotANormalSet<Random> NotMe4 { get; set; } = null!;
     }
 
     public class You;

--- a/test/EFCore.Tests/Infrastructure/EntityFrameworkMetricsTest.cs
+++ b/test/EFCore.Tests/Infrastructure/EntityFrameworkMetricsTest.cs
@@ -223,7 +223,7 @@ public class EntityFrameworkMetricsTest
 
                 using (var innerContext = new SomeDbContext())
                 {
-                    innerContext.Foos.Find(entity.Id).Token = 1;
+                    innerContext.Foos.Find(entity.Id)!.Token = 1;
                     innerContext.SaveChanges();
                 }
 
@@ -351,7 +351,7 @@ public class EntityFrameworkMetricsTest
         }
 
         // ReSharper disable once UnusedAutoPropertyAccessor.Local
-        public DbSet<Foo> Foos { get; set; }
+        public DbSet<Foo> Foos { get; set; } = null!;
 
         protected internal override void OnModelCreating(ModelBuilder modelBuilder)
             => modelBuilder.Entity<Foo>().Property(e => e.Token).IsConcurrencyToken();

--- a/test/EFCore.Tests/Infrastructure/EventIdTestBase.cs
+++ b/test/EFCore.Tests/Infrastructure/EventIdTestBase.cs
@@ -12,7 +12,7 @@ public abstract class EventIdTestBase
         Type loggerExtensionType,
         LoggingDefinitions loggerDefinitions,
         IDictionary<Type, Func<object>> fakeFactories,
-        Dictionary<string, IList<string>> eventMappings = null)
+        Dictionary<string, IList<string>>? eventMappings = null)
         => TestEventLogging(
             eventIdType,
             loggerExtensionType,
@@ -29,7 +29,7 @@ public abstract class EventIdTestBase
         LoggingDefinitions loggerDefinitions,
         IDictionary<Type, Func<object>> fakeFactories,
         Action<ServiceCollection> serviceCollectionBuilder,
-        Dictionary<string, IList<string>> eventMappings = null)
+        Dictionary<string, IList<string>>? eventMappings = null)
     {
         var testLoggerFactory = new TestLoggerFactory(loggerDefinitions);
         var testLogger = testLoggerFactory.Logger;
@@ -85,19 +85,19 @@ public abstract class EventIdTestBase
                     loggerMethod = loggerMethod.MakeGenericMethod(category);
                 }
 
-                var eventId = (EventId)eventIdField.GetValue(null);
+                var eventId = (EventId)eventIdField.GetValue(null)!;
 
                 Assert.InRange(eventId.Id, CoreEventId.CoreBaseId, ushort.MaxValue);
 
-                var categoryName = Activator.CreateInstance(category).ToString();
+                var categoryName = Activator.CreateInstance(category)!.ToString();
                 Assert.Equal(categoryName + "." + eventName, eventId.Name);
 
                 var diagnosticLogger = scopeServiceProvider.GetRequiredService(
                     isExtensionMethod
                         ? typeof(IDiagnosticsLogger<>).MakeGenericType(category)
-                        : loggerMethod.DeclaringType);
+                        : loggerMethod.DeclaringType!);
 
-                var args = new object[loggerParameters.Length];
+                    var args = new object?[loggerParameters.Length];
                 var i = 0;
                 if (isExtensionMethod)
                 {
@@ -130,7 +130,7 @@ public abstract class EventIdTestBase
                     }
                 }
 
-                foreach (var enableFor in new[] { "Foo", eventId.Name })
+                foreach (var enableFor in new[] { "Foo", eventId.Name! })
                 {
                     testDiagnostics.EnableFor = enableFor;
 
@@ -139,7 +139,7 @@ public abstract class EventIdTestBase
                     {
                         testLogger.EnabledFor = logLevel;
                         testLogger.LoggedAt = null;
-                        testDiagnostics.LoggedEventName = null;
+                        testDiagnostics.LoggedEventName = null!;
 
                         loggerMethod.Invoke(isExtensionMethod ? null : diagnosticLogger, args);
 

--- a/test/EFCore.Tests/Infrastructure/Internal/ConcurrencyDetectorTest.cs
+++ b/test/EFCore.Tests/Infrastructure/Internal/ConcurrencyDetectorTest.cs
@@ -70,24 +70,24 @@ public class ConcurrencyDetectorTest
         }
 
         // ReSharper disable once UnusedAutoPropertyAccessor.Local
-        public DbSet<Customer> Customers { get; set; }
+        public DbSet<Customer> Customers { get; set; } = null!;
 
         // ReSharper disable once UnusedAutoPropertyAccessor.Local
-        public DbSet<Order> Orders { get; set; }
+        public DbSet<Order> Orders { get; set; } = null!;
     }
 
     public class Customer
     {
         public int CustomerId { get; set; }
-        public string FirstName { get; set; }
-        public string LastName { get; set; }
-        public virtual ICollection<Order> Orders { get; set; }
+        public string FirstName { get; set; } = null!;
+        public string LastName { get; set; } = null!;
+        public virtual ICollection<Order> Orders { get; set; } = [];
     }
 
     public class Order
     {
-        private readonly ILazyLoader _lazyLoader;
-        private Customer _customer;
+        private readonly ILazyLoader? _lazyLoader;
+        private Customer? _customer;
 
         public Order()
         {
@@ -102,7 +102,7 @@ public class ConcurrencyDetectorTest
 
         public Customer Customer
         {
-            get => _lazyLoader.Load(this, ref _customer);
+            get => _lazyLoader.Load(this, ref _customer)!;
             set => _customer = value;
         }
     }

--- a/test/EFCore.Tests/Infrastructure/InternalServiceCollectionMapTest.cs
+++ b/test/EFCore.Tests/Infrastructure/InternalServiceCollectionMapTest.cs
@@ -267,7 +267,7 @@ public class InternalServiceCollectionMapTest
     public void Throws_if_attempt_is_made_to_register_dependency_as_delegate()
     {
         var serviceCollection = new ServiceCollection();
-        serviceCollection.AddSingleton<DatabaseProviderDependencies>(p => null);
+        serviceCollection.AddSingleton<DatabaseProviderDependencies>(p => null!);
 
         var builder = new EntityFrameworkServicesBuilder(serviceCollection);
 
@@ -305,10 +305,10 @@ public class InternalServiceCollectionMapTest
 
     private class FakeService : IFakeService, IPatchServiceInjectionSite
     {
-        public DbContext Context { get; private set; }
+        public DbContext Context { get; private set; } = null!;
 
         void IPatchServiceInjectionSite.InjectServices(IServiceProvider serviceProvider)
-            => Context = serviceProvider.GetService<ICurrentDbContext>().Context;
+            => Context = serviceProvider.GetService<ICurrentDbContext>()!.Context;
     }
 
     private class DerivedFakeService : FakeService;
@@ -317,10 +317,10 @@ public class InternalServiceCollectionMapTest
 
     private class FakeSingletonService : IFakeSingletonService, IPatchServiceInjectionSite
     {
-        public IModelSource ModelSource { get; private set; }
+        public IModelSource ModelSource { get; private set; } = null!;
 
         void IPatchServiceInjectionSite.InjectServices(IServiceProvider serviceProvider)
-            => ModelSource = serviceProvider.GetService<IModelSource>();
+            => ModelSource = serviceProvider.GetService<IModelSource>()!;
     }
 
     private class DerivedFakeSingletonService : FakeSingletonService;

--- a/test/EFCore.Tests/Infrastructure/ModelSourceTest.cs
+++ b/test/EFCore.Tests/Infrastructure/ModelSourceTest.cs
@@ -87,10 +87,10 @@ public class ModelSourceTest
 
     private class JustAClass
     {
-        public DbSet<Random> One { get; set; }
-        protected DbSet<object> Two { get; set; }
-        private DbSet<string> Three { get; set; }
-        private DbSet<string> Four { get; set; }
+        public DbSet<Random> One { get; set; } = null!;
+        protected DbSet<object> Two { get; set; } = null!;
+        private DbSet<string> Three { get; set; } = null!;
+        private DbSet<string> Four { get; set; } = null!;
     }
 
     private class SetA
@@ -232,7 +232,7 @@ public class ModelSourceTest
 
         var model = modelSource.GetModel(context, testModelDependencies, designTime: false);
         var packageVersion = typeof(Context1).Assembly.GetCustomAttributes<AssemblyMetadataAttribute>()
-            .Single(m => m.Key == "PackageVersion").Value;
+            .Single(m => m.Key == "PackageVersion").Value!;
 
         var prereleaseIndex = packageVersion.IndexOf("-", StringComparison.Ordinal);
         if (prereleaseIndex != -1)

--- a/test/EFCore.Tests/Infrastructure/ModelValidatorTest.PropertyMapping.cs
+++ b/test/EFCore.Tests/Infrastructure/ModelValidatorTest.PropertyMapping.cs
@@ -251,7 +251,7 @@ public partial class ModelValidatorTest
 
     protected class NonPrimitiveAsPropertyEntity
     {
-        public NavigationAsProperty Property { get; set; }
+        public NavigationAsProperty Property { get; set; } = null!;
     }
 
     protected class NavigationAsProperty;
@@ -268,12 +268,12 @@ public partial class ModelValidatorTest
 
     protected class NonPrimitiveReferenceTypePropertyEntity
     {
-        public ICollection<Uri> Property { get; set; }
+        public ICollection<Uri> Property { get; set; } = null!;
     }
 
     protected class NavigationEntity
     {
-        public PrimitivePropertyEntity Navigation { get; set; }
+        public PrimitivePropertyEntity Navigation { get; set; } = null!;
     }
 
     protected class NonCandidatePropertyEntity
@@ -295,43 +295,43 @@ public partial class ModelValidatorTest
 
     protected class ExplicitNavigationEntity : INavigationEntity
     {
-        PrimitivePropertyEntity INavigationEntity.Navigation { get; set; }
+        PrimitivePropertyEntity INavigationEntity.Navigation { get; set; } = null!;
 
-        public PrimitivePropertyEntity Navigation { get; set; }
+        public PrimitivePropertyEntity Navigation { get; set; } = null!;
     }
 
     protected class InterfaceNavigationEntity
     {
-        public IList<INavigationEntity> Navigation { get; set; }
+        public IList<INavigationEntity> Navigation { get; set; } = null!;
     }
 
     protected abstract class LivingBeing
     {
         public int Id { get; set; }
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
 
         [NotMapped]
-        public OwnedEntity Details { get; set; }
+        public OwnedEntity Details { get; set; } = null!;
     }
 
     protected class Animal : LivingBeing
     {
-        public Person FavoritePerson { get; set; }
+        public Person FavoritePerson { get; set; } = null!;
     }
 
     protected class Cat : Animal
     {
-        public string Breed { get; set; }
+        public string Breed { get; set; } = null!;
 
         [NotMapped]
-        public string Type { get; set; }
+        public string Type { get; set; } = null!;
 
         public int Identity { get; set; }
     }
 
     protected class Dog : Animal
     {
-        public string Breed { get; set; }
+        public string Breed { get; set; } = null!;
 
         [NotMapped]
         public int Type { get; set; }
@@ -341,7 +341,7 @@ public partial class ModelValidatorTest
 
     protected class Person : LivingBeing
     {
-        public string FavoriteBreed { get; set; }
+        public string FavoriteBreed { get; set; } = null!;
     }
 
     protected class Employee : Person;
@@ -349,12 +349,12 @@ public partial class ModelValidatorTest
     protected class Owner
     {
         public int Id { get; set; }
-        public OwnedEntity Owned { get; set; }
+        public OwnedEntity? Owned { get; set; }
     }
 
     protected class OwnedEntity
     {
-        public string Value { get; set; }
+        public string? Value { get; set; }
     }
 
     protected class CarbonComposite

--- a/test/EFCore.Tests/Infrastructure/ModelValidatorTest.cs
+++ b/test/EFCore.Tests/Infrastructure/ModelValidatorTest.cs
@@ -75,7 +75,7 @@ public partial class ModelValidatorTest : ModelValidatorTestBase
     protected class MyEntity<T>
     {
         public int Id { get; set; }
-        public List<T> JsonbFields { get; set; }
+        public List<T> JsonbFields { get; set; } = null!;
     }
 
     protected class JsonbField
@@ -191,7 +191,7 @@ public partial class ModelValidatorTest : ModelValidatorTestBase
     {
         var modelBuilder = CreateConventionModelBuilder();
 
-        IMutableProperty convertedProperty = null;
+        IMutableProperty convertedProperty = null!;
         modelBuilder.Entity<WithCollectionConversion>(eb =>
         {
             eb.Property(e => e.Id);
@@ -213,7 +213,7 @@ public partial class ModelValidatorTest : ModelValidatorTestBase
     {
         var modelBuilder = CreateConventionModelBuilder();
 
-        IMutableProperty convertedProperty = null;
+        IMutableProperty convertedProperty = null!;
         modelBuilder.Entity<WithCollectionConversion>(eb =>
         {
             eb.Property(e => e.Id);
@@ -237,7 +237,7 @@ public partial class ModelValidatorTest : ModelValidatorTestBase
     protected class WithCollectionConversion
     {
         public int Id { get; set; }
-        public string[] SomeStrings { get; set; }
+        public string[] SomeStrings { get; set; } = null!;
     }
 
     [Fact]
@@ -257,7 +257,7 @@ public partial class ModelValidatorTest : ModelValidatorTestBase
     protected class WithStringCollection
     {
         public int Id { get; set; }
-        public string SomeString { get; set; }
+        public string SomeString { get; set; } = null!;
     }
 
     [Fact]
@@ -277,7 +277,7 @@ public partial class ModelValidatorTest : ModelValidatorTestBase
     protected class WithReadOnlyIntCollection
     {
         public int Id { get; set; }
-        public IReadOnlyCollection<int> Tags { get; set; }
+        public IReadOnlyCollection<int> Tags { get; set; } = null!;
     }
 
     [Fact]
@@ -297,7 +297,7 @@ public partial class ModelValidatorTest : ModelValidatorTestBase
     protected class WithReadOnlyList
     {
         public int Id { get; set; }
-        public IReadOnlyList<char> Tags { get; set; }
+        public IReadOnlyList<char> Tags { get; set; } = null!;
     }
 
     [Fact]
@@ -364,7 +364,7 @@ public partial class ModelValidatorTest : ModelValidatorTestBase
     protected class WithNonGenericCollection
     {
         public int Id { get; set; }
-        public MyCollection Tags { get; set; }
+        public MyCollection Tags { get; set; } = null!;
     }
 
     [Fact]
@@ -392,8 +392,8 @@ public partial class ModelValidatorTest : ModelValidatorTestBase
 
     protected class WithStringAndBinaryKey
     {
-        public byte[] Id { get; set; }
-        public string AString { get; set; }
+        public byte[] Id { get; set; } = null!;
+        public string AString { get; set; } = null!;
     }
 
     [Fact]
@@ -407,7 +407,7 @@ public partial class ModelValidatorTest : ModelValidatorTestBase
 
         VerifyError(
             CoreStrings.BadFilterDerivedType(
-                entityTypeD.FindDeclaredQueryFilter(null).Expression, entityTypeD.DisplayName(), entityTypeA.DisplayName()),
+                entityTypeD.FindDeclaredQueryFilter(null)!.Expression, entityTypeD.DisplayName(), entityTypeA.DisplayName()),
             modelBuilder);
     }
 
@@ -436,7 +436,7 @@ public partial class ModelValidatorTest : ModelValidatorTestBase
         SetPrimaryKey(entityType);
         AddProperties(entityType);
 
-        var keyProperty = ((IConventionEntityType)entityType).AddProperty("Key", typeof(int));
+        var keyProperty = ((IConventionEntityType)entityType).AddProperty("Key", typeof(int))!;
         ((IConventionEntityType)entityType).AddKey(keyProperty);
 
         VerifyWarning(
@@ -450,7 +450,7 @@ public partial class ModelValidatorTest : ModelValidatorTestBase
         var modelBuilder = CreateConventionlessModelBuilder();
         var model = (IConventionModel)modelBuilder.Model;
 
-        var entityType = model.AddEntityType(typeof(A));
+        var entityType = model.AddEntityType(typeof(A))!;
         AddProperties((IMutableEntityType)entityType);
         entityType.AddProperty(nameof(A.Id), typeof(int));
 
@@ -643,14 +643,14 @@ public partial class ModelValidatorTest : ModelValidatorTestBase
     {
         var builder = CreateConventionlessModelBuilder();
         var modelBuilder = (InternalModelBuilder)builder.GetInfrastructure();
-        var dependentEntityBuilder = modelBuilder.Entity(typeof(SampleEntityMinimal), ConfigurationSource.Convention);
+        var dependentEntityBuilder = modelBuilder.Entity(typeof(SampleEntityMinimal), ConfigurationSource.Convention)!;
         dependentEntityBuilder.Property(typeof(int), "Id", ConfigurationSource.Convention);
         dependentEntityBuilder.Ignore(nameof(SampleEntityMinimal.ReferencedEntity), ConfigurationSource.Explicit);
 
         dependentEntityBuilder.PrimaryKey(
             new List<string> { "Id" }, ConfigurationSource.Convention);
 
-        var principalEntityBuilder = modelBuilder.Entity(typeof(ReferencedEntityMinimal), ConfigurationSource.Convention);
+        var principalEntityBuilder = modelBuilder.Entity(typeof(ReferencedEntityMinimal), ConfigurationSource.Convention)!;
         principalEntityBuilder.Property(typeof(int), "Id", ConfigurationSource.Convention);
         principalEntityBuilder.PrimaryKey(
             new List<string> { "Id" }, ConfigurationSource.Convention);
@@ -661,8 +661,8 @@ public partial class ModelValidatorTest : ModelValidatorTestBase
         dependentEntityBuilder.HasRelationship(
             principalEntityBuilder.Metadata,
             dependentEntityBuilder.GetOrCreateProperties(
-                new List<string> { "Foo" }, ConfigurationSource.Convention),
-            principalEntityBuilder.HasKey(["ReferencedFoo"], ConfigurationSource.Convention).Metadata,
+                new List<string> { "Foo" }, ConfigurationSource.Convention)!,
+            principalEntityBuilder.HasKey(["ReferencedFoo"], ConfigurationSource.Convention)!.Metadata,
             ConfigurationSource.Convention);
 
         VerifyError(
@@ -698,7 +698,7 @@ public partial class ModelValidatorTest : ModelValidatorTestBase
         var entityTypeA = model.AddEntityType(typeof(A));
         SetPrimaryKey(entityTypeA);
         AddProperties(entityTypeA);
-        entityTypeA.FindPrimaryKey().Properties.Single().ValueGenerated = ValueGenerated.OnUpdate;
+        entityTypeA.FindPrimaryKey()!.Properties.Single().ValueGenerated = ValueGenerated.OnUpdate;
 
         VerifyError(CoreStrings.MutableKeyProperty(nameof(A.Id)), modelBuilder);
     }
@@ -712,7 +712,7 @@ public partial class ModelValidatorTest : ModelValidatorTestBase
         var entityTypeA = model.AddEntityType(typeof(A));
         SetPrimaryKey(entityTypeA);
         AddProperties(entityTypeA);
-        entityTypeA.FindPrimaryKey().Properties.Single().ValueGenerated = ValueGenerated.OnAddOrUpdate;
+        entityTypeA.FindPrimaryKey()!.Properties.Single().ValueGenerated = ValueGenerated.OnAddOrUpdate;
 
         VerifyError(CoreStrings.MutableKeyProperty(nameof(A.Id)), modelBuilder);
     }
@@ -722,7 +722,7 @@ public partial class ModelValidatorTest : ModelValidatorTestBase
     {
         var modelBuilder = base.CreateConventionModelBuilder();
 
-        modelBuilder.Entity<C>().HasBaseType((string)null);
+        modelBuilder.Entity<C>().HasBaseType((string?)null);
         modelBuilder.Entity<A>().HasOne<B>().WithOne().HasForeignKey<A>(a => a.Id).HasPrincipalKey<B>(b => b.Id).IsRequired();
         modelBuilder.Entity<A>().HasOne<C>().WithOne().HasForeignKey<C>(a => a.Id).HasPrincipalKey<A>(b => b.Id).IsRequired();
         modelBuilder.Entity<C>().HasOne<B>().WithOne().HasForeignKey<B>(a => a.Id).HasPrincipalKey<C>(b => b.Id).IsRequired();
@@ -735,14 +735,14 @@ public partial class ModelValidatorTest : ModelValidatorTestBase
     {
         var modelBuilder = base.CreateConventionModelBuilder();
 
-        modelBuilder.Entity<C>().HasBaseType((string)null);
-        modelBuilder.Entity<D>().HasBaseType((string)null);
+        modelBuilder.Entity<C>().HasBaseType((string?)null);
+        modelBuilder.Entity<D>().HasBaseType((string?)null);
         modelBuilder.Entity<A>().HasOne<B>().WithOne().HasForeignKey<A>(a => a.Id).HasPrincipalKey<B>(b => b.Id).IsRequired();
         modelBuilder.Entity<A>().HasOne<C>().WithOne().HasForeignKey<C>(c => c.Id).HasPrincipalKey<A>(a => a.Id).IsRequired();
         modelBuilder.Entity<C>().HasOne<B>().WithOne().HasForeignKey<B>(b => b.Id).HasPrincipalKey<C>(c => c.Id).IsRequired();
         modelBuilder.Entity<D>().HasOne<B>().WithOne().HasForeignKey<D>(d => d.Id).HasPrincipalKey<B>(b => b.Id).IsRequired();
 
-        var dId = modelBuilder.Model.FindEntityType(typeof(D)).FindProperty(nameof(D.Id));
+        var dId = modelBuilder.Model.FindEntityType(typeof(D))!.FindProperty(nameof(D.Id))!;
 
         Assert.Null(dId.GetValueConverter());
         Assert.Null(dId.GetProviderClrType());
@@ -753,8 +753,8 @@ public partial class ModelValidatorTest : ModelValidatorTestBase
     {
         var modelBuilder = base.CreateConventionModelBuilder();
 
-        modelBuilder.Entity<C>().HasBaseType((string)null);
-        modelBuilder.Entity<D>().HasBaseType((string)null);
+        modelBuilder.Entity<C>().HasBaseType((string?)null);
+        modelBuilder.Entity<D>().HasBaseType((string?)null);
         modelBuilder.Entity<A>().HasOne<B>().WithOne().HasForeignKey<A>(a => a.Id).HasPrincipalKey<B>(b => b.Id).IsRequired();
         modelBuilder.Entity<A>().HasOne<C>().WithOne().HasForeignKey<C>(c => c.Id).HasPrincipalKey<A>(a => a.Id).IsRequired();
         modelBuilder.Entity<C>().HasOne<B>().WithOne().HasForeignKey<B>(b => b.Id).HasPrincipalKey<C>(c => c.Id).IsRequired();
@@ -762,7 +762,7 @@ public partial class ModelValidatorTest : ModelValidatorTestBase
         modelBuilder.Entity<D>().HasOne<E>().WithOne().HasForeignKey<E>(e => e.Id).HasPrincipalKey<D>(d => d.Id).IsRequired();
         modelBuilder.Entity<C>().HasOne<E>().WithOne().HasForeignKey<C>(c => c.Id).HasPrincipalKey<E>(e => e.Id).IsRequired();
 
-        var aId = modelBuilder.Model.FindEntityType(typeof(A)).FindProperty(nameof(A.Id));
+        var aId = modelBuilder.Model.FindEntityType(typeof(A))!.FindProperty(nameof(A.Id))!;
 
         Assert.Null(aId.GetValueConverter());
         Assert.Null(aId.GetProviderClrType());
@@ -773,8 +773,8 @@ public partial class ModelValidatorTest : ModelValidatorTestBase
     {
         var modelBuilder = base.CreateConventionModelBuilder();
 
-        modelBuilder.Entity<C>().HasBaseType((string)null);
-        modelBuilder.Entity<D>().HasBaseType((string)null);
+        modelBuilder.Entity<C>().HasBaseType((string?)null);
+        modelBuilder.Entity<D>().HasBaseType((string?)null);
         modelBuilder.Entity<A>().Property(b => b.Id).HasConversion<string>();
         modelBuilder.Entity<B>().Property(b => b.Id).HasConversion<CastingConverter<int, int>>();
 
@@ -783,7 +783,7 @@ public partial class ModelValidatorTest : ModelValidatorTestBase
         modelBuilder.Entity<A>().HasOne<D>().WithOne().HasForeignKey<D>(d => d.Id).HasPrincipalKey<A>(a => a.Id).IsRequired();
         modelBuilder.Entity<D>().HasOne<C>().WithOne().HasForeignKey<D>(d => d.Id).HasPrincipalKey<C>(c => c.Id).IsRequired();
 
-        var dId = modelBuilder.Model.FindEntityType(typeof(D)).FindProperty(nameof(D.Id));
+        var dId = modelBuilder.Model.FindEntityType(typeof(D))!.FindProperty(nameof(D.Id))!;
 
         Assert.Equal(
             CoreStrings.ConflictingRelationshipConversions("D", "Id", "string", "CastingConverter<int, int>"),
@@ -798,8 +798,8 @@ public partial class ModelValidatorTest : ModelValidatorTestBase
     {
         var modelBuilder = base.CreateConventionModelBuilder();
 
-        modelBuilder.Entity<C>().HasBaseType((string)null);
-        modelBuilder.Entity<D>().HasBaseType((string)null);
+        modelBuilder.Entity<C>().HasBaseType((string?)null);
+        modelBuilder.Entity<D>().HasBaseType((string?)null);
         modelBuilder.Entity<C>().Property(c => c.Id).HasConversion<long>();
         modelBuilder.Entity<A>().Property(a => a.Id).HasConversion<string>();
 
@@ -808,7 +808,7 @@ public partial class ModelValidatorTest : ModelValidatorTestBase
         modelBuilder.Entity<A>().HasOne<D>().WithOne().HasForeignKey<D>(d => d.Id).HasPrincipalKey<A>(a => a.Id).IsRequired();
         modelBuilder.Entity<D>().HasOne<C>().WithOne().HasForeignKey<D>(d => d.Id).HasPrincipalKey<C>(c => c.Id).IsRequired();
 
-        var dId = modelBuilder.Model.FindEntityType(typeof(D)).FindProperty(nameof(D.Id));
+        var dId = modelBuilder.Model.FindEntityType(typeof(D))!.FindProperty(nameof(D.Id))!;
 
         Assert.Equal(
             CoreStrings.ConflictingRelationshipConversions("D", "Id", "string", "long"),
@@ -823,18 +823,18 @@ public partial class ModelValidatorTest : ModelValidatorTestBase
     {
         var modelBuilder = base.CreateConventionModelBuilder();
 
-        modelBuilder.Entity<C>().HasBaseType((string)null);
+        modelBuilder.Entity<C>().HasBaseType((string?)null);
         modelBuilder.Entity<A>().HasOne<B>().WithOne().HasForeignKey<A>(a => a.Id).HasPrincipalKey<B>(b => b.Id).IsRequired();
         modelBuilder.Entity<A>().HasOne<C>().WithOne().HasForeignKey<C>(a => a.Id).HasPrincipalKey<A>(b => b.Id).IsRequired();
         modelBuilder.Entity<C>().HasOne<B>().WithOne().HasForeignKey<B>(a => a.Id).HasPrincipalKey<C>(b => b.Id).IsRequired();
-        modelBuilder.Entity<D>().HasBaseType((string)null);
+        modelBuilder.Entity<D>().HasBaseType((string?)null);
         modelBuilder.Entity<D>().HasOne<B>().WithOne().HasForeignKey<D>(a => a.Id).HasPrincipalKey<B>(b => b.Id).IsRequired();
 
-        var aId = modelBuilder.Model.FindEntityType(typeof(A)).FindProperty(nameof(A.Id));
-        aId.SetValueConverter((ValueConverter)null);
+        var aId = modelBuilder.Model.FindEntityType(typeof(A))!.FindProperty(nameof(A.Id))!;
+        aId.SetValueConverter((ValueConverter?)null);
         aId.SetProviderClrType(null);
 
-        var dId = modelBuilder.Model.FindEntityType(typeof(D)).FindProperty(nameof(D.Id));
+        var dId = modelBuilder.Model.FindEntityType(typeof(D))!.FindProperty(nameof(D.Id))!;
         Assert.Null(dId.GetValueConverter());
         Assert.Null(dId.GetProviderClrType());
 
@@ -850,7 +850,7 @@ public partial class ModelValidatorTest : ModelValidatorTestBase
 
         modelBuilder.Entity<A>();
         modelBuilder.Entity<B>();
-        modelBuilder.Entity<C>().HasBaseType((string)null);
+        modelBuilder.Entity<C>().HasBaseType((string?)null);
         modelBuilder.Entity<A>().HasOne<B>().WithOne().HasForeignKey<A>(a => a.Id).HasPrincipalKey<B>(b => b.Id).IsRequired();
         modelBuilder.Entity<A>().HasOne<C>().WithOne().HasForeignKey<A>(a => a.Id).HasPrincipalKey<C>(b => b.Id).IsRequired();
         modelBuilder.Entity<C>().HasOne<B>().WithOne().HasForeignKey<B>(a => a.Id).HasPrincipalKey<C>(b => b.Id).IsRequired();
@@ -1104,8 +1104,8 @@ public partial class ModelValidatorTest : ModelValidatorTestBase
 
         var model = modelBuilder.Model;
         var orderProductEntity = model.AddEntityType(typeof(OrderProduct));
-        var orderEntity = model.FindEntityType(typeof(Order));
-        var productEntity = model.FindEntityType(typeof(Product));
+        var orderEntity = model.FindEntityType(typeof(Order))!;
+        var productEntity = model.FindEntityType(typeof(Product))!;
         var orderProductForeignKey = orderProductEntity
             .GetForeignKeys().Single(fk => fk.PrincipalEntityType == orderEntity);
         var productOrderForeignKey = orderProductEntity
@@ -1134,8 +1134,8 @@ public partial class ModelValidatorTest : ModelValidatorTestBase
 
         var model = modelBuilder.Model;
         var orderProductEntity = model.AddEntityType(typeof(OrderProduct));
-        var orderEntity = model.FindEntityType(typeof(Order));
-        var productEntity = model.FindEntityType(typeof(Product));
+        var orderEntity = model.FindEntityType(typeof(Order))!;
+        var productEntity = model.FindEntityType(typeof(Product))!;
         var orderProductForeignKey = orderProductEntity
             .GetForeignKeys().Single(fk => fk.PrincipalEntityType == orderEntity);
         var productOrderForeignKey = orderProductEntity
@@ -1158,8 +1158,8 @@ public partial class ModelValidatorTest : ModelValidatorTestBase
 
         var model = modelBuilder.Model;
         var orderProductEntity = model.AddEntityType(typeof(OrderProduct));
-        var orderEntity = model.FindEntityType(typeof(Order));
-        var productEntity = model.FindEntityType(typeof(Product));
+        var orderEntity = model.FindEntityType(typeof(Order))!;
+        var productEntity = model.FindEntityType(typeof(Product))!;
         var orderProductForeignKey = orderProductEntity
             .GetForeignKeys().Single(fk => fk.PrincipalEntityType == orderEntity);
         var productOrderForeignKey = orderProductEntity
@@ -1184,7 +1184,7 @@ public partial class ModelValidatorTest : ModelValidatorTestBase
         var model = modelBuilder.Model;
         var customerEntity = model.AddEntityType(typeof(Customer));
         var orderEntity = model.FindEntityType(typeof(Order));
-        var orderDetailsEntity = model.FindEntityType(typeof(OrderDetails));
+        var orderDetailsEntity = model.FindEntityType(typeof(OrderDetails))!;
         new EntityTypeBuilder<OrderDetails>(orderDetailsEntity).Ignore(e => e.Customer);
 
         var productsNavigation = orderDetailsEntity.AddSkipNavigation(
@@ -1211,7 +1211,7 @@ public partial class ModelValidatorTest : ModelValidatorTestBase
     protected class WithStructCollection
     {
         public int Id { get; set; }
-        public List<StructTag> Foo { get; set; }
+        public List<StructTag> Foo { get; set; } = null!;
     }
 
     [Fact]
@@ -1270,7 +1270,7 @@ public partial class ModelValidatorTest : ModelValidatorTestBase
     protected class WithReadOnlyCollection
     {
         public int Id { get; set; }
-        public IReadOnlyCollection<JsonbField> Tags { get; set; }
+        public IReadOnlyCollection<JsonbField> Tags { get; set; } = null!;
     }
 
     [Fact]
@@ -1564,7 +1564,7 @@ public partial class ModelValidatorTest : ModelValidatorTestBase
     {
         var builder = CreateConventionlessModelBuilder();
         var modelBuilder = (InternalModelBuilder)builder.GetInfrastructure();
-        var entityTypeBuilder = modelBuilder.Entity(typeof(SampleEntity), ConfigurationSource.Convention);
+        var entityTypeBuilder = modelBuilder.Entity(typeof(SampleEntity), ConfigurationSource.Convention)!;
         entityTypeBuilder.PrimaryKey([nameof(SampleEntity.Id)], ConfigurationSource.Convention);
         entityTypeBuilder.Ignore(nameof(SampleEntity.Name), ConfigurationSource.Explicit);
         entityTypeBuilder.Ignore(nameof(SampleEntity.Number), ConfigurationSource.Explicit);
@@ -1572,9 +1572,9 @@ public partial class ModelValidatorTest : ModelValidatorTestBase
         entityTypeBuilder.Ignore(nameof(SampleEntity.AnotherReferencedEntity), ConfigurationSource.Explicit);
 
         var ownershipBuilder = entityTypeBuilder.HasOwnership(
-            typeof(ReferencedEntity), nameof(SampleEntity.ReferencedEntity), ConfigurationSource.Convention);
+            typeof(ReferencedEntity), nameof(SampleEntity.ReferencedEntity), ConfigurationSource.Convention)!;
 
-        var ownedTypeBuilder = ownershipBuilder.Metadata.DeclaringEntityType.Builder;
+        var ownedTypeBuilder = ownershipBuilder.Metadata.DeclaringEntityType.Builder!;
         ownedTypeBuilder.PrimaryKey(ownershipBuilder.Metadata.Properties.Select(p => p.Name).ToList(), ConfigurationSource.Convention);
         ownedTypeBuilder.Ignore(nameof(ReferencedEntity.Id), ConfigurationSource.Explicit);
         ownedTypeBuilder.Ignore(nameof(ReferencedEntity.SampleEntityId), ConfigurationSource.Explicit);
@@ -1588,21 +1588,21 @@ public partial class ModelValidatorTest : ModelValidatorTestBase
         var builder = CreateConventionlessModelBuilder();
         var modelBuilder = (InternalModelBuilder)builder.GetInfrastructure();
 
-        var entityTypeBuilder = modelBuilder.Entity(typeof(SampleEntity), ConfigurationSource.Convention);
+        var entityTypeBuilder = modelBuilder.Entity(typeof(SampleEntity), ConfigurationSource.Convention)!;
         entityTypeBuilder.PrimaryKey([nameof(SampleEntity.Id)], ConfigurationSource.Convention);
         entityTypeBuilder.Ignore(nameof(SampleEntity.Number), ConfigurationSource.Explicit);
         entityTypeBuilder.Ignore(nameof(SampleEntity.Name), ConfigurationSource.Explicit);
         entityTypeBuilder.Ignore(nameof(SampleEntity.OtherSamples), ConfigurationSource.Explicit);
 
         var ownershipBuilder = entityTypeBuilder.HasOwnership(
-            typeof(ReferencedEntity), nameof(SampleEntity.ReferencedEntity), ConfigurationSource.Convention);
+            typeof(ReferencedEntity), nameof(SampleEntity.ReferencedEntity), ConfigurationSource.Convention)!;
 
-        var ownedTypeBuilder = ownershipBuilder.Metadata.DeclaringEntityType.Builder;
+        var ownedTypeBuilder = ownershipBuilder.Metadata.DeclaringEntityType.Builder!;
         ownedTypeBuilder.PrimaryKey(ownershipBuilder.Metadata.Properties.Select(p => p.Name).ToList(), ConfigurationSource.Convention);
 
         ownedTypeBuilder.HasRelationship(
                 entityTypeBuilder.Metadata, null, nameof(SampleEntity.AnotherReferencedEntity), ConfigurationSource.Convention,
-                setTargetAsPrincipal: true)
+            setTargetAsPrincipal: true)!
             .Metadata.IsOwnership = true;
 
         ownedTypeBuilder.Ignore(nameof(ReferencedEntity.Id), ConfigurationSource.Explicit);
@@ -1619,7 +1619,7 @@ public partial class ModelValidatorTest : ModelValidatorTestBase
     {
         var builder = CreateConventionlessModelBuilder();
         var modelBuilder = (InternalModelBuilder)builder.GetInfrastructure();
-        var entityTypeBuilder = modelBuilder.Entity(typeof(SampleEntity), ConfigurationSource.Convention);
+        var entityTypeBuilder = modelBuilder.Entity(typeof(SampleEntity), ConfigurationSource.Convention)!;
         entityTypeBuilder.PrimaryKey([nameof(SampleEntity.Id)], ConfigurationSource.Convention);
         entityTypeBuilder.Ignore(nameof(SampleEntity.Name), ConfigurationSource.Explicit);
         entityTypeBuilder.Ignore(nameof(SampleEntity.Number), ConfigurationSource.Explicit);
@@ -1627,9 +1627,9 @@ public partial class ModelValidatorTest : ModelValidatorTestBase
         entityTypeBuilder.Ignore(nameof(SampleEntity.AnotherReferencedEntity), ConfigurationSource.Explicit);
 
         var ownershipBuilder = entityTypeBuilder.HasOwnership(
-            typeof(ReferencedEntity), nameof(SampleEntity.ReferencedEntity), ConfigurationSource.Convention);
+            typeof(ReferencedEntity), nameof(SampleEntity.ReferencedEntity), ConfigurationSource.Convention)!;
 
-        var ownedTypeBuilder = ownershipBuilder.Metadata.DeclaringEntityType.Builder;
+        var ownedTypeBuilder = ownershipBuilder.Metadata.DeclaringEntityType.Builder!;
         ownedTypeBuilder.PrimaryKey(ownershipBuilder.Metadata.Properties.Select(p => p.Name).ToList(), ConfigurationSource.Convention);
         ownedTypeBuilder.Ignore(nameof(ReferencedEntity.Id), ConfigurationSource.Explicit);
         ownedTypeBuilder.Ignore(nameof(ReferencedEntity.SampleEntityId), ConfigurationSource.Explicit);
@@ -1647,7 +1647,7 @@ public partial class ModelValidatorTest : ModelValidatorTestBase
     {
         var builder = CreateConventionlessModelBuilder();
         var modelBuilder = (InternalModelBuilder)builder.GetInfrastructure();
-        var entityTypeBuilder = modelBuilder.Entity(typeof(SampleEntity), ConfigurationSource.Convention);
+        var entityTypeBuilder = modelBuilder.Entity(typeof(SampleEntity), ConfigurationSource.Convention)!;
         entityTypeBuilder.PrimaryKey([nameof(SampleEntity.Id)], ConfigurationSource.Convention);
         entityTypeBuilder.Ignore(nameof(SampleEntity.Name), ConfigurationSource.Explicit);
         entityTypeBuilder.Ignore(nameof(SampleEntity.Number), ConfigurationSource.Explicit);
@@ -1655,9 +1655,9 @@ public partial class ModelValidatorTest : ModelValidatorTestBase
         entityTypeBuilder.Ignore(nameof(SampleEntity.AnotherReferencedEntity), ConfigurationSource.Explicit);
 
         var ownershipBuilder = entityTypeBuilder.HasOwnership(
-            typeof(ReferencedEntity), nameof(SampleEntity.ReferencedEntity), ConfigurationSource.Convention);
+            typeof(ReferencedEntity), nameof(SampleEntity.ReferencedEntity), ConfigurationSource.Convention)!;
 
-        var ownedTypeBuilder = ownershipBuilder.Metadata.DeclaringEntityType.Builder;
+        var ownedTypeBuilder = ownershipBuilder.Metadata.DeclaringEntityType.Builder!;
         ownedTypeBuilder.PrimaryKey(ownershipBuilder.Metadata.Properties.Select(p => p.Name).ToList(), ConfigurationSource.Convention);
         ownedTypeBuilder.Ignore(nameof(ReferencedEntity.Id), ConfigurationSource.Explicit);
         ownedTypeBuilder.Ignore(nameof(ReferencedEntity.SampleEntityId), ConfigurationSource.Explicit);
@@ -1675,7 +1675,7 @@ public partial class ModelValidatorTest : ModelValidatorTestBase
         var builder = CreateConventionlessModelBuilder();
         var modelBuilder = (InternalModelBuilder)builder.GetInfrastructure();
 
-        var entityTypeBuilder = modelBuilder.Entity(typeof(SampleEntity), ConfigurationSource.Convention);
+        var entityTypeBuilder = modelBuilder.Entity(typeof(SampleEntity), ConfigurationSource.Convention)!;
         entityTypeBuilder.PrimaryKey([nameof(SampleEntity.Id)], ConfigurationSource.Convention);
         entityTypeBuilder.Ignore(nameof(SampleEntity.Number), ConfigurationSource.Explicit);
         entityTypeBuilder.Ignore(nameof(SampleEntity.Name), ConfigurationSource.Explicit);
@@ -1683,14 +1683,14 @@ public partial class ModelValidatorTest : ModelValidatorTestBase
         entityTypeBuilder.Ignore(nameof(SampleEntity.AnotherReferencedEntity), ConfigurationSource.Explicit);
 
         var ownershipBuilder = entityTypeBuilder.HasOwnership(
-            typeof(ReferencedEntity), nameof(SampleEntity.ReferencedEntity), ConfigurationSource.Convention);
+            typeof(ReferencedEntity), nameof(SampleEntity.ReferencedEntity), ConfigurationSource.Convention)!;
 
-        var ownedTypeBuilder = ownershipBuilder.Metadata.DeclaringEntityType.Builder;
+        var ownedTypeBuilder = ownershipBuilder.Metadata.DeclaringEntityType.Builder!;
         ownedTypeBuilder.Ignore(nameof(ReferencedEntity.Id), ConfigurationSource.Explicit);
         ownedTypeBuilder.Ignore(nameof(ReferencedEntity.SampleEntityId), ConfigurationSource.Explicit);
         ownedTypeBuilder.PrimaryKey(ownershipBuilder.Metadata.Properties.Select(p => p.Name).ToList(), ConfigurationSource.Convention);
 
-        var anotherEntityTypeBuilder = modelBuilder.Entity(typeof(AnotherSampleEntity), ConfigurationSource.Convention);
+        var anotherEntityTypeBuilder = modelBuilder.Entity(typeof(AnotherSampleEntity), ConfigurationSource.Convention)!;
         anotherEntityTypeBuilder.PrimaryKey([nameof(AnotherSampleEntity.Id)], ConfigurationSource.Convention);
 
         anotherEntityTypeBuilder.HasRelationship(
@@ -1711,7 +1711,7 @@ public partial class ModelValidatorTest : ModelValidatorTestBase
         var builder = CreateConventionlessModelBuilder();
         var modelBuilder = (InternalModelBuilder)builder.GetInfrastructure();
 
-        var entityTypeBuilder = modelBuilder.Entity(typeof(SampleEntity), ConfigurationSource.Convention);
+        var entityTypeBuilder = modelBuilder.Entity(typeof(SampleEntity), ConfigurationSource.Convention)!;
         entityTypeBuilder.PrimaryKey([nameof(SampleEntity.Id)], ConfigurationSource.Convention);
         entityTypeBuilder.Ignore(nameof(SampleEntity.Number), ConfigurationSource.Explicit);
         entityTypeBuilder.Ignore(nameof(SampleEntity.Name), ConfigurationSource.Explicit);
@@ -1719,18 +1719,18 @@ public partial class ModelValidatorTest : ModelValidatorTestBase
         entityTypeBuilder.Ignore(nameof(SampleEntity.AnotherReferencedEntity), ConfigurationSource.Explicit);
 
         var ownershipBuilder = entityTypeBuilder.HasOwnership(
-            typeof(ReferencedEntity), nameof(SampleEntity.ReferencedEntity), ConfigurationSource.Convention);
+            typeof(ReferencedEntity), nameof(SampleEntity.ReferencedEntity), ConfigurationSource.Convention)!;
 
-        var ownedTypeBuilder = ownershipBuilder.Metadata.DeclaringEntityType.Builder;
+        var ownedTypeBuilder = ownershipBuilder.Metadata.DeclaringEntityType.Builder!;
         ownedTypeBuilder.PrimaryKey(ownershipBuilder.Metadata.Properties.Select(p => p.Name).ToList(), ConfigurationSource.Convention);
         ownedTypeBuilder.Ignore(nameof(ReferencedEntity.Id), ConfigurationSource.Explicit);
         ownedTypeBuilder.Ignore(nameof(ReferencedEntity.SampleEntityId), ConfigurationSource.Explicit);
 
-        var anotherEntityTypeBuilder = modelBuilder.Entity(typeof(AnotherSampleEntity), ConfigurationSource.Convention);
+        var anotherEntityTypeBuilder = modelBuilder.Entity(typeof(AnotherSampleEntity), ConfigurationSource.Convention)!;
         anotherEntityTypeBuilder.PrimaryKey([nameof(AnotherSampleEntity.Id)], ConfigurationSource.Convention);
 
         anotherEntityTypeBuilder.HasRelationship(
-                ownedTypeBuilder.Metadata, nameof(AnotherSampleEntity.ReferencedEntity), ConfigurationSource.Convention)
+            ownedTypeBuilder.Metadata, nameof(AnotherSampleEntity.ReferencedEntity), ConfigurationSource.Convention)!
             .HasEntityTypes(anotherEntityTypeBuilder.Metadata, ownedTypeBuilder.Metadata, ConfigurationSource.Convention);
 
         VerifyError(
@@ -1745,7 +1745,7 @@ public partial class ModelValidatorTest : ModelValidatorTestBase
         var builder = CreateConventionlessModelBuilder();
         var modelBuilder = (InternalModelBuilder)builder.GetInfrastructure();
 
-        var entityTypeBuilder = modelBuilder.Entity(typeof(B), ConfigurationSource.Convention);
+        var entityTypeBuilder = modelBuilder.Entity(typeof(B), ConfigurationSource.Convention)!;
         entityTypeBuilder.PrimaryKey([nameof(B.Id)], ConfigurationSource.Convention);
         entityTypeBuilder.Property(typeof(int?), nameof(B.P0), ConfigurationSource.Explicit);
         entityTypeBuilder.Property(typeof(int?), nameof(B.P1), ConfigurationSource.Explicit);
@@ -1754,14 +1754,14 @@ public partial class ModelValidatorTest : ModelValidatorTestBase
         entityTypeBuilder.Ignore(nameof(B.AnotherA), ConfigurationSource.Explicit);
         entityTypeBuilder.Ignore(nameof(B.ManyAs), ConfigurationSource.Explicit);
 
-        var ownershipBuilder = entityTypeBuilder.HasOwnership(typeof(D), nameof(B.A), ConfigurationSource.Convention);
-        var ownedTypeBuilder = ownershipBuilder.Metadata.DeclaringEntityType.Builder;
+        var ownershipBuilder = entityTypeBuilder.HasOwnership(typeof(D), nameof(B.A), ConfigurationSource.Convention)!;
+        var ownedTypeBuilder = ownershipBuilder.Metadata.DeclaringEntityType.Builder!;
         ownedTypeBuilder.PrimaryKey(ownershipBuilder.Metadata.Properties.Select(p => p.Name).ToList(), ConfigurationSource.Convention);
         ownedTypeBuilder.HasNoRelationship(ownershipBuilder.Metadata, ConfigurationSource.Convention);
 
-        var baseOwnershipBuilder = entityTypeBuilder.HasOwnership(typeof(A), nameof(B.A), ConfigurationSource.Convention);
-        var anotherEntityTypeBuilder = baseOwnershipBuilder.Metadata.DeclaringEntityType.Builder;
-        anotherEntityTypeBuilder = modelBuilder.Entity(typeof(A), ConfigurationSource.Convention);
+        var baseOwnershipBuilder = entityTypeBuilder.HasOwnership(typeof(A), nameof(B.A), ConfigurationSource.Convention)!;
+        var anotherEntityTypeBuilder = baseOwnershipBuilder.Metadata.DeclaringEntityType.Builder!;
+        anotherEntityTypeBuilder = modelBuilder.Entity(typeof(A), ConfigurationSource.Convention)!;
         anotherEntityTypeBuilder.PrimaryKey([nameof(A.Id)], ConfigurationSource.Convention);
         anotherEntityTypeBuilder.Property(typeof(int?), nameof(A.P0), ConfigurationSource.Explicit);
         anotherEntityTypeBuilder.Property(typeof(int?), nameof(A.P1), ConfigurationSource.Explicit);
@@ -1784,7 +1784,7 @@ public partial class ModelValidatorTest : ModelValidatorTestBase
         var builder = CreateConventionlessModelBuilder();
         var modelBuilder = (InternalModelBuilder)builder.GetInfrastructure();
         modelBuilder.Owned(typeof(A), ConfigurationSource.Convention);
-        var aBuilder = modelBuilder.Entity(typeof(A), ConfigurationSource.Convention);
+        var aBuilder = modelBuilder.Entity(typeof(A), ConfigurationSource.Convention)!;
         aBuilder.Ignore(nameof(A.Id), ConfigurationSource.Explicit);
         aBuilder.Ignore(nameof(A.P0), ConfigurationSource.Explicit);
         aBuilder.Ignore(nameof(A.P1), ConfigurationSource.Explicit);
@@ -1894,7 +1894,7 @@ public partial class ModelValidatorTest : ModelValidatorTestBase
     protected class WithFullNotificationCollection
     {
         public int Id { get; set; }
-        public List<FullNotificationEntity> Foo { get; set; }
+        public List<FullNotificationEntity> Foo { get; set; } = null!;
     }
 
     [Theory, InlineData(ChangeTrackingStrategy.ChangedNotifications),
@@ -1920,7 +1920,7 @@ public partial class ModelValidatorTest : ModelValidatorTestBase
     protected class WithFullNotificationProperty
     {
         public int Id { get; set; }
-        public FullNotificationEntity Foo { get; set; }
+        public FullNotificationEntity Foo { get; set; } = null!;
     }
 
     [Theory, InlineData(ChangeTrackingStrategy.Snapshot), InlineData(ChangeTrackingStrategy.ChangedNotifications),
@@ -2077,7 +2077,7 @@ public partial class ModelValidatorTest : ModelValidatorTestBase
 
         Assert.Equal(
             ValueGenerated.OnAdd,
-            modelBuilder.Model.FindEntityType(typeof(NonSignedIntegerKeyEntity)).FindProperty(nameof(NonSignedIntegerKeyEntity.Id))
+            modelBuilder.Model.FindEntityType(typeof(NonSignedIntegerKeyEntity))!.FindProperty(nameof(NonSignedIntegerKeyEntity.Id))!
                 .ValueGenerated);
         VerifyError(
             CoreStrings.SeedDatumDefaultValue(nameof(NonSignedIntegerKeyEntity), nameof(NonSignedIntegerKeyEntity.Id), entity.Id),
@@ -2448,7 +2448,7 @@ public partial class ModelValidatorTest : ModelValidatorTestBase
         var modelBuilder = CreateConventionModelBuilder();
         modelBuilder.Entity<Customer>().HasMany(x => x.Orders).WithOne(x => x.Customer).IsRequired();
         modelBuilder.Entity<Customer>().HasQueryFilter(x => x.Id > 5);
-        modelBuilder.Entity<Order>().HasQueryFilter(x => x.Customer.Id > 5);
+        modelBuilder.Entity<Order>().HasQueryFilter(x => x.Customer!.Id > 5);
 
         var message = CoreResources.LogPossibleIncorrectRequiredNavigationWithQueryFilterInteraction(
             CreateValidationLogger()).GenerateMessage(nameof(Customer), nameof(Order));
@@ -2530,8 +2530,8 @@ public partial class ModelValidatorTest : ModelValidatorTestBase
         public int Id { get; set; }
 
 #pragma warning disable 67
-        public event PropertyChangingEventHandler PropertyChanging;
-        public event PropertyChangedEventHandler PropertyChanged;
+        public event PropertyChangingEventHandler? PropertyChanging;
+        public event PropertyChangedEventHandler? PropertyChanged;
 #pragma warning restore 67
     }
 
@@ -2541,7 +2541,7 @@ public partial class ModelValidatorTest : ModelValidatorTestBase
         public int Id { get; set; }
 
 #pragma warning disable 67
-        public event PropertyChangedEventHandler PropertyChanged;
+        public event PropertyChangedEventHandler? PropertyChanged;
 #pragma warning restore 67
     }
 

--- a/test/EFCore.Tests/Infrastructure/ModelValidatorTestBase.cs
+++ b/test/EFCore.Tests/Infrastructure/ModelValidatorTestBase.cs
@@ -76,13 +76,13 @@ public abstract class ModelValidatorTestBase
         public int? P2 { get; set; }
         public int? P3 { get; set; }
 
-        public A A { get; set; }
+        public A A { get; set; } = null!;
 
         [NotMapped]
-        public A AnotherA { get; set; }
+        public A AnotherA { get; set; } = null!;
 
         [NotMapped]
-        public ICollection<A> ManyAs { get; set; }
+        public ICollection<A> ManyAs { get; set; } = null!;
     }
 
     protected class C : A;
@@ -100,7 +100,7 @@ public abstract class ModelValidatorTestBase
         public int? P2 { get; set; }
         public int? P3 { get; set; }
 
-        public A A { get; set; }
+        public A A { get; set; } = null!;
     }
 
     protected abstract class Abstract : A;
@@ -108,7 +108,6 @@ public abstract class ModelValidatorTestBase
     // ReSharper disable once UnusedTypeParameter
     protected class Generic<T> : Abstract;
 
-#nullable enable
     protected class BaseEntity
     {
         public int Id { get; set; }
@@ -142,19 +141,17 @@ public abstract class ModelValidatorTestBase
     {
     }
 
-#nullable restore
-
     protected class SampleEntity
     {
         public int Id { get; set; }
         public int Number { get; set; }
-        public string Name { get; set; }
-        public ReferencedEntity ReferencedEntity { get; set; }
+        public string? Name { get; set; }
+        public ReferencedEntity ReferencedEntity { get; set; } = null!;
 
         [NotMapped]
-        public ReferencedEntity AnotherReferencedEntity { get; set; }
+        public ReferencedEntity AnotherReferencedEntity { get; set; } = null!;
 
-        public ICollection<SampleEntity> OtherSamples { get; set; }
+        public ICollection<SampleEntity> OtherSamples { get; set; } = null!;
 
         protected StructTag Tag { get; set; }
     }
@@ -168,7 +165,7 @@ public abstract class ModelValidatorTestBase
     protected class AnotherSampleEntity
     {
         public int Id { get; set; }
-        public ReferencedEntity ReferencedEntity { get; set; }
+        public ReferencedEntity ReferencedEntity { get; set; } = null!;
     }
 
     protected class ReferencedEntity
@@ -180,7 +177,7 @@ public abstract class ModelValidatorTestBase
     protected class SampleEntityMinimal
     {
         public int Id { get; set; }
-        public ReferencedEntityMinimal ReferencedEntity { get; set; }
+        public ReferencedEntityMinimal ReferencedEntity { get; set; } = null!;
     }
 
     protected class ReferencedEntityMinimal;
@@ -188,7 +185,7 @@ public abstract class ModelValidatorTestBase
     protected class AnotherSampleEntityMinimal
     {
         public int Id { get; set; }
-        public ReferencedEntityMinimal ReferencedEntity { get; set; }
+        public ReferencedEntityMinimal ReferencedEntity { get; set; } = null!;
     }
 
     protected class E
@@ -273,8 +270,8 @@ public abstract class ModelValidatorTestBase
 
     protected class Customer
     {
-        private string _name;
-        public string OtherName;
+        private string _name = null!;
+        public string OtherName = null!;
 
         public int Id { get; set; }
 
@@ -284,79 +281,79 @@ public abstract class ModelValidatorTestBase
             set => _name = value;
         }
 
-        public string PartitionId { get; set; }
-        public ICollection<Order> Orders { get; set; }
+        public string PartitionId { get; set; } = null!;
+        public ICollection<Order> Orders { get; set; } = null!;
     }
 
     protected class Order
     {
-        public static readonly PropertyInfo IdProperty = typeof(Order).GetProperty(nameof(Id));
+        public static readonly PropertyInfo IdProperty = typeof(Order).GetProperty(nameof(Id))!;
 
         public int Id { get; set; }
-        public string PartitionId { get; set; }
-        public Customer Customer { get; set; }
+        public string? PartitionId { get; set; }
+        public Customer? Customer { get; set; }
 
-        public OrderDetails OrderDetails { get; set; }
+        public OrderDetails? OrderDetails { get; set; }
 
         [NotMapped]
-        public virtual ICollection<Product> Products { get; set; }
+        public virtual ICollection<Product> Products { get; set; } = null!;
     }
 
     [Owned]
     protected class OrderDetails
     {
-        public Customer Customer { get; set; }
-        public string ShippingAddress { get; set; }
+        public Customer? Customer { get; set; }
+        public string? ShippingAddress { get; set; }
     }
 
     protected class OrderProduct
     {
-        public static readonly PropertyInfo OrderIdProperty = typeof(OrderProduct).GetProperty(nameof(OrderId));
-        public static readonly PropertyInfo ProductIdProperty = typeof(OrderProduct).GetProperty(nameof(ProductId));
+        public static readonly PropertyInfo OrderIdProperty = typeof(OrderProduct).GetProperty(nameof(OrderId))!;
+        public static readonly PropertyInfo ProductIdProperty = typeof(OrderProduct).GetProperty(nameof(ProductId))!;
 
         public int OrderId { get; set; }
         public int ProductId { get; set; }
-        public virtual Order Order { get; set; }
-        public virtual Product Product { get; set; }
+        public virtual Order Order { get; set; } = null!;
+        public virtual Product Product { get; set; } = null!;
     }
 
     protected class Product
     {
-        public static readonly PropertyInfo IdProperty = typeof(Product).GetProperty(nameof(Id));
+        public static readonly PropertyInfo IdProperty = typeof(Product).GetProperty(nameof(Id))!;
 
         public int Id { get; set; }
 
         [NotMapped]
-        public virtual ICollection<Order> Orders { get; set; }
+        public virtual ICollection<Order> Orders { get; set; } = null!;
     }
 
     protected class KeylessSeed
     {
-        public string Species { get; set; }
+        public string Species { get; set; } = null!;
     }
 
     protected class PrincipalOne
     {
         public int Id { get; set; }
 
-        public ICollection<DependentOne> DependentsOnes { get; set; }
+        public ICollection<DependentOne> DependentsOnes { get; set; } = null!;
     }
 
     protected class DependentOne
     {
-        public static readonly PropertyInfo PrincipalOneIdProperty = typeof(DependentOne).GetProperty(nameof(PrincipalOneId));
+        public static readonly PropertyInfo PrincipalOneIdProperty = typeof(DependentOne).GetProperty(nameof(PrincipalOneId))!;
 
         public int Id { get; set; }
 
-        public string PrincipalOneId { get; set; }
-        public PrincipalOne PrincipalOne { get; set; }
+        public string PrincipalOneId { get; set; } = null!;
+        public PrincipalOne PrincipalOne { get; set; } = null!;
     }
 
     protected class PrincipalTwo
     {
         public int Id { get; set; }
 
-        public ICollection<DependentTwo> DependentsTwos { get; set; }
+        public ICollection<DependentTwo> DependentsTwos { get; set; } = null!;
     }
 
     protected class DependentTwo
@@ -364,75 +361,75 @@ public abstract class ModelValidatorTestBase
         public int Id { get; set; }
 
         public int? PrincipalTwoId { get; set; }
-        public PrincipalTwo PrincipalTwo { get; set; }
+        public PrincipalTwo PrincipalTwo { get; set; } = null!;
     }
 
     protected class PrincipalThree
     {
         public int Id { get; set; }
 
-        public ICollection<DependentThree> DependentsThreesA { get; set; }
-        public ICollection<DependentThree> DependentsThreesB { get; set; }
+        public ICollection<DependentThree> DependentsThreesA { get; set; } = null!;
+        public ICollection<DependentThree> DependentsThreesB { get; set; } = null!;
     }
 
     protected class DependentThree
     {
-        public static readonly PropertyInfo PrincipalThreeIdProperty = typeof(DependentThree).GetProperty(nameof(PrincipalThreeId));
+        public static readonly PropertyInfo PrincipalThreeIdProperty = typeof(DependentThree).GetProperty(nameof(PrincipalThreeId))!;
 
         public int Id { get; set; }
 
         public int? PrincipalThreeId { get; set; }
-        public PrincipalThree PrincipalThreeA { get; set; }
-        public PrincipalThree PrincipalThreeB { get; set; }
+        public PrincipalThree PrincipalThreeA { get; set; } = null!;
+        public PrincipalThree PrincipalThreeB { get; set; } = null!;
     }
 
     protected class PrincipalFour
     {
         public int Id { get; set; }
 
-        public ICollection<DependentFour> DependentsFours { get; set; }
+        public ICollection<DependentFour> DependentsFours { get; set; } = null!;
     }
 
     protected class DependentFour
     {
-        public static readonly PropertyInfo PrincipalFourIdProperty = typeof(DependentFour).GetProperty(nameof(PrincipalFourId));
-        public static readonly PropertyInfo PrincipalFourId1Property = typeof(DependentFour).GetProperty(nameof(PrincipalFourId1));
+        public static readonly PropertyInfo PrincipalFourIdProperty = typeof(DependentFour).GetProperty(nameof(PrincipalFourId))!;
+        public static readonly PropertyInfo PrincipalFourId1Property = typeof(DependentFour).GetProperty(nameof(PrincipalFourId1))!;
 
         public int Id { get; set; }
 
-        public string PrincipalFourId1 { get; set; }
-        public string PrincipalFourId { get; set; }
-        public PrincipalFour PrincipalFour { get; set; }
+        public string PrincipalFourId1 { get; set; } = null!;
+        public string PrincipalFourId { get; set; } = null!;
+        public PrincipalFour PrincipalFour { get; set; } = null!;
     }
 
     protected class Blog
     {
         public int BlogId { get; set; }
         public bool IsDeleted { get; set; }
-        public ICollection<PicturePost> PicturePosts { get; set; }
-        public List<BlogOwnedEntity> BlogOwnedEntities { get; set; }
+        public ICollection<PicturePost> PicturePosts { get; set; } = null!;
+        public List<BlogOwnedEntity> BlogOwnedEntities { get; set; } = null!;
     }
 
     protected class BlogOwnedEntity
     {
         public int BlogOwnedEntityId { get; set; }
         public int BlogId { get; set; }
-        public Blog Blog { get; set; }
+        public Blog Blog { get; set; } = null!;
     }
 
     protected class Post
     {
         public int PostId { get; set; }
         public int BlogId { get; set; }
-        public string Content { get; set; }
+        public string Content { get; set; } = null!;
         public bool IsDeleted { get; set; }
-        public Blog Blog { get; set; }
+        public Blog Blog { get; set; } = null!;
     }
 
     protected class PicturePost : Post
     {
-        public string PictureUrl { get; set; }
-        public List<Picture> Pictures { get; set; }
+        public string PictureUrl { get; set; } = null!;
+        public List<Picture> Pictures { get; set; } = null!;
     }
 
     protected class Picture
@@ -440,7 +437,7 @@ public abstract class ModelValidatorTestBase
         public int PictureId { get; set; }
         public bool IsDeleted { get; set; }
         public int PicturePostId { get; set; }
-        public PicturePost PicturePost { get; set; }
+        public PicturePost PicturePost { get; set; } = null!;
     }
 
     protected ModelValidatorTestBase()
@@ -488,7 +485,7 @@ public abstract class ModelValidatorTestBase
     {
         Validate(modelBuilder);
 
-        var logEntries = LoggerFactory.Log.Where(l => l.Message.Contains(expectedMessage));
+        var logEntries = LoggerFactory.Log.Where(l => l.Message?.Contains(expectedMessage) == true);
 
         Assert.Empty(logEntries);
     }
@@ -521,14 +518,14 @@ public abstract class ModelValidatorTestBase
     }
 
     protected virtual TestHelpers.TestModelBuilder CreateConventionModelBuilder(
-        Action<ModelConfigurationBuilder> configure = null,
+        Action<ModelConfigurationBuilder>? configure = null,
         bool sensitiveDataLoggingEnabled = false)
         => TestHelpers.CreateConventionBuilder(
             CreateModelLogger(sensitiveDataLoggingEnabled), CreateValidationLogger(sensitiveDataLoggingEnabled),
             configurationBuilder => configure?.Invoke(configurationBuilder));
 
     protected virtual TestHelpers.TestModelBuilder CreateConventionlessModelBuilder(
-        Action<ModelConfigurationBuilder> configure = null,
+        Action<ModelConfigurationBuilder>? configure = null,
         bool sensitiveDataLoggingEnabled = false)
         => TestHelpers.CreateConventionBuilder(
             CreateModelLogger(sensitiveDataLoggingEnabled), CreateValidationLogger(sensitiveDataLoggingEnabled),

--- a/test/EFCore.Tests/Infrastructure/ServiceCollectionMapTest.cs
+++ b/test/EFCore.Tests/Infrastructure/ServiceCollectionMapTest.cs
@@ -259,10 +259,10 @@ public class ServiceCollectionMapTest
 
     private class FakeService : IFakeService, IPatchServiceInjectionSite
     {
-        public DbContext Context { get; private set; }
+        public DbContext Context { get; private set; } = null!;
 
         void IPatchServiceInjectionSite.InjectServices(IServiceProvider serviceProvider)
-            => Context = serviceProvider.GetService<ICurrentDbContext>().Context;
+            => Context = serviceProvider.GetService<ICurrentDbContext>()!.Context;
     }
 
     private class DerivedFakeService : FakeService;

--- a/test/EFCore.Tests/Infrastructure/StructuredJsonPathTest.cs
+++ b/test/EFCore.Tests/Infrastructure/StructuredJsonPathTest.cs
@@ -33,7 +33,7 @@ public class StructuredJsonPathTest
         var path = StructuredJsonPath.Root;
         Assert.True(path.IsRoot);
         Assert.Empty(path.Segments);
-        Assert.Empty(path.Indices);
+        Assert.Empty(path.Indices!);
         Assert.Equal("$", path.ToString());
     }
 

--- a/test/EFCore.Tests/Metadata/Builders/MetadataBuilderTest.cs
+++ b/test/EFCore.Tests/Metadata/Builders/MetadataBuilderTest.cs
@@ -40,7 +40,7 @@ public class MetadataBuilderTest
         Assert.IsType<EntityTypeBuilder>(returnedBuilder);
 
         var model = builder.Model;
-        var entityType = model.FindEntityType(typeof(Gunter));
+        var entityType = model.FindEntityType(typeof(Gunter))!;
 
         Assert.Equal("V2.Annotation", entityType["Annotation"]);
         Assert.Equal("V2.Metadata", entityType["Metadata"]);
@@ -59,7 +59,7 @@ public class MetadataBuilderTest
         Assert.IsType<EntityTypeBuilder<Gunter>>(returnedBuilder);
 
         var model = builder.Model;
-        var entityType = model.FindEntityType(typeof(Gunter));
+        var entityType = model.FindEntityType(typeof(Gunter))!;
 
         Assert.Equal("V2.Annotation", entityType["Annotation"]);
         Assert.Equal("V2.Metadata", entityType["Metadata"]);
@@ -78,7 +78,7 @@ public class MetadataBuilderTest
         Assert.IsType<EntityTypeBuilder<Gunter>>(returnedBuilder);
 
         var model = builder.Model;
-        var entityType = model.FindEntityType(typeof(Gunter));
+        var entityType = model.FindEntityType(typeof(Gunter))!;
 
         Assert.Equal("V2.Annotation", entityType["Annotation"]);
         Assert.Equal("V2.Metadata", entityType["Metadata"]);
@@ -98,7 +98,7 @@ public class MetadataBuilderTest
         Assert.IsType<KeyBuilder<Gunter>>(returnedBuilder);
 
         var model = builder.Model;
-        var key = model.FindEntityType(typeof(Gunter)).FindPrimaryKey();
+        var key = model.FindEntityType(typeof(Gunter))!.FindPrimaryKey()!;
 
         Assert.Equal("V2.Annotation", key["Annotation"]);
         Assert.Equal("V2.Metadata", key["Metadata"]);
@@ -118,7 +118,7 @@ public class MetadataBuilderTest
         Assert.IsType<PropertyBuilder<int>>(returnedBuilder);
 
         var model = builder.Model;
-        var property = model.FindEntityType(typeof(Gunter)).FindProperty("Id");
+        var property = model.FindEntityType(typeof(Gunter))!.FindProperty("Id")!;
 
         Assert.Equal("V2.Annotation", property["Annotation"]);
         Assert.Equal("V2.Metadata", property["Metadata"]);
@@ -138,7 +138,7 @@ public class MetadataBuilderTest
         Assert.IsType<IndexBuilder<Gunter>>(returnedBuilder);
 
         var model = builder.Model;
-        var index = model.FindEntityType(typeof(Gunter)).GetIndexes().Single(i => i.Properties.All(p => p.Name == nameof(Gunter.Id)));
+        var index = model.FindEntityType(typeof(Gunter))!.GetIndexes().Single(i => i.Properties.All(p => p.Name == nameof(Gunter.Id)));
 
         Assert.Equal("V2.Annotation", index["Annotation"]);
         Assert.Equal("V2.Metadata", index["Metadata"]);
@@ -159,7 +159,7 @@ public class MetadataBuilderTest
         Assert.IsType(relationshipBuilder.GetType(), returnedBuilder);
 
         var model = builder.Model;
-        var foreignKey = model.FindEntityType(typeof(Gate)).GetForeignKeys().Single();
+        var foreignKey = model.FindEntityType(typeof(Gate))!.GetForeignKeys().Single();
 
         Assert.Equal("V2.Annotation", foreignKey["Annotation"]);
         Assert.Equal("V2.Metadata", foreignKey["Metadata"]);
@@ -180,7 +180,7 @@ public class MetadataBuilderTest
         Assert.IsType(relationshipBuilder.GetType(), returnedBuilder);
 
         var model = builder.Model;
-        var foreignKey = model.FindEntityType(typeof(Gate)).GetForeignKeys().Single();
+        var foreignKey = model.FindEntityType(typeof(Gate))!.GetForeignKeys().Single();
 
         Assert.Equal("V2.Annotation", foreignKey["Annotation"]);
         Assert.Equal("V2.Metadata", foreignKey["Metadata"]);
@@ -202,7 +202,7 @@ public class MetadataBuilderTest
         Assert.IsType(relationshipBuilder.GetType(), returnedBuilder);
 
         var model = builder.Model;
-        var foreignKey = model.FindEntityType(typeof(Avatar)).GetForeignKeys().Single();
+        var foreignKey = model.FindEntityType(typeof(Avatar))!.GetForeignKeys().Single();
 
         Assert.Equal("V2.Annotation", foreignKey["Annotation"]);
         Assert.Equal("V2.Metadata", foreignKey["Metadata"]);
@@ -238,7 +238,7 @@ public class MetadataBuilderTest
         Assert.IsType<EntityTypeBuilder>(returnedBuilder);
 
         var model = builder.Model;
-        var entityType = model.FindEntityType(typeof(Gunter));
+        var entityType = model.FindEntityType(typeof(Gunter))!;
 
         Assert.Equal("V2.Annotation", entityType["Annotation"]);
         Assert.Equal("V2.Metadata", entityType["Metadata"]);
@@ -257,7 +257,7 @@ public class MetadataBuilderTest
         Assert.IsType<EntityTypeBuilder<Gunter>>(returnedBuilder);
 
         var model = builder.Model;
-        var entityType = model.FindEntityType(typeof(Gunter));
+        var entityType = model.FindEntityType(typeof(Gunter))!;
 
         Assert.Equal("V2.Annotation", entityType["Annotation"]);
         Assert.Equal("V2.Metadata", entityType["Metadata"]);
@@ -276,7 +276,7 @@ public class MetadataBuilderTest
         Assert.IsType<EntityTypeBuilder<Gunter>>(returnedBuilder);
 
         var model = builder.Model;
-        var entityType = model.FindEntityType(typeof(Gunter));
+        var entityType = model.FindEntityType(typeof(Gunter))!;
 
         Assert.Equal("V2.Annotation", entityType["Annotation"]);
         Assert.Equal("V2.Metadata", entityType["Metadata"]);
@@ -296,7 +296,7 @@ public class MetadataBuilderTest
         Assert.IsType<KeyBuilder<Gunter>>(returnedBuilder);
 
         var model = builder.Model;
-        var key = model.FindEntityType(typeof(Gunter)).FindPrimaryKey();
+        var key = model.FindEntityType(typeof(Gunter))!.FindPrimaryKey()!;
 
         Assert.Equal("V2.Annotation", key["Annotation"]);
         Assert.Equal("V2.Metadata", key["Metadata"]);
@@ -316,7 +316,7 @@ public class MetadataBuilderTest
         Assert.IsType<PropertyBuilder<int>>(returnedBuilder);
 
         var model = builder.Model;
-        var property = model.FindEntityType(typeof(Gunter)).FindProperty("Id");
+        var property = model.FindEntityType(typeof(Gunter))!.FindProperty("Id")!;
 
         Assert.Equal("V2.Annotation", property["Annotation"]);
         Assert.Equal("V2.Metadata", property["Metadata"]);
@@ -336,7 +336,7 @@ public class MetadataBuilderTest
         Assert.IsType<IndexBuilder<Gunter>>(returnedBuilder);
 
         var model = builder.Model;
-        var index = model.FindEntityType(typeof(Gunter)).GetIndexes().Single(i => i.Properties.All(p => p.Name == nameof(Gunter.Id)));
+        var index = model.FindEntityType(typeof(Gunter))!.GetIndexes().Single(i => i.Properties.All(p => p.Name == nameof(Gunter.Id)));
 
         Assert.Equal("V2.Annotation", index["Annotation"]);
         Assert.Equal("V2.Metadata", index["Metadata"]);
@@ -357,7 +357,7 @@ public class MetadataBuilderTest
         Assert.IsType(relationshipBuilder.GetType(), returnedBuilder);
 
         var model = builder.Model;
-        var foreignKey = model.FindEntityType(typeof(Gate)).GetForeignKeys().Single();
+        var foreignKey = model.FindEntityType(typeof(Gate))!.GetForeignKeys().Single();
 
         Assert.Equal("V2.Annotation", foreignKey["Annotation"]);
         Assert.Equal("V2.Metadata", foreignKey["Metadata"]);
@@ -378,7 +378,7 @@ public class MetadataBuilderTest
         Assert.IsType(relationshipBuilder.GetType(), returnedBuilder);
 
         var model = builder.Model;
-        var foreignKey = model.FindEntityType(typeof(Gate)).GetForeignKeys().Single();
+        var foreignKey = model.FindEntityType(typeof(Gate))!.GetForeignKeys().Single();
 
         Assert.Equal("V2.Annotation", foreignKey["Annotation"]);
         Assert.Equal("V2.Metadata", foreignKey["Metadata"]);
@@ -400,7 +400,7 @@ public class MetadataBuilderTest
         Assert.IsType(relationshipBuilder.GetType(), returnedBuilder);
 
         var model = builder.Model;
-        var foreignKey = model.FindEntityType(typeof(Avatar)).GetForeignKeys().Single();
+        var foreignKey = model.FindEntityType(typeof(Avatar))!.GetForeignKeys().Single();
 
         Assert.Equal("V2.Annotation", foreignKey["Annotation"]);
         Assert.Equal("V2.Metadata", foreignKey["Metadata"]);
@@ -413,9 +413,9 @@ public class MetadataBuilderTest
     {
         public int Id { get; set; }
 
-        public ICollection<Gate> Gates { get; set; }
+        public ICollection<Gate> Gates { get; set; } = null!;
 
-        public Avatar Avatar { get; set; }
+        public Avatar Avatar { get; set; } = null!;
     }
 
     private class Gate
@@ -423,14 +423,14 @@ public class MetadataBuilderTest
         public int Id { get; set; }
 
         public int GunterId { get; set; }
-        public Gunter Gunter { get; set; }
+        public Gunter Gunter { get; set; } = null!;
     }
 
     private class Avatar
     {
         public int Id { get; set; }
 
-        public Gunter Gunter { get; set; }
+        public Gunter Gunter { get; set; } = null!;
     }
 }
 

--- a/test/EFCore.Tests/Metadata/Conventions/BackingFieldConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/BackingFieldConventionTest.cs
@@ -130,7 +130,7 @@ public class BackingFieldConventionTest
         Assert.Null(property.GetFieldName());
     }
 
-    private void FieldMatchTest<TEntity>(string propertyName, string fieldName)
+    private void FieldMatchTest<TEntity>(string propertyName, string? fieldName)
     {
         var entityType = CreateModel().AddEntityType(typeof(TEntity));
         var property = entityType.AddProperty(propertyName, typeof(int));
@@ -169,7 +169,7 @@ public class BackingFieldConventionTest
     public void Multiple_matches_throws()
     {
         var entityType = CreateModel().AddEntityType(typeof(AlwaysLookOnTheBrightSideOfLife));
-        var property = entityType.AddProperty("OnTheRun", typeof(int));
+        var property = entityType.AddProperty("OnTheRun", typeof(int))!;
 
         RunConvention(property);
         Assert.Equal(
@@ -222,8 +222,8 @@ public class BackingFieldConventionTest
     [Fact]
     public void FieldInfo_set_by_annotation_is_used()
     {
-        var entityType = ((IConventionModel)CreateModel()).AddEntityType(typeof(AlwaysLookOnTheBrightSideOfLife));
-        var property = entityType.AddProperty("OnTheRun", typeof(int));
+        var entityType = ((IConventionModel)CreateModel()).AddEntityType(typeof(AlwaysLookOnTheBrightSideOfLife))!;
+        var property = entityType.AddProperty("OnTheRun", typeof(int))!;
 
         RunConvention((IMutableProperty)property);
 
@@ -283,7 +283,7 @@ public class BackingFieldConventionTest
     private class TheDarkSideOfTheMoon
 #pragma warning restore RCS1222 // Merge preprocessor directives.
     {
-        private readonly string m_SpeakToMe;
+        private readonly string? m_SpeakToMe;
         private int _notSpeakToMe;
 
         public int SpeakToMe
@@ -302,16 +302,16 @@ public class BackingFieldConventionTest
 
         public int Breathe
         {
-            get { return (int)breathe; }
+            get { return (int)breathe!; }
             set { breathe = value; }
         }
 
-        private readonly string onTheRun;
+        private readonly string? onTheRun;
         private int? _onTheRun;
 
         public int OnTheRun
         {
-            get { return (int)_onTheRun; }
+            get { return (int)_onTheRun!; }
             set { _onTheRun = value; }
         }
 
@@ -319,7 +319,7 @@ public class BackingFieldConventionTest
 
         public int Time
         {
-            get { return (int)_time; }
+            get { return (int)_time!; }
             set { _time = value; }
         }
 
@@ -327,16 +327,16 @@ public class BackingFieldConventionTest
 
         public int Time2
         {
-            get { return (int)_time; }
+            get { return (int)_time!; }
             set { _time = value; }
         }
 
-        private readonly string _theGreatGigInTheSky;
+        private readonly string? _theGreatGigInTheSky;
         private int? _TheGreatGigInTheSky;
 
         public int TheGreatGigInTheSky
         {
-            get { return (int)_TheGreatGigInTheSky; }
+            get { return (int)_TheGreatGigInTheSky!; }
             set { _TheGreatGigInTheSky = value; }
         }
 
@@ -344,16 +344,16 @@ public class BackingFieldConventionTest
 
         public int Money
         {
-            get { return (int)_Money; }
+            get { return (int)_Money!; }
             set { _Money = value; }
         }
 
-        private readonly string _UsAndThem;
+        private readonly string? _UsAndThem;
         private int? m_usAndThem;
 
         public int UsAndThem
         {
-            get { return (int)m_usAndThem; }
+            get { return (int)m_usAndThem!; }
             set { m_usAndThem = value; }
         }
 
@@ -361,16 +361,16 @@ public class BackingFieldConventionTest
 
         public int AnyColourYouLike
         {
-            get { return (int)m_anyColourYouLike; }
+            get { return (int)m_anyColourYouLike!; }
             set { m_anyColourYouLike = value; }
         }
 
-        private readonly string m_brainDamage;
+        private readonly string? m_brainDamage;
         private int? m_BrainDamage;
 
         public int BrainDamage
         {
-            get { return (int)m_BrainDamage; }
+            get { return (int)m_BrainDamage!; }
             set { m_BrainDamage = value; }
         }
 
@@ -378,35 +378,35 @@ public class BackingFieldConventionTest
 
         public int Eclipse
         {
-            get { return (int)m_Eclipse; }
+            get { return (int)m_Eclipse!; }
             set { m_Eclipse = value; }
         }
     }
 
     private class TheDarkerSideOfTheMoon
     {
-        private readonly string m_SpeakToMe;
+        private readonly string? m_SpeakToMe;
 
         private readonly int IsThereAnybodyOutThere;
 
         private int? breathe;
 
-        private readonly string onTheRun;
+        private readonly string? onTheRun;
         private int? _onTheRun;
 
         private int? _time;
 
-        private readonly string _theGreatGigInTheSky;
+        private readonly string? _theGreatGigInTheSky;
         private int? _TheGreatGigInTheSky;
 
         private int? _Money;
 
-        private readonly string _UsAndThem;
+        private readonly string? _UsAndThem;
         private int? m_usAndThem;
 
         private int? m_anyColourYouLike;
 
-        private readonly string m_brainDamage;
+        private readonly string? m_brainDamage;
         private int? m_BrainDamage;
 
         private int? m_Eclipse;
@@ -415,7 +415,7 @@ public class BackingFieldConventionTest
     private class TheDarkSide : OfTheMoon
     {
         public static readonly PropertyInfo OnBaseProperty
-            = typeof(TheDarkSide).GetProperty(nameof(OnBase));
+            = typeof(TheDarkSide).GetProperty(nameof(OnBase))!;
 
         public int OnBase
         {
@@ -431,13 +431,13 @@ public class BackingFieldConventionTest
     private class OfTheMoon
     {
         public static readonly PropertyInfo TheGreatGigInTheSkyProperty =
-            typeof(OfTheMoon).GetProperty(nameof(TheGreatGigInTheSky));
+            typeof(OfTheMoon).GetProperty(nameof(TheGreatGigInTheSky))!;
 
         private int? _theGreatGigInTheSky;
 
         public int TheGreatGigInTheSky
         {
-            get { return (int)_theGreatGigInTheSky; }
+            get { return (int)_theGreatGigInTheSky!; }
             set { _theGreatGigInTheSky = value; }
         }
 
@@ -449,20 +449,20 @@ public class BackingFieldConventionTest
 
     private class AlwaysLookOnTheBrightSideOfLife
     {
-        private readonly string onTheRun;
+        private readonly string? onTheRun;
         private int? _onTheRun;
         private int? m_onTheRun;
 
         public int OnTheRun
         {
-            get { return (int)m_onTheRun; }
+            get { return (int)m_onTheRun!; }
             set { m_onTheRun = value; }
         }
     }
 
     private class HesNotTheMessiah
     {
-        private object _onTheRun;
+        private object? _onTheRun;
         private int m_onTheRun;
 
         public int OnTheRun
@@ -474,7 +474,7 @@ public class BackingFieldConventionTest
 
     private class HesAVeryNaughtyBoy
     {
-        private object _onTheRun;
+        private object? _onTheRun;
         private int m_onTheRun;
 
         public object OnTheRun
@@ -486,13 +486,13 @@ public class BackingFieldConventionTest
 
     private class IndexedClass
     {
-        private string nation;
-        private string _nation;
-        private string _Nation;
-        private string m_nation;
-        private string m_Nation;
+        private string? nation;
+        private string? _nation;
+        private string? _Nation;
+        private string? m_nation;
+        private string? m_Nation;
 
-        public object this[string name]
+        public object? this[string name]
         {
             get => null;
             set { }

--- a/test/EFCore.Tests/Metadata/Conventions/BaseTypeDiscoveryConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/BaseTypeDiscoveryConventionTest.cs
@@ -12,8 +12,8 @@ public class BaseTypeDiscoveryConventionTest
     public void Discovers_parent_type()
     {
         var entityBuilderA = CreateInternalEntityTypeBuilder<A>();
-        var entityBuilderB = entityBuilderA.ModelBuilder.Entity(typeof(B), ConfigurationSource.Explicit);
-        var entityBuilderC = entityBuilderA.ModelBuilder.Entity(typeof(C), ConfigurationSource.Explicit);
+        var entityBuilderB = entityBuilderA.ModelBuilder.Entity(typeof(B), ConfigurationSource.Explicit)!;
+        var entityBuilderC = entityBuilderA.ModelBuilder.Entity(typeof(C), ConfigurationSource.Explicit)!;
         Assert.Null(entityBuilderC.Metadata.BaseType);
 
         RunConvention(entityBuilderC);
@@ -25,7 +25,7 @@ public class BaseTypeDiscoveryConventionTest
     public void Discovers_grandparent_type()
     {
         var entityBuilderA = CreateInternalEntityTypeBuilder<A>();
-        var entityBuilderC = entityBuilderA.ModelBuilder.Entity(typeof(C), ConfigurationSource.Explicit);
+        var entityBuilderC = entityBuilderA.ModelBuilder.Entity(typeof(C), ConfigurationSource.Explicit)!;
         Assert.Null(entityBuilderC.Metadata.BaseType);
 
         RunConvention(entityBuilderC);
@@ -37,8 +37,8 @@ public class BaseTypeDiscoveryConventionTest
     public void Discovers_parent_type_if_base_type_set()
     {
         var entityBuilderA = CreateInternalEntityTypeBuilder<A>();
-        var entityBuilderB = entityBuilderA.ModelBuilder.Entity(typeof(B), ConfigurationSource.Explicit);
-        var entityBuilderC = entityBuilderA.ModelBuilder.Entity(typeof(C), ConfigurationSource.Explicit);
+        var entityBuilderB = entityBuilderA.ModelBuilder.Entity(typeof(B), ConfigurationSource.Explicit)!;
+        var entityBuilderC = entityBuilderA.ModelBuilder.Entity(typeof(C), ConfigurationSource.Explicit)!;
         entityBuilderC.HasBaseType(entityBuilderA.Metadata, ConfigurationSource.Convention);
 
         RunConvention(entityBuilderC);
@@ -67,6 +67,6 @@ public class BaseTypeDiscoveryConventionTest
     {
         var modelBuilder = new InternalModelBuilder(new Model());
 
-        return modelBuilder.Entity(typeof(T), ConfigurationSource.Explicit);
+        return modelBuilder.Entity(typeof(T), ConfigurationSource.Explicit)!;
     }
 }

--- a/test/EFCore.Tests/Metadata/Conventions/CascadeDeleteConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/CascadeDeleteConventionTest.cs
@@ -115,14 +115,14 @@ public class CascadeDeleteConventionTest
     {
         public int Id { get; set; }
 
-        public ICollection<Post> Posts { get; set; }
+        public ICollection<Post> Posts { get; set; } = null!;
     }
 
     private class Post
     {
         public int Id { get; set; }
 
-        public Blog Blog { get; set; }
+        public Blog Blog { get; set; } = null!;
         public int? BlogId { get; set; }
     }
 

--- a/test/EFCore.Tests/Metadata/Conventions/ConstructorBindingConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/ConstructorBindingConventionTest.cs
@@ -373,10 +373,10 @@ public class ConstructorBindingConventionTest
     {
         var constructorBinding = GetBinding<BlogConflict>(e => ((EntityType)e).ConstructorBinding = new ConstructorBinding(
             typeof(BlogConflict).GetConstructor(
-                [typeof(string), typeof(int)]),
+                [typeof(string), typeof(int)])!,
             [
-                new PropertyParameterBinding((IProperty)e.FindProperty(nameof(Blog.Title))),
-                new PropertyParameterBinding((IProperty)e.FindProperty(nameof(Blog.Id)))
+                new PropertyParameterBinding((IProperty)e.FindProperty(nameof(Blog.Title))!),
+                new PropertyParameterBinding((IProperty)e.FindProperty(nameof(Blog.Id))!)
             ]));
 
         Assert.NotNull(constructorBinding);
@@ -709,14 +709,14 @@ public class ConstructorBindingConventionTest
                 .UseInternalServiceProvider(InMemoryFixture.DefaultServiceProvider)
                 .UseInMemoryDatabase(Guid.NewGuid().ToString());
 
-        public DbSet<NoField> NoFields { get; }
-        public DbSet<NoFieldRelated> NoFieldRelateds { get; }
+        public DbSet<NoField> NoFields { get; } = null!;
+        public DbSet<NoFieldRelated> NoFieldRelateds { get; } = null!;
     }
 
     private class NoField(Action<object, string> lazyLoader)
     {
         private readonly Action<object, string> _loader = lazyLoader;
-        private ICollection<NoFieldRelated> _hidden_noFieldRelated;
+        private ICollection<NoFieldRelated> _hidden_noFieldRelated = null!;
         public int Id { get; set; }
 
         public ICollection<NoFieldRelated> NoFieldRelated
@@ -729,10 +729,10 @@ public class ConstructorBindingConventionTest
     private class NoFieldRelated
     {
         public int Id { get; set; }
-        public NoField NoField { get; set; }
+        public NoField NoField { get; set; } = null!;
     }
 
-    private ConstructorBinding GetBinding<TEntity>(Action<IMutableEntityType> setBinding = null)
+    private ConstructorBinding GetBinding<TEntity>(Action<IMutableEntityType>? setBinding = null)
     {
         var entityType = ((IMutableModel)new Model()).AddEntityType(typeof(TEntity));
         entityType.AddProperty(nameof(Blog.Id), typeof(int));
@@ -755,7 +755,7 @@ public class ConstructorBindingConventionTest
         var convention = new ConstructorBindingConvention(CreateDependencies());
         convention.ProcessModelFinalizing(model.Builder, context);
 
-        return (ConstructorBinding)((EntityType)entityType).ConstructorBinding;
+        return (ConstructorBinding)((EntityType)entityType).ConstructorBinding!;
     }
 
     private ProviderConventionSetBuilderDependencies CreateDependencies()
@@ -764,12 +764,12 @@ public class ConstructorBindingConventionTest
     private abstract class Blog
     {
 #pragma warning disable 649, IDE1006 // Naming Styles
-        public string _content;
+        public string _content = null!;
 
         public int m_follows;
 #pragma warning restore 649, IDE1006 // Naming Styles
 
         public int Id { get; set; }
-        public string Title { get; set; }
+        public string Title { get; set; } = null!;
     }
 }

--- a/test/EFCore.Tests/Metadata/Conventions/ConventionDispatcherTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/ConventionDispatcherTest.cs
@@ -16,7 +16,7 @@ public class ConventionDispatcherTest
         conventions.Add(new InfinitePropertyAddedConvention());
 
         var builder = new InternalModelBuilder(new Model(conventions));
-        var entityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention);
+        var entityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention)!;
         var shadowPropertyName = "ShadowProperty";
 
         Assert.Equal(
@@ -162,7 +162,7 @@ public class ConventionDispatcherTest
         {
             Assert.Empty(convention1.Calls);
             Assert.Empty(convention2.Calls);
-            scope.Dispose();
+            scope!.Dispose();
         }
 
         Assert.Equal(new[] { "bar" }, convention1.Calls);
@@ -206,13 +206,13 @@ public class ConventionDispatcherTest
     private class ModelAnnotationChangedConvention(bool terminate) : IModelAnnotationChangedConvention
     {
         private readonly bool _terminate = terminate;
-        public readonly List<object> Calls = [];
+        public readonly List<object?> Calls = [];
 
         public void ProcessModelAnnotationChanged(
             IConventionModelBuilder propertyBuilder,
             string name,
-            IConventionAnnotation annotation,
-            IConventionAnnotation oldAnnotation,
+            IConventionAnnotation? annotation,
+            IConventionAnnotation? oldAnnotation,
             IConventionContext<IConventionAnnotation> context)
         {
             Assert.NotNull(propertyBuilder.Metadata.Builder);
@@ -255,11 +255,13 @@ public class ConventionDispatcherTest
         {
             Assert.Empty(convention1.Calls);
             Assert.Empty(convention2.Calls);
-            scope.Dispose();
+            scope!.Dispose();
         }
 
-        Assert.Equal(new[] { ("Cheese", (string)null) }, convention1.Calls);
-        Assert.Equal(new[] { ("Cheese", (string)null) }, convention2.Calls);
+    #pragma warning disable CS8620 // The convention intentionally observes the previous null value.
+        Assert.Equal(new[] { ("Cheese", (string)null!) }, convention1.Calls);
+        Assert.Equal(new[] { ("Cheese", (string)null!) }, convention2.Calls);
+    #pragma warning restore CS8620
         Assert.Empty(convention3.Calls);
 
         if (useBuilder)
@@ -271,8 +273,10 @@ public class ConventionDispatcherTest
             builder.Metadata.SetEmbeddedDiscriminatorName("Cheese", ConfigurationSource.Convention);
         }
 
-        Assert.Equal(new[] { ("Cheese", (string)null) }, convention1.Calls);
-        Assert.Equal(new[] { ("Cheese", (string)null) }, convention2.Calls);
+    #pragma warning disable CS8620 // The convention intentionally observes the previous null value.
+        Assert.Equal(new[] { ("Cheese", (string)null!) }, convention1.Calls);
+        Assert.Equal(new[] { ("Cheese", (string)null!) }, convention2.Calls);
+    #pragma warning restore CS8620
         Assert.Empty(convention3.Calls);
 
         if (useBuilder)
@@ -284,8 +288,10 @@ public class ConventionDispatcherTest
             builder.Metadata.SetEmbeddedDiscriminatorName("Onion", ConfigurationSource.Convention);
         }
 
-        Assert.Equal(new[] { ("Cheese", null), ("Onion", "Cheese") }, convention1.Calls);
-        Assert.Equal(new[] { ("Cheese", null), ("Onion", "Cheese") }, convention2.Calls);
+    #pragma warning disable CS8620 // The convention intentionally observes the previous null value.
+        Assert.Equal(new[] { ("Cheese", null!), ("Onion", "Cheese") }, convention1.Calls);
+        Assert.Equal(new[] { ("Cheese", null!), ("Onion", "Cheese") }, convention2.Calls);
+    #pragma warning restore CS8620
         Assert.Empty(convention3.Calls);
 
         AssertSetOperations(
@@ -295,12 +301,12 @@ public class ConventionDispatcherTest
 
     private class ModelEmbeddedDiscriminatorNameConvention(bool terminate) : IModelEmbeddedDiscriminatorNameConvention
     {
-        public readonly List<(string, string)> Calls = [];
+        public readonly List<(string?, string?)> Calls = [];
 
         public void ProcessEmbeddedDiscriminatorName(
             IConventionModelBuilder modelBuilder,
-            string newName,
-            string oldName,
+            string? newName,
+            string? oldName,
             IConventionContext<string> context)
         {
             Assert.NotNull(modelBuilder.Metadata.Builder);
@@ -347,7 +353,7 @@ public class ConventionDispatcherTest
         {
             Assert.Equal(0, convention1.Calls);
             Assert.Equal(0, convention2.Calls);
-            scope.Dispose();
+            scope!.Dispose();
         }
 
         Assert.Equal(1, convention1.Calls);
@@ -425,7 +431,7 @@ public class ConventionDispatcherTest
             Assert.Equal(0, convention4.Calls);
             Assert.Equal(0, convention5.Calls);
             Assert.Equal(0, convention6.Calls);
-            scope.Dispose();
+            scope!.Dispose();
         }
 
         Assert.Equal(1, convention1.Calls);
@@ -451,7 +457,7 @@ public class ConventionDispatcherTest
         public void ProcessTypeIgnored(
             IConventionModelBuilder modelBuilder,
             string name,
-            Type type,
+            Type? type,
             IConventionContext<string> context)
         {
             Assert.Null(modelBuilder.Metadata.FindEntityType(name));
@@ -497,7 +503,7 @@ public class ConventionDispatcherTest
         conventions.Add(convention3);
 
         var builder = new InternalModelBuilder(new Model(conventions));
-        var entityBuilder = builder.Entity(typeof(SpecialOrder), ConfigurationSource.Convention);
+        var entityBuilder = builder.Entity(typeof(SpecialOrder), ConfigurationSource.Convention)!;
 
         var scope = useScope ? builder.Metadata.ConventionDispatcher.DelayConventions() : null;
 
@@ -515,7 +521,7 @@ public class ConventionDispatcherTest
             Assert.Empty(convention1.Calls);
             Assert.Empty(convention2.Calls);
             Assert.Empty(convention3.Calls);
-            scope.Dispose();
+            scope!.Dispose();
         }
 
         Assert.Equal(new[] { "A" }, convention1.Calls);
@@ -574,7 +580,7 @@ public class ConventionDispatcherTest
         conventions.Add(convention3);
 
         var builder = new InternalModelBuilder(new Model(conventions))
-            .Entity(typeof(SpecialOrder), ConfigurationSource.Convention);
+            .Entity(typeof(SpecialOrder), ConfigurationSource.Convention)!;
 
         var scope = useScope ? builder.Metadata.Model.DelayConventions() : null;
 
@@ -594,7 +600,7 @@ public class ConventionDispatcherTest
             Assert.Empty(convention1.Calls);
             Assert.Empty(convention2.Calls);
             Assert.Empty(convention3.Calls);
-            scope.Dispose();
+            scope!.Dispose();
         }
 
         Assert.Equal(new[] { typeof(Order) }, convention1.Calls);
@@ -616,7 +622,7 @@ public class ConventionDispatcherTest
 
         if (useBuilder)
         {
-            Assert.NotNull(builder.HasBaseType((Type)null, ConfigurationSource.Convention));
+            Assert.NotNull(builder.HasBaseType((Type?)null, ConfigurationSource.Convention));
         }
         else
         {
@@ -635,12 +641,12 @@ public class ConventionDispatcherTest
     private class EntityTypeBaseTypeChangedConvention(bool terminate) : IEntityTypeBaseTypeChangedConvention
     {
         private readonly bool _terminate = terminate;
-        public readonly List<Type> Calls = [];
+        public readonly List<Type?> Calls = [];
 
         public void ProcessEntityTypeBaseTypeChanged(
             IConventionEntityTypeBuilder entityTypeBuilder,
-            IConventionEntityType newBaseType,
-            IConventionEntityType oldBaseType,
+            IConventionEntityType? newBaseType,
+            IConventionEntityType? oldBaseType,
             IConventionContext<IConventionEntityType> context)
         {
             Assert.NotNull(entityTypeBuilder.Metadata.Builder);
@@ -667,8 +673,8 @@ public class ConventionDispatcherTest
         conventions.Add(convention3);
 
         var builder = new InternalModelBuilder(new Model(conventions));
-        var entityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention);
-        var propertyBuilder = entityBuilder.Property(Order.OrderIdProperty, ConfigurationSource.Convention);
+        var entityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention)!;
+        var propertyBuilder = entityBuilder.Property(Order.OrderIdProperty, ConfigurationSource.Convention)!;
 
         var scope = useScope ? builder.Metadata.ConventionDispatcher.DelayConventions() : null;
 
@@ -685,7 +691,7 @@ public class ConventionDispatcherTest
         {
             Assert.Empty(convention1.Calls);
             Assert.Empty(convention2.Calls);
-            scope.Dispose();
+            scope!.Dispose();
         }
 
         Assert.Equal(new[] { nameof(Order.OrderId) }, convention1.Calls);
@@ -726,12 +732,12 @@ public class ConventionDispatcherTest
     private class DiscriminatorPropertySetConvention(bool terminate) : IDiscriminatorPropertySetConvention
     {
         private readonly bool _terminate = terminate;
-        public readonly List<object> Calls = [];
+        public readonly List<string?> Calls = [];
 
         public void ProcessDiscriminatorPropertySet(
             IConventionTypeBaseBuilder structuralTypeBuilder,
-            string name,
-            IConventionContext<string> context)
+            string? name,
+            IConventionContext<string?> context)
         {
             Assert.True(structuralTypeBuilder.Metadata.IsInModel);
 
@@ -757,7 +763,7 @@ public class ConventionDispatcherTest
         conventions.Add(convention3);
 
         var builder = new InternalModelBuilder(new Model(conventions));
-        var entityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention);
+        var entityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention)!;
 
         entityBuilder.HasKey(["OrderId"], ConfigurationSource.Convention);
 
@@ -771,7 +777,7 @@ public class ConventionDispatcherTest
         {
             Assert.NotNull(
                 entityBuilder.Metadata.SetPrimaryKey(
-                    entityBuilder.Property("OrderId", ConfigurationSource.Convention).Metadata,
+                    entityBuilder.Property("OrderId", ConfigurationSource.Convention)!.Metadata,
                     ConfigurationSource.Convention));
         }
 
@@ -780,11 +786,11 @@ public class ConventionDispatcherTest
             Assert.Empty(convention1.Calls);
             Assert.Empty(convention2.Calls);
             Assert.Empty(convention3.Calls);
-            scope.Dispose();
+            scope!.Dispose();
         }
 
-        Assert.Equal(new string[] { null }, convention1.Calls);
-        Assert.Equal(new string[] { null }, convention2.Calls);
+        Assert.Equal(new string?[] { null }, convention1.Calls);
+        Assert.Equal(new string?[] { null }, convention2.Calls);
         Assert.Empty(convention3.Calls);
 
         if (useBuilder)
@@ -795,21 +801,21 @@ public class ConventionDispatcherTest
         {
             Assert.NotNull(
                 entityBuilder.Metadata.SetPrimaryKey(
-                    entityBuilder.Property("OrderId", ConfigurationSource.Convention).Metadata,
+                    entityBuilder.Property("OrderId", ConfigurationSource.Convention)!.Metadata,
                     ConfigurationSource.Convention));
         }
 
-        Assert.Equal(new string[] { null }, convention1.Calls);
-        Assert.Equal(new string[] { null }, convention2.Calls);
+        Assert.Equal(new string?[] { null }, convention1.Calls);
+        Assert.Equal(new string?[] { null }, convention2.Calls);
         Assert.Empty(convention3.Calls);
 
         if (useBuilder)
         {
-            Assert.Null(entityBuilder.PrimaryKey((IReadOnlyList<string>)null, ConfigurationSource.Convention));
+            Assert.Null(entityBuilder.PrimaryKey((IReadOnlyList<string>?)null, ConfigurationSource.Convention));
         }
         else
         {
-            Assert.Null(entityBuilder.Metadata.SetPrimaryKey((Property)null, ConfigurationSource.Convention));
+            Assert.Null(entityBuilder.Metadata.SetPrimaryKey((Property?)null, ConfigurationSource.Convention));
         }
 
         Assert.Equal(new[] { null, "OrderId" }, convention1.Calls);
@@ -825,12 +831,12 @@ public class ConventionDispatcherTest
     private class EntityTypePrimaryKeyChangedConvention(bool terminate) : IEntityTypePrimaryKeyChangedConvention
     {
         private readonly bool _terminate = terminate;
-        public readonly List<object> Calls = [];
+        public readonly List<string?> Calls = [];
 
         public void ProcessEntityTypePrimaryKeyChanged(
             IConventionEntityTypeBuilder entityTypeBuilder,
-            IConventionKey newPrimaryKey,
-            IConventionKey previousPrimaryKey,
+            IConventionKey? newPrimaryKey,
+            IConventionKey? previousPrimaryKey,
             IConventionContext<IConventionKey> context)
         {
             Assert.NotNull(entityTypeBuilder.Metadata.Builder);
@@ -857,7 +863,7 @@ public class ConventionDispatcherTest
         conventions.Add(convention3);
 
         var builder = new InternalModelBuilder(new Model(conventions));
-        var entityBuilder = builder.Entity(typeof(SpecialOrder), ConfigurationSource.Convention);
+        var entityBuilder = builder.Entity(typeof(SpecialOrder), ConfigurationSource.Convention)!;
 
         var scope = useScope ? builder.Metadata.ConventionDispatcher.DelayConventions() : null;
 
@@ -874,7 +880,7 @@ public class ConventionDispatcherTest
         {
             Assert.Empty(convention1.Calls);
             Assert.Empty(convention2.Calls);
-            scope.Dispose();
+            scope!.Dispose();
         }
 
         Assert.Equal(new[] { "bar" }, convention1.Calls);
@@ -918,13 +924,13 @@ public class ConventionDispatcherTest
     private class EntityTypeAnnotationChangedConvention(bool terminate) : IEntityTypeAnnotationChangedConvention
     {
         private readonly bool _terminate = terminate;
-        public readonly List<object> Calls = [];
+        public readonly List<object?> Calls = [];
 
         public void ProcessEntityTypeAnnotationChanged(
             IConventionEntityTypeBuilder entityTypeBuilder,
             string name,
-            IConventionAnnotation annotation,
-            IConventionAnnotation oldAnnotation,
+            IConventionAnnotation? annotation,
+            IConventionAnnotation? oldAnnotation,
             IConventionContext<IConventionAnnotation> context)
         {
             Calls.Add(annotation?.Value);
@@ -949,7 +955,7 @@ public class ConventionDispatcherTest
         conventions.Add(convention3);
 
         var builder = new InternalModelBuilder(new Model(conventions));
-        var entityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention);
+        var entityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention)!;
         entityBuilder.PrimaryKey(["OrderId"], ConfigurationSource.Convention);
 
         var scope = useScope ? builder.Metadata.ConventionDispatcher.DelayConventions() : null;
@@ -963,8 +969,8 @@ public class ConventionDispatcherTest
         else
         {
             var result = entityBuilder.Metadata.AddForeignKey(
-                entityBuilder.Property(typeof(int), "OrderId1", ConfigurationSource.Convention).Metadata,
-                entityBuilder.Metadata.FindPrimaryKey(),
+                entityBuilder.Property(typeof(int), "OrderId1", ConfigurationSource.Convention)!.Metadata,
+                entityBuilder.Metadata.FindPrimaryKey()!,
                 entityBuilder.Metadata,
                 ConfigurationSource.Convention,
                 ConfigurationSource.Convention);
@@ -976,7 +982,7 @@ public class ConventionDispatcherTest
         {
             Assert.Empty(convention1.Calls);
             Assert.Empty(convention2.Calls);
-            scope.Dispose();
+            scope!.Dispose();
         }
 
         Assert.Equal(new[] { "OrderId1" }, convention1.Calls);
@@ -991,7 +997,7 @@ public class ConventionDispatcherTest
     private class ForeignKeyAddedConvention(bool terminate) : IForeignKeyAddedConvention
     {
         private readonly bool _terminate = terminate;
-        public readonly List<object> Calls = [];
+        public readonly List<object?> Calls = [];
 
         public void ProcessForeignKeyAdded(
             IConventionForeignKeyBuilder relationshipBuilder,
@@ -1023,13 +1029,13 @@ public class ConventionDispatcherTest
         conventions.Add(convention3);
 
         var builder = new InternalModelBuilder(new Model(conventions));
-        var entityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention);
+        var entityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention)!;
         var foreignKey = entityBuilder.Metadata.AddForeignKey(
-            [entityBuilder.Property(typeof(int), "FK", ConfigurationSource.Convention).Metadata],
-            entityBuilder.HasKey(["OrderId"], ConfigurationSource.Convention).Metadata,
+            [entityBuilder.Property(typeof(int), "FK", ConfigurationSource.Convention)!.Metadata],
+            entityBuilder.HasKey(["OrderId"], ConfigurationSource.Convention)!.Metadata,
             entityBuilder.Metadata,
             ConfigurationSource.Explicit,
-            ConfigurationSource.Explicit);
+            ConfigurationSource.Explicit)!;
 
         var scope = useScope ? builder.Metadata.ConventionDispatcher.DelayConventions() : null;
 
@@ -1049,7 +1055,7 @@ public class ConventionDispatcherTest
         {
             Assert.Empty(convention1.Calls);
             Assert.Empty(convention2.Calls);
-            scope.Dispose();
+            scope!.Dispose();
         }
 
         Assert.Equal(new[] { "FK" }, convention1.Calls);
@@ -1095,29 +1101,29 @@ public class ConventionDispatcherTest
         conventions.Add(convention3);
 
         var builder = new InternalModelBuilder(new Model(conventions));
-        var entityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention);
+        var entityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention)!;
         entityBuilder.PrimaryKey(["OrderId"], ConfigurationSource.Convention);
-        var dependentEntityBuilder = builder.Entity(typeof(OrderDetails), ConfigurationSource.Convention);
+        var dependentEntityBuilder = builder.Entity(typeof(OrderDetails), ConfigurationSource.Convention)!;
         var relationship = dependentEntityBuilder
-            .HasRelationship(entityBuilder.Metadata, ConfigurationSource.Convention);
+            .HasRelationship(entityBuilder.Metadata, ConfigurationSource.Convention)!;
 
         var scope = useScope ? builder.Metadata.ConventionDispatcher.DelayConventions() : null;
 
-        relationship = relationship.HasPrincipalKey(Array.Empty<string>(), ConfigurationSource.Convention);
+        relationship = relationship.HasPrincipalKey(Array.Empty<string>(), ConfigurationSource.Convention)!;
         Assert.NotNull(relationship);
 
         if (useScope)
         {
             Assert.Empty(convention1.Calls);
             Assert.Empty(convention2.Calls);
-            scope.Dispose();
+            scope!.Dispose();
         }
 
         Assert.Equal(new[] { nameof(Order) }, convention1.Calls);
         Assert.Equal(new[] { nameof(Order) }, convention2.Calls);
         Assert.Empty(convention3.Calls);
 
-        relationship = relationship.HasPrincipalKey(relationship.Metadata.PrincipalKey.Properties, ConfigurationSource.Convention);
+        relationship = relationship.HasPrincipalKey(relationship.Metadata.PrincipalKey.Properties, ConfigurationSource.Convention)!;
         Assert.NotNull(relationship);
 
         Assert.Equal(new[] { nameof(Order) }, convention1.Calls);
@@ -1127,21 +1133,21 @@ public class ConventionDispatcherTest
         scope = useScope ? builder.Metadata.ConventionDispatcher.DelayConventions() : null;
 
         relationship.Metadata.SetPrincipalEndConfigurationSource(null);
-        relationship = relationship.HasForeignKey(Array.Empty<string>(), ConfigurationSource.Convention);
+        relationship = relationship.HasForeignKey(Array.Empty<string>(), ConfigurationSource.Convention)!;
         Assert.NotNull(relationship);
 
         if (useScope)
         {
             Assert.Equal(new[] { nameof(Order) }, convention1.Calls);
             Assert.Equal(new[] { nameof(Order) }, convention2.Calls);
-            scope.Dispose();
+            scope!.Dispose();
         }
 
         Assert.Equal(new[] { nameof(Order), nameof(Order) }, convention1.Calls);
         Assert.Equal(new[] { nameof(Order), nameof(Order) }, convention2.Calls);
         Assert.Empty(convention3.Calls);
 
-        relationship = relationship.HasForeignKey(relationship.Metadata.Properties, ConfigurationSource.Convention);
+        relationship = relationship.HasForeignKey(relationship.Metadata.Properties, ConfigurationSource.Convention)!;
         Assert.NotNull(relationship);
 
         Assert.Equal(new[] { nameof(Order), nameof(Order) }, convention1.Calls);
@@ -1151,14 +1157,14 @@ public class ConventionDispatcherTest
         scope = useScope ? builder.Metadata.ConventionDispatcher.DelayConventions() : null;
 
         relationship = relationship.HasEntityTypes(
-            relationship.Metadata.DeclaringEntityType, relationship.Metadata.PrincipalEntityType, ConfigurationSource.Convention);
+            relationship.Metadata.DeclaringEntityType, relationship.Metadata.PrincipalEntityType, ConfigurationSource.Convention)!;
         Assert.NotNull(relationship);
 
         if (useScope)
         {
             Assert.Equal(new[] { nameof(Order), nameof(Order) }, convention1.Calls);
             Assert.Equal(new[] { nameof(Order), nameof(Order) }, convention2.Calls);
-            scope.Dispose();
+            scope!.Dispose();
         }
 
         Assert.Equal(new[] { nameof(Order), nameof(Order), nameof(OrderDetails) }, convention1.Calls);
@@ -1166,7 +1172,7 @@ public class ConventionDispatcherTest
         Assert.Empty(convention3.Calls);
 
         relationship = relationship.HasEntityTypes(
-            relationship.Metadata.PrincipalEntityType, relationship.Metadata.DeclaringEntityType, ConfigurationSource.DataAnnotation);
+            relationship.Metadata.PrincipalEntityType, relationship.Metadata.DeclaringEntityType, ConfigurationSource.DataAnnotation)!;
         Assert.NotNull(relationship);
 
         Assert.Equal(new[] { nameof(Order), nameof(Order), nameof(OrderDetails), nameof(OrderDetails) }, convention1.Calls);
@@ -1174,7 +1180,7 @@ public class ConventionDispatcherTest
         Assert.Empty(convention3.Calls);
 
         relationship = relationship.HasEntityTypes(
-            relationship.Metadata.PrincipalEntityType, relationship.Metadata.DeclaringEntityType, ConfigurationSource.DataAnnotation);
+            relationship.Metadata.PrincipalEntityType, relationship.Metadata.DeclaringEntityType, ConfigurationSource.DataAnnotation)!;
         Assert.NotNull(relationship);
 
         Assert.Equal(new[] { nameof(Order), nameof(Order), nameof(OrderDetails), nameof(OrderDetails) }, convention1.Calls);
@@ -1219,18 +1225,18 @@ public class ConventionDispatcherTest
         conventions.Add(convention3);
 
         var builder = new InternalModelBuilder(new Model(conventions));
-        var entityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention);
+        var entityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention)!;
         var foreignKey = entityBuilder.Metadata.AddForeignKey(
-            [entityBuilder.Property(typeof(int), "FK", ConfigurationSource.Convention).Metadata],
-            entityBuilder.HasKey(["OrderId"], ConfigurationSource.Convention).Metadata,
+            [entityBuilder.Property(typeof(int), "FK", ConfigurationSource.Convention)!.Metadata],
+            entityBuilder.HasKey(["OrderId"], ConfigurationSource.Convention)!.Metadata,
             entityBuilder.Metadata,
             ConfigurationSource.Explicit,
-            ConfigurationSource.Explicit);
+            ConfigurationSource.Explicit)!;
 
         var scope = useScope ? builder.Metadata.ConventionDispatcher.DelayConventions() : null;
 
         foreignKey.SetProperties(
-            [entityBuilder.Property(typeof(int), "FK2", ConfigurationSource.Convention).Metadata],
+            [entityBuilder.Property(typeof(int), "FK2", ConfigurationSource.Convention)!.Metadata],
             foreignKey.PrincipalKey,
             ConfigurationSource.Convention);
 
@@ -1239,7 +1245,7 @@ public class ConventionDispatcherTest
             Assert.Empty(convention1.Calls);
             Assert.Empty(convention2.Calls);
             Assert.Empty(convention3.Calls);
-            scope.Dispose();
+            scope!.Dispose();
         }
 
         Assert.Equal(new[] { ("FK", "FK2"), ("FK2", "FK3"), ("FK", "FK3") }, convention1.Calls);
@@ -1273,7 +1279,7 @@ public class ConventionDispatcherTest
                 relationshipBuilder.Metadata.SetProperties(
                     [
                         relationshipBuilder.Metadata.DeclaringEntityType.Builder.Property(
-                            typeof(int), "FK3").Metadata
+                            typeof(int), "FK3")!.Metadata
                     ],
                     relationshipBuilder.Metadata.PrincipalKey);
                 context.StopProcessingIfChanged(relationshipBuilder.Metadata.Properties);
@@ -1299,9 +1305,9 @@ public class ConventionDispatcherTest
         conventions.Add(convention3);
 
         var builder = new InternalModelBuilder(new Model(conventions));
-        var principalEntityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention);
-        var dependentEntityBuilder = builder.Entity(typeof(OrderDetails), ConfigurationSource.Convention);
-        var foreignKey = dependentEntityBuilder.HasRelationship(principalEntityBuilder.Metadata, ConfigurationSource.Convention)
+        var principalEntityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention)!;
+        var dependentEntityBuilder = builder.Entity(typeof(OrderDetails), ConfigurationSource.Convention)!;
+        var foreignKey = dependentEntityBuilder.HasRelationship(principalEntityBuilder.Metadata, ConfigurationSource.Convention)!
             .Metadata;
 
         var scope = useScope ? builder.Metadata.ConventionDispatcher.DelayConventions() : null;
@@ -1319,7 +1325,7 @@ public class ConventionDispatcherTest
         {
             Assert.Empty(convention1.Calls);
             Assert.Empty(convention2.Calls);
-            scope.Dispose();
+            scope!.Dispose();
         }
 
         Assert.Equal(new[] { true }, convention1.Calls);
@@ -1395,9 +1401,9 @@ public class ConventionDispatcherTest
         conventions.Add(convention3);
 
         var builder = new InternalModelBuilder(new Model(conventions));
-        var principalEntityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention);
-        var dependentEntityBuilder = builder.Entity(typeof(OrderDetails), ConfigurationSource.Convention);
-        var foreignKey = dependentEntityBuilder.HasRelationship(principalEntityBuilder.Metadata, ConfigurationSource.Convention)
+        var principalEntityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention)!;
+        var dependentEntityBuilder = builder.Entity(typeof(OrderDetails), ConfigurationSource.Convention)!;
+        var foreignKey = dependentEntityBuilder.HasRelationship(principalEntityBuilder.Metadata, ConfigurationSource.Convention)!
             .Metadata;
 
         var scope = useScope ? builder.Metadata.ConventionDispatcher.DelayConventions() : null;
@@ -1415,7 +1421,7 @@ public class ConventionDispatcherTest
         {
             Assert.Empty(convention1.Calls);
             Assert.Empty(convention2.Calls);
-            scope.Dispose();
+            scope!.Dispose();
         }
 
         Assert.Equal(new[] { true }, convention1.Calls);
@@ -1491,11 +1497,11 @@ public class ConventionDispatcherTest
         conventions.Add(convention3);
 
         var builder = new InternalModelBuilder(new Model(conventions));
-        var principalEntityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention);
-        var dependentEntityBuilder = builder.Entity(typeof(OrderDetails), ConfigurationSource.Convention);
-        var foreignKey = dependentEntityBuilder.HasRelationship(principalEntityBuilder.Metadata, ConfigurationSource.Convention)
-            .IsUnique(true, ConfigurationSource.Convention)
-            .HasEntityTypes(principalEntityBuilder.Metadata, dependentEntityBuilder.Metadata, ConfigurationSource.Convention)
+        var principalEntityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention)!;
+        var dependentEntityBuilder = builder.Entity(typeof(OrderDetails), ConfigurationSource.Convention)!;
+        var foreignKey = dependentEntityBuilder.HasRelationship(principalEntityBuilder.Metadata, ConfigurationSource.Convention)!
+            .IsUnique(true, ConfigurationSource.Convention)!
+            .HasEntityTypes(principalEntityBuilder.Metadata, dependentEntityBuilder.Metadata, ConfigurationSource.Convention)!
             .Metadata;
 
         var scope = useScope ? builder.Metadata.ConventionDispatcher.DelayConventions() : null;
@@ -1513,7 +1519,7 @@ public class ConventionDispatcherTest
         {
             Assert.Empty(convention1.Calls);
             Assert.Empty(convention2.Calls);
-            scope.Dispose();
+            scope!.Dispose();
         }
 
         Assert.Equal(new[] { true }, convention1.Calls);
@@ -1589,10 +1595,10 @@ public class ConventionDispatcherTest
         conventions.Add(convention3);
 
         var builder = new InternalModelBuilder(new Model(conventions));
-        var principalEntityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention);
-        var dependentEntityBuilder = builder.Entity(typeof(OrderDetails), ConfigurationSource.Convention, shouldBeOwned: true);
+        var principalEntityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention)!;
+        var dependentEntityBuilder = builder.Entity(typeof(OrderDetails), ConfigurationSource.Convention, shouldBeOwned: true)!;
         var foreignKey = dependentEntityBuilder.HasRelationship(
-                principalEntityBuilder.Metadata, null, nameof(Order.OrderDetails), ConfigurationSource.Convention)
+            principalEntityBuilder.Metadata, null, nameof(Order.OrderDetails), ConfigurationSource.Convention)!
             .Metadata;
 
         var scope = useScope ? builder.Metadata.ConventionDispatcher.DelayConventions() : null;
@@ -1611,7 +1617,7 @@ public class ConventionDispatcherTest
             Assert.Empty(convention1.Calls);
             Assert.Empty(convention2.Calls);
             Assert.Empty(convention3.Calls);
-            scope.Dispose();
+            scope!.Dispose();
         }
 
         Assert.Equal(new[] { true }, convention1.Calls);
@@ -1687,9 +1693,9 @@ public class ConventionDispatcherTest
         conventions.Add(convention3);
 
         var builder = new InternalModelBuilder(new Model(conventions));
-        var principalEntityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention);
-        var dependentEntityBuilder = builder.Entity(typeof(OrderDetails), ConfigurationSource.Convention);
-        var foreignKey = dependentEntityBuilder.HasRelationship(principalEntityBuilder.Metadata, ConfigurationSource.Convention)
+        var principalEntityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention)!;
+        var dependentEntityBuilder = builder.Entity(typeof(OrderDetails), ConfigurationSource.Convention)!;
+        var foreignKey = dependentEntityBuilder.HasRelationship(principalEntityBuilder.Metadata, ConfigurationSource.Convention)!
             .Metadata;
 
         var scope = useScope ? builder.Metadata.ConventionDispatcher.DelayConventions() : null;
@@ -1707,7 +1713,7 @@ public class ConventionDispatcherTest
         {
             Assert.Empty(convention1.Calls);
             Assert.Empty(convention2.Calls);
-            scope.Dispose();
+            scope!.Dispose();
         }
 
         Assert.Equal(new[] { "bar" }, convention1.Calls);
@@ -1752,7 +1758,7 @@ public class ConventionDispatcherTest
     private class ForeignKeyAnnotationChangedConvention(bool terminate) : IForeignKeyAnnotationChangedConvention
     {
         private readonly bool _terminate = terminate;
-        public readonly List<object> Calls = [];
+        public readonly List<object?> Calls = [];
 
         /// <summary>
         ///     Called after an annotation is changed on a foreign key.
@@ -1765,8 +1771,8 @@ public class ConventionDispatcherTest
         public void ProcessForeignKeyAnnotationChanged(
             IConventionForeignKeyBuilder relationshipBuilder,
             string name,
-            IConventionAnnotation annotation,
-            IConventionAnnotation oldAnnotation,
+            IConventionAnnotation? annotation,
+            IConventionAnnotation? oldAnnotation,
             IConventionContext<IConventionAnnotation> context)
         {
             Assert.NotNull(relationshipBuilder.Metadata.Builder);
@@ -1793,28 +1799,28 @@ public class ConventionDispatcherTest
         conventions.Add(convention3);
 
         var builder = new InternalModelBuilder(new Model(conventions));
-        var principalEntityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention);
-        var dependentEntityBuilder = builder.Entity(typeof(OrderDetails), ConfigurationSource.Convention);
+        var principalEntityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention)!;
+        var dependentEntityBuilder = builder.Entity(typeof(OrderDetails), ConfigurationSource.Convention)!;
 
         var scope = useScope ? builder.Metadata.ConventionDispatcher.DelayConventions() : null;
 
         if (useBuilder)
         {
             var result = dependentEntityBuilder.HasRelationship(
-                principalEntityBuilder.Metadata, (MemberInfo)null, null, ConfigurationSource.Convention);
+                principalEntityBuilder.Metadata, (MemberInfo?)null, null, ConfigurationSource.Convention);
 
             Assert.NotNull(result);
         }
         else
         {
-            var fk = dependentEntityBuilder.HasRelationship(principalEntityBuilder.Metadata, ConfigurationSource.Convention)
-                .IsUnique(true, ConfigurationSource.Convention)
+            var fk = dependentEntityBuilder.HasRelationship(principalEntityBuilder.Metadata, ConfigurationSource.Convention)!
+                .IsUnique(true, ConfigurationSource.Convention)!
                 .Metadata;
-            var result = fk.SetDependentToPrincipal((MemberInfo)null, ConfigurationSource.Explicit);
+            var result = fk.SetDependentToPrincipal((MemberInfo?)null, ConfigurationSource.Explicit);
 
             Assert.Null(result);
 
-            result = fk.SetPrincipalToDependent((MemberInfo)null, ConfigurationSource.Explicit);
+            result = fk.SetPrincipalToDependent((MemberInfo?)null, ConfigurationSource.Explicit);
 
             Assert.Null(result);
         }
@@ -1823,7 +1829,7 @@ public class ConventionDispatcherTest
         {
             Assert.Empty(convention1.Calls);
             Assert.Empty(convention2.Calls);
-            scope.Dispose();
+            scope!.Dispose();
         }
 
         Assert.Equal(new[] { true, false }, convention1.Calls);
@@ -1869,8 +1875,8 @@ public class ConventionDispatcherTest
         conventions.Add(convention3);
 
         var builder = new InternalModelBuilder(new Model(conventions));
-        var principalEntityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention);
-        var dependentEntityBuilder = builder.Entity(typeof(OrderDetails), ConfigurationSource.Convention);
+        var principalEntityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention)!;
+        var dependentEntityBuilder = builder.Entity(typeof(OrderDetails), ConfigurationSource.Convention)!;
 
         var scope = useScope ? builder.Metadata.ConventionDispatcher.DelayConventions() : null;
 
@@ -1884,8 +1890,8 @@ public class ConventionDispatcherTest
         }
         else
         {
-            var fk = dependentEntityBuilder.HasRelationship(principalEntityBuilder.Metadata, ConfigurationSource.Convention)
-                .IsUnique(true, ConfigurationSource.Convention)
+            var fk = dependentEntityBuilder.HasRelationship(principalEntityBuilder.Metadata, ConfigurationSource.Convention)!
+                .IsUnique(true, ConfigurationSource.Convention)!
                 .Metadata;
             var result = fk.SetDependentToPrincipal(OrderDetails.OrderProperty, ConfigurationSource.Explicit);
 
@@ -1900,7 +1906,7 @@ public class ConventionDispatcherTest
         {
             Assert.Empty(convention1.Calls);
             Assert.Empty(convention2.Calls);
-            scope.Dispose();
+            scope!.Dispose();
         }
 
         Assert.Equal(new[] { nameof(OrderDetails.Order), nameof(Order.OrderDetails) }, convention1.Calls);
@@ -1915,7 +1921,7 @@ public class ConventionDispatcherTest
     private class NavigationAddedConvention(bool terminate) : INavigationAddedConvention
     {
         private readonly bool _terminate = terminate;
-        public readonly List<object> Calls = [];
+        public readonly List<object?> Calls = [];
 
         public void ProcessNavigationAdded(
             IConventionNavigationBuilder navigationBuilder,
@@ -1932,11 +1938,11 @@ public class ConventionDispatcherTest
             {
                 if (navigation.IsOnDependent)
                 {
-                    foreignKey.SetDependentToPrincipal((string)null);
+                    foreignKey.SetDependentToPrincipal((string?)null);
                 }
                 else
                 {
-                    foreignKey.SetPrincipalToDependent((string)null);
+                    foreignKey.SetPrincipalToDependent((string?)null);
                 }
 
                 context.StopProcessing();
@@ -1957,11 +1963,11 @@ public class ConventionDispatcherTest
         conventions.Add(convention3);
 
         var builder = new InternalModelBuilder(new Model(conventions));
-        var principalEntityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention);
-        var dependentEntityBuilder = builder.Entity(typeof(OrderDetails), ConfigurationSource.Convention);
+        var principalEntityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention)!;
+        var dependentEntityBuilder = builder.Entity(typeof(OrderDetails), ConfigurationSource.Convention)!;
         var navigation = dependentEntityBuilder.HasRelationship(
-                principalEntityBuilder.Metadata, OrderDetails.OrderProperty, ConfigurationSource.Convention)
-            .Metadata.DependentToPrincipal;
+                principalEntityBuilder.Metadata, OrderDetails.OrderProperty, ConfigurationSource.Convention)!
+            .Metadata.DependentToPrincipal!;
 
         var scope = useScope ? builder.Metadata.ConventionDispatcher.DelayConventions() : null;
 
@@ -1978,7 +1984,7 @@ public class ConventionDispatcherTest
         {
             Assert.Empty(convention1.Calls);
             Assert.Empty(convention2.Calls);
-            scope.Dispose();
+            scope!.Dispose();
         }
 
         Assert.Equal(new[] { "bar" }, convention1.Calls);
@@ -2023,14 +2029,14 @@ public class ConventionDispatcherTest
     private class NavigationAnnotationChangedConvention(bool terminate) : INavigationAnnotationChangedConvention
     {
         private readonly bool _terminate = terminate;
-        public readonly List<object> Calls = [];
+        public readonly List<object?> Calls = [];
 
         public virtual void ProcessNavigationAnnotationChanged(
             IConventionForeignKeyBuilder relationshipBuilder,
             IConventionNavigation navigation,
             string name,
-            IConventionAnnotation annotation,
-            IConventionAnnotation oldAnnotation,
+            IConventionAnnotation? annotation,
+            IConventionAnnotation? oldAnnotation,
             IConventionContext<IConventionAnnotation> context)
         {
             Assert.NotNull(relationshipBuilder.Metadata.Builder);
@@ -2057,10 +2063,10 @@ public class ConventionDispatcherTest
         conventions.Add(convention3);
 
         var builder = new InternalModelBuilder(new Model(conventions));
-        var principalEntityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention);
-        var dependentEntityBuilder = builder.Entity(typeof(OrderDetails), ConfigurationSource.Convention);
+        var principalEntityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention)!;
+        var dependentEntityBuilder = builder.Entity(typeof(OrderDetails), ConfigurationSource.Convention)!;
         var relationshipBuilder = dependentEntityBuilder.HasRelationship(
-            principalEntityBuilder.Metadata, nameof(OrderDetails.Order), nameof(Order.OrderDetails), ConfigurationSource.Convention);
+            principalEntityBuilder.Metadata, nameof(OrderDetails.Order), nameof(Order.OrderDetails), ConfigurationSource.Convention)!;
 
         var scope = useScope ? builder.Metadata.ConventionDispatcher.DelayConventions() : null;
 
@@ -2068,13 +2074,13 @@ public class ConventionDispatcherTest
         {
             Assert.NotNull(
                 relationshipBuilder.HasNavigation(
-                    (string)null,
+                    (string?)null,
                     pointsToPrincipal: true,
                     ConfigurationSource.Convention));
         }
         else
         {
-            var result = relationshipBuilder.Metadata.SetDependentToPrincipal((string)null, ConfigurationSource.Convention);
+            var result = relationshipBuilder.Metadata.SetDependentToPrincipal((string?)null, ConfigurationSource.Convention);
 
             Assert.Equal(!useScope, result == null);
         }
@@ -2083,7 +2089,7 @@ public class ConventionDispatcherTest
         {
             Assert.Empty(convention1.Calls);
             Assert.Empty(convention2.Calls);
-            scope.Dispose();
+            scope!.Dispose();
         }
 
         Assert.Equal(new[] { nameof(OrderDetails.Order) }, convention1.Calls);
@@ -2094,13 +2100,13 @@ public class ConventionDispatcherTest
         {
             Assert.NotNull(
                 relationshipBuilder.HasNavigation(
-                    (string)null,
+                    (string?)null,
                     pointsToPrincipal: true,
                     ConfigurationSource.Convention));
         }
         else
         {
-            Assert.Null(relationshipBuilder.Metadata.SetDependentToPrincipal((string)null, ConfigurationSource.Convention));
+            Assert.Null(relationshipBuilder.Metadata.SetDependentToPrincipal((string?)null, ConfigurationSource.Convention));
         }
 
         Assert.Equal(new[] { nameof(OrderDetails.Order) }, convention1.Calls);
@@ -2121,7 +2127,7 @@ public class ConventionDispatcherTest
             IConventionEntityTypeBuilder sourceEntityTypeBuilder,
             IConventionEntityTypeBuilder targetEntityTypeBuilder,
             string navigationName,
-            MemberInfo memberInfo,
+            MemberInfo? memberInfo,
             IConventionContext<string> context)
         {
             Assert.NotNull(sourceEntityTypeBuilder.Metadata.Builder);
@@ -2148,8 +2154,8 @@ public class ConventionDispatcherTest
         conventions.Add(convention3);
 
         var builder = new InternalModelBuilder(new Model(conventions));
-        var firstEntityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention);
-        var secondEntityBuilder = builder.Entity(typeof(Product), ConfigurationSource.Convention);
+        var firstEntityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention)!;
+        var secondEntityBuilder = builder.Entity(typeof(Product), ConfigurationSource.Convention)!;
 
         var scope = useScope ? builder.Metadata.ConventionDispatcher.DelayConventions() : null;
 
@@ -2170,7 +2176,7 @@ public class ConventionDispatcherTest
         {
             Assert.Empty(convention1.Calls);
             Assert.Empty(convention2.Calls);
-            scope.Dispose();
+            scope!.Dispose();
         }
 
         Assert.Equal(new[] { nameof(Order.Products) }, convention1.Calls);
@@ -2185,7 +2191,7 @@ public class ConventionDispatcherTest
     private class SkipNavigationAddedConvention(bool terminate) : ISkipNavigationAddedConvention
     {
         private readonly bool _terminate = terminate;
-        public readonly List<object> Calls = [];
+        public readonly List<object?> Calls = [];
 
         public void ProcessSkipNavigationAdded(
             IConventionSkipNavigationBuilder skipNavigationBuilder,
@@ -2217,11 +2223,11 @@ public class ConventionDispatcherTest
         conventions.Add(convention3);
 
         var builder = new InternalModelBuilder(new Model(conventions));
-        var firstEntityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention);
-        var secondEntityBuilder = builder.Entity(typeof(Product), ConfigurationSource.Convention);
+        var firstEntityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention)!;
+        var secondEntityBuilder = builder.Entity(typeof(Product), ConfigurationSource.Convention)!;
 
         var navigation = firstEntityBuilder.Metadata.AddSkipNavigation(
-            nameof(Order.Products), null, null, secondEntityBuilder.Metadata, true, false, ConfigurationSource.Convention);
+            nameof(Order.Products), null, null, secondEntityBuilder.Metadata, true, false, ConfigurationSource.Convention)!;
 
         var scope = useScope ? builder.Metadata.ConventionDispatcher.DelayConventions() : null;
 
@@ -2238,7 +2244,7 @@ public class ConventionDispatcherTest
         {
             Assert.Empty(convention1.Calls);
             Assert.Empty(convention2.Calls);
-            scope.Dispose();
+            scope!.Dispose();
         }
 
         Assert.Equal(new[] { "bar" }, convention1.Calls);
@@ -2283,13 +2289,13 @@ public class ConventionDispatcherTest
     private class SkipNavigationAnnotationChangedConvention(bool terminate) : ISkipNavigationAnnotationChangedConvention
     {
         private readonly bool _terminate = terminate;
-        public readonly List<object> Calls = [];
+        public readonly List<object?> Calls = [];
 
         public virtual void ProcessSkipNavigationAnnotationChanged(
             IConventionSkipNavigationBuilder navigationBuilder,
             string name,
-            IConventionAnnotation annotation,
-            IConventionAnnotation oldAnnotation,
+            IConventionAnnotation? annotation,
+            IConventionAnnotation? oldAnnotation,
             IConventionContext<IConventionAnnotation> context)
         {
             Assert.True(navigationBuilder.Metadata.IsInModel);
@@ -2316,16 +2322,16 @@ public class ConventionDispatcherTest
         conventions.Add(convention3);
 
         var builder = new InternalModelBuilder(new Model(conventions));
-        var firstEntityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention);
-        var secondEntityBuilder = builder.Entity(typeof(Product), ConfigurationSource.Convention);
-        var joinEntityBuilder = builder.Entity(typeof(OrderProduct), ConfigurationSource.Convention);
+        var firstEntityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention)!;
+        var secondEntityBuilder = builder.Entity(typeof(Product), ConfigurationSource.Convention)!;
+        var joinEntityBuilder = builder.Entity(typeof(OrderProduct), ConfigurationSource.Convention)!;
 
         var foreignKey = joinEntityBuilder
-            .HasRelationship(typeof(Order), [OrderProduct.OrderIdProperty], ConfigurationSource.Convention)
-            .IsUnique(false, ConfigurationSource.Convention)
+            .HasRelationship(typeof(Order), [OrderProduct.OrderIdProperty], ConfigurationSource.Convention)!
+            .IsUnique(false, ConfigurationSource.Convention)!
             .Metadata;
         var navigation = firstEntityBuilder.Metadata.AddSkipNavigation(
-            nameof(Order.Products), null, null, secondEntityBuilder.Metadata, true, false, ConfigurationSource.Convention);
+            nameof(Order.Products), null, null, secondEntityBuilder.Metadata, true, false, ConfigurationSource.Convention)!;
 
         var scope = useScope ? builder.Metadata.ConventionDispatcher.DelayConventions() : null;
 
@@ -2342,7 +2348,7 @@ public class ConventionDispatcherTest
         {
             Assert.Empty(convention1.Calls);
             Assert.Empty(convention2.Calls);
-            scope.Dispose();
+            scope!.Dispose();
         }
 
         Assert.Equal(new[] { foreignKey }, convention1.Calls);
@@ -2370,12 +2376,12 @@ public class ConventionDispatcherTest
     private class SkipNavigationForeignKeyChangedConvention(bool terminate) : ISkipNavigationForeignKeyChangedConvention
     {
         private readonly bool _terminate = terminate;
-        public readonly List<object> Calls = [];
+        public readonly List<IConventionForeignKey?> Calls = [];
 
         public virtual void ProcessSkipNavigationForeignKeyChanged(
             IConventionSkipNavigationBuilder navigationBuilder,
-            IConventionForeignKey foreignKey,
-            IConventionForeignKey oldForeignKey,
+            IConventionForeignKey? foreignKey,
+            IConventionForeignKey? oldForeignKey,
             IConventionContext<IConventionForeignKey> context)
         {
             Assert.True(navigationBuilder.Metadata.IsInModel);
@@ -2407,13 +2413,13 @@ public class ConventionDispatcherTest
         conventions.Add(convention3);
 
         var builder = new InternalModelBuilder(new Model(conventions));
-        var firstEntityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention);
-        var secondEntityBuilder = builder.Entity(typeof(Product), ConfigurationSource.Convention);
+        var firstEntityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention)!;
+        var secondEntityBuilder = builder.Entity(typeof(Product), ConfigurationSource.Convention)!;
 
         var navigation = firstEntityBuilder.Metadata.AddSkipNavigation(
-            nameof(Order.Products), null, null, secondEntityBuilder.Metadata, true, false, ConfigurationSource.Convention);
+            nameof(Order.Products), null, null, secondEntityBuilder.Metadata, true, false, ConfigurationSource.Convention)!;
         var inverse = secondEntityBuilder.Metadata.AddSkipNavigation(
-            nameof(Product.Orders), null, null, firstEntityBuilder.Metadata, true, false, ConfigurationSource.Convention);
+            nameof(Product.Orders), null, null, firstEntityBuilder.Metadata, true, false, ConfigurationSource.Convention)!;
 
         var scope = useScope ? builder.Metadata.ConventionDispatcher.DelayConventions() : null;
 
@@ -2439,7 +2445,7 @@ public class ConventionDispatcherTest
         {
             Assert.Empty(convention1.Calls);
             Assert.Empty(convention2.Calls);
-            scope.Dispose();
+            scope!.Dispose();
         }
 
         if (useBuilder)
@@ -2467,13 +2473,13 @@ public class ConventionDispatcherTest
 
         public virtual void ProcessSkipNavigationInverseChanged(
             IConventionSkipNavigationBuilder skipNavigationBuilder,
-            IConventionSkipNavigation inverse,
-            IConventionSkipNavigation oldInverse,
+            IConventionSkipNavigation? inverse,
+            IConventionSkipNavigation? oldInverse,
             IConventionContext<IConventionSkipNavigation> context)
         {
             Assert.True(skipNavigationBuilder.Metadata.IsInModel);
 
-            Calls.Add(inverse.Name);
+            Calls.Add(inverse!.Name);
 
             if (_terminate)
             {
@@ -2495,11 +2501,11 @@ public class ConventionDispatcherTest
         conventions.Add(convention3);
 
         var builder = new InternalModelBuilder(new Model(conventions));
-        var firstEntityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention);
-        var secondEntityBuilder = builder.Entity(typeof(Product), ConfigurationSource.Convention);
+        var firstEntityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention)!;
+        var secondEntityBuilder = builder.Entity(typeof(Product), ConfigurationSource.Convention)!;
 
         var navigation = firstEntityBuilder.Metadata.AddSkipNavigation(
-            nameof(Order.Products), null, null, secondEntityBuilder.Metadata, true, false, ConfigurationSource.Convention);
+            nameof(Order.Products), null, null, secondEntityBuilder.Metadata, true, false, ConfigurationSource.Convention)!;
 
         var scope = useScope ? builder.Metadata.ConventionDispatcher.DelayConventions() : null;
 
@@ -2518,7 +2524,7 @@ public class ConventionDispatcherTest
         {
             Assert.Empty(convention1.Calls);
             Assert.Empty(convention2.Calls);
-            scope.Dispose();
+            scope!.Dispose();
         }
 
         Assert.Equal(new[] { nameof(Order.Products) }, convention1.Calls);
@@ -2533,7 +2539,7 @@ public class ConventionDispatcherTest
     private class SkipNavigationRemovedConvention(bool terminate) : ISkipNavigationRemovedConvention
     {
         private readonly bool _terminate = terminate;
-        public readonly List<object> Calls = [];
+        public readonly List<object?> Calls = [];
 
         public void ProcessSkipNavigationRemoved(
             IConventionEntityTypeBuilder entityTypeBuilder,
@@ -2564,7 +2570,7 @@ public class ConventionDispatcherTest
         conventions.Add(convention3);
 
         var builder = new InternalModelBuilder(new Model(conventions));
-        var entityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention);
+        var entityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention)!;
 
         var scope = useScope ? builder.Metadata.ConventionDispatcher.DelayConventions() : null;
 
@@ -2585,7 +2591,7 @@ public class ConventionDispatcherTest
         {
             Assert.Empty(convention1.Calls);
             Assert.Empty(convention2.Calls);
-            scope.Dispose();
+            scope!.Dispose();
         }
 
         Assert.Equal(new[] { "MyTrigger" }, convention1.Calls);
@@ -2630,9 +2636,9 @@ public class ConventionDispatcherTest
         conventions.Add(convention3);
 
         var builder = new InternalModelBuilder(new Model(conventions));
-        var entityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention);
+        var entityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention)!;
 
-        var trigger = entityBuilder.Metadata.AddTrigger("MyTrigger", ConfigurationSource.Convention);
+        var trigger = entityBuilder.Metadata.AddTrigger("MyTrigger", ConfigurationSource.Convention)!;
 
         var scope = useScope ? builder.Metadata.ConventionDispatcher.DelayConventions() : null;
 
@@ -2651,7 +2657,7 @@ public class ConventionDispatcherTest
         {
             Assert.Empty(convention1.Calls);
             Assert.Empty(convention2.Calls);
-            scope.Dispose();
+            scope!.Dispose();
         }
 
         Assert.Equal(new[] { "MyTrigger" }, convention1.Calls);
@@ -2697,7 +2703,7 @@ public class ConventionDispatcherTest
         conventions.Add(convention3);
 
         var builder = new InternalModelBuilder(new Model(conventions));
-        var entityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention);
+        var entityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention)!;
         var keyPropertyName = "OrderId";
 
         var scope = useScope ? builder.Metadata.ConventionDispatcher.DelayConventions() : null;
@@ -2711,7 +2717,7 @@ public class ConventionDispatcherTest
         }
         else
         {
-            var property = entityBuilder.Property(keyPropertyName, ConfigurationSource.Convention).Metadata;
+            var property = entityBuilder.Property(keyPropertyName, ConfigurationSource.Convention)!.Metadata;
             property.IsNullable = false;
             var result = ((IMutableEntityType)entityBuilder.Metadata).AddKey(property);
 
@@ -2722,7 +2728,7 @@ public class ConventionDispatcherTest
         {
             Assert.Empty(convention1.Calls);
             Assert.Empty(convention2.Calls);
-            scope.Dispose();
+            scope!.Dispose();
         }
 
         Assert.Equal(new[] { keyPropertyName }, convention1.Calls);
@@ -2767,9 +2773,9 @@ public class ConventionDispatcherTest
 
         var builder = new InternalModelBuilder(new Model(conventions));
 
-        var entityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention);
+        var entityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention)!;
         var key = entityBuilder.HasKey(
-            new List<string> { "OrderId" }, ConfigurationSource.Convention).Metadata;
+            new List<string> { "OrderId" }, ConfigurationSource.Convention)!.Metadata;
 
         var scope = useScope ? builder.Metadata.ConventionDispatcher.DelayConventions() : null;
 
@@ -2778,7 +2784,7 @@ public class ConventionDispatcherTest
             Assert.Same(key, entityBuilder.Metadata.RemoveKey(key.Properties));
             Assert.Empty(convention1.Calls);
             Assert.Empty(convention2.Calls);
-            scope.Dispose();
+            scope!.Dispose();
         }
         else
         {
@@ -2828,9 +2834,9 @@ public class ConventionDispatcherTest
         conventions.Add(convention3);
 
         var builder = new InternalModelBuilder(new Model(conventions));
-        var entityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention);
+        var entityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention)!;
         var key = entityBuilder.HasKey(
-            new List<string> { "OrderId" }, ConfigurationSource.Convention).Metadata;
+            new List<string> { "OrderId" }, ConfigurationSource.Convention)!.Metadata;
 
         var scope = useScope ? builder.Metadata.ConventionDispatcher.DelayConventions() : null;
 
@@ -2847,7 +2853,7 @@ public class ConventionDispatcherTest
         {
             Assert.Empty(convention1.Calls);
             Assert.Empty(convention2.Calls);
-            scope.Dispose();
+            scope!.Dispose();
         }
 
         Assert.Equal(new[] { "bar" }, convention1.Calls);
@@ -2892,13 +2898,13 @@ public class ConventionDispatcherTest
     private class KeyAnnotationChangedConvention(bool terminate) : IKeyAnnotationChangedConvention
     {
         private readonly bool _terminate = terminate;
-        public readonly List<object> Calls = [];
+        public readonly List<object?> Calls = [];
 
         public void ProcessKeyAnnotationChanged(
             IConventionKeyBuilder keyBuilder,
             string name,
-            IConventionAnnotation annotation,
-            IConventionAnnotation oldAnnotation,
+            IConventionAnnotation? annotation,
+            IConventionAnnotation? oldAnnotation,
             IConventionContext<IConventionAnnotation> context)
         {
             Assert.NotNull(keyBuilder.Metadata.Builder);
@@ -2925,7 +2931,7 @@ public class ConventionDispatcherTest
         conventions.Add(convention3);
 
         var builder = new InternalModelBuilder(new Model(conventions));
-        var entityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention);
+        var entityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention)!;
 
         var scope = useScope ? builder.Metadata.ConventionDispatcher.DelayConventions() : null;
 
@@ -2938,7 +2944,7 @@ public class ConventionDispatcherTest
         }
         else
         {
-            var property = entityBuilder.Property("OrderId", ConfigurationSource.Convention).Metadata;
+            var property = entityBuilder.Property("OrderId", ConfigurationSource.Convention)!.Metadata;
             var result = ((IMutableEntityType)entityBuilder.Metadata).AddIndex(property);
 
             Assert.Equal(!useScope, result == null);
@@ -2949,7 +2955,7 @@ public class ConventionDispatcherTest
             Assert.Empty(convention1.Calls);
             Assert.Empty(convention2.Calls);
             Assert.Empty(convention3.Calls);
-            scope.Dispose();
+            scope!.Dispose();
         }
 
         Assert.Equal(new[] { "OrderId" }, convention1.Calls);
@@ -2964,7 +2970,7 @@ public class ConventionDispatcherTest
     private class IndexAddedConvention(bool terminate) : IIndexAddedConvention
     {
         private readonly bool _terminate = terminate;
-        public readonly List<object> Calls = [];
+        public readonly List<object?> Calls = [];
 
         public void ProcessIndexAdded(IConventionIndexBuilder indexBuilder, IConventionContext<IConventionIndexBuilder> context)
         {
@@ -2994,9 +3000,9 @@ public class ConventionDispatcherTest
         conventions.Add(convention3);
 
         var builder = new InternalModelBuilder(new Model(conventions));
-        var entityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention);
+        var entityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention)!;
         var index = entityBuilder.HasIndex(
-            new List<string> { "OrderId" }, ConfigurationSource.Convention).Metadata;
+            new List<string> { "OrderId" }, ConfigurationSource.Convention)!.Metadata;
 
         var scope = useScope ? builder.Metadata.ConventionDispatcher.DelayConventions() : null;
 
@@ -3015,7 +3021,7 @@ public class ConventionDispatcherTest
             Assert.Empty(convention1.Calls);
             Assert.Empty(convention2.Calls);
             Assert.Empty(convention3.Calls);
-            scope.Dispose();
+            scope!.Dispose();
         }
 
         Assert.Equal(new[] { "OrderId" }, convention1.Calls);
@@ -3061,9 +3067,9 @@ public class ConventionDispatcherTest
         conventions.Add(convention3);
 
         var builder = new InternalModelBuilder(new Model(conventions));
-        var entityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention);
+        var entityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention)!;
         var index = entityBuilder.HasIndex(
-            new List<string> { "OrderId" }, ConfigurationSource.Convention).Metadata;
+            new List<string> { "OrderId" }, ConfigurationSource.Convention)!.Metadata;
 
         var scope = useScope ? builder.Metadata.ConventionDispatcher.DelayConventions() : null;
 
@@ -3080,7 +3086,7 @@ public class ConventionDispatcherTest
         {
             Assert.Empty(convention1.Calls);
             Assert.Empty(convention2.Calls);
-            scope.Dispose();
+            scope!.Dispose();
         }
 
         Assert.Equal(new[] { true }, convention1.Calls);
@@ -3140,7 +3146,6 @@ public class ConventionDispatcherTest
         }
     }
 
-#nullable enable
     [InlineData(false, false), InlineData(true, false), InlineData(false, true), InlineData(true, true), Theory]
     public void OnIndexSortOrderChanged_calls_conventions_in_order(bool useBuilder, bool useScope)
     {
@@ -3231,8 +3236,6 @@ public class ConventionDispatcherTest
             }
         }
     }
-#nullable restore
-
     [InlineData(false, false), InlineData(true, false), InlineData(false, true), InlineData(true, true), Theory]
     public void OnIndexAnnotationChanged_calls_conventions_in_order(bool useBuilder, bool useScope)
     {
@@ -3246,8 +3249,8 @@ public class ConventionDispatcherTest
         conventions.Add(convention3);
 
         var builder = new InternalModelBuilder(new Model(conventions));
-        var indexBuilder = builder.Entity(typeof(SpecialOrder), ConfigurationSource.Convention)
-            .HasIndex([nameof(SpecialOrder.Name)], ConfigurationSource.Convention);
+        var indexBuilder = builder.Entity(typeof(SpecialOrder), ConfigurationSource.Convention)!
+            .HasIndex([nameof(SpecialOrder.Name)], ConfigurationSource.Convention)!;
 
         var scope = useScope ? builder.Metadata.ConventionDispatcher.DelayConventions() : null;
 
@@ -3264,7 +3267,7 @@ public class ConventionDispatcherTest
         {
             Assert.Empty(convention1.Calls);
             Assert.Empty(convention2.Calls);
-            scope.Dispose();
+            scope!.Dispose();
         }
 
         Assert.Equal(new[] { "bar" }, convention1.Calls);
@@ -3309,13 +3312,13 @@ public class ConventionDispatcherTest
     private class IndexAnnotationChangedConvention(bool terminate) : IIndexAnnotationChangedConvention
     {
         private readonly bool _terminate = terminate;
-        public readonly List<object> Calls = [];
+        public readonly List<object?> Calls = [];
 
         public void ProcessIndexAnnotationChanged(
             IConventionIndexBuilder indexBuilder,
             string name,
-            IConventionAnnotation annotation,
-            IConventionAnnotation oldAnnotation,
+            IConventionAnnotation? annotation,
+            IConventionAnnotation? oldAnnotation,
             IConventionContext<IConventionAnnotation> context)
         {
             Assert.NotNull(indexBuilder.Metadata.Builder);
@@ -3342,7 +3345,7 @@ public class ConventionDispatcherTest
         conventions.Add(convention3);
 
         var builder = new InternalModelBuilder(new Model(conventions));
-        var entityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention);
+        var entityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention)!;
         var shadowPropertyName = "ShadowProperty";
 
         var scope = useScope ? builder.Metadata.ConventionDispatcher.DelayConventions() : null;
@@ -3365,7 +3368,7 @@ public class ConventionDispatcherTest
         {
             Assert.Empty(convention1.Calls);
             Assert.Empty(convention2.Calls);
-            scope.Dispose();
+            scope!.Dispose();
         }
 
         Assert.Equal(new[] { shadowPropertyName }, convention1.Calls);
@@ -3391,7 +3394,7 @@ public class ConventionDispatcherTest
         {
             Assert.Equal(new[] { shadowPropertyName }, convention1.Calls);
             Assert.Equal(new[] { shadowPropertyName }, convention2.Calls);
-            scope.Dispose();
+            scope!.Dispose();
         }
 
         Assert.Equal(new[] { shadowPropertyName, nameof(Order.OrderId) }, convention1.Calls);
@@ -3408,7 +3411,7 @@ public class ConventionDispatcherTest
     private class PropertyAddedConvention(bool terminate) : IPropertyAddedConvention
     {
         private readonly bool _terminate = terminate;
-        public readonly List<object> Calls = [];
+        public readonly List<string?> Calls = [];
 
         public void ProcessPropertyAdded(
             IConventionPropertyBuilder propertyBuilder,
@@ -3442,8 +3445,8 @@ public class ConventionDispatcherTest
 
         var scope = useScope ? model.DelayConventions() : null;
 
-        var propertyBuilder = model.Builder.Entity(typeof(Order), ConfigurationSource.Convention)
-            .Property(typeof(string), "Name", ConfigurationSource.Convention);
+        var propertyBuilder = model.Builder.Entity(typeof(Order), ConfigurationSource.Convention)!
+            .Property(typeof(string), "Name", ConfigurationSource.Convention)!;
         if (useBuilder)
         {
             propertyBuilder.IsRequired(true, ConfigurationSource.Convention);
@@ -3573,8 +3576,8 @@ public class ConventionDispatcherTest
 
         var scope = useScope ? model.DelayConventions() : null;
 
-        var propertyBuilder = model.Builder.Entity(typeof(Order), ConfigurationSource.Convention)
-            .Property(typeof(string), "Name", ConfigurationSource.Convention);
+        var propertyBuilder = model.Builder.Entity(typeof(Order), ConfigurationSource.Convention)!
+            .Property(typeof(string), "Name", ConfigurationSource.Convention)!;
         if (useBuilder)
         {
             propertyBuilder.IsAutoLoaded(false, ConfigurationSource.Convention);
@@ -3701,8 +3704,8 @@ public class ConventionDispatcherTest
         conventions.Add(convention3);
 
         var builder = new InternalModelBuilder(new Model(conventions));
-        var entityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention);
-        var propertyBuilder = entityBuilder.Property(Order.OrderIdProperty, ConfigurationSource.Convention);
+        var entityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention)!;
+        var propertyBuilder = entityBuilder.Property(Order.OrderIdProperty, ConfigurationSource.Convention)!;
 
         var scope = useScope ? builder.Metadata.ConventionDispatcher.DelayConventions() : null;
 
@@ -3721,11 +3724,11 @@ public class ConventionDispatcherTest
         {
             Assert.Empty(convention1.Calls);
             Assert.Empty(convention2.Calls);
-            scope.Dispose();
+            scope!.Dispose();
         }
 
-        Assert.Equal(new string[] { null }, convention1.Calls);
-        Assert.Equal(new string[] { null }, convention2.Calls);
+        Assert.Equal(new string?[] { null }, convention1.Calls);
+        Assert.Equal(new string?[] { null }, convention2.Calls);
         Assert.Empty(convention3.Calls);
 
         if (useBuilder)
@@ -3739,13 +3742,13 @@ public class ConventionDispatcherTest
                 ConfigurationSource.Convention);
         }
 
-        Assert.Equal(new string[] { null }, convention1.Calls);
-        Assert.Equal(new string[] { null }, convention2.Calls);
+        Assert.Equal(new string?[] { null }, convention1.Calls);
+        Assert.Equal(new string?[] { null }, convention2.Calls);
         Assert.Empty(convention3.Calls);
 
         if (useBuilder)
         {
-            Assert.NotNull(propertyBuilder.HasField((string)null, ConfigurationSource.Convention));
+            Assert.NotNull(propertyBuilder.HasField((string?)null, ConfigurationSource.Convention));
         }
         else
         {
@@ -3766,12 +3769,12 @@ public class ConventionDispatcherTest
     private class PropertyFieldChangedConvention(bool terminate) : IPropertyFieldChangedConvention
     {
         private readonly bool _terminate = terminate;
-        public readonly List<object> Calls = [];
+        public readonly List<object?> Calls = [];
 
         public void ProcessPropertyFieldChanged(
             IConventionPropertyBuilder propertyBuilder,
-            FieldInfo newFieldInfo,
-            FieldInfo oldFieldInfo,
+            FieldInfo? newFieldInfo,
+            FieldInfo? oldFieldInfo,
             IConventionContext<FieldInfo> context)
         {
             Assert.True(propertyBuilder.Metadata.IsInModel);
@@ -3798,8 +3801,8 @@ public class ConventionDispatcherTest
         conventions.Add(convention3);
 
         var builder = new InternalModelBuilder(new Model(conventions));
-        var propertyBuilder = builder.Entity(typeof(SpecialOrder), ConfigurationSource.Convention)
-            .Property(nameof(SpecialOrder.Name), ConfigurationSource.Convention);
+        var propertyBuilder = builder.Entity(typeof(SpecialOrder), ConfigurationSource.Convention)!
+            .Property(nameof(SpecialOrder.Name), ConfigurationSource.Convention)!;
 
         var scope = useScope ? builder.Metadata.ConventionDispatcher.DelayConventions() : null;
 
@@ -3816,7 +3819,7 @@ public class ConventionDispatcherTest
         {
             Assert.Empty(convention1.Calls);
             Assert.Empty(convention2.Calls);
-            scope.Dispose();
+            scope!.Dispose();
         }
 
         Assert.Equal(new[] { "bar" }, convention1.Calls);
@@ -3861,13 +3864,13 @@ public class ConventionDispatcherTest
     private class PropertyAnnotationChangedConvention(bool terminate) : IPropertyAnnotationChangedConvention
     {
         private readonly bool _terminate = terminate;
-        public readonly List<object> Calls = [];
+        public readonly List<object?> Calls = [];
 
         public void ProcessPropertyAnnotationChanged(
             IConventionPropertyBuilder propertyBuilder,
             string name,
-            IConventionAnnotation annotation,
-            IConventionAnnotation oldAnnotation,
+            IConventionAnnotation? annotation,
+            IConventionAnnotation? oldAnnotation,
             IConventionContext<IConventionAnnotation> context)
         {
             Assert.True(propertyBuilder.Metadata.IsInModel);
@@ -3894,10 +3897,10 @@ public class ConventionDispatcherTest
         conventions.Add(convention3);
 
         var builder = new InternalModelBuilder(new Model(conventions));
-        var entityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention);
+        var entityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention)!;
         var shadowPropertyName = "ShadowProperty";
         var property = entityBuilder.Metadata.AddProperty(
-            shadowPropertyName, typeof(int), ConfigurationSource.Convention, ConfigurationSource.Convention);
+            shadowPropertyName, typeof(int), ConfigurationSource.Convention, ConfigurationSource.Convention)!;
 
         var scope = useScope ? builder.Metadata.ConventionDispatcher.DelayConventions() : null;
 
@@ -3916,7 +3919,7 @@ public class ConventionDispatcherTest
         {
             Assert.Empty(convention1.Calls);
             Assert.Empty(convention2.Calls);
-            scope.Dispose();
+            scope!.Dispose();
         }
 
         Assert.Equal(new[] { property }, convention1.Calls);
@@ -3962,9 +3965,9 @@ public class ConventionDispatcherTest
         conventions.Add(convention3);
 
         var builder = new InternalModelBuilder(new Model(conventions));
-        var entityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention);
+        var entityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention)!;
         var complexBuilder = entityBuilder.ComplexProperty(
-                Order.OrderDetailsProperty, complexTypeName: null, collection: false, ConfigurationSource.Convention)
+            Order.OrderDetailsProperty, complexTypeName: null, collection: false, ConfigurationSource.Convention)!
             .ComplexTypeBuilder;
         var shadowPropertyName = "ShadowProperty";
 
@@ -3989,7 +3992,7 @@ public class ConventionDispatcherTest
             Assert.Empty(convention1.Calls);
             Assert.Empty(convention2.Calls);
             Assert.Empty(convention3.Calls);
-            scope.Dispose();
+            scope!.Dispose();
         }
 
         Assert.Equal(new[] { shadowPropertyName }, convention1.Calls);
@@ -4016,7 +4019,7 @@ public class ConventionDispatcherTest
             Assert.Equal(new[] { shadowPropertyName }, convention1.Calls);
             Assert.Equal(new[] { shadowPropertyName }, convention2.Calls);
             Assert.Empty(convention3.Calls);
-            scope.Dispose();
+            scope!.Dispose();
         }
 
         Assert.Equal(new[] { shadowPropertyName, nameof(OrderDetails.Id) }, convention1.Calls);
@@ -4042,10 +4045,10 @@ public class ConventionDispatcherTest
 
         var scope = useScope ? model.DelayConventions() : null;
 
-        var propertyBuilder = model.Builder.Entity(typeof(Order), ConfigurationSource.Convention)
-            .ComplexProperty(Order.OrderDetailsProperty, complexTypeName: null, collection: false, ConfigurationSource.Convention)
+        var propertyBuilder = model.Builder.Entity(typeof(Order), ConfigurationSource.Convention)!
+            .ComplexProperty(Order.OrderDetailsProperty, complexTypeName: null, collection: false, ConfigurationSource.Convention)!
             .ComplexTypeBuilder
-            .Property(typeof(string), "Name", ConfigurationSource.Convention);
+            .Property(typeof(string), "Name", ConfigurationSource.Convention)!;
         if (useBuilder)
         {
             propertyBuilder.IsRequired(true, ConfigurationSource.Convention);
@@ -4150,11 +4153,11 @@ public class ConventionDispatcherTest
         conventions.Add(convention3);
 
         var builder = new InternalModelBuilder(new Model(conventions));
-        var entityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention);
+        var entityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention)!;
         var propertyBuilder = entityBuilder
-            .ComplexProperty(Order.OrderDetailsProperty, complexTypeName: null, collection: false, ConfigurationSource.Convention)
+            .ComplexProperty(Order.OrderDetailsProperty, complexTypeName: null, collection: false, ConfigurationSource.Convention)!
             .ComplexTypeBuilder
-            .Property(nameof(OrderDetails.Id), ConfigurationSource.Convention);
+            .Property(nameof(OrderDetails.Id), ConfigurationSource.Convention)!;
 
         var scope = useScope ? builder.Metadata.ConventionDispatcher.DelayConventions() : null;
 
@@ -4173,11 +4176,11 @@ public class ConventionDispatcherTest
         {
             Assert.Empty(convention1.Calls);
             Assert.Empty(convention2.Calls);
-            scope.Dispose();
+            scope!.Dispose();
         }
 
-        Assert.Equal(new string[] { null }, convention1.Calls);
-        Assert.Equal(new string[] { null }, convention2.Calls);
+        Assert.Equal(new string?[] { null }, convention1.Calls);
+        Assert.Equal(new string?[] { null }, convention2.Calls);
         Assert.Empty(convention3.Calls);
 
         if (useBuilder)
@@ -4191,13 +4194,13 @@ public class ConventionDispatcherTest
                 ConfigurationSource.Convention);
         }
 
-        Assert.Equal(new string[] { null }, convention1.Calls);
-        Assert.Equal(new string[] { null }, convention2.Calls);
+        Assert.Equal(new string?[] { null }, convention1.Calls);
+        Assert.Equal(new string?[] { null }, convention2.Calls);
         Assert.Empty(convention3.Calls);
 
         if (useBuilder)
         {
-            Assert.NotNull(propertyBuilder.HasField((string)null, ConfigurationSource.Convention));
+            Assert.NotNull(propertyBuilder.HasField((string?)null, ConfigurationSource.Convention));
         }
         else
         {
@@ -4224,10 +4227,10 @@ public class ConventionDispatcherTest
         conventions.Add(convention3);
 
         var builder = new InternalModelBuilder(new Model(conventions));
-        var propertyBuilder = builder.Entity(typeof(SpecialOrder), ConfigurationSource.Convention)
-            .ComplexProperty(Order.OrderDetailsProperty, complexTypeName: null, collection: false, ConfigurationSource.Convention)
+        var propertyBuilder = builder.Entity(typeof(SpecialOrder), ConfigurationSource.Convention)!
+            .ComplexProperty(Order.OrderDetailsProperty, complexTypeName: null, collection: false, ConfigurationSource.Convention)!
             .ComplexTypeBuilder
-            .Property(nameof(OrderDetails.Id), ConfigurationSource.Convention);
+            .Property(nameof(OrderDetails.Id), ConfigurationSource.Convention)!;
 
         var scope = useScope ? builder.Metadata.ConventionDispatcher.DelayConventions() : null;
 
@@ -4244,7 +4247,7 @@ public class ConventionDispatcherTest
         {
             Assert.Empty(convention1.Calls);
             Assert.Empty(convention2.Calls);
-            scope.Dispose();
+            scope!.Dispose();
         }
 
         Assert.Equal(new[] { "bar" }, convention1.Calls);
@@ -4295,12 +4298,12 @@ public class ConventionDispatcherTest
         conventions.Add(convention3);
 
         var builder = new InternalModelBuilder(new Model(conventions));
-        var entityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention);
+        var entityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention)!;
         var shadowPropertyName = "ShadowProperty";
         var property = entityBuilder
-            .ComplexProperty(Order.OrderDetailsProperty, complexTypeName: null, collection: false, ConfigurationSource.Convention)
+            .ComplexProperty(Order.OrderDetailsProperty, complexTypeName: null, collection: false, ConfigurationSource.Convention)!
             .ComplexTypeBuilder.Metadata.AddProperty(
-                shadowPropertyName, typeof(int), ConfigurationSource.Convention, ConfigurationSource.Convention);
+                shadowPropertyName, typeof(int), ConfigurationSource.Convention, ConfigurationSource.Convention)!;
 
         var scope = useScope ? builder.Metadata.ConventionDispatcher.DelayConventions() : null;
 
@@ -4319,7 +4322,7 @@ public class ConventionDispatcherTest
         {
             Assert.Empty(convention1.Calls);
             Assert.Empty(convention2.Calls);
-            scope.Dispose();
+            scope!.Dispose();
         }
 
         Assert.Equal(new[] { property }, convention1.Calls);
@@ -4340,7 +4343,7 @@ public class ConventionDispatcherTest
         conventions.Add(convention3);
 
         var builder = new InternalModelBuilder(new Model(conventions));
-        var entityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention);
+        var entityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention)!;
 
         var scope = useScope ? builder.Metadata.ConventionDispatcher.DelayConventions() : null;
 
@@ -4363,7 +4366,7 @@ public class ConventionDispatcherTest
         {
             Assert.Empty(convention1.Calls);
             Assert.Empty(convention2.Calls);
-            scope.Dispose();
+            scope!.Dispose();
         }
 
         Assert.Equal(new[] { Order.OrderDetailsProperty.Name }, convention1.Calls);
@@ -4392,7 +4395,7 @@ public class ConventionDispatcherTest
             Assert.Equal(new[] { Order.OrderDetailsProperty.Name }, convention1.Calls);
             Assert.Equal(new[] { Order.OrderDetailsProperty.Name }, convention2.Calls);
             Assert.Empty(convention3.Calls);
-            scope.Dispose();
+            scope!.Dispose();
         }
 
         Assert.Equal(new[] { Order.OrderDetailsProperty.Name, Order.OtherOrderDetailsProperty.Name }, convention1.Calls);
@@ -4443,8 +4446,8 @@ public class ConventionDispatcherTest
 
         var scope = useScope ? model.DelayConventions() : null;
 
-        var propertyBuilder = model.Builder.Entity(typeof(Order), ConfigurationSource.Convention)
-            .ComplexProperty(Order.OrderDetailsProperty, complexTypeName: null, collection: false, ConfigurationSource.Convention);
+        var propertyBuilder = model.Builder.Entity(typeof(Order), ConfigurationSource.Convention)!
+            .ComplexProperty(Order.OrderDetailsProperty, complexTypeName: null, collection: false, ConfigurationSource.Convention)!;
         if (useBuilder)
         {
             Assert.NotNull(propertyBuilder.IsRequired(true, ConfigurationSource.Convention));
@@ -4571,9 +4574,9 @@ public class ConventionDispatcherTest
         conventions.Add(convention3);
 
         var builder = new InternalModelBuilder(new Model(conventions));
-        var entityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention);
+        var entityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention)!;
         var propertyBuilder = entityBuilder
-            .ComplexProperty(Order.OrderDetailsProperty, complexTypeName: null, collection: false, ConfigurationSource.Convention);
+            .ComplexProperty(Order.OrderDetailsProperty, complexTypeName: null, collection: false, ConfigurationSource.Convention)!;
 
         var scope = useScope ? builder.Metadata.ConventionDispatcher.DelayConventions() : null;
 
@@ -4592,11 +4595,11 @@ public class ConventionDispatcherTest
         {
             Assert.Empty(convention1.Calls);
             Assert.Empty(convention2.Calls);
-            scope.Dispose();
+            scope!.Dispose();
         }
 
-        Assert.Equal(new string[] { null }, convention1.Calls);
-        Assert.Equal(new string[] { null }, convention2.Calls);
+        Assert.Equal(new string?[] { null }, convention1.Calls);
+        Assert.Equal(new string?[] { null }, convention2.Calls);
         Assert.Empty(convention3.Calls);
 
         if (useBuilder)
@@ -4610,13 +4613,13 @@ public class ConventionDispatcherTest
                 ConfigurationSource.Convention);
         }
 
-        Assert.Equal(new string[] { null }, convention1.Calls);
-        Assert.Equal(new string[] { null }, convention2.Calls);
+        Assert.Equal(new string?[] { null }, convention1.Calls);
+        Assert.Equal(new string?[] { null }, convention2.Calls);
         Assert.Empty(convention3.Calls);
 
         if (useBuilder)
         {
-            Assert.NotNull(propertyBuilder.HasField((string)null, ConfigurationSource.Convention));
+            Assert.NotNull(propertyBuilder.HasField((string?)null, ConfigurationSource.Convention));
         }
         else
         {
@@ -4637,12 +4640,12 @@ public class ConventionDispatcherTest
     private class ComplexPropertyFieldChangedConvention(bool terminate) : IComplexPropertyFieldChangedConvention
     {
         private readonly bool _terminate = terminate;
-        public readonly List<object> Calls = [];
+        public readonly List<object?> Calls = [];
 
         public void ProcessComplexPropertyFieldChanged(
             IConventionComplexPropertyBuilder propertyBuilder,
-            FieldInfo newFieldInfo,
-            FieldInfo oldFieldInfo,
+            FieldInfo? newFieldInfo,
+            FieldInfo? oldFieldInfo,
             IConventionContext<FieldInfo> context)
         {
             Assert.True(propertyBuilder.Metadata.IsInModel);
@@ -4669,8 +4672,8 @@ public class ConventionDispatcherTest
         conventions.Add(convention3);
 
         var builder = new InternalModelBuilder(new Model(conventions));
-        var propertyBuilder = builder.Entity(typeof(SpecialOrder), ConfigurationSource.Convention)
-            .ComplexProperty(Order.OrderDetailsProperty, complexTypeName: null, collection: false, ConfigurationSource.Convention);
+        var propertyBuilder = builder.Entity(typeof(SpecialOrder), ConfigurationSource.Convention)!
+            .ComplexProperty(Order.OrderDetailsProperty, complexTypeName: null, collection: false, ConfigurationSource.Convention)!;
 
         var scope = useScope ? builder.Metadata.ConventionDispatcher.DelayConventions() : null;
 
@@ -4687,7 +4690,7 @@ public class ConventionDispatcherTest
         {
             Assert.Empty(convention1.Calls);
             Assert.Empty(convention2.Calls);
-            scope.Dispose();
+            scope!.Dispose();
         }
 
         Assert.Equal(new[] { "bar" }, convention1.Calls);
@@ -4732,13 +4735,13 @@ public class ConventionDispatcherTest
     private class ComplexPropertyAnnotationChangedConvention(bool terminate) : IComplexPropertyAnnotationChangedConvention
     {
         private readonly bool _terminate = terminate;
-        public readonly List<object> Calls = [];
+        public readonly List<object?> Calls = [];
 
         public void ProcessComplexPropertyAnnotationChanged(
             IConventionComplexPropertyBuilder propertyBuilder,
             string name,
-            IConventionAnnotation annotation,
-            IConventionAnnotation oldAnnotation,
+            IConventionAnnotation? annotation,
+            IConventionAnnotation? oldAnnotation,
             IConventionContext<IConventionAnnotation> context)
         {
             Assert.True(propertyBuilder.Metadata.IsInModel);
@@ -4765,9 +4768,9 @@ public class ConventionDispatcherTest
         conventions.Add(convention3);
 
         var builder = new InternalModelBuilder(new Model(conventions));
-        var entityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention);
+        var entityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention)!;
         var property = entityBuilder
-            .ComplexProperty(Order.OrderDetailsProperty, complexTypeName: null, collection: false, ConfigurationSource.Convention)
+            .ComplexProperty(Order.OrderDetailsProperty, complexTypeName: null, collection: false, ConfigurationSource.Convention)!
             .Metadata;
 
         var scope = useScope ? builder.Metadata.ConventionDispatcher.DelayConventions() : null;
@@ -4787,7 +4790,7 @@ public class ConventionDispatcherTest
         {
             Assert.Empty(convention1.Calls);
             Assert.Empty(convention2.Calls);
-            scope.Dispose();
+            scope!.Dispose();
         }
 
         Assert.Equal(new[] { property }, convention1.Calls);
@@ -4802,7 +4805,7 @@ public class ConventionDispatcherTest
     private class ComplexPropertyRemovedConvention(bool terminate) : IComplexPropertyRemovedConvention
     {
         private readonly bool _terminate = terminate;
-        public readonly List<object> Calls = [];
+        public readonly List<object?> Calls = [];
 
         public void ProcessComplexPropertyRemoved(
             IConventionTypeBaseBuilder typeBaseBuilder,
@@ -4833,8 +4836,8 @@ public class ConventionDispatcherTest
         conventions.Add(convention3);
 
         var builder = new InternalModelBuilder(new Model(conventions));
-        var typeBuilder = builder.Entity(typeof(SpecialOrder), ConfigurationSource.Convention)
-            .ComplexProperty(Order.OrderDetailsProperty, complexTypeName: null, collection: false, ConfigurationSource.Convention)
+        var typeBuilder = builder.Entity(typeof(SpecialOrder), ConfigurationSource.Convention)!
+            .ComplexProperty(Order.OrderDetailsProperty, complexTypeName: null, collection: false, ConfigurationSource.Convention)!
             .ComplexTypeBuilder;
 
         var scope = useScope ? builder.Metadata.ConventionDispatcher.DelayConventions() : null;
@@ -4852,7 +4855,7 @@ public class ConventionDispatcherTest
         {
             Assert.Empty(convention1.Calls);
             Assert.Empty(convention2.Calls);
-            scope.Dispose();
+            scope!.Dispose();
         }
 
         Assert.Equal(new[] { "bar" }, convention1.Calls);
@@ -4897,13 +4900,13 @@ public class ConventionDispatcherTest
     private class ComplexTypeAnnotationChangedConvention(bool terminate) : IComplexTypeAnnotationChangedConvention
     {
         private readonly bool _terminate = terminate;
-        public readonly List<object> Calls = [];
+        public readonly List<object?> Calls = [];
 
         public void ProcessComplexTypeAnnotationChanged(
             IConventionComplexTypeBuilder propertyBuilder,
             string name,
-            IConventionAnnotation annotation,
-            IConventionAnnotation oldAnnotation,
+            IConventionAnnotation? annotation,
+            IConventionAnnotation? oldAnnotation,
             IConventionContext<IConventionAnnotation> context)
         {
             Assert.True(propertyBuilder.Metadata.IsInModel);
@@ -4930,9 +4933,9 @@ public class ConventionDispatcherTest
         conventions.Add(convention3);
 
         var builder = new InternalModelBuilder(new Model(conventions));
-        var entityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention);
+        var entityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention)!;
         var complexBuilder = entityBuilder.ComplexProperty(
-                Order.OrderDetailsProperty, complexTypeName: null, collection: false, ConfigurationSource.Convention)
+            Order.OrderDetailsProperty, complexTypeName: null, collection: false, ConfigurationSource.Convention)!
             .ComplexTypeBuilder;
         var shadowPropertyName = "ShadowProperty";
 
@@ -4955,7 +4958,7 @@ public class ConventionDispatcherTest
         {
             Assert.Empty(convention1.Calls);
             Assert.Empty(convention2.Calls);
-            scope.Dispose();
+            scope!.Dispose();
         }
 
         Assert.Equal(new[] { shadowPropertyName }, convention1.Calls);
@@ -4982,7 +4985,7 @@ public class ConventionDispatcherTest
         Assert.Empty(convention3.Calls);
         if (useScope)
         {
-            scope.Dispose();
+            scope!.Dispose();
         }
 
         Assert.Empty(entityBuilder.Metadata.GetIgnoredMembers());
@@ -4995,7 +4998,7 @@ public class ConventionDispatcherTest
     private class ComplexTypeMemberIgnoredConvention(bool terminate) : IComplexTypeMemberIgnoredConvention
     {
         private readonly bool _terminate = terminate;
-        public readonly List<object> Calls = [];
+        public readonly List<object?> Calls = [];
 
         public void ProcessComplexTypeMemberIgnored(
             IConventionComplexTypeBuilder complexTypeBuilder,
@@ -5045,7 +5048,7 @@ public class ConventionDispatcherTest
         {
             Assert.Empty(convention1.Calls);
             Assert.Empty(convention2.Calls);
-            scope.Dispose();
+            scope!.Dispose();
         }
 
         Assert.Equal(new[] { "bar" }, convention1.Calls);
@@ -5090,13 +5093,13 @@ public class ConventionDispatcherTest
     private class ElementTypeAnnotationChangedConvention(bool terminate) : IElementTypeAnnotationChangedConvention
     {
         private readonly bool _terminate = terminate;
-        public readonly List<object> Calls = [];
+        public readonly List<object?> Calls = [];
 
         public void ProcessElementTypeAnnotationChanged(
             IConventionElementTypeBuilder builder,
             string name,
-            IConventionAnnotation annotation,
-            IConventionAnnotation oldAnnotation,
+            IConventionAnnotation? annotation,
+            IConventionAnnotation? oldAnnotation,
             IConventionContext<IConventionAnnotation> context)
         {
             Assert.True(builder.Metadata.IsInModel);
@@ -5260,52 +5263,52 @@ public class ConventionDispatcherTest
 
     private class Order
     {
-        public static readonly PropertyInfo OrderIdProperty = typeof(Order).GetProperty(nameof(OrderId));
-        public static readonly PropertyInfo OrderIdsProperty = typeof(Order).GetProperty(nameof(OrderIds));
-        public static readonly PropertyInfo OrderDetailsProperty = typeof(Order).GetProperty(nameof(OrderDetails));
-        public static readonly PropertyInfo OtherOrderDetailsProperty = typeof(Order).GetProperty(nameof(OtherOrderDetails));
+        public static readonly PropertyInfo OrderIdProperty = typeof(Order).GetProperty(nameof(OrderId))!;
+        public static readonly PropertyInfo OrderIdsProperty = typeof(Order).GetProperty(nameof(OrderIds))!;
+        public static readonly PropertyInfo OrderDetailsProperty = typeof(Order).GetProperty(nameof(OrderDetails))!;
+        public static readonly PropertyInfo OtherOrderDetailsProperty = typeof(Order).GetProperty(nameof(OtherOrderDetails))!;
 
         public readonly int IntField = 1;
 
         // ReSharper disable once RedundantDefaultMemberInitializer
-        public readonly OrderDetails OrderDetailsField = default;
+        public readonly OrderDetails OrderDetailsField = null!;
 
         public int OrderId { get; set; }
-        public int[] OrderIds { get; set; }
-        public string[] Notes { get; set; }
+        public int[] OrderIds { get; set; } = null!;
+        public string[] Notes { get; set; } = null!;
 
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
 
-        public virtual OrderDetails OrderDetails { get; set; }
-        public virtual OrderDetails OtherOrderDetails { get; set; }
-        public virtual ICollection<Product> Products { get; set; }
+        public virtual OrderDetails OrderDetails { get; set; } = null!;
+        public virtual OrderDetails OtherOrderDetails { get; set; } = null!;
+        public virtual ICollection<Product> Products { get; set; } = null!;
     }
 
     private class SpecialOrder : Order;
 
     private class OrderDetails
     {
-        public static readonly PropertyInfo OrderProperty = typeof(OrderDetails).GetProperty(nameof(Order));
+        public static readonly PropertyInfo OrderProperty = typeof(OrderDetails).GetProperty(nameof(Order))!;
         public readonly int IntField = 1;
 
         public int Id { get; set; }
-        public virtual Order Order { get; set; }
+        public virtual Order Order { get; set; } = null!;
     }
 
     private class OrderProduct
     {
-        public static readonly PropertyInfo OrderIdProperty = typeof(OrderProduct).GetProperty(nameof(OrderId));
-        public static readonly PropertyInfo ProductIdProperty = typeof(OrderProduct).GetProperty(nameof(ProductId));
+        public static readonly PropertyInfo OrderIdProperty = typeof(OrderProduct).GetProperty(nameof(OrderId))!;
+        public static readonly PropertyInfo ProductIdProperty = typeof(OrderProduct).GetProperty(nameof(ProductId))!;
 
         public int OrderId { get; set; }
         public int ProductId { get; set; }
-        public virtual Order Order { get; set; }
-        public virtual Product Product { get; set; }
+        public virtual Order Order { get; set; } = null!;
+        public virtual Product Product { get; set; } = null!;
     }
 
     private class Product
     {
         public int Id { get; set; }
-        public virtual ICollection<Order> Orders { get; set; }
+        public virtual ICollection<Order> Orders { get; set; } = null!;
     }
 }

--- a/test/EFCore.Tests/Metadata/Conventions/ConventionSetBuilderTests.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/ConventionSetBuilderTests.cs
@@ -111,6 +111,6 @@ public class ConventionSetBuilderTests
     protected class Product
     {
         public virtual int Id { get; set; }
-        public virtual string Name { get; set; }
+        public virtual string Name { get; set; } = null!;
     }
 }

--- a/test/EFCore.Tests/Metadata/Conventions/DeleteBehaviorAttributeConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/DeleteBehaviorAttributeConventionTest.cs
@@ -178,14 +178,14 @@ public class DeleteBehaviorAttributeConventionTest
     {
         public int Id { get; set; }
 
-        public ICollection<Post> Posts { get; set; }
+        public ICollection<Post> Posts { get; set; } = null!;
     }
 
     private class Post
     {
         public int Id { get; set; }
 
-        public Blog Blog { get; set; }
+        public Blog Blog { get; set; } = null!;
 
         public int? BlogId { get; set; }
     }
@@ -198,7 +198,7 @@ public class DeleteBehaviorAttributeConventionTest
     {
         public int Id { get; set; }
 
-        public ICollection<Post_Restrict> Posts { get; set; }
+        public ICollection<Post_Restrict> Posts { get; set; } = null!;
     }
 
     private class Post_Restrict
@@ -206,7 +206,7 @@ public class DeleteBehaviorAttributeConventionTest
         public int Id { get; set; }
 
         [DeleteBehavior(DeleteBehavior.Restrict)]
-        public Blog_Restrict Blog_Restrict { get; set; }
+        public Blog_Restrict Blog_Restrict { get; set; } = null!;
 
         public int? BlogId { get; set; }
     }
@@ -219,7 +219,7 @@ public class DeleteBehaviorAttributeConventionTest
     {
         public int Id { get; set; }
 
-        public ICollection<Post_SetDefault> Posts { get; set; }
+        public ICollection<Post_SetDefault> Posts { get; set; } = null!;
     }
 
     private class Post_SetDefault
@@ -227,7 +227,7 @@ public class DeleteBehaviorAttributeConventionTest
         public int Id { get; set; }
 
         [DeleteBehavior(DeleteBehavior.SetDefault)]
-        public Blog_SetDefault Blog_SetDefault { get; set; }
+        public Blog_SetDefault Blog_SetDefault { get; set; } = null!;
 
         public int? BlogId { get; set; }
     }
@@ -240,7 +240,7 @@ public class DeleteBehaviorAttributeConventionTest
     {
         public int Id { get; set; }
 
-        public ICollection<Post_ClientSetDefault> Posts { get; set; }
+        public ICollection<Post_ClientSetDefault> Posts { get; set; } = null!;
     }
 
     private class Post_ClientSetDefault
@@ -248,7 +248,7 @@ public class DeleteBehaviorAttributeConventionTest
         public int Id { get; set; }
 
         [DeleteBehavior(DeleteBehavior.ClientSetDefault)]
-        public Blog_ClientSetDefault Blog_ClientSetDefault { get; set; }
+        public Blog_ClientSetDefault Blog_ClientSetDefault { get; set; } = null!;
 
         public int? BlogId { get; set; }
     }
@@ -265,7 +265,7 @@ public class DeleteBehaviorAttributeConventionTest
         [Key, Column(Order = 1)]
         public int Id2 { get; set; }
 
-        public ICollection<Post_Compound> Posts { get; set; }
+        public ICollection<Post_Compound> Posts { get; set; } = null!;
     }
 
     private class Post_Compound
@@ -273,7 +273,7 @@ public class DeleteBehaviorAttributeConventionTest
         public int Id { get; set; }
 
         [ForeignKey("BlogId, BlogId2"), DeleteBehavior(DeleteBehavior.Cascade)]
-        public Blog_Compound Blog_Compound { get; set; }
+        public Blog_Compound Blog_Compound { get; set; } = null!;
 
         [Column(Order = 0)]
         public int? BlogId { get; set; }
@@ -290,14 +290,14 @@ public class DeleteBehaviorAttributeConventionTest
     {
         public int Id { get; set; }
 
-        public ICollection<Post_Both> Posts { get; set; }
+        public ICollection<Post_Both> Posts { get; set; } = null!;
     }
 
     private class Blog_Two
     {
         public int Id { get; set; }
 
-        public ICollection<Post_Both> Posts { get; set; }
+        public ICollection<Post_Both> Posts { get; set; } = null!;
     }
 
     private class Post_Both
@@ -305,10 +305,10 @@ public class DeleteBehaviorAttributeConventionTest
         public int Id { get; set; }
 
         [DeleteBehavior(DeleteBehavior.Restrict)]
-        public Blog_One Blog_One { get; set; }
+        public Blog_One Blog_One { get; set; } = null!;
 
         [DeleteBehavior(DeleteBehavior.Cascade)]
-        public Blog_Two Blog_Two { get; set; }
+        public Blog_Two Blog_Two { get; set; } = null!;
 
         public int? Blog_OneId { get; set; }
 
@@ -323,14 +323,14 @@ public class DeleteBehaviorAttributeConventionTest
     {
         public int Id { get; set; }
 
-        public ICollection<Post_On_FK_Property> Posts { get; set; }
+        public ICollection<Post_On_FK_Property> Posts { get; set; } = null!;
     }
 
     private class Post_On_FK_Property
     {
         public int Id { get; set; }
 
-        public Blog_On_FK_Property Blog_On_FK_Property { get; set; }
+        public Blog_On_FK_Property Blog_On_FK_Property { get; set; } = null!;
 
         [DeleteBehavior(DeleteBehavior.Restrict)]
         public int? Blog_On_FK_PropertyId { get; set; }
@@ -344,7 +344,7 @@ public class DeleteBehaviorAttributeConventionTest
     {
         public int Id { get; set; }
 
-        public ICollection<Post_On_Property> Posts { get; set; }
+        public ICollection<Post_On_Property> Posts { get; set; } = null!;
     }
 
     private class Post_On_Property
@@ -352,7 +352,7 @@ public class DeleteBehaviorAttributeConventionTest
         [DeleteBehavior(DeleteBehavior.Restrict)]
         public int Id { get; set; }
 
-        public Blog_On_Property Blog_On_Property { get; set; }
+        public Blog_On_Property Blog_On_Property { get; set; } = null!;
 
         public int? Blog_On_PropertyId { get; set; }
     }
@@ -366,14 +366,14 @@ public class DeleteBehaviorAttributeConventionTest
         public int Id { get; set; }
 
         [DeleteBehavior(DeleteBehavior.Restrict)]
-        public ICollection<Post_On_Principal> Posts { get; set; }
+        public ICollection<Post_On_Principal> Posts { get; set; } = null!;
     }
 
     private class Post_On_Principal
     {
         public int Id { get; set; }
 
-        public Blog_On_Principal Blog_On_Principal { get; set; }
+        public Blog_On_Principal Blog_On_Principal { get; set; } = null!;
 
         public int? Blog_On_PrincipalId { get; set; }
     }
@@ -387,14 +387,14 @@ public class DeleteBehaviorAttributeConventionTest
         public int Id { get; set; }
 
         [DeleteBehavior(DeleteBehavior.Restrict)]
-        public Post_On_Principal_OneToOne Post_On_Principal_OneToOne { get; set; }
+        public Post_On_Principal_OneToOne Post_On_Principal_OneToOne { get; set; } = null!;
     }
 
     private class Post_On_Principal_OneToOne
     {
         public int Id { get; set; }
 
-        public Blog_On_Principal_OneToOne Blog_On_Principal_OneToOne { get; set; }
+        public Blog_On_Principal_OneToOne Blog_On_Principal_OneToOne { get; set; } = null!;
 
         public int? Blog_On_PrincipalId { get; set; }
     }

--- a/test/EFCore.Tests/Metadata/Conventions/DerivedTypeDiscoveryConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/DerivedTypeDiscoveryConventionTest.cs
@@ -17,13 +17,13 @@ public class DerivedTypeDiscoveryConventionTest
 
         Assert.Null(entityBuilderC.Metadata.BaseType);
 
-        var entityBuilderA = entityBuilderC.ModelBuilder.Entity(typeof(A), ConfigurationSource.Explicit);
+        var entityBuilderA = entityBuilderC.ModelBuilder.Entity(typeof(A), ConfigurationSource.Explicit)!;
 
         RunConvention(entityBuilderA);
 
         Assert.Same(entityBuilderA.Metadata, entityBuilderC.Metadata.BaseType);
 
-        var entityBuilderB = entityBuilderC.ModelBuilder.Entity(typeof(B), ConfigurationSource.Explicit);
+        var entityBuilderB = entityBuilderC.ModelBuilder.Entity(typeof(B), ConfigurationSource.Explicit)!;
         Assert.Null(entityBuilderB.Metadata.BaseType);
 
         RunConvention(entityBuilderB);
@@ -39,7 +39,7 @@ public class DerivedTypeDiscoveryConventionTest
 
         RunConvention(entityBuilderB);
 
-        var entityBuilderC = entityBuilderB.ModelBuilder.Entity(typeof(C), ConfigurationSource.Explicit);
+        var entityBuilderC = entityBuilderB.ModelBuilder.Entity(typeof(C), ConfigurationSource.Explicit)!;
 
         Assert.Null(entityBuilderC.Metadata.BaseType);
 
@@ -47,7 +47,7 @@ public class DerivedTypeDiscoveryConventionTest
 
         Assert.Same(entityBuilderB.Metadata, entityBuilderC.Metadata.BaseType);
 
-        var entityBuilderA = entityBuilderB.ModelBuilder.Entity(typeof(A), ConfigurationSource.Explicit);
+        var entityBuilderA = entityBuilderB.ModelBuilder.Entity(typeof(A), ConfigurationSource.Explicit)!;
 
         RunConvention(entityBuilderA);
 
@@ -59,13 +59,13 @@ public class DerivedTypeDiscoveryConventionTest
     public void Discovers_child_type_if_base_type_set()
     {
         var entityBuilderA = CreateInternalEntityTypeBuilder<A>();
-        var entityBuilderC = entityBuilderA.ModelBuilder.Entity(typeof(C), ConfigurationSource.Explicit);
+        var entityBuilderC = entityBuilderA.ModelBuilder.Entity(typeof(C), ConfigurationSource.Explicit)!;
 
         RunConvention(entityBuilderC);
 
         Assert.Same(entityBuilderA.Metadata, entityBuilderC.Metadata.BaseType);
 
-        var entityBuilderB = entityBuilderA.ModelBuilder.Entity(typeof(B), ConfigurationSource.Explicit);
+        var entityBuilderB = entityBuilderA.ModelBuilder.Entity(typeof(B), ConfigurationSource.Explicit)!;
 
         Assert.Null(entityBuilderB.Metadata.BaseType);
 
@@ -96,6 +96,6 @@ public class DerivedTypeDiscoveryConventionTest
     {
         var modelBuilder = new InternalModelBuilder(new Model());
 
-        return modelBuilder.Entity(typeof(T), ConfigurationSource.Explicit);
+        return modelBuilder.Entity(typeof(T), ConfigurationSource.Explicit)!;
     }
 }

--- a/test/EFCore.Tests/Metadata/Conventions/DiscriminatorConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/DiscriminatorConventionTest.cs
@@ -20,7 +20,7 @@ public class DiscriminatorConventionTest
         Assert.Null(((IReadOnlyEntityType)entityTypeBuilder.Metadata).FindDiscriminatorProperty());
         Assert.Null(entityTypeBuilder.Metadata.GetDiscriminatorValue());
 
-        var baseTypeBuilder = entityTypeBuilder.ModelBuilder.Entity(typeof(EntityBase), ConfigurationSource.Explicit);
+        var baseTypeBuilder = entityTypeBuilder.ModelBuilder.Entity(typeof(EntityBase), ConfigurationSource.Explicit)!;
         Assert.Same(entityTypeBuilder, entityTypeBuilder.HasBaseType(baseTypeBuilder.Metadata, ConfigurationSource.DataAnnotation));
 
         RunConvention(entityTypeBuilder, null);
@@ -32,7 +32,7 @@ public class DiscriminatorConventionTest
         Assert.Equal(typeof(EntityBase).Name, baseTypeBuilder.Metadata.GetDiscriminatorValue());
         Assert.Equal(typeof(Entity).Name, entityTypeBuilder.Metadata.GetDiscriminatorValue());
 
-        Assert.NotNull(entityTypeBuilder.HasBaseType((Type)null, ConfigurationSource.DataAnnotation));
+        Assert.NotNull(entityTypeBuilder.HasBaseType((Type?)null, ConfigurationSource.DataAnnotation));
         RunConvention(entityTypeBuilder, baseTypeBuilder.Metadata);
         Assert.Null(((IReadOnlyEntityType)baseTypeBuilder.Metadata).FindDiscriminatorProperty());
         Assert.Null(((IReadOnlyEntityType)entityTypeBuilder.Metadata).FindDiscriminatorProperty());
@@ -48,16 +48,16 @@ public class DiscriminatorConventionTest
         Assert.Null(((IReadOnlyEntityType)entityTypeBuilder.Metadata).FindDiscriminatorProperty());
         Assert.Null(entityTypeBuilder.Metadata.GetDiscriminatorValue());
 
-        var baseTypeBuilder = entityTypeBuilder.ModelBuilder.Entity(typeof(EntityBase), ConfigurationSource.Explicit);
+        var baseTypeBuilder = entityTypeBuilder.ModelBuilder.Entity(typeof(EntityBase), ConfigurationSource.Explicit)!;
         Assert.Same(entityTypeBuilder, entityTypeBuilder.HasBaseType(baseTypeBuilder.Metadata, ConfigurationSource.DataAnnotation));
 
         RunConvention(entityTypeBuilder, null);
 
-        var derivedTypeBuilder = entityTypeBuilder.ModelBuilder.Entity(typeof(DerivedEntity), ConfigurationSource.Explicit);
+        var derivedTypeBuilder = entityTypeBuilder.ModelBuilder.Entity(typeof(DerivedEntity), ConfigurationSource.Explicit)!;
         Assert.Same(derivedTypeBuilder, derivedTypeBuilder.HasBaseType(entityTypeBuilder.Metadata, ConfigurationSource.DataAnnotation));
         Assert.Same(
             derivedTypeBuilder.Metadata,
-            entityTypeBuilder.ModelBuilder.Entity(typeof(DerivedEntity).FullName, ConfigurationSource.Convention).Metadata);
+            entityTypeBuilder.ModelBuilder.Entity(typeof(DerivedEntity).FullName!, ConfigurationSource.Convention)!.Metadata);
 
         RunConvention(entityTypeBuilder, null);
 
@@ -69,7 +69,7 @@ public class DiscriminatorConventionTest
         Assert.Equal(typeof(Entity).Name, entityTypeBuilder.Metadata.GetDiscriminatorValue());
         Assert.Equal(typeof(DerivedEntity).Name, derivedTypeBuilder.Metadata.GetDiscriminatorValue());
 
-        entityTypeBuilder.HasBaseType((Type)null, ConfigurationSource.DataAnnotation);
+        entityTypeBuilder.HasBaseType((Type?)null, ConfigurationSource.DataAnnotation);
 
         RunConvention(entityTypeBuilder, baseTypeBuilder.Metadata);
 
@@ -86,7 +86,7 @@ public class DiscriminatorConventionTest
     {
         var entityTypeBuilder = CreateInternalEntityTypeBuilder<Entity>();
 
-        var baseTypeBuilder = entityTypeBuilder.ModelBuilder.Entity(typeof(EntityBase), ConfigurationSource.DataAnnotation);
+        var baseTypeBuilder = entityTypeBuilder.ModelBuilder.Entity(typeof(EntityBase), ConfigurationSource.DataAnnotation)!;
         entityTypeBuilder.HasBaseType(baseTypeBuilder.Metadata, ConfigurationSource.DataAnnotation);
         new EntityTypeBuilder(baseTypeBuilder.Metadata).HasDiscriminator("T", typeof(string));
 
@@ -106,7 +106,7 @@ public class DiscriminatorConventionTest
     {
         var entityTypeBuilder = CreateInternalEntityTypeBuilder<Entity>();
 
-        var baseTypeBuilder = entityTypeBuilder.ModelBuilder.Entity(typeof(EntityBase), ConfigurationSource.DataAnnotation);
+        var baseTypeBuilder = entityTypeBuilder.ModelBuilder.Entity(typeof(EntityBase), ConfigurationSource.DataAnnotation)!;
         entityTypeBuilder.HasBaseType(baseTypeBuilder.Metadata, ConfigurationSource.DataAnnotation);
         new EntityTypeBuilder(baseTypeBuilder.Metadata).HasDiscriminator("T", typeof(int));
 
@@ -128,7 +128,7 @@ public class DiscriminatorConventionTest
 
         new EntityTypeBuilder(entityTypeBuilder.Metadata).HasDiscriminator("T", typeof(int));
 
-        var baseTypeBuilder = entityTypeBuilder.ModelBuilder.Entity(typeof(EntityBase), ConfigurationSource.Convention);
+        var baseTypeBuilder = entityTypeBuilder.ModelBuilder.Entity(typeof(EntityBase), ConfigurationSource.Convention)!;
         entityTypeBuilder.HasBaseType(baseTypeBuilder.Metadata, ConfigurationSource.Convention);
 
         RunConvention(entityTypeBuilder, null);
@@ -138,7 +138,7 @@ public class DiscriminatorConventionTest
         Assert.Null(baseTypeBuilder.Metadata[CoreAnnotationNames.DiscriminatorValue]);
         Assert.Null(entityTypeBuilder.Metadata[CoreAnnotationNames.DiscriminatorValue]);
 
-        entityTypeBuilder.HasBaseType((Type)null, ConfigurationSource.DataAnnotation);
+        entityTypeBuilder.HasBaseType((Type?)null, ConfigurationSource.DataAnnotation);
 
         RunConvention(entityTypeBuilder, baseTypeBuilder.Metadata);
 
@@ -148,7 +148,7 @@ public class DiscriminatorConventionTest
         Assert.Null(entityTypeBuilder.Metadata.GetDiscriminatorValue());
     }
 
-    private void RunConvention(InternalEntityTypeBuilder entityTypeBuilder, EntityType oldBaseType)
+    private void RunConvention(InternalEntityTypeBuilder entityTypeBuilder, EntityType? oldBaseType)
     {
         var context = new ConventionContext<IConventionEntityType>(entityTypeBuilder.Metadata.Model.ConventionDispatcher);
         new DiscriminatorConvention(CreateDependencies())
@@ -166,7 +166,7 @@ public class DiscriminatorConventionTest
     {
         public int Id { get; set; }
 
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
     }
 
     private class DerivedEntity : Entity;
@@ -176,6 +176,6 @@ public class DiscriminatorConventionTest
         var modelBuilder = (InternalModelBuilder)
             InMemoryTestHelpers.Instance.CreateConventionBuilder().GetInfrastructure();
 
-        return modelBuilder.Entity(typeof(T), ConfigurationSource.Explicit);
+        return modelBuilder.Entity(typeof(T), ConfigurationSource.Explicit)!;
     }
 }

--- a/test/EFCore.Tests/Metadata/Conventions/EntityTypeAttributeConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/EntityTypeAttributeConventionTest.cs
@@ -19,7 +19,7 @@ public class EntityTypeAttributeConventionTest
     {
         var modelBuilder = new InternalModelBuilder(new Model());
 
-        var entityBuilder = modelBuilder.Entity(typeof(A), ConfigurationSource.Convention);
+        var entityBuilder = modelBuilder.Entity(typeof(A), ConfigurationSource.Convention)!;
 
         RunConvention(entityBuilder);
 
@@ -31,7 +31,7 @@ public class EntityTypeAttributeConventionTest
     {
         var modelBuilder = new InternalModelBuilder(new Model());
 
-        var entityBuilder = modelBuilder.Entity(typeof(A), ConfigurationSource.Explicit);
+        var entityBuilder = modelBuilder.Entity(typeof(A), ConfigurationSource.Explicit)!;
 
         RunConvention(entityBuilder);
 
@@ -61,7 +61,7 @@ public class EntityTypeAttributeConventionTest
 
         Assert.Equal(2, modelBuilder.Model.GetEntityTypes().Count());
         Assert.True(
-            modelBuilder.Model.FindEntityType(typeof(Customer)).FindNavigation(nameof(Customer.Address)).ForeignKey.IsOwnership);
+            modelBuilder.Model.FindEntityType(typeof(Customer))!.FindNavigation(nameof(Customer.Address))!.ForeignKey.IsOwnership);
     }
 
     [Fact]
@@ -84,7 +84,7 @@ public class EntityTypeAttributeConventionTest
     {
         var modelBuilder = new InternalModelBuilder(new Model());
 
-        var entityBuilder = modelBuilder.Entity(typeof(KeylessEntity), ConfigurationSource.Convention);
+        var entityBuilder = modelBuilder.Entity(typeof(KeylessEntity), ConfigurationSource.Convention)!;
         entityBuilder.Property("Id", ConfigurationSource.Convention);
         entityBuilder.PrimaryKey(new List<string> { "Id" }, ConfigurationSource.Convention);
 
@@ -146,27 +146,27 @@ public class EntityTypeAttributeConventionTest
     {
         public int Id { get; set; }
 
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
     }
 
     private class B
     {
         public int Id { get; set; }
 
-        public virtual A NavToA { get; set; }
+        public virtual A NavToA { get; set; } = null!;
     }
 
     private class Customer
     {
         public int Id { get; set; }
-        public Address Address { get; set; }
+        public Address Address { get; set; } = null!;
     }
 
     [Owned]
     private class Address
     {
         public int Id { get; set; }
-        public Customer Customer { get; }
+        public Customer Customer { get; } = null!;
     }
 
     [Keyless]

--- a/test/EFCore.Tests/Metadata/Conventions/EntityTypeConfigurationAttributeConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/EntityTypeConfigurationAttributeConventionTest.cs
@@ -14,8 +14,8 @@ public class EntityTypeConfigurationAttributeConventionTest
 
         builder.Entity<Customer>();
 
-        var entityType = builder.Model.FindEntityType(typeof(Customer));
-        Assert.Equal(1000, entityType.FindProperty(nameof(Customer.Name)).GetMaxLength());
+        var entityType = builder.Model.FindEntityType(typeof(Customer))!;
+        Assert.Equal(1000, entityType.FindProperty(nameof(Customer.Name))!.GetMaxLength());
     }
 
     [Fact]
@@ -25,8 +25,8 @@ public class EntityTypeConfigurationAttributeConventionTest
 
         builder.Entity<CustomerGeneric>();
 
-        var entityType = builder.Model.FindEntityType(typeof(CustomerGeneric));
-        Assert.Equal(1000, entityType.FindProperty(nameof(CustomerGeneric.Name)).GetMaxLength());
+        var entityType = builder.Model.FindEntityType(typeof(CustomerGeneric))!;
+        Assert.Equal(1000, entityType.FindProperty(nameof(CustomerGeneric.Name))!.GetMaxLength());
     }
 
     [Fact]
@@ -59,7 +59,7 @@ public class EntityTypeConfigurationAttributeConventionTest
     {
         public int Id { get; set; }
 
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
     }
 
     private class CustomerConfiguration : IEntityTypeConfiguration<Customer>
@@ -79,7 +79,7 @@ public class EntityTypeConfigurationAttributeConventionTest
     {
         public int Id { get; set; }
 
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
     }
 
     [EntityTypeConfigurationAttribute<CustomerGenericConfiguration, CustomerGeneric>]
@@ -87,7 +87,7 @@ public class EntityTypeConfigurationAttributeConventionTest
     {
         public int Id { get; set; }
 
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
     }
 
     [EntityTypeConfiguration(typeof(CustomerConfiguration))]
@@ -95,6 +95,6 @@ public class EntityTypeConfigurationAttributeConventionTest
     {
         public int Id { get; set; }
 
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
     }
 }

--- a/test/EFCore.Tests/Metadata/Conventions/ForeignKeyIndexConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/ForeignKeyIndexConventionTest.cs
@@ -22,9 +22,9 @@ public class ForeignKeyIndexConventionTest
         dependentTypeBuilder.HasIndex(t => t.PrincipalId).IsUnique(false);
         principalTypeBuilder.HasKey(t => t.ChangedPrincipalId);
 
-        var entityType = modelBuilder.Model.FindEntityType(typeof(DependentEntity));
-        var property = entityType.FindProperty(nameof(DependentEntity.PrincipalId));
-        var index = entityType.FindIndex(property);
+        var entityType = modelBuilder.Model.FindEntityType(typeof(DependentEntity))!;
+        var property = entityType.FindProperty(nameof(DependentEntity.PrincipalId))!;
+        var index = entityType.FindIndex(property)!;
 
         Assert.False(index.IsUnique);
     }
@@ -42,6 +42,6 @@ public class ForeignKeyIndexConventionTest
 
         public int DependentId { get; set; }
 
-        public virtual PrincipalEntity Principal { get; set; }
+        public virtual PrincipalEntity Principal { get; set; } = null!;
     }
 }

--- a/test/EFCore.Tests/Metadata/Conventions/ForeignKeyPropertyDiscoveryConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/ForeignKeyPropertyDiscoveryConventionTest.cs
@@ -26,14 +26,14 @@ public class ForeignKeyPropertyDiscoveryConventionTest
         dependentTypeBuilder.Property(DependentEntity.PrincipalEntityPeEKaYProperty, ConfigurationSource.Convention);
         dependentTypeBuilder.Property(DependentEntity.IDProperty, ConfigurationSource.Convention);
         dependentTypeBuilder.Property(DependentEntity.PeEKaYProperty, ConfigurationSource.Convention);
-        var fkProperty = dependentTypeBuilder.Property(typeof(int), "No!No!", ConfigurationSource.Convention).Metadata;
+        var fkProperty = dependentTypeBuilder.Property(typeof(int), "No!No!", ConfigurationSource.Convention)!.Metadata;
 
         var relationshipBuilder = dependentTypeBuilder.HasRelationship(
                 PrincipalType,
                 "SomeNav",
                 null,
-                ConfigurationSource.Explicit)
-            .HasForeignKey([fkProperty], ConfigurationSource.Explicit);
+                ConfigurationSource.Explicit)!
+            .HasForeignKey([fkProperty], ConfigurationSource.Explicit)!;
 
         RunConvention(relationshipBuilder);
 
@@ -59,16 +59,16 @@ public class ForeignKeyPropertyDiscoveryConventionTest
             DependentEntityWithCompositeKey.PrincipalEntityWithCompositeKeyNameProperty, ConfigurationSource.Convention);
         dependentTypeBuilder.Property(DependentEntityWithCompositeKey.IdProperty, ConfigurationSource.Convention);
         dependentTypeBuilder.Property(DependentEntityWithCompositeKey.NameProperty, ConfigurationSource.Convention);
-        var fkProperty1 = dependentTypeBuilder.Property(typeof(int), "No!No!", ConfigurationSource.Convention);
-        var fkProperty2 = dependentTypeBuilder.Property(typeof(string), "No!No!2", ConfigurationSource.Convention);
+        var fkProperty1 = dependentTypeBuilder.Property(typeof(int), "No!No!", ConfigurationSource.Convention)!;
+        var fkProperty2 = dependentTypeBuilder.Property(typeof(string), "No!No!2", ConfigurationSource.Convention)!;
         fkProperty2.IsRequired(true, ConfigurationSource.Convention);
 
         var relationshipBuilder = dependentTypeBuilder.HasRelationship(
                 PrincipalTypeWithCompositeKey,
                 "NavProp",
                 null,
-                ConfigurationSource.Explicit)
-            .HasForeignKey([fkProperty1.Metadata, fkProperty2.Metadata], ConfigurationSource.Explicit);
+                ConfigurationSource.Explicit)!
+            .HasForeignKey([fkProperty1.Metadata, fkProperty2.Metadata], ConfigurationSource.Explicit)!;
 
         RunConvention(relationshipBuilder);
 
@@ -95,7 +95,7 @@ public class ForeignKeyPropertyDiscoveryConventionTest
         var newRelationshipBuilder = RunConvention(relationshipBuilder);
         Assert.Same(relationshipBuilder, newRelationshipBuilder);
 
-        var fk = relationshipBuilder.Metadata;
+        var fk = relationshipBuilder!.Metadata;
         Assert.Same(fk, DependentType.GetForeignKeys().Single());
         Assert.Null(fk.GetPropertiesConfigurationSource());
         Assert.Equal("SomeNav" + PrimaryKey.Name, fk.Properties.Single().Name);
@@ -108,7 +108,7 @@ public class ForeignKeyPropertyDiscoveryConventionTest
     public void Matches_navigation_plus_PK_name_property()
     {
         var dependentTypeBuilder = DependentType.Builder;
-        var fkProperty = dependentTypeBuilder.Property(DependentEntity.SomeNavPeEKaYProperty, ConfigurationSource.Convention).Metadata;
+        var fkProperty = dependentTypeBuilder.Property(DependentEntity.SomeNavPeEKaYProperty, ConfigurationSource.Convention)!.Metadata;
         dependentTypeBuilder.Property(DependentEntity.SomeNavIDProperty, ConfigurationSource.Convention);
         dependentTypeBuilder.Property(DependentEntity.PrincipalEntityIDProperty, ConfigurationSource.Convention);
         dependentTypeBuilder.Property(DependentEntity.PrincipalEntityPeEKaYProperty, ConfigurationSource.Convention);
@@ -138,9 +138,9 @@ public class ForeignKeyPropertyDiscoveryConventionTest
     {
         var dependentTypeBuilder = DependentTypeWithCompositeKey.Builder;
         var fkProperty1 = dependentTypeBuilder.Property(
-            DependentEntityWithCompositeKey.NavPropIdProperty, ConfigurationSource.Convention);
+            DependentEntityWithCompositeKey.NavPropIdProperty, ConfigurationSource.Convention)!;
         var fkProperty2 = dependentTypeBuilder.Property(
-            DependentEntityWithCompositeKey.NavPropNameProperty, ConfigurationSource.Convention);
+            DependentEntityWithCompositeKey.NavPropNameProperty, ConfigurationSource.Convention)!;
         fkProperty2.IsRequired(true, ConfigurationSource.Convention);
         dependentTypeBuilder.Property(
             DependentEntityWithCompositeKey.PrincipalEntityWithCompositeKeyIdProperty, ConfigurationSource.Convention);
@@ -173,7 +173,7 @@ public class ForeignKeyPropertyDiscoveryConventionTest
     public void Matches_navigation_plus_Id_property()
     {
         var dependentTypeBuilder = DependentType.Builder;
-        var fkProperty = dependentTypeBuilder.Property(DependentEntity.SomeNavIDProperty, ConfigurationSource.Convention).Metadata;
+        var fkProperty = dependentTypeBuilder.Property(DependentEntity.SomeNavIDProperty, ConfigurationSource.Convention)!.Metadata;
         dependentTypeBuilder.Property(DependentEntity.PrincipalEntityIDProperty, ConfigurationSource.Convention);
         dependentTypeBuilder.Property(DependentEntity.PrincipalEntityPeEKaYProperty, ConfigurationSource.Convention);
         dependentTypeBuilder.Property(DependentEntity.PeEKaYProperty, ConfigurationSource.Convention);
@@ -202,7 +202,7 @@ public class ForeignKeyPropertyDiscoveryConventionTest
     {
         var dependentTypeBuilder = DependentType.Builder;
         var fkProperty = dependentTypeBuilder.Property(DependentEntity.PrincipalEntityPeEKaYProperty, ConfigurationSource.Convention)
-            .Metadata;
+            !.Metadata;
         dependentTypeBuilder.Property(DependentEntity.PrincipalEntityIDProperty, ConfigurationSource.Convention);
         dependentTypeBuilder.Property(DependentEntity.PeEKaYProperty, ConfigurationSource.Convention);
 
@@ -228,7 +228,7 @@ public class ForeignKeyPropertyDiscoveryConventionTest
     {
         var dependentTypeBuilder = DependentType.Builder;
         var fkProperty = dependentTypeBuilder.Property(DependentEntity.PrincipalEntityIDProperty, ConfigurationSource.Convention)
-            .Metadata;
+            !.Metadata;
         dependentTypeBuilder.Property(DependentEntity.PeEKaYProperty, ConfigurationSource.Convention);
 
         var relationshipBuilder = dependentTypeBuilder.HasRelationship(
@@ -253,9 +253,9 @@ public class ForeignKeyPropertyDiscoveryConventionTest
     {
         var dependentTypeBuilder = DependentTypeWithCompositeKey.Builder;
         var fkProperty1 = dependentTypeBuilder.Property(
-            DependentEntityWithCompositeKey.PrincipalEntityWithCompositeKeyIdProperty, ConfigurationSource.Convention);
+            DependentEntityWithCompositeKey.PrincipalEntityWithCompositeKeyIdProperty, ConfigurationSource.Convention)!;
         var fkProperty2 = dependentTypeBuilder.Property(
-            DependentEntityWithCompositeKey.PrincipalEntityWithCompositeKeyNameProperty, ConfigurationSource.Convention);
+            DependentEntityWithCompositeKey.PrincipalEntityWithCompositeKeyNameProperty, ConfigurationSource.Convention)!;
         fkProperty2.IsRequired(true, ConfigurationSource.Convention);
         dependentTypeBuilder.Property(DependentEntityWithCompositeKey.IdProperty, ConfigurationSource.Convention);
         dependentTypeBuilder.Property(DependentEntityWithCompositeKey.NameProperty, ConfigurationSource.Convention);
@@ -306,16 +306,16 @@ public class ForeignKeyPropertyDiscoveryConventionTest
     public void Matches_key_Id_property()
     {
         var dependentTypeBuilder = DependentType.Builder;
-        var fkProperty = dependentTypeBuilder.PrimaryKey([DependentEntity.IDProperty], ConfigurationSource.Explicit)
+        var fkProperty = dependentTypeBuilder.PrimaryKey([DependentEntity.IDProperty], ConfigurationSource.Explicit)!
             .Metadata.Properties.Single();
 
         var relationshipBuilder = dependentTypeBuilder.HasRelationship(
                 PrincipalType,
                 "SomeNav",
                 null,
-                ConfigurationSource.Convention)
-            .IsUnique(true, ConfigurationSource.DataAnnotation)
-            .DependentEntityType(DependentType, ConfigurationSource.DataAnnotation);
+                ConfigurationSource.Convention)!
+            .IsUnique(true, ConfigurationSource.DataAnnotation)!
+            .DependentEntityType(DependentType, ConfigurationSource.DataAnnotation)!;
 
         var newRelationshipBuilder = RunConvention(relationshipBuilder);
         Assert.Same(relationshipBuilder, newRelationshipBuilder);
@@ -332,17 +332,17 @@ public class ForeignKeyPropertyDiscoveryConventionTest
     [Fact]
     public void Does_not_match_non_key_Id_property()
     {
-        var relationshipBuilder = DependentType.Builder.HasRelationship(
+        var relationshipBuilder = DependentType!.Builder!.HasRelationship(
                 PrincipalType,
                 "SomeNav",
                 null,
-                ConfigurationSource.Convention)
+                ConfigurationSource.Convention)!
             .IsUnique(true, ConfigurationSource.DataAnnotation);
 
         var newRelationshipBuilder = RunConvention(relationshipBuilder);
         Assert.Same(relationshipBuilder, newRelationshipBuilder);
 
-        Assert.NotEqual(DependentEntity.IDProperty.Name, DependentType.FindPrimaryKey().Properties.Single().Name);
+        Assert.NotEqual(DependentEntity.IDProperty.Name, DependentType.FindPrimaryKey()!.Properties.Single().Name);
 
         var fk = (IReadOnlyForeignKey)newRelationshipBuilder.Metadata;
         Assert.Same(fk, DependentType.GetForeignKeys().Single());
@@ -359,7 +359,7 @@ public class ForeignKeyPropertyDiscoveryConventionTest
         dependentTypeBuilder.Property(
             DependentEntityWithCompositeKey.IdProperty, ConfigurationSource.Convention);
         dependentTypeBuilder.Property(
-                DependentEntityWithCompositeKey.NameProperty, ConfigurationSource.Convention)
+            DependentEntityWithCompositeKey.NameProperty, ConfigurationSource.Convention)!
             .IsRequired(true, ConfigurationSource.Convention);
 
         var relationshipBuilder = dependentTypeBuilder.HasRelationship(
@@ -385,14 +385,14 @@ public class ForeignKeyPropertyDiscoveryConventionTest
     {
         var dependentTypeBuilder = DependentTypeWithCompositeKey.Builder;
         var pkProperty1 = dependentTypeBuilder.Property(
-                DependentEntityWithCompositeKey.IdProperty, ConfigurationSource.Convention)
+                DependentEntityWithCompositeKey.IdProperty, ConfigurationSource.Convention)!
             .Metadata;
         var pkProperty2 = dependentTypeBuilder.Property(
-                DependentEntityWithCompositeKey.NameProperty, ConfigurationSource.Convention)
-            .IsRequired(true, ConfigurationSource.Convention)
+                DependentEntityWithCompositeKey.NameProperty, ConfigurationSource.Convention)!
+            .IsRequired(true, ConfigurationSource.Convention)!
             .Metadata;
         var pkProperty3 = dependentTypeBuilder.Property(
-                DependentEntityWithCompositeKey.NavPropIdProperty, ConfigurationSource.Convention)
+                DependentEntityWithCompositeKey.NavPropIdProperty, ConfigurationSource.Convention)!
             .Metadata;
 
         dependentTypeBuilder.PrimaryKey([pkProperty1, pkProperty2, pkProperty3], ConfigurationSource.Explicit);
@@ -420,11 +420,11 @@ public class ForeignKeyPropertyDiscoveryConventionTest
     {
         var dependentTypeBuilder = DependentType.Builder;
         var pkProperty = dependentTypeBuilder.Property(
-                DependentEntity.IDProperty, ConfigurationSource.Convention)
-            .IsRequired(true, ConfigurationSource.Convention)
+                DependentEntity.IDProperty, ConfigurationSource.Convention)!
+            .IsRequired(true, ConfigurationSource.Convention)!
             .Metadata;
         var fkProperty = dependentTypeBuilder.Property(
-                DependentEntity.PrincipalEntityPeEKaYProperty, ConfigurationSource.Convention)
+                DependentEntity.PrincipalEntityPeEKaYProperty, ConfigurationSource.Convention)!
             .Metadata;
 
         dependentTypeBuilder.PrimaryKey([pkProperty, fkProperty], ConfigurationSource.Explicit);
@@ -449,14 +449,14 @@ public class ForeignKeyPropertyDiscoveryConventionTest
     public void Matches_dependent_PK_for_unique_FK_set_by_higher_source_than_convention()
     {
         var dependentTypeBuilder = DependentType.Builder;
-        var fkProperty = DependentType.FindPrimaryKey().Properties.Single();
+        var fkProperty = DependentType.FindPrimaryKey()!.Properties.Single();
         var relationshipBuilder = dependentTypeBuilder.HasRelationship(
                 PrincipalType,
                 "SomeNav",
                 "InverseReferenceNav",
-                ConfigurationSource.Convention)
-            .IsUnique(true, ConfigurationSource.DataAnnotation)
-            .DependentEntityType(DependentType, ConfigurationSource.DataAnnotation);
+                ConfigurationSource.Convention)!
+            .IsUnique(true, ConfigurationSource.DataAnnotation)!
+            .DependentEntityType(DependentType, ConfigurationSource.DataAnnotation)!;
 
         var newRelationshipBuilder = RunConvention(relationshipBuilder);
         Assert.Same(relationshipBuilder, newRelationshipBuilder);
@@ -475,7 +475,7 @@ public class ForeignKeyPropertyDiscoveryConventionTest
     public void Does_not_match_principal_type_plus_PK_name_property_of_different_type()
     {
         var dependentTypeBuilder = DependentType.Builder;
-        var fkProperty = dependentTypeBuilder.Property(typeof(string), "PrincipalEntityPeeKay", ConfigurationSource.Explicit).Metadata;
+        var fkProperty = dependentTypeBuilder.Property(typeof(string), "PrincipalEntityPeeKay", ConfigurationSource.Explicit)!.Metadata;
         dependentTypeBuilder.Property(DependentEntity.IDProperty, ConfigurationSource.Convention);
 
         var relationshipBuilder = dependentTypeBuilder.HasRelationship(
@@ -511,8 +511,8 @@ public class ForeignKeyPropertyDiscoveryConventionTest
         var dependentTypeBuilder = DependentType.Builder;
         dependentTypeBuilder.PrimaryKey([DependentEntity.PrincipalEntityPeEKaYProperty], ConfigurationSource.Explicit);
 
-        var relationshipBuilder = dependentTypeBuilder.HasRelationship(PrincipalType, ConfigurationSource.Convention)
-            .IsUnique(false, ConfigurationSource.Convention);
+        var relationshipBuilder = dependentTypeBuilder.HasRelationship(PrincipalType, ConfigurationSource.Convention)!
+            .IsUnique(false, ConfigurationSource.Convention)!;
 
         var newRelationshipBuilder = RunConvention(relationshipBuilder);
         Assert.Same(relationshipBuilder, newRelationshipBuilder);
@@ -528,11 +528,11 @@ public class ForeignKeyPropertyDiscoveryConventionTest
     [Fact]
     public void Does_not_match_non_nullable_dependent_PK_for_optional_unique_FK()
     {
-        var fkProperty = DependentType.FindPrimaryKey().Properties.Single();
+        var fkProperty = DependentType.FindPrimaryKey()!.Properties.Single();
 
-        var relationshipBuilder = DependentType.Builder.HasRelationship(PrincipalType, ConfigurationSource.Convention)
-            .IsUnique(true, ConfigurationSource.DataAnnotation)
-            .IsRequired(false, ConfigurationSource.DataAnnotation);
+        var relationshipBuilder = DependentType.Builder.HasRelationship(PrincipalType, ConfigurationSource.Convention)!
+            .IsUnique(true, ConfigurationSource.DataAnnotation)!
+            .IsRequired(false, ConfigurationSource.DataAnnotation)!;
 
         var newRelationshipBuilder = RunConvention(relationshipBuilder);
         Assert.Same(relationshipBuilder, newRelationshipBuilder);
@@ -550,8 +550,8 @@ public class ForeignKeyPropertyDiscoveryConventionTest
     [Fact]
     public void Does_not_match_dependent_PK_for_self_ref()
     {
-        var relationshipBuilder = PrincipalType.Builder.HasRelationship(PrincipalType, ConfigurationSource.Convention)
-            .IsUnique(true, ConfigurationSource.DataAnnotation);
+        var relationshipBuilder = PrincipalType.Builder.HasRelationship(PrincipalType, ConfigurationSource.Convention)!
+            .IsUnique(true, ConfigurationSource.DataAnnotation)!;
 
         var newRelationshipBuilder = RunConvention(relationshipBuilder);
         Assert.Same(relationshipBuilder, newRelationshipBuilder);
@@ -568,13 +568,13 @@ public class ForeignKeyPropertyDiscoveryConventionTest
     [Fact]
     public void Does_not_match_for_convention_identifying_FK()
     {
-        var derivedType = PrincipalType.Builder.ModelBuilder.Entity(typeof(DerivedPrincipalEntity), ConfigurationSource.Convention);
+        var derivedType = PrincipalType.Builder.ModelBuilder.Entity(typeof(DerivedPrincipalEntity), ConfigurationSource.Convention)!;
         derivedType.HasBaseType(PrincipalType, ConfigurationSource.Convention);
 
         PrincipalType.Builder.Property(typeof(int), nameof(PrincipalEntity.PrincipalEntityId), ConfigurationSource.Convention);
         var relationshipBuilder = derivedType.HasRelationship(
-                PrincipalType, PrincipalType.FindPrimaryKey().Properties, ConfigurationSource.Convention)
-            .IsUnique(true, ConfigurationSource.DataAnnotation);
+                PrincipalType, PrincipalType.FindPrimaryKey()!.Properties, ConfigurationSource.Convention)!
+            .IsUnique(true, ConfigurationSource.DataAnnotation)!;
 
         var newRelationshipBuilder = RunConvention(relationshipBuilder);
         Assert.Same(relationshipBuilder, newRelationshipBuilder);
@@ -592,15 +592,15 @@ public class ForeignKeyPropertyDiscoveryConventionTest
     public void Matches_composite_dependent_PK_for_unique_FK()
     {
         var dependentTypeBuilder = DependentTypeWithCompositeKey.Builder;
-        var fkProperty1 = DependentTypeWithCompositeKey.FindPrimaryKey().Properties[0];
-        var fkProperty2 = DependentTypeWithCompositeKey.FindPrimaryKey().Properties[1];
+        var fkProperty1 = DependentTypeWithCompositeKey.FindPrimaryKey()!.Properties[0];
+        var fkProperty2 = DependentTypeWithCompositeKey.FindPrimaryKey()!.Properties[1];
 
         var relationshipBuilder = dependentTypeBuilder.HasRelationship(
                 PrincipalTypeWithCompositeKey,
                 "NavProp",
-                "InverseReferenceNav", ConfigurationSource.Convention)
-            .IsUnique(true, ConfigurationSource.DataAnnotation)
-            .DependentEntityType(DependentTypeWithCompositeKey, ConfigurationSource.DataAnnotation);
+                "InverseReferenceNav", ConfigurationSource.Convention)!
+            .IsUnique(true, ConfigurationSource.DataAnnotation)!
+            .DependentEntityType(DependentTypeWithCompositeKey, ConfigurationSource.DataAnnotation)!;
 
         var newRelationshipBuilder = RunConvention(relationshipBuilder);
         Assert.Same(relationshipBuilder, newRelationshipBuilder);
@@ -621,15 +621,15 @@ public class ForeignKeyPropertyDiscoveryConventionTest
     {
         var modelBuilder = new InternalModelBuilder(new Model());
 
-        var principalTypeWithCompositeKey = modelBuilder.Entity(typeof(PrincipalEntityWithCompositeKey), ConfigurationSource.Explicit);
+        var principalTypeWithCompositeKey = modelBuilder.Entity(typeof(PrincipalEntityWithCompositeKey), ConfigurationSource.Explicit)!;
         principalTypeWithCompositeKey.PrimaryKey(
             [PrincipalEntityWithCompositeKey.IdProperty, PrincipalEntityWithCompositeKey.NameProperty],
             ConfigurationSource.Explicit);
-        principalTypeWithCompositeKey.Property(PrincipalEntityWithCompositeKey.NameProperty, ConfigurationSource.Explicit)
+        principalTypeWithCompositeKey.Property(PrincipalEntityWithCompositeKey.NameProperty, ConfigurationSource.Explicit)!
             .IsRequired(true, ConfigurationSource.Explicit);
 
-        var dependentTypeWithCompositeKeyBase = modelBuilder.Entity(typeof(DependentCompositeBase), ConfigurationSource.Explicit);
-        var dependentTypeWithCompositeKey = modelBuilder.Entity(typeof(DependentEntityWithCompositeKey), ConfigurationSource.Explicit);
+        var dependentTypeWithCompositeKeyBase = modelBuilder.Entity(typeof(DependentCompositeBase), ConfigurationSource.Explicit)!;
+        var dependentTypeWithCompositeKey = modelBuilder.Entity(typeof(DependentEntityWithCompositeKey), ConfigurationSource.Explicit)!;
         dependentTypeWithCompositeKey.HasBaseType(dependentTypeWithCompositeKeyBase.Metadata, ConfigurationSource.Explicit);
         dependentTypeWithCompositeKeyBase.PrimaryKey(
             [nameof(DependentEntityWithCompositeKey.NotId), nameof(DependentEntityWithCompositeKey.NotName)],
@@ -638,9 +638,9 @@ public class ForeignKeyPropertyDiscoveryConventionTest
         var relationshipBuilder = dependentTypeWithCompositeKey.HasRelationship(
                 principalTypeWithCompositeKey.Metadata,
                 "NavProp",
-                "InverseReferenceNav", ConfigurationSource.Convention)
-            .IsUnique(true, ConfigurationSource.DataAnnotation)
-            .DependentEntityType(dependentTypeWithCompositeKey.Metadata, ConfigurationSource.DataAnnotation);
+                "InverseReferenceNav", ConfigurationSource.Convention)!
+            .IsUnique(true, ConfigurationSource.DataAnnotation)!
+            .DependentEntityType(dependentTypeWithCompositeKey.Metadata, ConfigurationSource.DataAnnotation)!;
 
         var newRelationshipBuilder = RunConvention(relationshipBuilder);
 
@@ -649,8 +649,8 @@ public class ForeignKeyPropertyDiscoveryConventionTest
         Assert.True(fk.IsUnique);
         Assert.Null(fk.GetPropertiesConfigurationSource());
         Assert.Same(principalTypeWithCompositeKey.Metadata.FindPrimaryKey(), fk.PrincipalKey);
-        Assert.NotEqual(dependentTypeWithCompositeKey.Metadata.FindPrimaryKey().Properties[0], fk.Properties[0]);
-        Assert.NotEqual(dependentTypeWithCompositeKey.Metadata.FindPrimaryKey().Properties[1], fk.Properties[1]);
+        Assert.NotEqual(dependentTypeWithCompositeKey.Metadata.FindPrimaryKey()!.Properties[0], fk.Properties[0]);
+        Assert.NotEqual(dependentTypeWithCompositeKey.Metadata.FindPrimaryKey()!.Properties[1], fk.Properties[1]);
         Assert.Equal("NavProp" + CompositePrimaryKey[0].Name + "1", fk.Properties[0].Name);
         Assert.Equal("NavProp" + CompositePrimaryKey[1].Name + "1", fk.Properties[1].Name);
 
@@ -668,13 +668,13 @@ public class ForeignKeyPropertyDiscoveryConventionTest
                 PrincipalTypeWithCompositeKey,
                 "NavProp",
                 null,
-                ConfigurationSource.Convention)
-            .IsUnique(false, ConfigurationSource.DataAnnotation);
+                ConfigurationSource.Convention)!
+            .IsUnique(false, ConfigurationSource.DataAnnotation)!;
 
         var newRelationshipBuilder = RunConvention(relationshipBuilder);
         Assert.Same(relationshipBuilder, newRelationshipBuilder);
 
-        var fk = relationshipBuilder.Metadata;
+        var fk = relationshipBuilder!.Metadata;
         Assert.Same(fk, DependentTypeWithCompositeKey.GetForeignKeys().Single());
         Assert.Null(fk.GetPropertiesConfigurationSource());
         Assert.Equal("NavProp" + CompositePrimaryKey[0].Name + "1", fk.Properties[0].Name);
@@ -690,13 +690,13 @@ public class ForeignKeyPropertyDiscoveryConventionTest
     [Fact]
     public void Does_not_match_composite_dependent_PK_for_unique_FK_if_count_mismatched()
     {
-        var fkProperty1 = DependentTypeWithCompositeKey.FindPrimaryKey().Properties[0];
+        var fkProperty1 = DependentTypeWithCompositeKey.FindPrimaryKey()!.Properties[0];
         DependentTypeWithCompositeKey.Builder.PrimaryKey([fkProperty1.Name], ConfigurationSource.Explicit);
 
         var relationshipBuilder = DependentTypeWithCompositeKey.Builder
-            .HasRelationship(PrincipalTypeWithCompositeKey, ConfigurationSource.Convention)
-            .HasPrincipalKey(PrincipalTypeWithCompositeKey.FindPrimaryKey().Properties, ConfigurationSource.DataAnnotation)
-            .IsUnique(true, ConfigurationSource.DataAnnotation);
+            .HasRelationship(PrincipalTypeWithCompositeKey, ConfigurationSource.Convention)!
+            .HasPrincipalKey(PrincipalTypeWithCompositeKey.FindPrimaryKey()!.Properties, ConfigurationSource.DataAnnotation)!
+            .IsUnique(true, ConfigurationSource.DataAnnotation)!;
 
         var newRelationshipBuilder = RunConvention(relationshipBuilder);
         Assert.Same(relationshipBuilder, newRelationshipBuilder);
@@ -717,19 +717,19 @@ public class ForeignKeyPropertyDiscoveryConventionTest
     [Fact]
     public void Does_not_match_composite_dependent_PK_for_unique_FK_if_order_mismatched()
     {
-        var fkProperty1 = DependentTypeWithCompositeKey.FindPrimaryKey().Properties[0];
-        var fkProperty2 = DependentTypeWithCompositeKey.FindPrimaryKey().Properties[1];
+        var fkProperty1 = DependentTypeWithCompositeKey.FindPrimaryKey()!.Properties[0];
+        var fkProperty2 = DependentTypeWithCompositeKey.FindPrimaryKey()!.Properties[1];
         DependentTypeWithCompositeKey.Builder.PrimaryKey([fkProperty2.Name, fkProperty1.Name], ConfigurationSource.Explicit);
 
         var relationshipBuilder = DependentTypeWithCompositeKey.Builder.HasRelationship(
-                PrincipalTypeWithCompositeKey, "NavProp", "InverseReferenceNav", ConfigurationSource.Convention)
-            .HasPrincipalKey(PrincipalTypeWithCompositeKey.FindPrimaryKey().Properties, ConfigurationSource.DataAnnotation)
-            .IsUnique(true, ConfigurationSource.DataAnnotation);
+                PrincipalTypeWithCompositeKey, "NavProp", "InverseReferenceNav", ConfigurationSource.Convention)!
+            .HasPrincipalKey(PrincipalTypeWithCompositeKey.FindPrimaryKey()!.Properties, ConfigurationSource.DataAnnotation)!
+            .IsUnique(true, ConfigurationSource.DataAnnotation)!;
 
         var newRelationshipBuilder = RunConvention(relationshipBuilder);
         Assert.Same(relationshipBuilder, newRelationshipBuilder);
 
-        var fk = relationshipBuilder.Metadata;
+        var fk = relationshipBuilder!.Metadata;
         Assert.Same(fk, DependentTypeWithCompositeKey.GetForeignKeys().Single());
         Assert.Null(fk.GetPropertiesConfigurationSource());
         Assert.Equal(2, fk.Properties.Count);
@@ -760,7 +760,7 @@ public class ForeignKeyPropertyDiscoveryConventionTest
         var newRelationshipBuilder = RunConvention(relationshipBuilder);
         Assert.Same(relationshipBuilder, newRelationshipBuilder);
 
-        var fk = relationshipBuilder.Metadata;
+        var fk = relationshipBuilder!.Metadata;
         Assert.Same(fk, DependentTypeWithCompositeKey.GetForeignKeys().Single());
         Assert.Null(fk.GetPropertiesConfigurationSource());
         Assert.Same(CompositePrimaryKey[0], fk.PrincipalKey.Properties[0]);
@@ -773,15 +773,15 @@ public class ForeignKeyPropertyDiscoveryConventionTest
     public void Does_not_match_if_a_foreign_key_on_the_best_candidate_property_already_exists()
     {
         var dependentTypeBuilder = DependentType.Builder;
-        var fkProperty = dependentTypeBuilder.Property(DependentEntity.SomeNavPeEKaYProperty, ConfigurationSource.Convention).Metadata;
+        var fkProperty = dependentTypeBuilder.Property(DependentEntity.SomeNavPeEKaYProperty, ConfigurationSource.Convention)!.Metadata;
         dependentTypeBuilder.Property(DependentEntity.PrincipalEntityIDProperty, ConfigurationSource.Convention);
         dependentTypeBuilder.Property(DependentEntity.PrincipalEntityPeEKaYProperty, ConfigurationSource.Convention);
         dependentTypeBuilder.Property(DependentEntity.PeEKaYProperty, ConfigurationSource.Convention);
 
-        var relationshipBuilder = dependentTypeBuilder.HasRelationship(PrincipalType, [fkProperty], ConfigurationSource.Convention);
+        var relationshipBuilder = dependentTypeBuilder.HasRelationship(PrincipalType, [fkProperty], ConfigurationSource.Convention)!;
 
         var newRelationshipBuilder = dependentTypeBuilder.HasRelationship(
-            PrincipalType, "SomeNav", null, ConfigurationSource.Convention);
+            PrincipalType, "SomeNav", null, ConfigurationSource.Convention)!;
 
         Assert.Equal(
             "SomeNav" + nameof(PrincipalEntity.PeeKay),
@@ -812,21 +812,21 @@ public class ForeignKeyPropertyDiscoveryConventionTest
     public void Does_not_match_if_a_foreign_key_on_the_best_candidate_property_already_configured_explicitly()
     {
         var dependentTypeBuilder = DependentType.Builder;
-        var fkProperty = dependentTypeBuilder.Property(DependentEntity.SomeNavPeEKaYProperty, ConfigurationSource.Convention).Metadata;
+        var fkProperty = dependentTypeBuilder.Property(DependentEntity.SomeNavPeEKaYProperty, ConfigurationSource.Convention)!.Metadata;
         dependentTypeBuilder.Property(DependentEntity.PrincipalEntityIDProperty, ConfigurationSource.Convention);
         dependentTypeBuilder.Property(DependentEntity.PrincipalEntityPeEKaYProperty, ConfigurationSource.Convention);
         dependentTypeBuilder.Property(DependentEntity.PeEKaYProperty, ConfigurationSource.Convention);
 
-        var derivedTypeBuilder = _model.Entity(typeof(DerivedPrincipalEntity), ConfigurationSource.Convention);
+        var derivedTypeBuilder = _model.Entity(typeof(DerivedPrincipalEntity), ConfigurationSource.Convention)!;
         derivedTypeBuilder.HasBaseType(PrincipalType, ConfigurationSource.Convention);
 
         var relationshipBuilder = dependentTypeBuilder
-            .HasRelationship(derivedTypeBuilder.Metadata, [fkProperty], ConfigurationSource.Explicit);
+            .HasRelationship(derivedTypeBuilder.Metadata, [fkProperty], ConfigurationSource.Explicit)!;
         var compositeRelationshipBuilder = dependentTypeBuilder
-            .HasRelationship(PrincipalTypeWithCompositeKey, [fkProperty], ConfigurationSource.Explicit);
+            .HasRelationship(PrincipalTypeWithCompositeKey, [fkProperty], ConfigurationSource.Explicit)!;
 
         var newRelationshipBuilder = dependentTypeBuilder.HasRelationship(
-            PrincipalType, "SomeNav", null, ConfigurationSource.Convention);
+            PrincipalType, "SomeNav", null, ConfigurationSource.Convention)!;
 
         Assert.Equal(
             "SomeNav" + nameof(PrincipalEntity.PeeKay),
@@ -850,10 +850,10 @@ public class ForeignKeyPropertyDiscoveryConventionTest
     public void Logs_warning_if_foreign_key_property_names_are_order_dependent()
     {
         var relationshipBuilder = DependentType.Builder.HasRelationship(
-            PrincipalType, (string)null, null, ConfigurationSource.Convention);
+            PrincipalType, (string?)null, null, ConfigurationSource.Convention)!;
 
         var otherRelationshipBuilder = DependentType.Builder.HasRelationship(
-            PrincipalType, (string)null, null, ConfigurationSource.Convention);
+            PrincipalType, (string?)null, null, ConfigurationSource.Convention)!;
 
         Assert.Equal(
             nameof(PrincipalEntity) + nameof(PrincipalEntity.PeeKay),
@@ -881,10 +881,10 @@ public class ForeignKeyPropertyDiscoveryConventionTest
     public void Inverts_if_principal_entity_type_can_have_non_pk_fk_property()
     {
         var fkProperty = DependentType.Builder.Property(
-            DependentEntity.PrincipalEntityPeEKaYProperty, ConfigurationSource.Convention).Metadata;
+            DependentEntity.PrincipalEntityPeEKaYProperty, ConfigurationSource.Convention)!.Metadata;
 
-        var relationshipBuilder = PrincipalType.Builder.HasRelationship(DependentType, ConfigurationSource.Convention)
-            .IsUnique(true, ConfigurationSource.Convention);
+        var relationshipBuilder = PrincipalType.Builder.HasRelationship(DependentType, ConfigurationSource.Convention)!
+            .IsUnique(true, ConfigurationSource.Convention)!;
 
         var newRelationshipBuilder = RunConvention(relationshipBuilder);
         Assert.NotSame(relationshipBuilder, newRelationshipBuilder);
@@ -906,10 +906,10 @@ public class ForeignKeyPropertyDiscoveryConventionTest
     public void Does_not_invert_if_weak_entity_type_can_have_non_pk_fk_property()
     {
         var fkProperty = DependentType.Builder.Property(DependentEntity.PrincipalEntityPeEKaYProperty, ConfigurationSource.Convention)
-            .Metadata;
+            !.Metadata;
 
-        var relationshipBuilder = DependentType.Builder.HasRelationship(PrincipalType, ConfigurationSource.Convention)
-            .IsUnique(true, ConfigurationSource.Convention);
+        var relationshipBuilder = DependentType.Builder.HasRelationship(PrincipalType, ConfigurationSource.Convention)!
+            .IsUnique(true, ConfigurationSource.Convention)!;
 
         var newRelationshipBuilder = RunConvention(relationshipBuilder);
         Assert.Same(relationshipBuilder, newRelationshipBuilder);
@@ -935,8 +935,8 @@ public class ForeignKeyPropertyDiscoveryConventionTest
         dependentTypeBuilder.Property(DependentEntity.PrincipalEntityPeEKaYProperty, ConfigurationSource.Convention);
         PrincipalType.Builder.Property(PrincipalEntity.DependentEntityKayPeeProperty, ConfigurationSource.Convention);
 
-        var relationshipBuilder = dependentTypeBuilder.HasRelationship(PrincipalType, ConfigurationSource.Convention)
-            .IsUnique(true, ConfigurationSource.Convention);
+        var relationshipBuilder = dependentTypeBuilder.HasRelationship(PrincipalType, ConfigurationSource.Convention)!
+            .IsUnique(true, ConfigurationSource.Convention)!;
 
         var newRelationshipBuilder = RunConvention(relationshipBuilder);
         Assert.Same(relationshipBuilder, newRelationshipBuilder);
@@ -956,7 +956,7 @@ public class ForeignKeyPropertyDiscoveryConventionTest
         PrincipalType.Builder.Property(nameof(PrincipalEntity.DependentEntityKayPee), ConfigurationSource.Convention);
         PrincipalType.Model.RemoveEntityType(typeof(DependentEntity));
         var relationshipBuilder = PrincipalType.Builder.HasOwnership(
-            typeof(DependentEntity), nameof(PrincipalEntity.InverseReferenceNav), ConfigurationSource.Convention);
+            typeof(DependentEntity), nameof(PrincipalEntity.InverseReferenceNav), ConfigurationSource.Convention)!;
         var dependentTypeBuilder = relationshipBuilder.Metadata.DeclaringEntityType.Builder;
         dependentTypeBuilder.PrimaryKey([nameof(DependentEntity.KayPee)], ConfigurationSource.Convention);
 
@@ -983,7 +983,7 @@ public class ForeignKeyPropertyDiscoveryConventionTest
         var newRelationshipBuilder = RunConvention(relationshipBuilder);
         Assert.Same(relationshipBuilder, newRelationshipBuilder);
 
-        var fk = relationshipBuilder.Metadata;
+        var fk = relationshipBuilder!.Metadata;
         Assert.Same(fk, DependentType.GetForeignKeys().Single());
         Assert.Null(fk.GetPropertiesConfigurationSource());
         Assert.Equal("SomeNav" + PrimaryKey.Name, fk.Properties.Single().Name);
@@ -1008,7 +1008,7 @@ public class ForeignKeyPropertyDiscoveryConventionTest
         var newRelationshipBuilder = RunConvention(relationshipBuilder);
         Assert.Same(relationshipBuilder, newRelationshipBuilder);
 
-        var fk = (IConventionForeignKey)relationshipBuilder.Metadata;
+        var fk = (IConventionForeignKey)relationshipBuilder!.Metadata;
         Assert.Same(fk, DependentType.GetForeignKeys().Single());
         Assert.Null(fk.GetPropertiesConfigurationSource());
         Assert.Equal("SomeNav" + PrimaryKey.Name, fk.Properties.Single().Name);
@@ -1021,7 +1021,7 @@ public class ForeignKeyPropertyDiscoveryConventionTest
 
         var newFk = DependentType.GetForeignKeys().Single();
         Assert.Same(fk, newFk);
-        Assert.Equal(property.Metadata, newFk.Properties.Single());
+        Assert.Equal(property!.Metadata, newFk.Properties.Single());
 
         ValidateModel();
     }
@@ -1030,8 +1030,8 @@ public class ForeignKeyPropertyDiscoveryConventionTest
     public void Inverts_and_sets_foreign_key_if_matching_non_shadow_property_added_on_principal_type()
     {
         var relationshipBuilder = PrincipalType.Builder
-            .HasRelationship(DependentType, "InverseReferenceNav", "SomeNav", ConfigurationSource.Convention)
-            .IsUnique(true, ConfigurationSource.Convention);
+            .HasRelationship(DependentType, "InverseReferenceNav", "SomeNav", ConfigurationSource.Convention)!
+            .IsUnique(true, ConfigurationSource.Convention)!;
 
         var fk = (IConventionForeignKey)relationshipBuilder.Metadata;
         Assert.Same(fk, PrincipalType.GetForeignKeys().Single());
@@ -1048,7 +1048,7 @@ public class ForeignKeyPropertyDiscoveryConventionTest
 
         var newFk = DependentType.GetForeignKeys().Single();
         Assert.NotSame(fk, newFk);
-        Assert.Equal(property.Metadata, newFk.Properties.Single());
+        Assert.Equal(property!.Metadata, newFk.Properties.Single());
         Assert.Same(newFk.DeclaringEntityType, fk.PrincipalEntityType);
         Assert.Same(newFk.PrincipalEntityType, fk.DeclaringEntityType);
         Assert.True(newFk.IsUnique);
@@ -1075,7 +1075,7 @@ public class ForeignKeyPropertyDiscoveryConventionTest
 
         var otherRelationshipBuilder = dependentTypeBuilder.HasRelationship(
             PrincipalType,
-            (string)null,
+            (string?)null,
             null,
             ConfigurationSource.Convention);
 
@@ -1100,20 +1100,20 @@ public class ForeignKeyPropertyDiscoveryConventionTest
     {
         var modelBuilder = new InternalModelBuilder(new Model());
 
-        var principalType = modelBuilder.Entity(typeof(PrincipalEntity), ConfigurationSource.Explicit);
+        var principalType = modelBuilder.Entity(typeof(PrincipalEntity), ConfigurationSource.Explicit)!;
         principalType.PrimaryKey([nameof(PrincipalEntity.PeeKay)], ConfigurationSource.Explicit);
 
-        var dependentType = modelBuilder.Entity(typeof(DependentEntity), ConfigurationSource.Explicit);
+        var dependentType = modelBuilder.Entity(typeof(DependentEntity), ConfigurationSource.Explicit)!;
         dependentType.PrimaryKey([nameof(DependentEntity.KayPee)], ConfigurationSource.Explicit);
 
-        var principalTypeWithCompositeKey = modelBuilder.Entity(typeof(PrincipalEntityWithCompositeKey), ConfigurationSource.Explicit);
+        var principalTypeWithCompositeKey = modelBuilder.Entity(typeof(PrincipalEntityWithCompositeKey), ConfigurationSource.Explicit)!;
         principalTypeWithCompositeKey.PrimaryKey(
             [PrincipalEntityWithCompositeKey.IdProperty, PrincipalEntityWithCompositeKey.NameProperty],
             ConfigurationSource.Explicit);
-        principalTypeWithCompositeKey.Property(PrincipalEntityWithCompositeKey.NameProperty, ConfigurationSource.Explicit)
+        principalTypeWithCompositeKey.Property(PrincipalEntityWithCompositeKey.NameProperty, ConfigurationSource.Explicit)!
             .IsRequired(true, ConfigurationSource.Explicit);
 
-        var dependentTypeWithCompositeKey = modelBuilder.Entity(typeof(DependentEntityWithCompositeKey), ConfigurationSource.Explicit);
+        var dependentTypeWithCompositeKey = modelBuilder.Entity(typeof(DependentEntityWithCompositeKey), ConfigurationSource.Explicit)!;
         dependentTypeWithCompositeKey.PrimaryKey(
             [nameof(DependentEntityWithCompositeKey.NotId), nameof(DependentEntityWithCompositeKey.NotName)],
             ConfigurationSource.Explicit);
@@ -1121,32 +1121,36 @@ public class ForeignKeyPropertyDiscoveryConventionTest
         return modelBuilder;
     }
 
-    private InternalForeignKeyBuilder RunConvention(InternalForeignKeyBuilder relationshipBuilder)
+    private InternalForeignKeyBuilder RunConvention(
+        InternalForeignKeyBuilder? relationshipBuilder)
     {
+        var nonNullRelationshipBuilder = relationshipBuilder!;
         var convention = CreateForeignKeyPropertyDiscoveryConvention();
         var context = new ConventionContext<IConventionForeignKeyBuilder>(
-            relationshipBuilder.Metadata.DeclaringEntityType.Model.ConventionDispatcher);
-        convention.ProcessForeignKeyAdded(relationshipBuilder, context);
+            nonNullRelationshipBuilder.Metadata.DeclaringEntityType.Model.ConventionDispatcher);
+        convention.ProcessForeignKeyAdded(nonNullRelationshipBuilder, context);
         if (context.ShouldStopProcessing())
         {
-            return (InternalForeignKeyBuilder)context.Result;
+            return (InternalForeignKeyBuilder)context.Result!;
         }
 
-        return relationshipBuilder;
+        return nonNullRelationshipBuilder;
     }
 
-    private InternalPropertyBuilder RunConvention(InternalPropertyBuilder propertyBuilder)
+    private InternalPropertyBuilder RunConvention(
+        InternalPropertyBuilder? propertyBuilder)
     {
+        var nonNullPropertyBuilder = propertyBuilder!;
         var convention = CreateForeignKeyPropertyDiscoveryConvention();
         var context = new ConventionContext<IConventionPropertyBuilder>(
-            propertyBuilder.Metadata.DeclaringType.Model.ConventionDispatcher);
-        convention.ProcessPropertyAdded(propertyBuilder, context);
+            nonNullPropertyBuilder.Metadata.DeclaringType.Model.ConventionDispatcher);
+        convention.ProcessPropertyAdded(nonNullPropertyBuilder, context);
         if (context.ShouldStopProcessing())
         {
-            return (InternalPropertyBuilder)context.Result;
+            return (InternalPropertyBuilder)context.Result!;
         }
 
-        return propertyBuilder;
+        return nonNullPropertyBuilder;
     }
 
     private void ValidateModel()
@@ -1188,51 +1192,51 @@ public class ForeignKeyPropertyDiscoveryConventionTest
         = new(l => l == DbLoggerCategory.Model.Name);
 
     private Property PrimaryKey
-        => PrincipalType.FindPrimaryKey().Properties.Single();
+        => PrincipalType.FindPrimaryKey()!.Properties.Single();
 
     private EntityType PrincipalType
-        => _model.Entity(typeof(PrincipalEntity), ConfigurationSource.Convention).Metadata;
+        => _model.Entity(typeof(PrincipalEntity), ConfigurationSource.Convention)!.Metadata;
 
     private EntityType DependentType
-        => _model.Entity(typeof(DependentEntity), ConfigurationSource.Convention).Metadata;
+        => _model.Entity(typeof(DependentEntity), ConfigurationSource.Convention)!.Metadata;
 
     private IReadOnlyList<Property> CompositePrimaryKey
-        => PrincipalTypeWithCompositeKey.FindPrimaryKey().Properties;
+        => PrincipalTypeWithCompositeKey.FindPrimaryKey()!.Properties;
 
     private EntityType PrincipalTypeWithCompositeKey
         => _model.Entity(
-            typeof(PrincipalEntityWithCompositeKey), ConfigurationSource.Convention).Metadata;
+            typeof(PrincipalEntityWithCompositeKey), ConfigurationSource.Convention)!.Metadata;
 
     private EntityType DependentTypeWithCompositeKey
         => _model.Entity(
-            typeof(DependentEntityWithCompositeKey), ConfigurationSource.Convention).Metadata;
+            typeof(DependentEntityWithCompositeKey), ConfigurationSource.Convention)!.Metadata;
 
     private class PrincipalEntity
     {
         public static readonly PropertyInfo DependentEntityKayPeeProperty =
-            typeof(PrincipalEntity).GetProperty("DependentEntityKayPee");
+            typeof(PrincipalEntity).GetProperty("DependentEntityKayPee")!;
 
         public int PrincipalEntityId { get; set; }
         public int PeeKay { get; set; }
         public int? DependentEntityKayPee { get; set; }
-        public IEnumerable<DependentEntity> InverseNav { get; set; }
-        public DependentEntity InverseReferenceNav { get; set; }
-        public PrincipalEntity SelfRef { get; set; }
+        public IEnumerable<DependentEntity> InverseNav { get; set; } = null!;
+        public DependentEntity InverseReferenceNav { get; set; } = null!;
+        public PrincipalEntity SelfRef { get; set; } = null!;
     }
 
     private class DerivedPrincipalEntity : PrincipalEntity;
 
     private class DependentEntity
     {
-        public static readonly PropertyInfo SomeNavIDProperty = typeof(DependentEntity).GetProperty("SomeNavID");
-        public static readonly PropertyInfo SomeNavPeEKaYProperty = typeof(DependentEntity).GetProperty("SomeNavPeEKaY");
-        public static readonly PropertyInfo PrincipalEntityIDProperty = typeof(DependentEntity).GetProperty("PrincipalEntityID");
+        public static readonly PropertyInfo SomeNavIDProperty = typeof(DependentEntity).GetProperty("SomeNavID")!;
+        public static readonly PropertyInfo SomeNavPeEKaYProperty = typeof(DependentEntity).GetProperty("SomeNavPeEKaY")!;
+        public static readonly PropertyInfo PrincipalEntityIDProperty = typeof(DependentEntity).GetProperty("PrincipalEntityID")!;
 
         public static readonly PropertyInfo PrincipalEntityPeEKaYProperty =
-            typeof(DependentEntity).GetProperty("PrincipalEntityPeEKaY");
+            typeof(DependentEntity).GetProperty("PrincipalEntityPeEKaY")!;
 
-        public static readonly PropertyInfo IDProperty = typeof(DependentEntity).GetProperty("ID");
-        public static readonly PropertyInfo PeEKaYProperty = typeof(DependentEntity).GetProperty("PeEKaY");
+        public static readonly PropertyInfo IDProperty = typeof(DependentEntity).GetProperty("ID")!;
+        public static readonly PropertyInfo PeEKaYProperty = typeof(DependentEntity).GetProperty("PeEKaY")!;
 
         public int KayPee { get; set; }
         public int SomeNavID { get; set; }
@@ -1242,48 +1246,48 @@ public class ForeignKeyPropertyDiscoveryConventionTest
         public int ID { get; set; }
         public int PeEKaY { get; set; }
 
-        public PrincipalEntity SomeNav { get; set; }
-        public PrincipalEntity SomeOtherNav { get; set; }
+        public PrincipalEntity SomeNav { get; set; } = null!;
+        public PrincipalEntity SomeOtherNav { get; set; } = null!;
     }
 
     private class PrincipalEntityWithCompositeKey
     {
-        public static readonly PropertyInfo IdProperty = typeof(PrincipalEntityWithCompositeKey).GetProperty("Id");
-        public static readonly PropertyInfo NameProperty = typeof(PrincipalEntityWithCompositeKey).GetProperty("Name");
+        public static readonly PropertyInfo IdProperty = typeof(PrincipalEntityWithCompositeKey).GetProperty("Id")!;
+        public static readonly PropertyInfo NameProperty = typeof(PrincipalEntityWithCompositeKey).GetProperty("Name")!;
 
         public int Id { get; set; }
-        public string Name { get; set; }
-        public IEnumerable<DependentEntityWithCompositeKey> InverseNav { get; set; }
-        public DependentEntityWithCompositeKey InverseReferenceNav { get; set; }
+        public string Name { get; set; } = null!;
+        public IEnumerable<DependentEntityWithCompositeKey> InverseNav { get; set; } = null!;
+        public DependentEntityWithCompositeKey InverseReferenceNav { get; set; } = null!;
     }
 
     private class DependentCompositeBase
     {
         public int NotId { get; set; }
-        public string NotName { get; set; }
+        public string NotName { get; set; } = null!;
     }
 
     private class DependentEntityWithCompositeKey : DependentCompositeBase
     {
-        public static readonly PropertyInfo NavPropIdProperty = typeof(DependentEntityWithCompositeKey).GetProperty("NavPropId");
-        public static readonly PropertyInfo NavPropNameProperty = typeof(DependentEntityWithCompositeKey).GetProperty("NavPropName");
+        public static readonly PropertyInfo NavPropIdProperty = typeof(DependentEntityWithCompositeKey).GetProperty("NavPropId")!;
+        public static readonly PropertyInfo NavPropNameProperty = typeof(DependentEntityWithCompositeKey).GetProperty("NavPropName")!;
 
         public static readonly PropertyInfo PrincipalEntityWithCompositeKeyIdProperty =
-            typeof(DependentEntityWithCompositeKey).GetProperty("PrincipalEntityWithCompositeKeyId");
+            typeof(DependentEntityWithCompositeKey).GetProperty("PrincipalEntityWithCompositeKeyId")!;
 
         public static readonly PropertyInfo PrincipalEntityWithCompositeKeyNameProperty =
-            typeof(DependentEntityWithCompositeKey).GetProperty("PrincipalEntityWithCompositeKeyName");
+            typeof(DependentEntityWithCompositeKey).GetProperty("PrincipalEntityWithCompositeKeyName")!;
 
-        public static readonly PropertyInfo IdProperty = typeof(DependentEntityWithCompositeKey).GetProperty("Id");
-        public static readonly PropertyInfo NameProperty = typeof(DependentEntityWithCompositeKey).GetProperty("Name");
+        public static readonly PropertyInfo IdProperty = typeof(DependentEntityWithCompositeKey).GetProperty("Id")!;
+        public static readonly PropertyInfo NameProperty = typeof(DependentEntityWithCompositeKey).GetProperty("Name")!;
 
         public int NavPropId { get; set; }
-        public string NavPropName { get; set; }
+        public string NavPropName { get; set; } = null!;
         public int PrincipalEntityWithCompositeKeyId { get; set; }
-        public string PrincipalEntityWithCompositeKeyName { get; set; }
+        public string PrincipalEntityWithCompositeKeyName { get; set; } = null!;
         public int Id { get; set; }
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
 
-        public PrincipalEntityWithCompositeKey NavProp { get; set; }
+        public PrincipalEntityWithCompositeKey NavProp { get; set; } = null!;
     }
 }

--- a/test/EFCore.Tests/Metadata/Conventions/IndexAttributeConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/IndexAttributeConventionTest.cs
@@ -19,14 +19,14 @@ public class IndexAttributeConventionTest
     {
         var modelBuilder = new InternalModelBuilder(new Model());
 
-        var entityBuilder = modelBuilder.Entity(typeof(EntityWithIndex), ConfigurationSource.Convention);
+        var entityBuilder = modelBuilder.Entity(typeof(EntityWithIndex), ConfigurationSource.Convention)!;
         entityBuilder.Property("Id", ConfigurationSource.Convention);
-        var propABuilder = entityBuilder.Property("A", ConfigurationSource.Convention);
-        var propBBuilder = entityBuilder.Property("B", ConfigurationSource.Convention);
+        var propABuilder = entityBuilder.Property("A", ConfigurationSource.Convention)!;
+        var propBBuilder = entityBuilder.Property("B", ConfigurationSource.Convention)!;
         entityBuilder.PrimaryKey(new List<string> { "Id" }, ConfigurationSource.Convention);
 
         var indexProperties = new List<string> { propABuilder.Metadata.Name, propBBuilder.Metadata.Name };
-        var indexBuilder = entityBuilder.HasIndex(indexProperties, "IndexOnAAndB", ConfigurationSource.Convention);
+        var indexBuilder = entityBuilder.HasIndex(indexProperties, "IndexOnAAndB", ConfigurationSource.Convention)!;
         indexBuilder.IsUnique(false, ConfigurationSource.Convention);
         indexBuilder.IsDescending([false, true], ConfigurationSource.Convention);
 
@@ -223,7 +223,7 @@ public class IndexAttributeConventionTest
         Assert.Empty(parentEntityBuilder.Metadata.GetDeclaredIndexes());
         Assert.Single(childEntityBuilder.Metadata.GetDeclaredIndexes());
 
-        parentEntityBuilder.HasBaseType((string)null);
+        parentEntityBuilder.HasBaseType((string?)null);
 
         Assert.Null(parentEntityBuilder.Metadata.BaseType);
         Assert.NotNull(childEntityBuilder.Metadata.BaseType);
@@ -348,7 +348,7 @@ public class IndexAttributeConventionTest
         public int D { get; set; }
     }
 
-    [Index(nameof(A), (string)null, Name = "IndexOnAAndNull")]
+    [Index(nameof(A), (string)null!, Name = "IndexOnAAndNull")]
     private class EntityWithInvalidNullIndexProperty
     {
         public int Id { get; set; }

--- a/test/EFCore.Tests/Metadata/Conventions/KeyDiscoveryConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/KeyDiscoveryConventionTest.cs
@@ -29,7 +29,7 @@ public class KeyDiscoveryConventionTest
     public void Primary_key_is_set_when_shadow_property_not_defined_by_convention_matches()
     {
         var entityBuilder = CreateInternalEntityBuilder<EntityWithNoId>();
-        var propertyBuilder = entityBuilder.Property(typeof(int), "Id", ConfigurationSource.DataAnnotation);
+        var propertyBuilder = entityBuilder.Property(typeof(int), "Id", ConfigurationSource.DataAnnotation)!;
 
         RunConvention(propertyBuilder);
 
@@ -42,7 +42,7 @@ public class KeyDiscoveryConventionTest
     public void Primary_key_is_not_set_when_shadow_property_defined_by_convention_matches()
     {
         var entityBuilder = CreateInternalEntityBuilder<EntityWithNoId>();
-        var propertyBuilder = entityBuilder.Property(typeof(int), "Id", ConfigurationSource.Convention);
+        var propertyBuilder = entityBuilder.Property(typeof(int), "Id", ConfigurationSource.Convention)!;
 
         RunConvention(propertyBuilder);
 
@@ -131,7 +131,7 @@ public class KeyDiscoveryConventionTest
 
         CreateKeyDiscoveryConvention().ProcessEntityTypeMemberIgnored(entityBuilder, "ID", context);
 
-        Assert.Equal("Id", entityBuilder.Metadata.FindPrimaryKey().Properties.Single().Name);
+        Assert.Equal("Id", entityBuilder.Metadata.FindPrimaryKey()!.Properties.Single().Name);
     }
 
     public ListLoggerFactory ListLoggerFactory { get; }
@@ -180,7 +180,7 @@ public class KeyDiscoveryConventionTest
     private InternalEntityTypeBuilder CreateInternalEntityBuilder<T>()
     {
         var modelBuilder = new InternalModelBuilder(new Model());
-        var entityBuilder = modelBuilder.Entity(typeof(T), ConfigurationSource.Convention);
+        var entityBuilder = modelBuilder.Entity(typeof(T), ConfigurationSource.Convention)!;
 
         var context = new ConventionContext<IConventionEntityTypeBuilder>(modelBuilder.Metadata.ConventionDispatcher);
         new PropertyDiscoveryConvention(CreateDependencies())
@@ -191,7 +191,7 @@ public class KeyDiscoveryConventionTest
 
     private class EntityWithNoId
     {
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
         public DateTime ModifiedDate { get; set; }
     }
 }

--- a/test/EFCore.Tests/Metadata/Conventions/ManyToManyJoinEntityTypeConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/ManyToManyJoinEntityTypeConventionTest.cs
@@ -20,18 +20,18 @@ public class ManyToManyJoinEntityTypeConventionTest
     public void Join_entity_type_is_created_for_self_join()
     {
         var modelBuilder = CreateInternalModeBuilder();
-        var manyToManySelf = modelBuilder.Entity(typeof(ManyToManySelf), ConfigurationSource.Convention);
+        var manyToManySelf = modelBuilder.Entity(typeof(ManyToManySelf), ConfigurationSource.Convention)!;
 
         manyToManySelf.PrimaryKey([nameof(ManyToManySelf.Id)], ConfigurationSource.Convention);
 
         var firstSkipNav = manyToManySelf.HasSkipNavigation(
-            new MemberIdentity(typeof(ManyToManySelf).GetProperty(nameof(ManyToManySelf.ManyToManySelf1))),
+            new MemberIdentity(typeof(ManyToManySelf).GetProperty(nameof(ManyToManySelf.ManyToManySelf1))!),
             manyToManySelf.Metadata,
-            ConfigurationSource.Convention);
+            ConfigurationSource.Convention)!;
         var secondSkipNav = manyToManySelf.HasSkipNavigation(
-            new MemberIdentity(typeof(ManyToManySelf).GetProperty(nameof(ManyToManySelf.ManyToManySelf2))),
+            new MemberIdentity(typeof(ManyToManySelf).GetProperty(nameof(ManyToManySelf.ManyToManySelf2))!),
             manyToManySelf.Metadata,
-            ConfigurationSource.Convention);
+            ConfigurationSource.Convention)!;
         firstSkipNav.HasInverse(secondSkipNav.Metadata, ConfigurationSource.Convention);
 
         RunConvention(firstSkipNav);
@@ -45,21 +45,21 @@ public class ManyToManyJoinEntityTypeConventionTest
     public void Join_entity_type_is_not_created_when_no_inverse_skip_navigation()
     {
         var modelBuilder = CreateInternalModeBuilder();
-        var manyToManyFirst = modelBuilder.Entity(typeof(ManyToManyFirst), ConfigurationSource.Convention);
-        var manyToManySecond = modelBuilder.Entity(typeof(ManyToManySecond), ConfigurationSource.Convention);
-        var manyToManyJoin = modelBuilder.Entity(typeof(ManyToManyJoin), ConfigurationSource.Convention);
+        var manyToManyFirst = modelBuilder.Entity(typeof(ManyToManyFirst), ConfigurationSource.Convention)!;
+        var manyToManySecond = modelBuilder.Entity(typeof(ManyToManySecond), ConfigurationSource.Convention)!;
+        var manyToManyJoin = modelBuilder.Entity(typeof(ManyToManyJoin), ConfigurationSource.Convention)!;
 
-        var manyToManyFirstPK = manyToManyFirst.PrimaryKey([nameof(ManyToManyFirst.Id)], ConfigurationSource.Convention);
-        var manyToManySecondPK = manyToManySecond.PrimaryKey([nameof(ManyToManySecond.Id)], ConfigurationSource.Convention);
+        var manyToManyFirstPK = manyToManyFirst.PrimaryKey([nameof(ManyToManyFirst.Id)], ConfigurationSource.Convention)!;
+        var manyToManySecondPK = manyToManySecond.PrimaryKey([nameof(ManyToManySecond.Id)], ConfigurationSource.Convention)!;
 
         var skipNavOnFirst = manyToManyFirst.HasSkipNavigation(
-            new MemberIdentity(typeof(ManyToManyFirst).GetProperty(nameof(ManyToManyFirst.ManyToManySeconds))),
+            new MemberIdentity(typeof(ManyToManyFirst).GetProperty(nameof(ManyToManyFirst.ManyToManySeconds))!),
             manyToManySecond.Metadata,
-            ConfigurationSource.Convention);
+            ConfigurationSource.Convention)!;
         var skipNavOnSecond = manyToManySecond.HasSkipNavigation(
-            new MemberIdentity(typeof(ManyToManySecond).GetProperty(nameof(ManyToManySecond.ManyToManyFirsts))),
+            new MemberIdentity(typeof(ManyToManySecond).GetProperty(nameof(ManyToManySecond.ManyToManyFirsts))!),
             manyToManyFirst.Metadata,
-            ConfigurationSource.Convention);
+            ConfigurationSource.Convention)!;
         // do not set SkipNav's as inverses of one another
 
         RunConvention(skipNavOnFirst);
@@ -73,22 +73,22 @@ public class ManyToManyJoinEntityTypeConventionTest
     public void Join_entity_type_is_not_created_when_skip_navigation_is_not_collection()
     {
         var modelBuilder = CreateInternalModeBuilder();
-        var manyToManyFirst = modelBuilder.Entity(typeof(ManyToManyFirst), ConfigurationSource.Convention);
-        var manyToManySecond = modelBuilder.Entity(typeof(ManyToManySecond), ConfigurationSource.Convention);
-        var manyToManyJoin = modelBuilder.Entity(typeof(ManyToManyJoin), ConfigurationSource.Convention);
+        var manyToManyFirst = modelBuilder.Entity(typeof(ManyToManyFirst), ConfigurationSource.Convention)!;
+        var manyToManySecond = modelBuilder.Entity(typeof(ManyToManySecond), ConfigurationSource.Convention)!;
+        var manyToManyJoin = modelBuilder.Entity(typeof(ManyToManyJoin), ConfigurationSource.Convention)!;
 
-        var manyToManyFirstPK = manyToManyFirst.PrimaryKey([nameof(ManyToManyFirst.Id)], ConfigurationSource.Convention);
-        var manyToManySecondPK = manyToManySecond.PrimaryKey([nameof(ManyToManySecond.Id)], ConfigurationSource.Convention);
+        var manyToManyFirstPK = manyToManyFirst.PrimaryKey([nameof(ManyToManyFirst.Id)], ConfigurationSource.Convention)!;
+        var manyToManySecondPK = manyToManySecond.PrimaryKey([nameof(ManyToManySecond.Id)], ConfigurationSource.Convention)!;
 
         var skipNavOnFirst = manyToManyFirst.HasSkipNavigation(
-            new MemberIdentity(typeof(ManyToManyFirst).GetProperty(nameof(ManyToManyFirst.Second))),
+            new MemberIdentity(typeof(ManyToManyFirst).GetProperty(nameof(ManyToManyFirst.Second))!),
             manyToManySecond.Metadata,
             ConfigurationSource.Convention,
-            collection: false);
+            collection: false)!;
         var skipNavOnSecond = manyToManySecond.HasSkipNavigation(
-            new MemberIdentity(typeof(ManyToManySecond).GetProperty(nameof(ManyToManySecond.ManyToManyFirsts))),
+            new MemberIdentity(typeof(ManyToManySecond).GetProperty(nameof(ManyToManySecond.ManyToManyFirsts))!),
             manyToManyFirst.Metadata,
-            ConfigurationSource.Convention);
+            ConfigurationSource.Convention)!;
         skipNavOnFirst.HasInverse(skipNavOnSecond.Metadata, ConfigurationSource.Convention);
 
         RunConvention(skipNavOnFirst);
@@ -102,22 +102,22 @@ public class ManyToManyJoinEntityTypeConventionTest
     public void Join_entity_type_is_not_created_when_inverse_skip_navigation_is_not_collection()
     {
         var modelBuilder = CreateInternalModeBuilder();
-        var manyToManyFirst = modelBuilder.Entity(typeof(ManyToManyFirst), ConfigurationSource.Convention);
-        var manyToManySecond = modelBuilder.Entity(typeof(ManyToManySecond), ConfigurationSource.Convention);
-        var manyToManyJoin = modelBuilder.Entity(typeof(ManyToManyJoin), ConfigurationSource.Convention);
+        var manyToManyFirst = modelBuilder.Entity(typeof(ManyToManyFirst), ConfigurationSource.Convention)!;
+        var manyToManySecond = modelBuilder.Entity(typeof(ManyToManySecond), ConfigurationSource.Convention)!;
+        var manyToManyJoin = modelBuilder.Entity(typeof(ManyToManyJoin), ConfigurationSource.Convention)!;
 
-        var manyToManyFirstPK = manyToManyFirst.PrimaryKey([nameof(ManyToManyFirst.Id)], ConfigurationSource.Convention);
-        var manyToManySecondPK = manyToManySecond.PrimaryKey([nameof(ManyToManySecond.Id)], ConfigurationSource.Convention);
+        var manyToManyFirstPK = manyToManyFirst.PrimaryKey([nameof(ManyToManyFirst.Id)], ConfigurationSource.Convention)!;
+        var manyToManySecondPK = manyToManySecond.PrimaryKey([nameof(ManyToManySecond.Id)], ConfigurationSource.Convention)!;
 
         var skipNavOnFirst = manyToManyFirst.HasSkipNavigation(
-            new MemberIdentity(typeof(ManyToManyFirst).GetProperty(nameof(ManyToManyFirst.ManyToManySeconds))),
+            new MemberIdentity(typeof(ManyToManyFirst).GetProperty(nameof(ManyToManyFirst.ManyToManySeconds))!),
             manyToManySecond.Metadata,
-            ConfigurationSource.Convention);
+            ConfigurationSource.Convention)!;
         var skipNavOnSecond = manyToManySecond.HasSkipNavigation(
-            new MemberIdentity(typeof(ManyToManySecond).GetProperty(nameof(ManyToManySecond.First))),
+            new MemberIdentity(typeof(ManyToManySecond).GetProperty(nameof(ManyToManySecond.First))!),
             manyToManyFirst.Metadata,
             ConfigurationSource.Convention,
-            collection: false);
+            collection: false)!;
         skipNavOnFirst.HasInverse(skipNavOnSecond.Metadata, ConfigurationSource.Convention);
 
         RunConvention(skipNavOnFirst);
@@ -131,21 +131,21 @@ public class ManyToManyJoinEntityTypeConventionTest
     public void Join_entity_type_is_not_created_when_skip_navigation_already_in_use()
     {
         var modelBuilder = CreateInternalModeBuilder();
-        var manyToManyFirst = modelBuilder.Entity(typeof(ManyToManyFirst), ConfigurationSource.Convention);
-        var manyToManySecond = modelBuilder.Entity(typeof(ManyToManySecond), ConfigurationSource.Convention);
-        var manyToManyJoin = modelBuilder.Entity(typeof(ManyToManyJoin), ConfigurationSource.Convention);
+        var manyToManyFirst = modelBuilder.Entity(typeof(ManyToManyFirst), ConfigurationSource.Convention)!;
+        var manyToManySecond = modelBuilder.Entity(typeof(ManyToManySecond), ConfigurationSource.Convention)!;
+        var manyToManyJoin = modelBuilder.Entity(typeof(ManyToManyJoin), ConfigurationSource.Convention)!;
 
-        var manyToManyFirstPK = manyToManyFirst.PrimaryKey([nameof(ManyToManyFirst.Id)], ConfigurationSource.Convention);
-        var manyToManySecondPK = manyToManySecond.PrimaryKey([nameof(ManyToManySecond.Id)], ConfigurationSource.Convention);
+        var manyToManyFirstPK = manyToManyFirst.PrimaryKey([nameof(ManyToManyFirst.Id)], ConfigurationSource.Convention)!;
+        var manyToManySecondPK = manyToManySecond.PrimaryKey([nameof(ManyToManySecond.Id)], ConfigurationSource.Convention)!;
 
         var skipNavOnFirst = manyToManyFirst.HasSkipNavigation(
-            new MemberIdentity(typeof(ManyToManyFirst).GetProperty(nameof(ManyToManyFirst.ManyToManySeconds))),
+            new MemberIdentity(typeof(ManyToManyFirst).GetProperty(nameof(ManyToManyFirst.ManyToManySeconds))!),
             manyToManySecond.Metadata,
-            ConfigurationSource.Convention);
+            ConfigurationSource.Convention)!;
         var skipNavOnSecond = manyToManySecond.HasSkipNavigation(
-            new MemberIdentity(typeof(ManyToManySecond).GetProperty(nameof(ManyToManySecond.ManyToManyFirsts))),
+            new MemberIdentity(typeof(ManyToManySecond).GetProperty(nameof(ManyToManySecond.ManyToManyFirsts))!),
             manyToManyFirst.Metadata,
-            ConfigurationSource.Convention);
+            ConfigurationSource.Convention)!;
         skipNavOnFirst.HasInverse(skipNavOnSecond.Metadata, ConfigurationSource.Convention);
 
         // assign a non-null foreign key to skipNavOnFirst to make it appear to be "in use"
@@ -153,7 +153,7 @@ public class ManyToManyJoinEntityTypeConventionTest
             manyToManyFirst.Metadata.Name,
             [nameof(ManyToManyJoin.LeftId)],
             manyToManyFirstPK.Metadata,
-            ConfigurationSource.Convention);
+            ConfigurationSource.Convention)!;
         skipNavOnFirst.Metadata.SetForeignKey(leftFK.Metadata, ConfigurationSource.Convention);
 
         RunConvention(skipNavOnFirst);
@@ -167,21 +167,21 @@ public class ManyToManyJoinEntityTypeConventionTest
     public void Join_entity_type_is_not_created_when_inverse_skip_navigation_already_in_use()
     {
         var modelBuilder = CreateInternalModeBuilder();
-        var manyToManyFirst = modelBuilder.Entity(typeof(ManyToManyFirst), ConfigurationSource.Convention);
-        var manyToManySecond = modelBuilder.Entity(typeof(ManyToManySecond), ConfigurationSource.Convention);
-        var manyToManyJoin = modelBuilder.Entity(typeof(ManyToManyJoin), ConfigurationSource.Convention);
+        var manyToManyFirst = modelBuilder.Entity(typeof(ManyToManyFirst), ConfigurationSource.Convention)!;
+        var manyToManySecond = modelBuilder.Entity(typeof(ManyToManySecond), ConfigurationSource.Convention)!;
+        var manyToManyJoin = modelBuilder.Entity(typeof(ManyToManyJoin), ConfigurationSource.Convention)!;
 
-        var manyToManyFirstPK = manyToManyFirst.PrimaryKey([nameof(ManyToManyFirst.Id)], ConfigurationSource.Convention);
-        var manyToManySecondPK = manyToManySecond.PrimaryKey([nameof(ManyToManySecond.Id)], ConfigurationSource.Convention);
+        var manyToManyFirstPK = manyToManyFirst.PrimaryKey([nameof(ManyToManyFirst.Id)], ConfigurationSource.Convention)!;
+        var manyToManySecondPK = manyToManySecond.PrimaryKey([nameof(ManyToManySecond.Id)], ConfigurationSource.Convention)!;
 
         var skipNavOnFirst = manyToManyFirst.HasSkipNavigation(
-            new MemberIdentity(typeof(ManyToManyFirst).GetProperty(nameof(ManyToManyFirst.ManyToManySeconds))),
+            new MemberIdentity(typeof(ManyToManyFirst).GetProperty(nameof(ManyToManyFirst.ManyToManySeconds))!),
             manyToManySecond.Metadata,
-            ConfigurationSource.Convention);
+            ConfigurationSource.Convention)!;
         var skipNavOnSecond = manyToManySecond.HasSkipNavigation(
-            new MemberIdentity(typeof(ManyToManySecond).GetProperty(nameof(ManyToManySecond.ManyToManyFirsts))),
+            new MemberIdentity(typeof(ManyToManySecond).GetProperty(nameof(ManyToManySecond.ManyToManyFirsts))!),
             manyToManyFirst.Metadata,
-            ConfigurationSource.Convention);
+            ConfigurationSource.Convention)!;
         skipNavOnFirst.HasInverse(skipNavOnSecond.Metadata, ConfigurationSource.Convention);
 
         // assign a non-null foreign key to skipNavOnSecond to make it appear to be "in use"
@@ -189,7 +189,7 @@ public class ManyToManyJoinEntityTypeConventionTest
             manyToManySecond.Metadata.Name,
             [nameof(ManyToManyJoin.RightId)],
             manyToManySecondPK.Metadata,
-            ConfigurationSource.Convention);
+            ConfigurationSource.Convention)!;
         skipNavOnSecond.Metadata.SetForeignKey(rightFK.Metadata, ConfigurationSource.Convention);
 
         RunConvention(skipNavOnFirst);
@@ -203,20 +203,20 @@ public class ManyToManyJoinEntityTypeConventionTest
     public void Join_entity_type_is_created()
     {
         var modelBuilder = CreateInternalModeBuilder();
-        var manyToManyFirst = modelBuilder.Entity(typeof(ManyToManyFirst), ConfigurationSource.Convention);
-        var manyToManySecond = modelBuilder.Entity(typeof(ManyToManySecond), ConfigurationSource.Convention);
+        var manyToManyFirst = modelBuilder.Entity(typeof(ManyToManyFirst), ConfigurationSource.Convention)!;
+        var manyToManySecond = modelBuilder.Entity(typeof(ManyToManySecond), ConfigurationSource.Convention)!;
 
         manyToManyFirst.PrimaryKey([nameof(ManyToManyFirst.Id)], ConfigurationSource.Convention);
         manyToManySecond.PrimaryKey([nameof(ManyToManySecond.Id)], ConfigurationSource.Convention);
 
         var skipNavOnFirst = manyToManyFirst.HasSkipNavigation(
-            new MemberIdentity(typeof(ManyToManyFirst).GetProperty(nameof(ManyToManyFirst.ManyToManySeconds))),
+            new MemberIdentity(typeof(ManyToManyFirst).GetProperty(nameof(ManyToManyFirst.ManyToManySeconds))!),
             manyToManySecond.Metadata,
-            ConfigurationSource.Convention);
+            ConfigurationSource.Convention)!;
         var skipNavOnSecond = manyToManySecond.HasSkipNavigation(
-            new MemberIdentity(typeof(ManyToManySecond).GetProperty(nameof(ManyToManySecond.ManyToManyFirsts))),
+            new MemberIdentity(typeof(ManyToManySecond).GetProperty(nameof(ManyToManySecond.ManyToManyFirsts))!),
             manyToManyFirst.Metadata,
-            ConfigurationSource.Convention);
+            ConfigurationSource.Convention)!;
         skipNavOnFirst.HasInverse(skipNavOnSecond.Metadata, ConfigurationSource.Convention);
 
         RunConvention(skipNavOnSecond);
@@ -263,7 +263,7 @@ public class ManyToManyJoinEntityTypeConventionTest
         var context = new ConventionContext<IConventionSkipNavigationBuilder>(
             skipNavBuilder.Metadata.DeclaringEntityType.Model.ConventionDispatcher);
         CreateManyToManyConvention().ProcessSkipNavigationAdded(skipNavBuilder, context);
-        return context.ShouldStopProcessing() ? (InternalSkipNavigationBuilder)context.Result : skipNavBuilder;
+        return context.ShouldStopProcessing() ? (InternalSkipNavigationBuilder)context.Result! : skipNavBuilder;
     }
 
     private ManyToManyJoinEntityTypeConvention CreateManyToManyConvention()
@@ -282,22 +282,22 @@ public class ManyToManyJoinEntityTypeConventionTest
     private class ManyToManyFirst
     {
         public int Id { get; set; }
-        public IEnumerable<ManyToManySecond> ManyToManySeconds { get; set; }
-        public ManyToManySecond Second { get; set; }
+        public IEnumerable<ManyToManySecond> ManyToManySeconds { get; set; } = null!;
+        public ManyToManySecond Second { get; set; } = null!;
     }
 
     private class ManyToManySecond
     {
         public int Id { get; set; }
-        public IEnumerable<ManyToManyFirst> ManyToManyFirsts { get; set; }
-        public ManyToManyFirst First { get; set; }
+        public IEnumerable<ManyToManyFirst> ManyToManyFirsts { get; set; } = null!;
+        public ManyToManyFirst First { get; set; } = null!;
     }
 
     private class ManyToManySelf
     {
         public int Id { get; set; }
-        public IEnumerable<ManyToManySelf> ManyToManySelf1 { get; set; }
-        public IEnumerable<ManyToManySelf> ManyToManySelf2 { get; set; }
+        public IEnumerable<ManyToManySelf> ManyToManySelf1 { get; set; } = null!;
+        public IEnumerable<ManyToManySelf> ManyToManySelf2 { get; set; } = null!;
     }
 
     private class ManyToManyJoin

--- a/test/EFCore.Tests/Metadata/Conventions/ModelCleanupConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/ModelCleanupConventionTest.cs
@@ -14,8 +14,8 @@ public class ModelCleanupConventionTest
     {
         var principalEntityBuilder = CreateInternalEntityBuilder<OneToOnePrincipal>();
         var modelBuilder = principalEntityBuilder.ModelBuilder;
-        var dependentEntityBuilder = modelBuilder.Entity(typeof(OneToOneDependent), ConfigurationSource.Convention);
-        var baseEntityBuilder = modelBuilder.Entity(typeof(Base), ConfigurationSource.Convention);
+        var dependentEntityBuilder = modelBuilder.Entity(typeof(OneToOneDependent), ConfigurationSource.Convention)!;
+        var baseEntityBuilder = modelBuilder.Entity(typeof(Base), ConfigurationSource.Convention)!;
         principalEntityBuilder.HasBaseType(baseEntityBuilder.Metadata, ConfigurationSource.Convention);
         dependentEntityBuilder.HasBaseType(baseEntityBuilder.Metadata, ConfigurationSource.Convention);
         dependentEntityBuilder.HasRelationship(
@@ -31,7 +31,7 @@ public class ModelCleanupConventionTest
     {
         var principalEntityBuilder = CreateInternalEntityBuilder<OneToOnePrincipal>();
         var modelBuilder = principalEntityBuilder.ModelBuilder;
-        var dependentEntityBuilder = modelBuilder.Entity(typeof(OneToOneDependent), ConfigurationSource.Convention);
+        var dependentEntityBuilder = modelBuilder.Entity(typeof(OneToOneDependent), ConfigurationSource.Convention)!;
         dependentEntityBuilder.HasRelationship(
             principalEntityBuilder.Metadata, null, nameof(OneToOnePrincipal.OneToOneDependent), ConfigurationSource.Convention);
 
@@ -45,8 +45,8 @@ public class ModelCleanupConventionTest
     {
         var principalEntityBuilder = CreateInternalEntityBuilder<OneToOnePrincipal>();
         var modelBuilder = principalEntityBuilder.ModelBuilder;
-        var dependentEntityBuilder = modelBuilder.Entity(typeof(OneToOneDependent), ConfigurationSource.DataAnnotation);
-        var baseEntityBuilder = modelBuilder.Entity(typeof(Base), ConfigurationSource.DataAnnotation);
+        var dependentEntityBuilder = modelBuilder.Entity(typeof(OneToOneDependent), ConfigurationSource.DataAnnotation)!;
+        var baseEntityBuilder = modelBuilder.Entity(typeof(Base), ConfigurationSource.DataAnnotation)!;
         principalEntityBuilder.HasBaseType(baseEntityBuilder.Metadata, ConfigurationSource.Convention);
         dependentEntityBuilder.HasBaseType(baseEntityBuilder.Metadata, ConfigurationSource.Convention);
 
@@ -74,7 +74,7 @@ public class ModelCleanupConventionTest
         => InMemoryTestHelpers.Instance.CreateContextServices().GetRequiredService<ProviderConventionSetBuilderDependencies>();
 
     private static InternalEntityTypeBuilder CreateInternalEntityBuilder<T>()
-        => new InternalModelBuilder(new Model()).Entity(typeof(T), ConfigurationSource.Explicit);
+        => new InternalModelBuilder(new Model()).Entity(typeof(T), ConfigurationSource.Explicit)!;
 
     private class Base
     {
@@ -83,11 +83,11 @@ public class ModelCleanupConventionTest
 
     private class OneToOnePrincipal : Base
     {
-        public OneToOneDependent OneToOneDependent { get; set; }
+        public OneToOneDependent OneToOneDependent { get; set; } = null!;
     }
 
     private class OneToOneDependent : Base
     {
-        public OneToOnePrincipal OneToOnePrincipal { get; set; }
+        public OneToOnePrincipal OneToOnePrincipal { get; set; } = null!;
     }
 }

--- a/test/EFCore.Tests/Metadata/Conventions/NavigationAttributeConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/NavigationAttributeConventionTest.cs
@@ -23,7 +23,7 @@ public class NavigationAttributeConventionTest
     public void NotMappedAttribute_overrides_configuration_from_convention_source()
     {
         var dependentEntityTypeBuilder = CreateInternalEntityTypeBuilder<BlogDetails>();
-        var principalEntityTypeBuilder = dependentEntityTypeBuilder.ModelBuilder.Entity(typeof(Blog), ConfigurationSource.Convention);
+        var principalEntityTypeBuilder = dependentEntityTypeBuilder.ModelBuilder.Entity(typeof(Blog), ConfigurationSource.Convention)!;
 
         dependentEntityTypeBuilder.HasRelationship(
             principalEntityTypeBuilder.Metadata,
@@ -49,7 +49,7 @@ public class NavigationAttributeConventionTest
     public void NotMappedAttribute_does_not_override_configuration_from_explicit_source()
     {
         var dependentEntityTypeBuilder = CreateInternalEntityTypeBuilder<BlogDetails>();
-        var principalEntityTypeBuilder = dependentEntityTypeBuilder.ModelBuilder.Entity(typeof(Blog), ConfigurationSource.Convention);
+        var principalEntityTypeBuilder = dependentEntityTypeBuilder.ModelBuilder.Entity(typeof(Blog), ConfigurationSource.Convention)!;
 
         dependentEntityTypeBuilder.HasRelationship(
             principalEntityTypeBuilder.Metadata,
@@ -73,8 +73,8 @@ public class NavigationAttributeConventionTest
         var model = modelBuilder.Model;
         modelBuilder.Entity<BlogDetails>();
 
-        Assert.DoesNotContain(model.FindEntityType(typeof(Blog)).GetNavigations(), nav => nav.Name == nameof(Blog.BlogDetails));
-        Assert.Contains(model.FindEntityType(typeof(BlogDetails)).GetNavigations(), nav => nav.Name == nameof(BlogDetails.Blog));
+        Assert.DoesNotContain(model.FindEntityType(typeof(Blog))!.GetNavigations(), nav => nav.Name == nameof(Blog.BlogDetails));
+        Assert.Contains(model.FindEntityType(typeof(BlogDetails))!.GetNavigations(), nav => nav.Name == nameof(BlogDetails.Blog));
     }
 
     #endregion
@@ -85,14 +85,14 @@ public class NavigationAttributeConventionTest
     public void RequiredAttribute_overrides_configuration_from_convention_source()
     {
         var dependentEntityTypeBuilder = CreateInternalEntityTypeBuilder<Post>();
-        var principalEntityTypeBuilder = dependentEntityTypeBuilder.ModelBuilder.Entity(typeof(Blog), ConfigurationSource.Convention);
+        var principalEntityTypeBuilder = dependentEntityTypeBuilder.ModelBuilder.Entity(typeof(Blog), ConfigurationSource.Convention)!;
 
         var relationshipBuilder = dependentEntityTypeBuilder.HasRelationship(
             principalEntityTypeBuilder.Metadata,
             nameof(Post.Blog),
             nameof(Blog.Posts),
             ConfigurationSource.Convention,
-            setTargetAsPrincipal: true);
+            setTargetAsPrincipal: true)!;
 
         var navigation = dependentEntityTypeBuilder.Metadata.FindNavigation(nameof(Post.Blog));
 
@@ -111,13 +111,13 @@ public class NavigationAttributeConventionTest
     public void RequiredAttribute_does_not_override_configuration_from_explicit_source()
     {
         var dependentEntityTypeBuilder = CreateInternalEntityTypeBuilder<Post>();
-        var principalEntityTypeBuilder = dependentEntityTypeBuilder.ModelBuilder.Entity(typeof(Blog), ConfigurationSource.Convention);
+        var principalEntityTypeBuilder = dependentEntityTypeBuilder.ModelBuilder.Entity(typeof(Blog), ConfigurationSource.Convention)!;
 
         var relationshipBuilder = dependentEntityTypeBuilder.HasRelationship(
             principalEntityTypeBuilder.Metadata,
             nameof(Post.Blog),
             nameof(Blog.Posts),
-            ConfigurationSource.Convention);
+            ConfigurationSource.Convention)!;
 
         var navigation = dependentEntityTypeBuilder.Metadata.FindNavigation(nameof(BlogDetails.Blog));
 
@@ -137,13 +137,13 @@ public class NavigationAttributeConventionTest
     {
         var dependentEntityTypeBuilder = CreateInternalEntityTypeBuilder<Dependent>();
         var principalEntityTypeBuilder =
-            dependentEntityTypeBuilder.ModelBuilder.Entity(typeof(Principal), ConfigurationSource.Convention);
+            dependentEntityTypeBuilder.ModelBuilder.Entity(typeof(Principal), ConfigurationSource.Convention)!;
 
         var relationshipBuilder = principalEntityTypeBuilder.HasRelationship(
             dependentEntityTypeBuilder.Metadata,
             nameof(Principal.Dependents),
             nameof(Dependent.Principal),
-            ConfigurationSource.Convention);
+            ConfigurationSource.Convention)!;
 
         var navigation = principalEntityTypeBuilder.Metadata.FindNavigation(nameof(Principal.Dependents));
 
@@ -165,13 +165,13 @@ public class NavigationAttributeConventionTest
     {
         var dependentEntityTypeBuilder = CreateInternalEntityTypeBuilder<Dependent>();
         var principalEntityTypeBuilder =
-            dependentEntityTypeBuilder.ModelBuilder.Entity(typeof(Principal), ConfigurationSource.Convention);
+            dependentEntityTypeBuilder.ModelBuilder.Entity(typeof(Principal), ConfigurationSource.Convention)!;
 
         var relationshipBuilder = dependentEntityTypeBuilder.HasRelationship(
             principalEntityTypeBuilder.Metadata,
             nameof(Dependent.Principal),
             nameof(Principal.Dependent),
-            ConfigurationSource.Convention);
+            ConfigurationSource.Convention)!;
 
         Assert.Equal(nameof(Dependent), relationshipBuilder.Metadata.DeclaringEntityType.DisplayName());
         Assert.False(relationshipBuilder.Metadata.IsRequired);
@@ -181,7 +181,7 @@ public class NavigationAttributeConventionTest
         RunRequiredNavigationAttributeConvention(relationshipBuilder, navigation);
 
         var newForeignKey = dependentEntityTypeBuilder.Metadata.GetForeignKeys().Single();
-        Assert.Equal(nameof(Principal.Dependent), newForeignKey.PrincipalToDependent.Name);
+        Assert.Equal(nameof(Principal.Dependent), newForeignKey.PrincipalToDependent!.Name);
         Assert.False(newForeignKey.IsRequired);
         Assert.Empty(ListLoggerFactory.Log);
     }
@@ -194,7 +194,7 @@ public class NavigationAttributeConventionTest
         modelBuilder.Entity<BlogDetails>();
 
         Assert.True(
-            model.FindEntityType(typeof(BlogDetails)).GetForeignKeys().Single(fk => fk.PrincipalEntityType?.ClrType == typeof(Blog))
+            model.FindEntityType(typeof(BlogDetails))!.GetForeignKeys().Single(fk => fk.PrincipalEntityType?.ClrType == typeof(Blog))
                 .IsRequired);
     }
 
@@ -203,7 +203,7 @@ public class NavigationAttributeConventionTest
     {
         var postEntityTypeBuilder = CreateInternalEntityTypeBuilder<Post>();
         var blogEntityTypeBuilder = postEntityTypeBuilder.ModelBuilder.Entity(
-            typeof(Blog), ConfigurationSource.Convention);
+            typeof(Blog), ConfigurationSource.Convention)!;
 
         var navigationBuilder = postEntityTypeBuilder.HasSkipNavigation(
             new MemberIdentity(nameof(Post.Blogs)),
@@ -213,7 +213,7 @@ public class NavigationAttributeConventionTest
             null,
             ConfigurationSource.Convention,
             collections: true,
-            onDependent: false);
+            onDependent: false)!;
 
         var convention = new RequiredNavigationAttributeConvention(CreateDependencies());
         convention.ProcessSkipNavigationAdded(
@@ -241,7 +241,7 @@ public class NavigationAttributeConventionTest
     {
         var dependentEntityTypeBuilder = CreateInternalEntityTypeBuilder<Dependent>();
         var principalEntityTypeBuilder =
-            dependentEntityTypeBuilder.ModelBuilder.Entity(typeof(Principal), ConfigurationSource.Convention);
+            dependentEntityTypeBuilder.ModelBuilder.Entity(typeof(Principal), ConfigurationSource.Convention)!;
 
         dependentEntityTypeBuilder.HasRelationship(
             principalEntityTypeBuilder.Metadata,
@@ -267,7 +267,7 @@ public class NavigationAttributeConventionTest
     {
         var dependentEntityTypeBuilder = CreateInternalEntityTypeBuilder<Dependent>();
         var principalEntityTypeBuilder =
-            dependentEntityTypeBuilder.ModelBuilder.Entity(typeof(Principal), ConfigurationSource.Convention);
+            dependentEntityTypeBuilder.ModelBuilder.Entity(typeof(Principal), ConfigurationSource.Convention)!;
 
         dependentEntityTypeBuilder.HasRelationship(
             principalEntityTypeBuilder.Metadata,
@@ -293,7 +293,7 @@ public class NavigationAttributeConventionTest
     {
         var dependentEntityTypeBuilder = CreateInternalEntityTypeBuilder<AmbiguousDependent>();
         var principalEntityTypeBuilder = dependentEntityTypeBuilder.ModelBuilder.Entity(
-            typeof(AmbiguousPrincipal), ConfigurationSource.Convention);
+            typeof(AmbiguousPrincipal), ConfigurationSource.Convention)!;
 
         dependentEntityTypeBuilder.HasRelationship(
             principalEntityTypeBuilder.Metadata,
@@ -345,7 +345,7 @@ public class NavigationAttributeConventionTest
         var dependentEntityTypeBuilder = principalEntityTypeBuilder.HasOwnership(
             typeof(Dependent),
             nameof(Principal.Dependents),
-            ConfigurationSource.Convention).Metadata.DeclaringEntityType.Builder;
+            ConfigurationSource.Convention)!.Metadata.DeclaringEntityType.Builder;
 
         Assert.Contains(principalEntityTypeBuilder.Metadata.GetNavigations(), nav => nav.Name == nameof(Principal.Dependents));
         Assert.DoesNotContain(principalEntityTypeBuilder.Metadata.GetNavigations(), nav => nav.Name == nameof(Principal.Dependent));
@@ -426,17 +426,17 @@ public class NavigationAttributeConventionTest
     {
         var dependentEntityTypeBuilder = CreateInternalEntityTypeBuilder<Dependent>();
         var principalEntityTypeBuilder =
-            dependentEntityTypeBuilder.ModelBuilder.Entity(typeof(Principal), ConfigurationSource.Convention);
+            dependentEntityTypeBuilder.ModelBuilder.Entity(typeof(Principal), ConfigurationSource.Convention)!;
 
         var relationshipBuilder = dependentEntityTypeBuilder.HasRelationship(
                 principalEntityTypeBuilder.Metadata,
                 "Principal",
                 "Dependent",
-                ConfigurationSource.Convention)
+                ConfigurationSource.Convention)!
             .HasForeignKey(
                 dependentEntityTypeBuilder.GetOrCreateProperties(
-                    new List<PropertyInfo> { Dependent.PrincipalIdProperty }, ConfigurationSource.Convention),
-                ConfigurationSource.Convention);
+                    new List<PropertyInfo> { Dependent.PrincipalIdProperty }, ConfigurationSource.Convention)!,
+                ConfigurationSource.Convention)!;
 
         Assert.Equal("PrincipalId", relationshipBuilder.Metadata.Properties.First().Name);
 
@@ -458,17 +458,17 @@ public class NavigationAttributeConventionTest
     {
         var dependentEntityTypeBuilder = CreateInternalEntityTypeBuilder<Dependent>();
         var principalEntityTypeBuilder =
-            dependentEntityTypeBuilder.ModelBuilder.Entity(typeof(Principal), ConfigurationSource.Convention);
+            dependentEntityTypeBuilder.ModelBuilder.Entity(typeof(Principal), ConfigurationSource.Convention)!;
 
         var relationshipBuilder = dependentEntityTypeBuilder.HasRelationship(
                 principalEntityTypeBuilder.Metadata,
                 "Principal",
                 "Dependent",
-                ConfigurationSource.Convention)
+                ConfigurationSource.Convention)!
             .HasForeignKey(
                 dependentEntityTypeBuilder.GetOrCreateProperties(
-                    new List<PropertyInfo> { Dependent.PrincipalIdProperty }, ConfigurationSource.Convention),
-                ConfigurationSource.Explicit);
+                    new List<PropertyInfo> { Dependent.PrincipalIdProperty }, ConfigurationSource.Convention)!,
+                ConfigurationSource.Explicit)!;
 
         Assert.Equal("PrincipalId", relationshipBuilder.Metadata.Properties.First().Name);
 
@@ -490,17 +490,17 @@ public class NavigationAttributeConventionTest
     {
         var dependentEntityTypeBuilder = CreateInternalEntityTypeBuilder<Dependent>();
         var principalEntityTypeBuilder =
-            dependentEntityTypeBuilder.ModelBuilder.Entity(typeof(Principal), ConfigurationSource.Convention);
+            dependentEntityTypeBuilder.ModelBuilder.Entity(typeof(Principal), ConfigurationSource.Convention)!;
 
         var relationshipBuilder = dependentEntityTypeBuilder.HasRelationship(
                 principalEntityTypeBuilder.Metadata,
                 "Principal",
                 "Dependent",
-                ConfigurationSource.Convention)
+                ConfigurationSource.Convention)!
             .HasForeignKey(
                 dependentEntityTypeBuilder.GetOrCreateProperties(
-                    new List<PropertyInfo> { Dependent.PrincipalIdProperty }, ConfigurationSource.Convention),
-                ConfigurationSource.Convention);
+                    new List<PropertyInfo> { Dependent.PrincipalIdProperty }, ConfigurationSource.Convention)!,
+                ConfigurationSource.Convention)!;
 
         Assert.Equal("PrincipalId", relationshipBuilder.Metadata.Properties.First().Name);
 
@@ -522,17 +522,17 @@ public class NavigationAttributeConventionTest
     {
         var dependentEntityTypeBuilder = CreateInternalEntityTypeBuilder<Dependent>();
         var principalEntityTypeBuilder =
-            dependentEntityTypeBuilder.ModelBuilder.Entity(typeof(Principal), ConfigurationSource.Convention);
+            dependentEntityTypeBuilder.ModelBuilder.Entity(typeof(Principal), ConfigurationSource.Convention)!;
 
         var relationshipBuilder = dependentEntityTypeBuilder.HasRelationship(
                 principalEntityTypeBuilder.Metadata,
                 "AnotherPrincipal",
                 "Dependent",
-                ConfigurationSource.Convention)
+                ConfigurationSource.Convention)!
             .HasForeignKey(
                 dependentEntityTypeBuilder.GetOrCreateProperties(
-                    new List<PropertyInfo> { Dependent.PrincipalIdProperty }, ConfigurationSource.Convention),
-                ConfigurationSource.Convention);
+                    new List<PropertyInfo> { Dependent.PrincipalIdProperty }, ConfigurationSource.Convention)!,
+                ConfigurationSource.Convention)!;
 
         Assert.Equal("PrincipalId", relationshipBuilder.Metadata.Properties.First().Name);
 
@@ -554,17 +554,17 @@ public class NavigationAttributeConventionTest
     {
         var dependentEntityTypeBuilder = CreateInternalEntityTypeBuilder<Dependent>();
         var principalEntityTypeBuilder =
-            dependentEntityTypeBuilder.ModelBuilder.Entity(typeof(Principal), ConfigurationSource.Convention);
+            dependentEntityTypeBuilder.ModelBuilder.Entity(typeof(Principal), ConfigurationSource.Convention)!;
 
         var relationshipBuilder = dependentEntityTypeBuilder.HasRelationship(
                 principalEntityTypeBuilder.Metadata,
                 "AnotherPrincipal",
                 "Dependent",
-                ConfigurationSource.Convention)
+                ConfigurationSource.Convention)!
             .HasForeignKey(
                 dependentEntityTypeBuilder.GetOrCreateProperties(
-                    new List<PropertyInfo> { Dependent.PrincipalIdProperty }, ConfigurationSource.Convention),
-                ConfigurationSource.Convention);
+                    new List<PropertyInfo> { Dependent.PrincipalIdProperty }, ConfigurationSource.Convention)!,
+                ConfigurationSource.Convention)!;
 
         Assert.Equal("PrincipalId", relationshipBuilder.Metadata.Properties.First().Name);
 
@@ -586,17 +586,17 @@ public class NavigationAttributeConventionTest
     {
         var dependentEntityTypeBuilder = CreateInternalEntityTypeBuilder<DependentField>();
         var principalEntityTypeBuilder =
-            dependentEntityTypeBuilder.ModelBuilder.Entity(typeof(PrincipalField), ConfigurationSource.Convention);
+            dependentEntityTypeBuilder.ModelBuilder.Entity(typeof(PrincipalField), ConfigurationSource.Convention)!;
 
         var relationshipBuilder = dependentEntityTypeBuilder.HasRelationship(
                 principalEntityTypeBuilder.Metadata,
                 "AnotherPrincipalField",
                 "DependentField",
-                ConfigurationSource.Convention)
+                ConfigurationSource.Convention)!
             .HasForeignKey(
                 dependentEntityTypeBuilder.GetOrCreateProperties(
-                    new List<PropertyInfo> { DependentField.PrincipalIdProperty }, ConfigurationSource.Convention),
-                ConfigurationSource.Convention);
+                    new List<PropertyInfo> { DependentField.PrincipalIdProperty }, ConfigurationSource.Convention)!,
+                ConfigurationSource.Convention)!;
 
         Assert.Equal("PrincipalFieldId", relationshipBuilder.Metadata.Properties.First().Name);
 
@@ -619,17 +619,17 @@ public class NavigationAttributeConventionTest
     {
         var dependentEntityTypeBuilder = CreateInternalEntityTypeBuilder<Principal>();
         var principalEntityTypeBuilder =
-            dependentEntityTypeBuilder.ModelBuilder.Entity(typeof(Dependent), ConfigurationSource.Convention);
+            dependentEntityTypeBuilder.ModelBuilder.Entity(typeof(Dependent), ConfigurationSource.Convention)!;
 
         var relationshipBuilder = dependentEntityTypeBuilder.HasRelationship(
                 principalEntityTypeBuilder.Metadata,
                 "Dependent",
                 "AnotherPrincipal",
-                ConfigurationSource.Convention)
+                ConfigurationSource.Convention)!
             .HasForeignKey(
                 dependentEntityTypeBuilder.GetOrCreateProperties(
-                    new List<PropertyInfo> { Principal.DependentIdProperty }, ConfigurationSource.Convention),
-                ConfigurationSource.Convention);
+                    new List<PropertyInfo> { Principal.DependentIdProperty }, ConfigurationSource.Convention)!,
+                ConfigurationSource.Convention)!;
 
         Assert.Equal("DependentId", relationshipBuilder.Metadata.Properties.First().Name);
         Assert.Equal(typeof(Principal), relationshipBuilder.Metadata.DeclaringEntityType.ClrType);
@@ -655,17 +655,17 @@ public class NavigationAttributeConventionTest
     {
         var dependentEntityTypeBuilder = CreateInternalEntityTypeBuilder<Dependent>();
         var principalEntityTypeBuilder =
-            dependentEntityTypeBuilder.ModelBuilder.Entity(typeof(Principal), ConfigurationSource.Convention);
+            dependentEntityTypeBuilder.ModelBuilder.Entity(typeof(Principal), ConfigurationSource.Convention)!;
 
         var relationshipBuilder = dependentEntityTypeBuilder.HasRelationship(
                 principalEntityTypeBuilder.Metadata,
                 "CompositePrincipal",
                 "Dependent",
-                ConfigurationSource.Convention)
+                ConfigurationSource.Convention)!
             .HasForeignKey(
                 dependentEntityTypeBuilder.GetOrCreateProperties(
-                    new List<PropertyInfo> { Dependent.PrincipalIdProperty }, ConfigurationSource.Convention),
-                ConfigurationSource.Convention);
+                    new List<PropertyInfo> { Dependent.PrincipalIdProperty }, ConfigurationSource.Convention)!,
+                ConfigurationSource.Convention)!;
 
         Assert.Equal("PrincipalId", relationshipBuilder.Metadata.Properties.First().Name);
 
@@ -691,13 +691,13 @@ public class NavigationAttributeConventionTest
     {
         var dependentEntityTypeBuilder = CreateInternalEntityTypeBuilder<FkPropertyNavigationMismatch>();
         var principalEntityTypeBuilder =
-            dependentEntityTypeBuilder.ModelBuilder.Entity(typeof(Principal), ConfigurationSource.Convention);
+            dependentEntityTypeBuilder.ModelBuilder.Entity(typeof(Principal), ConfigurationSource.Convention)!;
 
         var relationshipBuilder = dependentEntityTypeBuilder.HasRelationship(
             principalEntityTypeBuilder.Metadata,
             "Principal",
             null,
-            ConfigurationSource.Convention);
+            ConfigurationSource.Convention)!;
 
         var navigation = relationshipBuilder.Metadata.DependentToPrincipal;
         Assert.Equal(
@@ -713,13 +713,13 @@ public class NavigationAttributeConventionTest
     {
         var dependentEntityTypeBuilder = CreateInternalEntityTypeBuilder<CompositeFkOnProperty>();
         var principalEntityTypeBuilder =
-            dependentEntityTypeBuilder.ModelBuilder.Entity(typeof(Principal), ConfigurationSource.Convention);
+            dependentEntityTypeBuilder.ModelBuilder.Entity(typeof(Principal), ConfigurationSource.Convention)!;
 
         var relationshipBuilder = dependentEntityTypeBuilder.HasRelationship(
             principalEntityTypeBuilder.Metadata,
             "Principal",
             null,
-            ConfigurationSource.Convention);
+            ConfigurationSource.Convention)!;
 
         var navigation = relationshipBuilder.Metadata.DependentToPrincipal;
         Assert.Equal(
@@ -735,13 +735,13 @@ public class NavigationAttributeConventionTest
     {
         var dependentEntityTypeBuilder = CreateInternalEntityTypeBuilder<InvalidPropertyListOnNavigation>();
         var principalEntityTypeBuilder =
-            dependentEntityTypeBuilder.ModelBuilder.Entity(typeof(Principal), ConfigurationSource.Convention);
+            dependentEntityTypeBuilder.ModelBuilder.Entity(typeof(Principal), ConfigurationSource.Convention)!;
 
         var relationshipBuilder = dependentEntityTypeBuilder.HasRelationship(
             principalEntityTypeBuilder.Metadata,
             "Principal",
             null,
-            ConfigurationSource.Convention);
+            ConfigurationSource.Convention)!;
 
         var navigation = relationshipBuilder.Metadata.DependentToPrincipal;
         Assert.Equal(
@@ -758,13 +758,13 @@ public class NavigationAttributeConventionTest
     {
         var dependentEntityTypeBuilder = CreateInternalEntityTypeBuilder<MultipleNavigationsSameFk>();
         var principalEntityTypeBuilder =
-            dependentEntityTypeBuilder.ModelBuilder.Entity(typeof(Principal), ConfigurationSource.Convention);
+            dependentEntityTypeBuilder.ModelBuilder.Entity(typeof(Principal), ConfigurationSource.Convention)!;
 
         var relationshipBuilder = dependentEntityTypeBuilder.HasRelationship(
             principalEntityTypeBuilder.Metadata,
             "One",
             null,
-            ConfigurationSource.Convention);
+            ConfigurationSource.Convention)!;
 
         var navigation = relationshipBuilder.Metadata.DependentToPrincipal;
         Assert.Equal(
@@ -780,13 +780,13 @@ public class NavigationAttributeConventionTest
     {
         var dependentEntityTypeBuilder = CreateInternalEntityTypeBuilder<Dependent>();
         var principalEntityTypeBuilder = dependentEntityTypeBuilder.ModelBuilder.Entity(
-            typeof(InvertedPrincipal), ConfigurationSource.Convention);
+            typeof(InvertedPrincipal), ConfigurationSource.Convention)!;
 
         var relationshipBuilder = dependentEntityTypeBuilder.HasRelationship(
             principalEntityTypeBuilder.Metadata,
             null,
             nameof(InvertedPrincipal.Dependents),
-            ConfigurationSource.Convention);
+            ConfigurationSource.Convention)!;
 
         if (useNavigation)
         {
@@ -822,42 +822,50 @@ public class NavigationAttributeConventionTest
             .ProcessEntityTypeAdded(entityTypeBuilder, context);
     }
 
-    private InternalForeignKeyBuilder RunForeignKeyAttributeConvention(InternalForeignKeyBuilder relationshipBuilder)
+    private InternalForeignKeyBuilder RunForeignKeyAttributeConvention(
+        InternalForeignKeyBuilder? relationshipBuilder)
     {
+        var nonNullRelationshipBuilder = relationshipBuilder!;
         var dependencies = CreateDependencies();
         var context = new ConventionContext<IConventionForeignKeyBuilder>(
-            relationshipBuilder.Metadata.DeclaringEntityType.Model.ConventionDispatcher);
+            nonNullRelationshipBuilder.Metadata.DeclaringEntityType.Model.ConventionDispatcher);
 
         new ForeignKeyAttributeConvention(dependencies)
-            .ProcessForeignKeyAdded(relationshipBuilder, context);
+            .ProcessForeignKeyAdded(nonNullRelationshipBuilder, context);
 
-        return context.ShouldStopProcessing() ? (InternalForeignKeyBuilder)context.Result : relationshipBuilder;
+        return context.ShouldStopProcessing() ? (InternalForeignKeyBuilder)context.Result! : nonNullRelationshipBuilder;
     }
 
     private InternalForeignKeyBuilder RunForeignKeyAttributeConvention(
-        InternalForeignKeyBuilder relationshipBuilder,
-        Navigation navigation)
+        InternalForeignKeyBuilder? relationshipBuilder,
+        Navigation? navigation)
     {
+        var nonNullRelationshipBuilder = relationshipBuilder!;
+        var nonNullNavigation = navigation!;
         var dependencies = CreateDependencies();
         var context = new ConventionContext<IConventionNavigationBuilder>(
-            relationshipBuilder.Metadata.DeclaringEntityType.Model.ConventionDispatcher);
+            nonNullRelationshipBuilder.Metadata.DeclaringEntityType.Model.ConventionDispatcher);
 
         new ForeignKeyAttributeConvention(dependencies)
-            .ProcessNavigationAdded(navigation.Builder, context);
+            .ProcessNavigationAdded(nonNullNavigation.Builder, context);
 
-        return context.ShouldStopProcessing()
-            ? (InternalForeignKeyBuilder)context.Result?.Metadata.ForeignKey.Builder
-            : relationshipBuilder;
+        return context.ShouldStopProcessing() && context.Result != null
+            ? (InternalForeignKeyBuilder)context.Result!.Metadata.ForeignKey.Builder
+            : nonNullRelationshipBuilder;
     }
 
-    private void RunRequiredNavigationAttributeConvention(InternalForeignKeyBuilder relationshipBuilder, Navigation navigation)
+    private void RunRequiredNavigationAttributeConvention(
+        InternalForeignKeyBuilder? relationshipBuilder,
+        Navigation? navigation)
     {
+        var nonNullRelationshipBuilder = relationshipBuilder!;
+        var nonNullNavigation = navigation!;
         var dependencies = CreateDependencies();
         var context = new ConventionContext<IConventionNavigationBuilder>(
-            relationshipBuilder.Metadata.DeclaringEntityType.Model.ConventionDispatcher);
+            nonNullRelationshipBuilder.Metadata.DeclaringEntityType.Model.ConventionDispatcher);
 
         new RequiredNavigationAttributeConvention(dependencies)
-            .ProcessNavigationAdded(navigation.Builder, context);
+            .ProcessNavigationAdded(nonNullNavigation.Builder, context);
     }
 
     private void RunNavigationBackingFieldAttributeConvention(
@@ -898,15 +906,15 @@ public class NavigationAttributeConventionTest
         var dependentEntityTypeBuilder = CreateInternalEntityTypeBuilder<DependentForNavWithBackingField>();
         var principalEntityTypeBuilder =
             dependentEntityTypeBuilder.ModelBuilder.Entity(
-                typeof(PrincipalForNavWithBackingField), ConfigurationSource.Convention);
+                typeof(PrincipalForNavWithBackingField), ConfigurationSource.Convention)!;
 
         var relationshipBuilder = dependentEntityTypeBuilder.HasRelationship(
             principalEntityTypeBuilder.Metadata,
             "PrincipalForNavWithBackingField",
             "DependentForNavWithBackingField",
-            ConfigurationSource.Convention);
+            ConfigurationSource.Convention)!;
 
-        IConventionNavigationBuilder navigationBuilder = relationshipBuilder.Metadata.DependentToPrincipal.Builder;
+        IConventionNavigationBuilder navigationBuilder = relationshipBuilder.Metadata.DependentToPrincipal!.Builder;
         RunNavigationBackingFieldAttributeConvention(relationshipBuilder, navigationBuilder);
 
         Assert.Equal("_backingFieldFromAttribute", navigationBuilder.Metadata.GetFieldName());
@@ -918,15 +926,15 @@ public class NavigationAttributeConventionTest
         var dependentEntityTypeBuilder = CreateInternalEntityTypeBuilder<DependentForNavWithBackingField>();
         var principalEntityTypeBuilder =
             dependentEntityTypeBuilder.ModelBuilder.Entity(
-                typeof(PrincipalForNavWithBackingField), ConfigurationSource.Convention);
+                typeof(PrincipalForNavWithBackingField), ConfigurationSource.Convention)!;
 
         var relationshipBuilder = dependentEntityTypeBuilder.HasRelationship(
             principalEntityTypeBuilder.Metadata,
             "PrincipalForNavWithBackingField",
             "DependentForNavWithBackingField",
-            ConfigurationSource.Convention);
+            ConfigurationSource.Convention)!;
 
-        var navigationBuilder = relationshipBuilder.Metadata.DependentToPrincipal.Builder;
+        var navigationBuilder = relationshipBuilder.Metadata.DependentToPrincipal!.Builder;
         navigationBuilder.HasField("_backingFieldFromFluentApi", ConfigurationSource.Explicit);
 
         RunNavigationBackingFieldAttributeConvention(relationshipBuilder, navigationBuilder);
@@ -944,15 +952,15 @@ public class NavigationAttributeConventionTest
         var dependentEntityTypeBuilder = CreateInternalEntityTypeBuilder<Dependent>();
         var principalEntityTypeBuilder =
             dependentEntityTypeBuilder.ModelBuilder.Entity(
-                typeof(Principal), ConfigurationSource.Convention);
+                typeof(Principal), ConfigurationSource.Convention)!;
 
         var relationshipBuilder = dependentEntityTypeBuilder.HasRelationship(
             principalEntityTypeBuilder.Metadata,
             nameof(Dependent.Principal),
             nameof(Principal.Dependents),
-            ConfigurationSource.Convention);
+            ConfigurationSource.Convention)!;
 
-        var navigationBuilder = relationshipBuilder.Metadata.DependentToPrincipal.Builder;
+        var navigationBuilder = relationshipBuilder.Metadata.DependentToPrincipal!.Builder;
         var foreignKey = navigationBuilder.Metadata.ForeignKey;
         foreignKey.SetDeleteBehavior(DeleteBehavior.NoAction, ConfigurationSource.Convention);
 
@@ -967,15 +975,15 @@ public class NavigationAttributeConventionTest
         var dependentEntityTypeBuilder = CreateInternalEntityTypeBuilder<Dependent>();
         var principalEntityTypeBuilder =
             dependentEntityTypeBuilder.ModelBuilder.Entity(
-                typeof(Principal), ConfigurationSource.Convention);
+                typeof(Principal), ConfigurationSource.Convention)!;
 
         var relationshipBuilder = dependentEntityTypeBuilder.HasRelationship(
             principalEntityTypeBuilder.Metadata,
             nameof(Dependent.Principal),
             nameof(Principal.Dependents),
-            ConfigurationSource.Convention);
+            ConfigurationSource.Convention)!;
 
-        var navigationBuilder = relationshipBuilder.Metadata.DependentToPrincipal.Builder;
+        var navigationBuilder = relationshipBuilder.Metadata.DependentToPrincipal!.Builder;
         var foreignKey = navigationBuilder.Metadata.ForeignKey;
         foreignKey.SetDeleteBehavior(DeleteBehavior.NoAction, ConfigurationSource.Explicit);
 
@@ -1021,15 +1029,15 @@ public class NavigationAttributeConventionTest
 
         var modelBuilder = new InternalModelBuilder(new Model(conventionSet));
 
-        return modelBuilder.Entity(typeof(T), ConfigurationSource.Explicit);
+        return modelBuilder.Entity(typeof(T), ConfigurationSource.Explicit)!;
     }
 
     private ModelBuilder CreateModelBuilder()
     {
         var serviceProvider = CreateServiceProvider();
         return new ModelBuilder(
-            serviceProvider.GetService<IConventionSetBuilder>().CreateConventionSet(),
-            serviceProvider.GetService<ModelDependencies>());
+            serviceProvider.GetRequiredService<IConventionSetBuilder>().CreateConventionSet(),
+            serviceProvider.GetRequiredService<ModelDependencies>());
     }
 
     private ProviderConventionSetBuilderDependencies CreateDependencies()
@@ -1059,9 +1067,9 @@ public class NavigationAttributeConventionTest
         public int Id { get; set; }
 
         [NotMapped, Required]
-        public BlogDetails BlogDetails { get; set; }
+        public BlogDetails BlogDetails { get; set; } = null!;
 
-        public ICollection<Post> Posts { get; set; }
+        public ICollection<Post> Posts { get; set; } = null!;
     }
 
     private class BlogDetails
@@ -1070,10 +1078,10 @@ public class NavigationAttributeConventionTest
         public int BlogId { get; set; }
 
         [Required]
-        public Blog Blog { get; set; }
+        public Blog Blog { get; set; } = null!;
 
         [Required]
-        private Post Post { get; set; }
+        private Post Post { get; set; } = null!;
     }
 
     private class Post
@@ -1081,10 +1089,10 @@ public class NavigationAttributeConventionTest
         public int Id { get; set; }
 
         [Required]
-        public Blog Blog { get; set; }
+        public Blog Blog { get; set; } = null!;
 
         [NotMapped, Required]
-        public ICollection<Blog> Blogs { get; set; }
+        public ICollection<Blog> Blogs { get; set; } = null!;
     }
 
     private interface IPrincipal
@@ -1094,29 +1102,29 @@ public class NavigationAttributeConventionTest
 
     private class Principal : IPrincipal
     {
-        public static readonly PropertyInfo DependentIdProperty = typeof(Principal).GetProperty("DependentId");
+        public static readonly PropertyInfo DependentIdProperty = typeof(Principal).GetProperty("DependentId")!;
 
         public int Id { get; set; }
 
         public int DependentId { get; set; }
 
         [Required, ForeignKey("PrincipalFk")]
-        public ICollection<Dependent> Dependents { get; set; }
+        public ICollection<Dependent> Dependents { get; set; } = null!;
 
         [Required]
-        public Dependent Dependent { get; set; }
+        public Dependent Dependent { get; set; } = null!;
 
-        public NonExistentNavigation MissingNavigation { get; set; }
+        public NonExistentNavigation MissingNavigation { get; set; } = null!;
 
         [InverseProperty("AnotherPrincipal")]
-        public MismatchedInverseProperty MismatchedInverseProperty { get; set; }
+        public MismatchedInverseProperty MismatchedInverseProperty { get; set; } = null!;
 
-        MismatchedInverseProperty IPrincipal.MismatchedInverseProperty { get; set; }
+        MismatchedInverseProperty IPrincipal.MismatchedInverseProperty { get; set; } = null!;
     }
 
     private class Dependent
     {
-        public static readonly PropertyInfo PrincipalIdProperty = typeof(Dependent).GetProperty("PrincipalId");
+        public static readonly PropertyInfo PrincipalIdProperty = typeof(Dependent).GetProperty("PrincipalId")!;
 
         public int Id { get; set; }
 
@@ -1128,12 +1136,12 @@ public class NavigationAttributeConventionTest
         public int PrincipalAnotherFk { get; set; }
 
         [ForeignKey("PrincipalFk"), InverseProperty("Dependent"), DeleteBehavior(DeleteBehavior.Restrict)]
-        public Principal Principal { get; set; }
+        public Principal Principal { get; set; } = null!;
 
-        public Principal AnotherPrincipal { get; set; }
+        public Principal AnotherPrincipal { get; set; } = null!;
 
         [ForeignKey("PrincipalId, PrincipalFk")]
-        public Principal CompositePrincipal { get; set; }
+        public Principal CompositePrincipal { get; set; } = null!;
     }
 
     private class PrincipalField
@@ -1142,12 +1150,12 @@ public class NavigationAttributeConventionTest
 
         public int DependentFieldId { get; set; }
 
-        public DependentField DependentField { get; set; }
+        public DependentField DependentField { get; set; } = null!;
     }
 
     private class DependentField
     {
-        public static readonly PropertyInfo PrincipalIdProperty = typeof(DependentField).GetProperty("PrincipalFieldId");
+        public static readonly PropertyInfo PrincipalIdProperty = typeof(DependentField).GetProperty("PrincipalFieldId")!;
 
         public int Id { get; set; }
 
@@ -1160,7 +1168,7 @@ public class NavigationAttributeConventionTest
         private readonly int _principalFieldAnotherFk;
 #pragma warning restore 169
 
-        public PrincipalField AnotherPrincipalField { get; set; }
+        public PrincipalField AnotherPrincipalField { get; set; } = null!;
     }
 
     private class SelfReferencingEntity
@@ -1168,7 +1176,7 @@ public class NavigationAttributeConventionTest
         public int Id { get; set; }
 
         [InverseProperty("AnotherEntity")]
-        public SelfReferencingEntity AnotherEntity { get; set; }
+        public SelfReferencingEntity AnotherEntity { get; set; } = null!;
     }
 
     private class NonExistentNavigation
@@ -1176,7 +1184,7 @@ public class NavigationAttributeConventionTest
         public int Id { get; set; }
 
         [InverseProperty("WrongNavigation")]
-        public Principal Principal { get; set; }
+        public Principal Principal { get; set; } = null!;
     }
 
     private class WrongNavigationType
@@ -1184,7 +1192,7 @@ public class NavigationAttributeConventionTest
         public int Id { get; set; }
 
         [InverseProperty("Dependent")]
-        public Principal Principal { get; set; }
+        public Principal Principal { get; set; } = null!;
     }
 
     private class MismatchedInverseProperty
@@ -1192,7 +1200,7 @@ public class NavigationAttributeConventionTest
         public int Id { get; set; }
 
         [InverseProperty("MismatchedInverseProperty")]
-        public Principal Principal { get; set; }
+        public Principal Principal { get; set; } = null!;
     }
 
     private class AmbiguousDependent
@@ -1200,17 +1208,17 @@ public class NavigationAttributeConventionTest
         public int Id { get; set; }
 
         [InverseProperty("Dependent")]
-        public AmbiguousPrincipal AmbiguousPrincipal { get; set; }
+        public AmbiguousPrincipal AmbiguousPrincipal { get; set; } = null!;
 
         [InverseProperty("Dependent")]
-        public AmbiguousPrincipal AnotherAmbiguousPrincipal { get; set; }
+        public AmbiguousPrincipal AnotherAmbiguousPrincipal { get; set; } = null!;
     }
 
     private class AmbiguousPrincipal
     {
         public int Id { get; set; }
 
-        public AmbiguousDependent Dependent { get; set; }
+        public AmbiguousDependent Dependent { get; set; } = null!;
     }
 
     private class FkPropertyNavigationMismatch
@@ -1221,7 +1229,7 @@ public class NavigationAttributeConventionTest
         public int PrincipalId { get; set; }
 
         [ForeignKey("PrincipalFk")]
-        public Principal Principal { get; set; }
+        public Principal Principal { get; set; } = null!;
     }
 
     private class CompositeFkOnProperty
@@ -1234,7 +1242,7 @@ public class NavigationAttributeConventionTest
         [ForeignKey("Principal")]
         public int PrincipalId2 { get; set; }
 
-        public Principal Principal { get; set; }
+        public Principal Principal { get; set; } = null!;
     }
 
     private class InvalidPropertyListOnNavigation
@@ -1246,7 +1254,7 @@ public class NavigationAttributeConventionTest
         public int PrincipalId2 { get; set; }
 
         [ForeignKey("PrincipalId1,,PrincipalId2")]
-        public Principal Principal { get; set; }
+        public Principal Principal { get; set; } = null!;
     }
 
     private class MultipleNavigationsSameFk
@@ -1256,29 +1264,29 @@ public class NavigationAttributeConventionTest
         public int CommonFkProperty { get; set; }
 
         [ForeignKey("CommonFkProperty")]
-        public Principal One { get; set; }
+        public Principal One { get; set; } = null!;
 
         [ForeignKey("CommonFkProperty")]
-        public Principal Two { get; set; }
+        public Principal Two { get; set; } = null!;
     }
 
     private class InvertedPrincipal
     {
-        public static readonly PropertyInfo DependentIdProperty = typeof(Principal).GetProperty("DependentId");
+        public static readonly PropertyInfo DependentIdProperty = typeof(Principal).GetProperty("DependentId")!;
 
         public int Id { get; set; }
 
         [ForeignKey("Dependents")]
         public int DependentId { get; set; }
 
-        public ICollection<Dependent> Dependents { get; set; }
+        public ICollection<Dependent> Dependents { get; set; } = null!;
     }
 
     private class PrincipalForNavWithBackingField
     {
         public int Id { get; set; }
 
-        public DependentForNavWithBackingField DependentForNavWithBackingField { get; set; }
+        public DependentForNavWithBackingField DependentForNavWithBackingField { get; set; } = null!;
     }
 
     private class DependentForNavWithBackingField
@@ -1287,12 +1295,12 @@ public class NavigationAttributeConventionTest
 
 #pragma warning disable IDE0044 // Add readonly modifier
 #pragma warning disable CS0169 // Field never used
-        private PrincipalForNavWithBackingField _backingFieldFromAttribute;
-        private PrincipalForNavWithBackingField _backingFieldFromFluentApi;
+    private PrincipalForNavWithBackingField? _backingFieldFromAttribute;
+    private PrincipalForNavWithBackingField? _backingFieldFromFluentApi;
 #pragma warning restore CS0169 // Field never used
 #pragma warning restore IDE0044 // Add readonly modifier
 
         [BackingField(nameof(_backingFieldFromAttribute))]
-        public PrincipalForNavWithBackingField PrincipalForNavWithBackingField { get; set; }
+        public PrincipalForNavWithBackingField PrincipalForNavWithBackingField { get; set; } = null!;
     }
 }

--- a/test/EFCore.Tests/Metadata/Conventions/NonNullableNavigationConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/NonNullableNavigationConventionTest.cs
@@ -8,8 +8,6 @@ using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Conventions;
 
-#nullable enable
-
 public class NonNullableNavigationConventionTest
 {
     [Fact]

--- a/test/EFCore.Tests/Metadata/Conventions/PrimaryKeyAttributeConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/PrimaryKeyAttributeConventionTest.cs
@@ -7,8 +7,6 @@ using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Conventions;
 
-#nullable enable
-
 public class PrimaryKeyAttributeConventionTest
 {
     [Fact]

--- a/test/EFCore.Tests/Metadata/Conventions/PropertyAttributeConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/PropertyAttributeConventionTest.cs
@@ -22,7 +22,7 @@ public class PropertyAttributeConventionTest
     {
         var entityTypeBuilder = CreateInternalEntityTypeBuilder<A>();
 
-        var propertyBuilder = entityTypeBuilder.Property(typeof(Guid), "RowVersion", ConfigurationSource.Explicit);
+        var propertyBuilder = entityTypeBuilder.Property(typeof(Guid), "RowVersion", ConfigurationSource.Explicit)!;
 
         propertyBuilder.IsConcurrencyToken(false, ConfigurationSource.Convention);
 
@@ -36,7 +36,7 @@ public class PropertyAttributeConventionTest
     {
         var entityTypeBuilder = CreateInternalEntityTypeBuilder<A>();
 
-        var propertyBuilder = entityTypeBuilder.Property(typeof(Guid), "RowVersion", ConfigurationSource.Explicit);
+        var propertyBuilder = entityTypeBuilder.Property(typeof(Guid), "RowVersion", ConfigurationSource.Explicit)!;
 
         propertyBuilder.IsConcurrencyToken(false, ConfigurationSource.Explicit);
 
@@ -72,7 +72,7 @@ public class PropertyAttributeConventionTest
     {
         var entityTypeBuilder = CreateInternalEntityTypeBuilder<A>();
 
-        var propertyBuilder = entityTypeBuilder.Property(typeof(int), "Id", ConfigurationSource.Explicit);
+        var propertyBuilder = entityTypeBuilder.Property(typeof(int), "Id", ConfigurationSource.Explicit)!;
 
         propertyBuilder.ValueGenerated(ValueGenerated.OnAdd, ConfigurationSource.Convention);
 
@@ -86,7 +86,7 @@ public class PropertyAttributeConventionTest
     {
         var entityTypeBuilder = CreateInternalEntityTypeBuilder<A>();
 
-        var propertyBuilder = entityTypeBuilder.Property(typeof(int), "Id", ConfigurationSource.Explicit);
+        var propertyBuilder = entityTypeBuilder.Property(typeof(int), "Id", ConfigurationSource.Explicit)!;
 
         propertyBuilder.ValueGenerated(ValueGenerated.Never, ConfigurationSource.Explicit);
 
@@ -122,14 +122,14 @@ public class PropertyAttributeConventionTest
     {
         var entityTypeBuilder = CreateInternalEntityTypeBuilder<A>();
 
-        var propertyBuilder = entityTypeBuilder.Property(typeof(int), "MyPrimaryKey", ConfigurationSource.Explicit);
+        var propertyBuilder = entityTypeBuilder.Property(typeof(int), "MyPrimaryKey", ConfigurationSource.Explicit)!;
 
         entityTypeBuilder.PrimaryKey(
             new List<string> { "Id" }, ConfigurationSource.Convention);
 
         RunConvention(propertyBuilder);
 
-        Assert.Equal("MyPrimaryKey", entityTypeBuilder.Metadata.FindPrimaryKey().Properties[0].Name);
+        Assert.Equal("MyPrimaryKey", entityTypeBuilder.Metadata.FindPrimaryKey()!.Properties[0].Name);
     }
 
     [Fact]
@@ -137,14 +137,14 @@ public class PropertyAttributeConventionTest
     {
         var entityTypeBuilder = CreateInternalEntityTypeBuilder<A>();
 
-        var propertyBuilder = entityTypeBuilder.Property(typeof(int), "MyPrimaryKey", ConfigurationSource.Explicit);
+        var propertyBuilder = entityTypeBuilder.Property(typeof(int), "MyPrimaryKey", ConfigurationSource.Explicit)!;
 
         entityTypeBuilder.PrimaryKey(
             new List<string> { "Id" }, ConfigurationSource.Explicit);
 
         RunConvention(propertyBuilder);
 
-        Assert.Equal("Id", entityTypeBuilder.Metadata.FindPrimaryKey().Properties[0].Name);
+        Assert.Equal("Id", entityTypeBuilder.Metadata.FindPrimaryKey()!.Properties[0].Name);
     }
 
     [Fact]
@@ -152,14 +152,14 @@ public class PropertyAttributeConventionTest
     {
         var entityTypeBuilder = CreateInternalEntityTypeBuilder<A>();
 
-        var propertyBuilder = entityTypeBuilder.Property(typeof(int), "MyPrimaryKey", ConfigurationSource.Explicit);
+        var propertyBuilder = entityTypeBuilder.Property(typeof(int), "MyPrimaryKey", ConfigurationSource.Explicit)!;
 
         Assert.Null(entityTypeBuilder.Metadata.FindPrimaryKey());
 
         RunConvention(propertyBuilder);
 
-        Assert.Equal(1, entityTypeBuilder.Metadata.FindPrimaryKey().Properties.Count);
-        Assert.Equal("MyPrimaryKey", entityTypeBuilder.Metadata.FindPrimaryKey().Properties[0].Name);
+        Assert.Equal(1, entityTypeBuilder.Metadata.FindPrimaryKey()!.Properties.Count);
+        Assert.Equal("MyPrimaryKey", entityTypeBuilder.Metadata.FindPrimaryKey()!.Properties[0].Name);
     }
 
     [Fact]
@@ -169,19 +169,19 @@ public class PropertyAttributeConventionTest
 
         Assert.Null(entityTypeBuilder.Metadata.FindPrimaryKey());
 
-        var idPropertyBuilder = entityTypeBuilder.Property(typeof(int), "Id", ConfigurationSource.Explicit);
-        var myPrimaryKeyPropertyBuilder = entityTypeBuilder.Property(typeof(int), "MyPrimaryKey", ConfigurationSource.Explicit);
+        var idPropertyBuilder = entityTypeBuilder.Property(typeof(int), "Id", ConfigurationSource.Explicit)!;
+        var myPrimaryKeyPropertyBuilder = entityTypeBuilder.Property(typeof(int), "MyPrimaryKey", ConfigurationSource.Explicit)!;
 
         RunConvention(idPropertyBuilder);
 
-        Assert.Equal(1, entityTypeBuilder.Metadata.FindPrimaryKey().Properties.Count);
-        Assert.Equal("Id", entityTypeBuilder.Metadata.FindPrimaryKey().Properties[0].Name);
+        Assert.Equal(1, entityTypeBuilder.Metadata.FindPrimaryKey()!.Properties.Count);
+        Assert.Equal("Id", entityTypeBuilder.Metadata.FindPrimaryKey()!.Properties[0].Name);
 
         RunConvention(myPrimaryKeyPropertyBuilder);
 
-        Assert.Equal(2, entityTypeBuilder.Metadata.FindPrimaryKey().Properties.Count);
-        Assert.Equal("Id", entityTypeBuilder.Metadata.FindPrimaryKey().Properties[0].Name);
-        Assert.Equal("MyPrimaryKey", entityTypeBuilder.Metadata.FindPrimaryKey().Properties[1].Name);
+        Assert.Equal(2, entityTypeBuilder.Metadata.FindPrimaryKey()!.Properties.Count);
+        Assert.Equal("Id", entityTypeBuilder.Metadata.FindPrimaryKey()!.Properties[0].Name);
+        Assert.Equal("MyPrimaryKey", entityTypeBuilder.Metadata.FindPrimaryKey()!.Properties[1].Name);
 
         Assert.Equal(
             CoreStrings.CompositePKWithDataAnnotation(entityTypeBuilder.Metadata.DisplayName()),
@@ -193,9 +193,9 @@ public class PropertyAttributeConventionTest
     {
         var model = new MyContext().Model;
 
-        Assert.Equal(2, model.FindEntityType(typeof(B)).FindPrimaryKey().Properties.Count);
-        Assert.Equal("MyPrimaryKey", model.FindEntityType(typeof(B)).FindPrimaryKey().Properties[0].Name);
-        Assert.Equal("Id", model.FindEntityType(typeof(B)).FindPrimaryKey().Properties[1].Name);
+        Assert.Equal(2, model.FindEntityType(typeof(B))!.FindPrimaryKey()!.Properties.Count);
+        Assert.Equal("MyPrimaryKey", model.FindEntityType(typeof(B))!.FindPrimaryKey()!.Properties[0].Name);
+        Assert.Equal("Id", model.FindEntityType(typeof(B))!.FindPrimaryKey()!.Properties[1].Name);
     }
 
     [Fact]
@@ -203,19 +203,19 @@ public class PropertyAttributeConventionTest
     {
         var model = new MyContext().Model;
 
-        Assert.Equal(2, model.FindEntityType(typeof(B2)).FindPrimaryKey().Properties.Count);
-        Assert.Equal("MyPrimaryKey", model.FindEntityType(typeof(B2)).FindPrimaryKey().Properties[0].Name);
-        Assert.Equal("Id", model.FindEntityType(typeof(B2)).FindPrimaryKey().Properties[1].Name);
+        Assert.Equal(2, model.FindEntityType(typeof(B2))!.FindPrimaryKey()!.Properties.Count);
+        Assert.Equal("MyPrimaryKey", model.FindEntityType(typeof(B2))!.FindPrimaryKey()!.Properties[0].Name);
+        Assert.Equal("Id", model.FindEntityType(typeof(B2))!.FindPrimaryKey()!.Properties[1].Name);
     }
 
     [Fact]
     public void KeyAttribute_throws_when_setting_key_in_derived_type()
     {
         var derivedEntityTypeBuilder = CreateInternalEntityTypeBuilder<DerivedEntity>();
-        var baseEntityType = derivedEntityTypeBuilder.ModelBuilder.Entity(typeof(BaseEntity), ConfigurationSource.Explicit).Metadata;
+        var baseEntityType = derivedEntityTypeBuilder.ModelBuilder.Entity(typeof(BaseEntity), ConfigurationSource.Explicit)!.Metadata;
         derivedEntityTypeBuilder.HasBaseType(baseEntityType, ConfigurationSource.Explicit);
 
-        var propertyBuilder = derivedEntityTypeBuilder.Property(typeof(int), "Number", ConfigurationSource.Explicit);
+        var propertyBuilder = derivedEntityTypeBuilder.Property(typeof(int), "Number", ConfigurationSource.Explicit)!;
 
         Assert.Equal(
             CoreStrings.KeyAttributeOnDerivedEntity(
@@ -228,7 +228,7 @@ public class PropertyAttributeConventionTest
     public void KeyAttribute_does_not_throw_when_setting_key_in_derived_type_when_base_has_PrimaryKeyAttribute()
     {
         var derivedEntityTypeBuilder = CreateInternalEntityTypeBuilder<DerivedEntity2>();
-        var baseEntityType = derivedEntityTypeBuilder.ModelBuilder.Entity(typeof(BaseEntity2), ConfigurationSource.Explicit).Metadata;
+        var baseEntityType = derivedEntityTypeBuilder.ModelBuilder.Entity(typeof(BaseEntity2), ConfigurationSource.Explicit)!.Metadata;
         derivedEntityTypeBuilder.HasBaseType(baseEntityType, ConfigurationSource.Explicit);
 
         derivedEntityTypeBuilder.Property(typeof(int), "Number", ConfigurationSource.Explicit);
@@ -240,7 +240,7 @@ public class PropertyAttributeConventionTest
     public void KeyAttribute_allows_composite_key_with_inheritance()
     {
         var derivedEntityTypeBuilder = CreateInternalEntityTypeBuilder<CompositeKeyDerivedEntity>();
-        var baseEntityTypeBuilder = derivedEntityTypeBuilder.ModelBuilder.Entity(typeof(BaseEntity), ConfigurationSource.Explicit);
+        var baseEntityTypeBuilder = derivedEntityTypeBuilder.ModelBuilder.Entity(typeof(BaseEntity), ConfigurationSource.Explicit)!;
         derivedEntityTypeBuilder.HasBaseType(baseEntityTypeBuilder.Metadata, ConfigurationSource.Explicit);
 
         baseEntityTypeBuilder.PrimaryKey(
@@ -248,7 +248,7 @@ public class PropertyAttributeConventionTest
 
         Validate(derivedEntityTypeBuilder);
 
-        Assert.Equal(2, baseEntityTypeBuilder.Metadata.FindPrimaryKey().Properties.Count);
+        Assert.Equal(2, baseEntityTypeBuilder.Metadata.FindPrimaryKey()!.Properties.Count);
     }
 
     [Fact]
@@ -258,7 +258,7 @@ public class PropertyAttributeConventionTest
         var entityTypeBuilder = modelBuilder.Entity<F>();
         entityTypeBuilder.Property<int>(nameof(F.MyPrimaryKey));
 
-        Assert.Equal(nameof(F.MyPrimaryKey), entityTypeBuilder.Metadata.FindPrimaryKey().Properties.Single().Name);
+        Assert.Equal(nameof(F.MyPrimaryKey), entityTypeBuilder.Metadata.FindPrimaryKey()!.Properties.Single().Name);
     }
 
     #endregion
@@ -270,7 +270,7 @@ public class PropertyAttributeConventionTest
     {
         var entityTypeBuilder = CreateInternalEntityTypeBuilder<A>();
 
-        var propertyBuilder = entityTypeBuilder.Property(typeof(string), "MaxLengthProperty", ConfigurationSource.Explicit);
+        var propertyBuilder = entityTypeBuilder.Property(typeof(string), "MaxLengthProperty", ConfigurationSource.Explicit)!;
 
         propertyBuilder.HasMaxLength(100, ConfigurationSource.Convention);
 
@@ -284,7 +284,7 @@ public class PropertyAttributeConventionTest
     {
         var entityTypeBuilder = CreateInternalEntityTypeBuilder<A>();
 
-        var propertyBuilder = entityTypeBuilder.Property(typeof(string), "MaxLengthProperty", ConfigurationSource.Explicit);
+        var propertyBuilder = entityTypeBuilder.Property(typeof(string), "MaxLengthProperty", ConfigurationSource.Explicit)!;
 
         propertyBuilder.HasMaxLength(-1, ConfigurationSource.Convention);
 
@@ -298,7 +298,7 @@ public class PropertyAttributeConventionTest
     {
         var entityTypeBuilder = CreateInternalEntityTypeBuilder<A>();
 
-        var propertyBuilder = entityTypeBuilder.Property(typeof(string), "MaxLengthProperty", ConfigurationSource.Explicit);
+        var propertyBuilder = entityTypeBuilder.Property(typeof(string), "MaxLengthProperty", ConfigurationSource.Explicit)!;
 
         propertyBuilder.HasMaxLength(100, ConfigurationSource.Explicit);
 
@@ -391,7 +391,7 @@ public class PropertyAttributeConventionTest
     {
         var entityTypeBuilder = CreateInternalEntityTypeBuilder<A>();
 
-        var propertyBuilder = entityTypeBuilder.Property(typeof(string), "Name", ConfigurationSource.Explicit);
+        var propertyBuilder = entityTypeBuilder.Property(typeof(string), "Name", ConfigurationSource.Explicit)!;
 
         propertyBuilder.IsRequired(false, ConfigurationSource.Convention);
 
@@ -405,7 +405,7 @@ public class PropertyAttributeConventionTest
     {
         var entityTypeBuilder = CreateInternalEntityTypeBuilder<A>();
 
-        var propertyBuilder = entityTypeBuilder.Property(typeof(string), "Name", ConfigurationSource.Explicit);
+        var propertyBuilder = entityTypeBuilder.Property(typeof(string), "Name", ConfigurationSource.Explicit)!;
 
         propertyBuilder.IsRequired(false, ConfigurationSource.Explicit);
 
@@ -441,7 +441,7 @@ public class PropertyAttributeConventionTest
     {
         var entityTypeBuilder = CreateInternalEntityTypeBuilder<A>();
 
-        var propertyBuilder = entityTypeBuilder.Property(typeof(string), "StringLengthProperty", ConfigurationSource.Explicit);
+        var propertyBuilder = entityTypeBuilder.Property(typeof(string), "StringLengthProperty", ConfigurationSource.Explicit)!;
 
         propertyBuilder.HasMaxLength(100, ConfigurationSource.Convention);
 
@@ -455,7 +455,7 @@ public class PropertyAttributeConventionTest
     {
         var entityTypeBuilder = CreateInternalEntityTypeBuilder<A>();
 
-        var propertyBuilder = entityTypeBuilder.Property(typeof(string), "StringLengthProperty", ConfigurationSource.Explicit);
+        var propertyBuilder = entityTypeBuilder.Property(typeof(string), "StringLengthProperty", ConfigurationSource.Explicit)!;
 
         propertyBuilder.HasMaxLength(100, ConfigurationSource.Explicit);
 
@@ -550,7 +550,7 @@ public class PropertyAttributeConventionTest
         var entityTypeBuilder = CreateInternalEntityTypeBuilder<A>();
 
         IConventionPropertyBuilder propertyBuilder = entityTypeBuilder.Property(
-            typeof(int?), "BackingFieldProperty", ConfigurationSource.Explicit);
+            typeof(int?), "BackingFieldProperty", ConfigurationSource.Explicit)!;
 
         RunConvention(propertyBuilder);
 
@@ -564,7 +564,7 @@ public class PropertyAttributeConventionTest
         var entityTypeBuilder = CreateInternalEntityTypeBuilder<A>();
 
         var propertyBuilder = entityTypeBuilder.Property(
-            typeof(int?), "BackingFieldProperty", ConfigurationSource.Explicit);
+            typeof(int?), "BackingFieldProperty", ConfigurationSource.Explicit)!;
 
         propertyBuilder.HasField("_backingFieldForFluentApi", ConfigurationSource.Explicit);
 
@@ -583,7 +583,7 @@ public class PropertyAttributeConventionTest
     {
         var entityTypeBuilder = CreateInternalEntityTypeBuilder<A>();
 
-        var propertyBuilder = entityTypeBuilder.Property(typeof(string), "UnicodeProperty", ConfigurationSource.Explicit);
+        var propertyBuilder = entityTypeBuilder.Property(typeof(string), "UnicodeProperty", ConfigurationSource.Explicit)!;
 
         propertyBuilder.IsUnicode(false, ConfigurationSource.Convention);
 
@@ -597,7 +597,7 @@ public class PropertyAttributeConventionTest
     {
         var entityTypeBuilder = CreateInternalEntityTypeBuilder<A>();
 
-        var propertyBuilder = entityTypeBuilder.Property(typeof(string), "UnicodeProperty", ConfigurationSource.Explicit);
+        var propertyBuilder = entityTypeBuilder.Property(typeof(string), "UnicodeProperty", ConfigurationSource.Explicit)!;
 
         propertyBuilder.IsUnicode(false, ConfigurationSource.Explicit);
 
@@ -635,7 +635,7 @@ public class PropertyAttributeConventionTest
     {
         var entityTypeBuilder = CreateInternalEntityTypeBuilder<A>();
 
-        var propertyBuilder = entityTypeBuilder.Property(typeof(decimal), "DecimalProperty", ConfigurationSource.Explicit);
+        var propertyBuilder = entityTypeBuilder.Property(typeof(decimal), "DecimalProperty", ConfigurationSource.Explicit)!;
 
         propertyBuilder.HasPrecision(12, ConfigurationSource.Convention);
         propertyBuilder.HasScale(5, ConfigurationSource.Convention);
@@ -651,7 +651,7 @@ public class PropertyAttributeConventionTest
     {
         var entityTypeBuilder = CreateInternalEntityTypeBuilder<A>();
 
-        var propertyBuilder = entityTypeBuilder.Property(typeof(decimal), "DecimalProperty", ConfigurationSource.Explicit);
+        var propertyBuilder = entityTypeBuilder.Property(typeof(decimal), "DecimalProperty", ConfigurationSource.Explicit)!;
 
         propertyBuilder.HasPrecision(12, ConfigurationSource.Explicit);
         propertyBuilder.HasScale(5, ConfigurationSource.Explicit);
@@ -701,7 +701,7 @@ public class PropertyAttributeConventionTest
 
         var modelBuilder = new Model(conventionSet).Builder;
 
-        return modelBuilder.Entity(typeof(T), ConfigurationSource.Explicit);
+        return modelBuilder.Entity(typeof(T), ConfigurationSource.Explicit)!;
     }
 
     private static void RunConvention(IConventionPropertyBuilder propertyBuilder)
@@ -773,13 +773,13 @@ public class PropertyAttributeConventionTest
         public Guid RowVersion { get; set; }
 
         [Required]
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
 
         [Unicode]
-        public string UnicodeProperty { get; set; }
+        public string UnicodeProperty { get; set; } = null!;
 
         [Unicode(false)]
-        public string NonUnicodeProperty { get; set; }
+        public string NonUnicodeProperty { get; set; } = null!;
 
         [Precision(10, 2)]
         public decimal DecimalProperty { get; set; }
@@ -788,16 +788,16 @@ public class PropertyAttributeConventionTest
         public int MyPrimaryKey { get; set; }
 
         [NotMapped]
-        public string IgnoredProperty { get; set; }
+        public string IgnoredProperty { get; set; } = null!;
 
         [MaxLength(10)]
-        public string MaxLengthProperty { get; set; }
+        public string MaxLengthProperty { get; set; } = null!;
 
         [StringLength(20)]
-        public string StringLengthProperty { get; set; }
+        public string StringLengthProperty { get; set; } = null!;
 
         [Timestamp]
-        public byte[] Timestamp { get; set; }
+        public byte[] Timestamp { get; set; } = null!;
 
         [Timestamp]
         public long LongTimestamp { get; set; }
@@ -853,13 +853,13 @@ public class PropertyAttributeConventionTest
         public Guid RowVersion;
 
         [Required]
-        public string Name;
+        public string Name = null!;
 
         [Unicode]
-        public string UnicodeField;
+        public string UnicodeField = null!;
 
         [Unicode(false)]
-        public string NonUnicodeField;
+        public string NonUnicodeField = null!;
 
         [Precision(10, 2)]
         public decimal DecimalField;
@@ -868,16 +868,16 @@ public class PropertyAttributeConventionTest
         public int MyPrimaryKey;
 
         [NotMapped]
-        public string IgnoredProperty;
+        public string IgnoredProperty = null!;
 
         [MaxLength(10)]
-        public string MaxLengthProperty;
+        public string MaxLengthProperty = null!;
 
         [StringLength(20)]
-        public string StringLengthProperty;
+        public string StringLengthProperty = null!;
 
         [Timestamp]
-        public byte[] Timestamp { get; set; }
+        public byte[] Timestamp { get; set; } = null!;
 
         [Timestamp]
         public long LongTimestamp { get; set; }
@@ -890,7 +890,7 @@ public class PropertyAttributeConventionTest
     {
         public int Id { get; set; }
 
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
     }
 
     private class DerivedEntity : BaseEntity
@@ -906,7 +906,7 @@ public class PropertyAttributeConventionTest
     {
         public int Id { get; set; }
 
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
     }
 
     private class DerivedEntity2 : BaseEntity2

--- a/test/EFCore.Tests/Metadata/Conventions/PropertyDiscoveryConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/PropertyDiscoveryConventionTest.cs
@@ -16,7 +16,7 @@ public class PropertyDiscoveryConventionTest
     {
         public int Id { get; private set; }
 
-        private string _code;
+        private string _code = null!;
 
         // ReSharper disable once ConvertToAutoProperty
         public string Code
@@ -25,7 +25,7 @@ public class PropertyDiscoveryConventionTest
             private set => _code = value;
         }
 
-        public string Description { get; private set; }
+        public string Description { get; private set; } = null!;
 
         public void SetInformation(string code, string description)
         {
@@ -39,7 +39,7 @@ public class PropertyDiscoveryConventionTest
     private class WithPrivatesContext : DbContext
     {
         // ReSharper disable once UnusedAutoPropertyAccessor.Local
-        public DbSet<DerivedWithoutPrivates> Entities { get; set; }
+        public DbSet<DerivedWithoutPrivates> Entities { get; set; } = null!;
 
         protected internal override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
             => optionsBuilder
@@ -55,19 +55,19 @@ public class PropertyDiscoveryConventionTest
 
         Assert.Single(model.GetEntityTypes());
 
-        var entityType = (IRuntimeEntityType)model.FindEntityType(typeof(DerivedWithoutPrivates));
+        var entityType = (IRuntimeEntityType)model.FindEntityType(typeof(DerivedWithoutPrivates))!;
 
         Assert.Equal(3, entityType.PropertyCount);
 
-        var idProperty = entityType.FindProperty(nameof(BaseWithPrivates.Id));
+        var idProperty = entityType.FindProperty(nameof(BaseWithPrivates.Id))!;
         Assert.NotNull(idProperty.PropertyInfo);
         Assert.NotNull(idProperty.FieldInfo);
 
-        var codeProperty = entityType.FindProperty(nameof(BaseWithPrivates.Code));
+        var codeProperty = entityType.FindProperty(nameof(BaseWithPrivates.Code))!;
         Assert.NotNull(codeProperty.PropertyInfo);
         Assert.NotNull(codeProperty.FieldInfo);
 
-        var descriptionProperty = entityType.FindProperty(nameof(BaseWithPrivates.Description));
+        var descriptionProperty = entityType.FindProperty(nameof(BaseWithPrivates.Description))!;
         Assert.NotNull(descriptionProperty.PropertyInfo);
         Assert.NotNull(descriptionProperty.FieldInfo);
 
@@ -150,7 +150,7 @@ public class PropertyDiscoveryConventionTest
     {
         public bool Boolean { get; set; }
         public byte Byte { get; set; }
-        public byte[] ByteArray { get; set; }
+        public byte[] ByteArray { get; set; } = null!;
         public char Char { get; set; }
         public DateTime DateTime { get; set; }
         public DateTimeOffset DateTimeOffset { get; set; }
@@ -182,7 +182,7 @@ public class PropertyDiscoveryConventionTest
         public int PrivateSetter { get; private set; }
         public sbyte SByte { get; set; }
         public float Single { get; set; }
-        public string String { get; set; }
+        public string String { get; set; } = null!;
         public TimeSpan TimeSpan { get; set; }
         public ushort UInt16 { get; set; }
         public uint UInt32 { get; set; }
@@ -210,7 +210,7 @@ public class PropertyDiscoveryConventionTest
 
     private class EntityWithNoPrimitives
     {
-        public object Object { get; set; }
+        public object Object { get; set; } = null!;
     }
 
     [Fact]
@@ -241,6 +241,6 @@ public class PropertyDiscoveryConventionTest
         var modelBuilder = new InternalModelBuilder(new Model());
         var entityBuilder = modelBuilder.Entity(typeof(T), ConfigurationSource.Convention);
 
-        return entityBuilder;
+        return entityBuilder!;
     }
 }

--- a/test/EFCore.Tests/Metadata/Conventions/QueryFilterRewritingConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/QueryFilterRewritingConventionTest.cs
@@ -16,7 +16,7 @@ public class QueryFilterRewritingConventionTest
     {
         var modelBuilder = new InternalModelBuilder(new Model());
         Expression<Func<Blog, bool>> lambda = e => new MyContext().Set<Post>().Single().Id == e.Id;
-        modelBuilder.Entity(typeof(Blog), ConfigurationSource.Explicit)
+        modelBuilder.Entity(typeof(Blog), ConfigurationSource.Explicit)!
             .HasQueryFilter(lambda, ConfigurationSource.Explicit);
 
         Assert.Equal(
@@ -30,7 +30,7 @@ public class QueryFilterRewritingConventionTest
         var modelBuilder = new InternalModelBuilder(new Model());
         modelBuilder.SharedTypeEntity("Post1", typeof(Post), ConfigurationSource.Explicit);
         Expression<Func<Blog, bool>> lambda = e => new MyContext().Set<Post>().Single().Id == e.Id;
-        modelBuilder.Entity(typeof(Blog), ConfigurationSource.Explicit)
+        modelBuilder.Entity(typeof(Blog), ConfigurationSource.Explicit)!
             .HasQueryFilter(lambda, ConfigurationSource.Explicit);
 
         Assert.Equal(
@@ -44,7 +44,7 @@ public class QueryFilterRewritingConventionTest
         var modelBuilder = new InternalModelBuilder(new Model());
         modelBuilder.SharedTypeEntity("Post1", typeof(Post), ConfigurationSource.Explicit);
         Expression<Func<Blog, bool>> lambda = e => new MyContext().Set<Blog>("Post1").Single().Id == e.Id;
-        modelBuilder.Entity(typeof(Blog), ConfigurationSource.Explicit)
+        modelBuilder.Entity(typeof(Blog), ConfigurationSource.Explicit)!
             .HasQueryFilter(lambda, ConfigurationSource.Explicit);
 
         Assert.Equal(
@@ -56,11 +56,11 @@ public class QueryFilterRewritingConventionTest
     public virtual void QueryFilter_containing_db_set_of_owned()
     {
         var modelBuilder = new InternalModelBuilder(new Model());
-        modelBuilder.Entity(typeof(Owner), ConfigurationSource.Explicit)
+        modelBuilder.Entity(typeof(Owner), ConfigurationSource.Explicit)!
             .HasOwnership(typeof(Blog), "Blog", ConfigurationSource.Explicit);
 
         Expression<Func<Owner, bool>> lambda = e => new MyContext().Set<Blog>().Single().Id == e.Id;
-        modelBuilder.Entity(typeof(Owner), ConfigurationSource.Explicit)
+        modelBuilder.Entity(typeof(Owner), ConfigurationSource.Explicit)!
             .HasQueryFilter(lambda, ConfigurationSource.Explicit);
 
         Assert.Equal(
@@ -94,7 +94,7 @@ public class QueryFilterRewritingConventionTest
     protected class Owner
     {
         public int Id { get; set; }
-        public Blog Blog { get; set; }
+        public Blog Blog { get; set; } = null!;
     }
 
     protected class MyContext : DbContext;

--- a/test/EFCore.Tests/Metadata/Conventions/RelationshipDiscoveryConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/RelationshipDiscoveryConventionTest.cs
@@ -22,7 +22,7 @@ public class RelationshipDiscoveryConventionTest
     public void Entity_type_is_not_discovered_if_ignored()
     {
         var entityBuilder = CreateInternalEntityBuilder<OneToManyDependent>();
-        entityBuilder.ModelBuilder.Ignore(typeof(OneToManyPrincipal).FullName, ConfigurationSource.DataAnnotation);
+        entityBuilder.ModelBuilder.Ignore(typeof(OneToManyPrincipal).FullName!, ConfigurationSource.DataAnnotation);
 
         Assert.Same(entityBuilder, RunConvention(entityBuilder));
 
@@ -62,10 +62,10 @@ public class RelationshipDiscoveryConventionTest
     {
         var principalEntityBuilder = CreateInternalEntityBuilder<OneToOnePrincipal>();
         var dependentEntityBuilder =
-            principalEntityBuilder.ModelBuilder.Entity(typeof(OneToOneDependent), ConfigurationSource.Convention);
+            principalEntityBuilder.ModelBuilder.Entity(typeof(OneToOneDependent), ConfigurationSource.Convention)!;
 
         principalEntityBuilder.HasRelationship(
-                dependentEntityBuilder.Metadata, OneToOnePrincipal.NavigationProperty, null, ConfigurationSource.Convention)
+                dependentEntityBuilder.Metadata, OneToOnePrincipal.NavigationProperty, null, ConfigurationSource.Convention)!
             .IsUnique(false, ConfigurationSource.Convention);
 
         Assert.Same(dependentEntityBuilder, RunConvention(dependentEntityBuilder));
@@ -80,14 +80,14 @@ public class RelationshipDiscoveryConventionTest
     {
         var principalEntityBuilder = CreateInternalEntityBuilder<OneToOnePrincipal>();
         var dependentEntityBuilder =
-            principalEntityBuilder.ModelBuilder.Entity(typeof(OneToOneDependent), ConfigurationSource.Convention);
+            principalEntityBuilder.ModelBuilder.Entity(typeof(OneToOneDependent), ConfigurationSource.Convention)!;
 
         principalEntityBuilder.HasRelationship(
-                dependentEntityBuilder.Metadata, OneToOnePrincipal.NavigationProperty, null, ConfigurationSource.Convention)
+                dependentEntityBuilder.Metadata, OneToOnePrincipal.NavigationProperty, null, ConfigurationSource.Convention)!
             .IsUnique(false, ConfigurationSource.Convention);
 
         dependentEntityBuilder.HasRelationship(
-                principalEntityBuilder.Metadata, OneToOneDependent.NavigationProperty, null, ConfigurationSource.Convention)
+                principalEntityBuilder.Metadata, OneToOneDependent.NavigationProperty, null, ConfigurationSource.Convention)!
             .IsUnique(false, ConfigurationSource.Convention);
 
         Assert.Same(dependentEntityBuilder, RunConvention(dependentEntityBuilder));
@@ -102,10 +102,10 @@ public class RelationshipDiscoveryConventionTest
     {
         var principalEntityBuilder = CreateInternalEntityBuilder<OneToOnePrincipal>();
         var dependentEntityBuilder =
-            principalEntityBuilder.ModelBuilder.Entity(typeof(OneToOneDependent), ConfigurationSource.Convention);
+            principalEntityBuilder.ModelBuilder.Entity(typeof(OneToOneDependent), ConfigurationSource.Convention)!;
 
         principalEntityBuilder.HasRelationship(
-                dependentEntityBuilder.Metadata, OneToOnePrincipal.NavigationProperty, null, ConfigurationSource.Explicit)
+                dependentEntityBuilder.Metadata, OneToOnePrincipal.NavigationProperty, null, ConfigurationSource.Explicit)!
             .IsUnique(false, ConfigurationSource.Convention);
 
         Assert.Same(dependentEntityBuilder, RunConvention(dependentEntityBuilder));
@@ -130,7 +130,7 @@ public class RelationshipDiscoveryConventionTest
     {
         var principalEntityBuilder = CreateInternalEntityBuilder<OneToManyPrincipal>();
         var dependentEntityBuilder = principalEntityBuilder.ModelBuilder.Entity(
-            typeof(OneToManyDependent), ConfigurationSource.Convention);
+            typeof(OneToManyDependent), ConfigurationSource.Convention)!;
 
         dependentEntityBuilder.HasRelationship(
             principalEntityBuilder.Metadata, null, OneToManyPrincipal.NavigationProperty, ConfigurationSource.Convention);
@@ -147,7 +147,7 @@ public class RelationshipDiscoveryConventionTest
     {
         var principalEntityBuilder = CreateInternalEntityBuilder<OneToManyPrincipal>();
         var dependentEntityBuilder = principalEntityBuilder.ModelBuilder.Entity(
-            typeof(OneToManyDependent), ConfigurationSource.Convention);
+            typeof(OneToManyDependent), ConfigurationSource.Convention)!;
 
         dependentEntityBuilder.HasRelationship(
             principalEntityBuilder.Metadata, null, OneToManyPrincipal.NavigationProperty, ConfigurationSource.Explicit);
@@ -186,7 +186,7 @@ public class RelationshipDiscoveryConventionTest
     {
         var principalEntityBuilder = CreateInternalEntityBuilder<OneToManyPrincipal>();
         var dependentEntityBuilder = principalEntityBuilder.ModelBuilder.Entity(
-            typeof(OneToManyDependent), ConfigurationSource.Convention);
+            typeof(OneToManyDependent), ConfigurationSource.Convention)!;
 
         dependentEntityBuilder.HasRelationship(
             principalEntityBuilder.Metadata, OneToManyDependent.NavigationProperty, null, ConfigurationSource.Convention);
@@ -203,7 +203,7 @@ public class RelationshipDiscoveryConventionTest
     {
         var principalEntityBuilder = CreateInternalEntityBuilder<OneToManyPrincipal>();
         var dependentEntityBuilder = principalEntityBuilder.ModelBuilder.Entity(
-            typeof(OneToManyDependent), ConfigurationSource.Convention);
+            typeof(OneToManyDependent), ConfigurationSource.Convention)!;
 
         dependentEntityBuilder.HasRelationship(
             principalEntityBuilder.Metadata, OneToManyDependent.NavigationProperty, null, ConfigurationSource.Explicit);
@@ -230,7 +230,7 @@ public class RelationshipDiscoveryConventionTest
     public void Many_to_many_skip_navigations_are_discovered_if_self_join()
     {
         var modelBuilder = CreateInternalModeBuilder();
-        var manyToManySelf = modelBuilder.Entity(typeof(ManyToManySelf), ConfigurationSource.Convention);
+        var manyToManySelf = modelBuilder.Entity(typeof(ManyToManySelf), ConfigurationSource.Convention)!;
 
         manyToManySelf.PrimaryKey([nameof(ManyToManySelf.Id)], ConfigurationSource.Convention);
 
@@ -249,8 +249,8 @@ public class RelationshipDiscoveryConventionTest
     public void Many_to_many_skip_navigations_are_not_discovered_if_relationship_should_be_on_ancestors()
     {
         var modelBuilder = CreateInternalModeBuilder();
-        var derivedManyToManyFirst = modelBuilder.Entity(typeof(DerivedManyToManyFirst), ConfigurationSource.Convention);
-        var derivedManyToManySecond = modelBuilder.Entity(typeof(DerivedManyToManySecond), ConfigurationSource.Convention);
+        var derivedManyToManyFirst = modelBuilder.Entity(typeof(DerivedManyToManyFirst), ConfigurationSource.Convention)!;
+        var derivedManyToManySecond = modelBuilder.Entity(typeof(DerivedManyToManySecond), ConfigurationSource.Convention)!;
 
         derivedManyToManyFirst.PrimaryKey([nameof(DerivedManyToManyFirst.Id)], ConfigurationSource.Convention);
         derivedManyToManySecond.PrimaryKey([nameof(DerivedManyToManySecond.Id)], ConfigurationSource.Convention);
@@ -265,8 +265,8 @@ public class RelationshipDiscoveryConventionTest
     public void Many_to_many_bidirectional_sets_up_skip_navigations()
     {
         var modelBuilder = CreateInternalModeBuilder();
-        var manyToManyFirst = modelBuilder.Entity(typeof(ManyToManyFirst), ConfigurationSource.Convention);
-        var manyToManySecond = modelBuilder.Entity(typeof(ManyToManySecond), ConfigurationSource.Convention);
+        var manyToManyFirst = modelBuilder.Entity(typeof(ManyToManyFirst), ConfigurationSource.Convention)!;
+        var manyToManySecond = modelBuilder.Entity(typeof(ManyToManySecond), ConfigurationSource.Convention)!;
 
         manyToManyFirst.PrimaryKey([nameof(ManyToManyFirst.Id)], ConfigurationSource.Convention);
         manyToManySecond.PrimaryKey([nameof(ManyToManySecond.Id)], ConfigurationSource.Convention);
@@ -299,7 +299,7 @@ public class RelationshipDiscoveryConventionTest
         var entityBuilderFirst =
             CreateInternalEntityBuilder<MultipleNavigationsFirst>(MultipleNavigationsSecond.IgnoreCollectionNavigation);
         var entityBuilderSecond = entityBuilderFirst.ModelBuilder.Entity(
-            typeof(MultipleNavigationsSecond), ConfigurationSource.Convention);
+            typeof(MultipleNavigationsSecond), ConfigurationSource.Convention)!;
 
         entityBuilderFirst.HasRelationship(
             entityBuilderSecond.Metadata, MultipleNavigationsFirst.CollectionNavigationProperty, null, ConfigurationSource.Convention);
@@ -318,7 +318,7 @@ public class RelationshipDiscoveryConventionTest
         var entityBuilderFirst =
             CreateInternalEntityBuilder<MultipleNavigationsFirst>(MultipleNavigationsSecond.IgnoreCollectionNavigation);
         var entityBuilderSecond = entityBuilderFirst.ModelBuilder.Entity(
-            typeof(MultipleNavigationsSecond), ConfigurationSource.Convention);
+            typeof(MultipleNavigationsSecond), ConfigurationSource.Convention)!;
 
         entityBuilderFirst.HasRelationship(
             entityBuilderSecond.Metadata, MultipleNavigationsFirst.CollectionNavigationProperty, null,
@@ -341,7 +341,7 @@ public class RelationshipDiscoveryConventionTest
         var entityBuilderFirst = CreateInternalEntityBuilder<MultipleNavigationsSecond>(
             MultipleNavigationsSecond.IgnoreCollectionNavigation);
         var entityBuilderSecond = entityBuilderFirst.ModelBuilder.Entity(
-            typeof(MultipleNavigationsSecond), ConfigurationSource.Convention);
+            typeof(MultipleNavigationsSecond), ConfigurationSource.Convention)!;
 
         Assert.Same(entityBuilderFirst, RunConvention(entityBuilderFirst));
 
@@ -357,7 +357,7 @@ public class RelationshipDiscoveryConventionTest
         var entityBuilderFirst =
             CreateInternalEntityBuilder<MultipleNavigationsFirst>(MultipleNavigationsSecond.IgnoreCollectionNavigation);
         var entityBuilderSecond = entityBuilderFirst.ModelBuilder.Entity(
-            typeof(MultipleNavigationsSecond), ConfigurationSource.Convention);
+            typeof(MultipleNavigationsSecond), ConfigurationSource.Convention)!;
 
         entityBuilderFirst.HasRelationship(
             entityBuilderSecond.Metadata, MultipleNavigationsFirst.CollectionNavigationProperty, null, ConfigurationSource.Convention);
@@ -385,7 +385,7 @@ public class RelationshipDiscoveryConventionTest
         var entityBuilderFirst =
             CreateInternalEntityBuilder<MultipleNavigationsFirst>(MultipleNavigationsSecond.IgnoreCollectionNavigation);
         var entityBuilderSecond = entityBuilderFirst.ModelBuilder.Entity(
-            typeof(MultipleNavigationsSecond), ConfigurationSource.Convention);
+            typeof(MultipleNavigationsSecond), ConfigurationSource.Convention)!;
 
         entityBuilderFirst.HasRelationship(
             entityBuilderSecond.Metadata, MultipleNavigationsFirst.CollectionNavigationProperty, null,
@@ -444,8 +444,8 @@ public class RelationshipDiscoveryConventionTest
             Base.IgnoreBaseNavigation,
             DerivedOne.IgnoreDerivedNavigation);
         var modelBuilder = entityBuilder.ModelBuilder;
-        var baseBuilder = modelBuilder.Entity(typeof(Base), ConfigurationSource.Explicit);
-        var derivedBuilder = modelBuilder.Entity(typeof(DerivedOne), ConfigurationSource.Explicit);
+        var baseBuilder = modelBuilder.Entity(typeof(Base), ConfigurationSource.Explicit)!;
+        var derivedBuilder = modelBuilder.Entity(typeof(DerivedOne), ConfigurationSource.Explicit)!;
         derivedBuilder.HasBaseType(baseBuilder.Metadata, ConfigurationSource.Convention);
 
         Assert.Same(entityBuilder, RunConvention(entityBuilder));
@@ -467,8 +467,8 @@ public class RelationshipDiscoveryConventionTest
             NavigationsToBaseAndDerived.IgnoreDerivedTwoNavigation,
             DerivedOne.IgnoreDerivedNavigation);
         var modelBuilder = entityBuilder.ModelBuilder;
-        var baseBuilder = modelBuilder.Entity(typeof(Base), ConfigurationSource.Explicit);
-        var derivedBuilder = modelBuilder.Entity(typeof(DerivedOne), ConfigurationSource.Explicit);
+        var baseBuilder = modelBuilder.Entity(typeof(Base), ConfigurationSource.Explicit)!;
+        var derivedBuilder = modelBuilder.Entity(typeof(DerivedOne), ConfigurationSource.Explicit)!;
         derivedBuilder.HasBaseType(baseBuilder.Metadata, ConfigurationSource.Convention);
 
         Assert.Same(entityBuilder, RunConvention(entityBuilder));
@@ -490,8 +490,8 @@ public class RelationshipDiscoveryConventionTest
             NavigationsToBaseAndDerived.IgnoreDerivedOneNavigation,
             DerivedTwo.IgnoreDerivedNavigation);
         var modelBuilder = entityBuilder.ModelBuilder;
-        var baseBuilder = modelBuilder.Entity(typeof(Base), ConfigurationSource.Explicit);
-        var derivedBuilder = modelBuilder.Entity(typeof(DerivedTwo), ConfigurationSource.Explicit);
+        var baseBuilder = modelBuilder.Entity(typeof(Base), ConfigurationSource.Explicit)!;
+        var derivedBuilder = modelBuilder.Entity(typeof(DerivedTwo), ConfigurationSource.Explicit)!;
         derivedBuilder.HasBaseType(baseBuilder.Metadata, ConfigurationSource.Convention);
 
         Assert.Same(entityBuilder, RunConvention(entityBuilder));
@@ -513,8 +513,8 @@ public class RelationshipDiscoveryConventionTest
             NavigationsToBaseAndDerived.IgnoreDerivedTwoNavigation,
             Base.IgnoreBaseNavigation);
         var modelBuilder = entityBuilder.ModelBuilder;
-        var baseBuilder = modelBuilder.Entity(typeof(Base), ConfigurationSource.Explicit);
-        var derivedBuilder = modelBuilder.Entity(typeof(DerivedOne), ConfigurationSource.Explicit);
+        var baseBuilder = modelBuilder.Entity(typeof(Base), ConfigurationSource.Explicit)!;
+        var derivedBuilder = modelBuilder.Entity(typeof(DerivedOne), ConfigurationSource.Explicit)!;
         derivedBuilder.HasBaseType(baseBuilder.Metadata, ConfigurationSource.Convention);
 
         Assert.Same(entityBuilder, RunConvention(entityBuilder));
@@ -534,10 +534,10 @@ public class RelationshipDiscoveryConventionTest
     {
         var entityBuilder = CreateInternalEntityBuilder<NavigationsToBaseAndDerived>();
         var modelBuilder = entityBuilder.ModelBuilder;
-        var baseBuilder = modelBuilder.Entity(typeof(Base), ConfigurationSource.Explicit);
-        var derivedBuilder = modelBuilder.Entity(typeof(DerivedOne), ConfigurationSource.Explicit);
+        var baseBuilder = modelBuilder.Entity(typeof(Base), ConfigurationSource.Explicit)!;
+        var derivedBuilder = modelBuilder.Entity(typeof(DerivedOne), ConfigurationSource.Explicit)!;
         derivedBuilder.HasBaseType(baseBuilder.Metadata, ConfigurationSource.Convention);
-        var derivedBuilderTwo = modelBuilder.Entity(typeof(DerivedTwo), ConfigurationSource.Explicit);
+        var derivedBuilderTwo = modelBuilder.Entity(typeof(DerivedTwo), ConfigurationSource.Explicit)!;
         derivedBuilderTwo.HasBaseType(baseBuilder.Metadata, ConfigurationSource.Convention);
 
         Assert.Same(entityBuilder, RunConvention(entityBuilder));
@@ -579,8 +579,8 @@ public class RelationshipDiscoveryConventionTest
             DerivedOne.IgnoreDerivedNavigation);
         var modelBuilder = entityBuilder.ModelBuilder;
         modelBuilder.Entity(typeof(Base), ConfigurationSource.Explicit);
-        var baseBuilder = modelBuilder.Entity(typeof(Base), ConfigurationSource.Explicit);
-        var derivedBuilder = modelBuilder.Entity(typeof(DerivedOne), ConfigurationSource.Explicit);
+        var baseBuilder = modelBuilder.Entity(typeof(Base), ConfigurationSource.Explicit)!;
+        var derivedBuilder = modelBuilder.Entity(typeof(DerivedOne), ConfigurationSource.Explicit)!;
         derivedBuilder.HasBaseType(baseBuilder.Metadata, ConfigurationSource.Convention);
 
         derivedBuilder.HasRelationship(entityBuilder.Metadata, nameof(Base.BaseNavigation), null, ConfigurationSource.Convention);
@@ -603,8 +603,8 @@ public class RelationshipDiscoveryConventionTest
             DerivedOne.IgnoreDerivedNavigation);
         var modelBuilder = entityBuilder.ModelBuilder;
         modelBuilder.Entity(typeof(Base), ConfigurationSource.Explicit);
-        var baseBuilder = modelBuilder.Entity(typeof(Base), ConfigurationSource.Explicit);
-        var derivedBuilder = modelBuilder.Entity(typeof(DerivedOne), ConfigurationSource.Explicit);
+        var baseBuilder = modelBuilder.Entity(typeof(Base), ConfigurationSource.Explicit)!;
+        var derivedBuilder = modelBuilder.Entity(typeof(DerivedOne), ConfigurationSource.Explicit)!;
         derivedBuilder.HasBaseType(baseBuilder.Metadata, ConfigurationSource.Convention);
 
         derivedBuilder.HasRelationship(entityBuilder.Metadata, nameof(Base.BaseNavigation), null, ConfigurationSource.Convention);
@@ -625,8 +625,8 @@ public class RelationshipDiscoveryConventionTest
             NavigationsToBaseAndDerived.IgnoreDerivedTwoNavigation,
             NavigationsToBaseAndDerived.IgnoreBaseNavigation);
         var modelBuilder = entityBuilder.ModelBuilder;
-        var baseBuilder = modelBuilder.Entity(typeof(Base), ConfigurationSource.Explicit);
-        var derivedBuilder = modelBuilder.Entity(typeof(DerivedOne), ConfigurationSource.Explicit);
+        var baseBuilder = modelBuilder.Entity(typeof(Base), ConfigurationSource.Explicit)!;
+        var derivedBuilder = modelBuilder.Entity(typeof(DerivedOne), ConfigurationSource.Explicit)!;
         derivedBuilder.HasBaseType(baseBuilder.Metadata, ConfigurationSource.Convention);
 
         Assert.Same(derivedBuilder, RunConvention(derivedBuilder));
@@ -645,8 +645,8 @@ public class RelationshipDiscoveryConventionTest
             NavigationsToBaseAndDerived.IgnoreDerivedTwoNavigation,
             NavigationsToBaseAndDerived.IgnoreBaseNavigation);
         var modelBuilder = entityBuilder.ModelBuilder;
-        var baseBuilder = modelBuilder.Entity(typeof(Base), ConfigurationSource.Explicit);
-        var derivedBuilder = modelBuilder.Entity(typeof(DerivedOne), ConfigurationSource.Explicit);
+        var baseBuilder = modelBuilder.Entity(typeof(Base), ConfigurationSource.Explicit)!;
+        var derivedBuilder = modelBuilder.Entity(typeof(DerivedOne), ConfigurationSource.Explicit)!;
         derivedBuilder.HasBaseType(baseBuilder.Metadata, ConfigurationSource.Convention);
 
         baseBuilder.HasRelationship(entityBuilder.Metadata, nameof(Base.BaseNavigation), null, ConfigurationSource.Convention);
@@ -668,8 +668,8 @@ public class RelationshipDiscoveryConventionTest
             NavigationsToBaseAndDerived.IgnoreDerivedTwoNavigation,
             NavigationsToBaseAndDerived.IgnoreBaseNavigation);
         var modelBuilder = entityBuilder.ModelBuilder;
-        var baseBuilder = modelBuilder.Entity(typeof(Base), ConfigurationSource.Explicit);
-        var derivedBuilder = modelBuilder.Entity(typeof(DerivedOne), ConfigurationSource.Explicit);
+        var baseBuilder = modelBuilder.Entity(typeof(Base), ConfigurationSource.Explicit)!;
+        var derivedBuilder = modelBuilder.Entity(typeof(DerivedOne), ConfigurationSource.Explicit)!;
         derivedBuilder.HasBaseType(baseBuilder.Metadata, ConfigurationSource.Convention);
 
         Assert.Same(entityBuilder, RunConvention(entityBuilder));
@@ -688,8 +688,8 @@ public class RelationshipDiscoveryConventionTest
             NavigationsToBaseAndDerived.IgnoreDerivedTwoNavigation,
             NavigationsToBaseAndDerived.IgnoreBaseNavigation);
         var modelBuilder = entityBuilder.ModelBuilder;
-        var baseBuilder = modelBuilder.Entity(typeof(Base), ConfigurationSource.Explicit);
-        var derivedBuilder = modelBuilder.Entity(typeof(DerivedOne), ConfigurationSource.Explicit);
+        var baseBuilder = modelBuilder.Entity(typeof(Base), ConfigurationSource.Explicit)!;
+        var derivedBuilder = modelBuilder.Entity(typeof(DerivedOne), ConfigurationSource.Explicit)!;
         derivedBuilder.HasBaseType(baseBuilder.Metadata, ConfigurationSource.Convention);
 
         baseBuilder.HasRelationship(entityBuilder.Metadata, nameof(Base.BaseNavigation), null, ConfigurationSource.Convention);
@@ -712,8 +712,8 @@ public class RelationshipDiscoveryConventionTest
             NavigationsToBaseAndDerived.IgnoreBaseNavigation,
             Base.IgnoreBaseNavigation);
         var modelBuilder = entityBuilder.ModelBuilder;
-        var baseBuilder = modelBuilder.Entity(typeof(Base), ConfigurationSource.Explicit);
-        var derivedBuilder = modelBuilder.Entity(typeof(DerivedOne), ConfigurationSource.Explicit);
+        var baseBuilder = modelBuilder.Entity(typeof(Base), ConfigurationSource.Explicit)!;
+        var derivedBuilder = modelBuilder.Entity(typeof(DerivedOne), ConfigurationSource.Explicit)!;
         derivedBuilder.HasBaseType(baseBuilder.Metadata, ConfigurationSource.Convention);
 
         Assert.Same(entityBuilder, RunConvention(entityBuilder));
@@ -733,8 +733,8 @@ public class RelationshipDiscoveryConventionTest
             NavigationsToBaseAndDerived.IgnoreBaseNavigation,
             DerivedOne.IgnoreDerivedNavigation);
         var modelBuilder = entityBuilder.ModelBuilder;
-        var baseBuilder = modelBuilder.Entity(typeof(Base), ConfigurationSource.Explicit);
-        var derivedBuilder = modelBuilder.Entity(typeof(DerivedOne), ConfigurationSource.Explicit);
+        var baseBuilder = modelBuilder.Entity(typeof(Base), ConfigurationSource.Explicit)!;
+        var derivedBuilder = modelBuilder.Entity(typeof(DerivedOne), ConfigurationSource.Explicit)!;
         derivedBuilder.HasBaseType(baseBuilder.Metadata, ConfigurationSource.Convention);
 
         Assert.Same(entityBuilder, RunConvention(entityBuilder));
@@ -776,7 +776,7 @@ public class RelationshipDiscoveryConventionTest
 
         Assert.Same(entityBuilder, RunConvention(entityBuilder));
 
-        var derivedFk = entityBuilder.Metadata.FindNavigation(nameof(NavigationsToBaseAndDerived.DerivedOne)).ForeignKey;
+        var derivedFk = entityBuilder.Metadata.FindNavigation(nameof(NavigationsToBaseAndDerived.DerivedOne))!.ForeignKey;
         Assert.Equal(nameof(DerivedOne.BaseNavigation), derivedFk.FindNavigationsTo(entityBuilder.Metadata).Single().Name);
         Assert.Single(entityBuilder.Metadata.GetNavigations());
         Assert.Equal(2, entityBuilder.Metadata.Model.GetEntityTypes().Count());
@@ -864,7 +864,7 @@ public class RelationshipDiscoveryConventionTest
     {
         var entityBuilder = CreateInternalEntityBuilder<SelfRef>(SelfRef.IgnoreNavigation3, SelfRef.IgnoreNavigation4);
 
-        entityBuilder.HasRelationship(entityBuilder.Metadata, nameof(SelfRef.SelfRef1), null, ConfigurationSource.Explicit)
+        entityBuilder.HasRelationship(entityBuilder.Metadata, nameof(SelfRef.SelfRef1), null, ConfigurationSource.Explicit)!
             .IsUnique(false, ConfigurationSource.Convention);
 
         Assert.Same(entityBuilder, RunConvention(entityBuilder));
@@ -1030,9 +1030,9 @@ public class RelationshipDiscoveryConventionTest
     {
         public int Id { get; set; }
 
-        public object Object { get; set; }
+        public object Object { get; set; } = null!;
 
-        public static OneToManyDependent Static { get; set; }
+        public static OneToManyDependent Static { get; set; } = null!;
 
         public OneToManyDependent WriteOnly
         {
@@ -1041,7 +1041,7 @@ public class RelationshipDiscoveryConventionTest
         }
 
         // ReSharper disable once UnusedParameter.Local
-        public OneToManyDependent this[int index]
+        public OneToManyDependent? this[int index]
         {
             get => null;
             // ReSharper disable once ValueParameterNotUsed
@@ -1049,7 +1049,7 @@ public class RelationshipDiscoveryConventionTest
         }
 
         public MyStruct Struct { get; set; }
-        public IInterface Interface { get; set; }
+        public IInterface Interface { get; set; } = null!;
     }
 
     private struct MyStruct
@@ -1065,13 +1065,14 @@ public class RelationshipDiscoveryConventionTest
     private abstract class AbstractClass
     {
         public int Id { get; set; }
-        public AbstractClass Abstract { get; set; }
+        public AbstractClass Abstract { get; set; } = null!;
     }
 
     private class ReadOnlyCollectionNavigationEntity
     {
         public static readonly PropertyInfo NavigationProperty =
-            typeof(ReadOnlyCollectionNavigationEntity).GetProperty("CollectionNavigation", BindingFlags.Public | BindingFlags.Instance);
+            typeof(ReadOnlyCollectionNavigationEntity).GetProperty(
+                "CollectionNavigation", BindingFlags.Public | BindingFlags.Instance)!;
 
         public int Id { get; set; }
 
@@ -1079,13 +1080,15 @@ public class RelationshipDiscoveryConventionTest
     }
 
     private static void VerifyRelationship(
-        Navigation navigation,
-        string expectedInverseName,
+        Navigation? navigation,
+        string? expectedInverseName,
         bool unique,
         bool singleRelationship = true)
     {
-        IReadOnlyForeignKey fk = navigation.ForeignKey;
-        Assert.Equal(expectedInverseName, navigation.Inverse?.Name);
+        var nonNullNavigation = navigation!;
+        IReadOnlyForeignKey fk = nonNullNavigation.ForeignKey;
+        Assert.Equal(expectedInverseName, navigation!.Inverse?.Name);
+        Assert.Equal(expectedInverseName, nonNullNavigation.Inverse?.Name);
         Assert.Equal(unique, fk.IsUnique);
         Assert.NotSame(fk.Properties.Single(), fk.PrincipalKey.Properties.Single());
         Assert.NotEqual(fk.PrincipalToDependent?.Name, fk.DependentToPrincipal?.Name);
@@ -1097,7 +1100,7 @@ public class RelationshipDiscoveryConventionTest
             Assert.Single(principalEntityType.GetKeys());
             Assert.Empty(principalEntityType.GetDeclaredForeignKeys());
             if ((expectedInverseName == null)
-                && navigation.IsOnDependent)
+                && nonNullNavigation.IsOnDependent)
             {
                 Assert.Empty(principalEntityType.GetNavigations());
             }
@@ -1106,7 +1109,7 @@ public class RelationshipDiscoveryConventionTest
             Assert.Single(dependentEntityType.GetDeclaredProperties());
             Assert.Equal(principalEntityType.IsAssignableFrom(dependentEntityType) ? 1 : 0, dependentEntityType.GetKeys().Count());
             if ((expectedInverseName == null)
-                && !navigation.IsOnDependent)
+                && !nonNullNavigation.IsOnDependent)
             {
                 Assert.Empty(dependentEntityType.GetNavigations());
             }
@@ -1114,14 +1117,16 @@ public class RelationshipDiscoveryConventionTest
     }
 
     private static void VerifySelfRef(
-        Navigation navigation,
-        string expectedInverseName,
+        Navigation? navigation,
+        string? expectedInverseName,
         bool unique,
         bool singleRelationship = true)
     {
-        IReadOnlyForeignKey fk = navigation.ForeignKey;
+        var nonNullNavigation = navigation!;
+        IReadOnlyForeignKey fk = nonNullNavigation.ForeignKey;
         Assert.Single(fk.DeclaringEntityType.Model.GetEntityTypes());
-        Assert.Equal(expectedInverseName, navigation.Inverse?.Name);
+        Assert.Equal(expectedInverseName, navigation!.Inverse?.Name);
+        Assert.Equal(expectedInverseName, nonNullNavigation.Inverse?.Name);
         Assert.Equal(unique, fk.IsUnique);
         Assert.NotSame(fk.Properties.Single(), fk.PrincipalKey.Properties.Single());
         Assert.NotEqual(fk.PrincipalToDependent?.Name, fk.DependentToPrincipal?.Name);
@@ -1142,11 +1147,13 @@ public class RelationshipDiscoveryConventionTest
         }
     }
 
-    private InternalEntityTypeBuilder RunConvention(InternalEntityTypeBuilder entityBuilder)
+    private InternalEntityTypeBuilder RunConvention(
+        InternalEntityTypeBuilder? entityBuilder)
     {
-        var context = new ConventionContext<IConventionEntityTypeBuilder>(entityBuilder.Metadata.Model.ConventionDispatcher);
-        CreateRelationshipDiscoveryConvention().ProcessEntityTypeAdded(entityBuilder, context);
-        return context.ShouldStopProcessing() ? (InternalEntityTypeBuilder)context.Result : entityBuilder;
+        var nonNullEntityBuilder = entityBuilder!;
+        var context = new ConventionContext<IConventionEntityTypeBuilder>(nonNullEntityBuilder.Metadata.Model.ConventionDispatcher);
+        CreateRelationshipDiscoveryConvention().ProcessEntityTypeAdded(nonNullEntityBuilder, context);
+        return context.ShouldStopProcessing() ? (InternalEntityTypeBuilder)context.Result! : nonNullEntityBuilder;
     }
 
     private RelationshipDiscoveryConvention CreateRelationshipDiscoveryConvention()
@@ -1165,7 +1172,7 @@ public class RelationshipDiscoveryConventionTest
                 Logger = CreateLogger()
             };
 
-    private InternalModelBuilder CreateInternalModeBuilder(params Action<IConventionEntityTypeBuilder>[] onEntityAdded)
+    private InternalModelBuilder CreateInternalModeBuilder(params Action<IConventionEntityTypeBuilder>[]? onEntityAdded)
     {
         var conventions = new ConventionSet();
         if (onEntityAdded != null)
@@ -1185,7 +1192,7 @@ public class RelationshipDiscoveryConventionTest
     private InternalEntityTypeBuilder CreateInternalEntityBuilder<T>(params Action<IConventionEntityTypeBuilder>[] onEntityAdded)
     {
         var modelBuilder = CreateInternalModeBuilder(onEntityAdded);
-        var entityBuilder = modelBuilder.Entity(typeof(T), ConfigurationSource.DataAnnotation);
+        var entityBuilder = modelBuilder.Entity(typeof(T), ConfigurationSource.DataAnnotation)!;
 
         return entityBuilder;
     }
@@ -1208,10 +1215,10 @@ public class RelationshipDiscoveryConventionTest
     private class OneToOnePrincipal
     {
         public static readonly PropertyInfo NavigationProperty =
-            typeof(OneToOnePrincipal).GetProperty("OneToOneDependent", BindingFlags.Public | BindingFlags.Instance);
+            typeof(OneToOnePrincipal).GetProperty("OneToOneDependent", BindingFlags.Public | BindingFlags.Instance)!;
 
         public int Id { get; set; }
-        public OneToOneDependent OneToOneDependent { get; set; }
+        public OneToOneDependent OneToOneDependent { get; set; } = null!;
 
         public static void IgnoreNavigation(InternalEntityTypeBuilder entityTypeBuilder)
         {
@@ -1225,10 +1232,10 @@ public class RelationshipDiscoveryConventionTest
     private class OneToOneDependent
     {
         public static readonly PropertyInfo NavigationProperty =
-            typeof(OneToOneDependent).GetProperty("OneToOnePrincipal", BindingFlags.Public | BindingFlags.Instance);
+            typeof(OneToOneDependent).GetProperty("OneToOnePrincipal", BindingFlags.Public | BindingFlags.Instance)!;
 
         public int Id { get; set; }
-        public OneToOnePrincipal OneToOnePrincipal { get; set; }
+        public OneToOnePrincipal OneToOnePrincipal { get; set; } = null!;
 
         public static void IgnoreNavigation(IConventionEntityTypeBuilder entityTypeBuilder)
         {
@@ -1242,11 +1249,11 @@ public class RelationshipDiscoveryConventionTest
     private class OneToManyPrincipal
     {
         public static readonly PropertyInfo NavigationProperty =
-            typeof(OneToManyPrincipal).GetProperty("OneToManyDependents", BindingFlags.Public | BindingFlags.Instance);
+            typeof(OneToManyPrincipal).GetProperty("OneToManyDependents", BindingFlags.Public | BindingFlags.Instance)!;
 
         public int Id { get; set; }
 
-        public IEnumerable<OneToManyDependent> OneToManyDependents { get; set; }
+        public IEnumerable<OneToManyDependent> OneToManyDependents { get; set; } = null!;
 
         public static void IgnoreNavigation(IConventionEntityTypeBuilder entityTypeBuilder)
         {
@@ -1260,11 +1267,11 @@ public class RelationshipDiscoveryConventionTest
     private class OneToManyDependent
     {
         public static readonly PropertyInfo NavigationProperty =
-            typeof(OneToManyDependent).GetProperty("OneToManyPrincipal", BindingFlags.Public | BindingFlags.Instance);
+            typeof(OneToManyDependent).GetProperty("OneToManyPrincipal", BindingFlags.Public | BindingFlags.Instance)!;
 
         public int Id { get; set; }
 
-        public OneToManyPrincipal OneToManyPrincipal { get; set; }
+        public OneToManyPrincipal OneToManyPrincipal { get; set; } = null!;
 
         public static void IgnoreNavigation(IConventionEntityTypeBuilder entityTypeBuilder)
         {
@@ -1278,52 +1285,54 @@ public class RelationshipDiscoveryConventionTest
     private class ManyToManyFirst
     {
         public int Id { get; set; }
-        public IEnumerable<ManyToManySecond> ManyToManySeconds { get; set; }
+        public IEnumerable<ManyToManySecond> ManyToManySeconds { get; set; } = null!;
     }
 
     private class ManyToManySecond
     {
         public int Id { get; set; }
-        public IEnumerable<ManyToManyFirst> ManyToManyFirsts { get; set; }
+        public IEnumerable<ManyToManyFirst> ManyToManyFirsts { get; set; } = null!;
     }
 
     private class ManyToManySelf
     {
         public int Id { get; set; }
-        public IEnumerable<ManyToManySelf> ManyToManySelf1 { get; set; }
-        public IEnumerable<ManyToManySelf> ManyToManySelf2 { get; set; }
+        public IEnumerable<ManyToManySelf> ManyToManySelf1 { get; set; } = null!;
+        public IEnumerable<ManyToManySelf> ManyToManySelf2 { get; set; } = null!;
     }
 
     private class DerivedManyToManyFirst : ManyToManyFirst
     {
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
     }
 
     private class DerivedManyToManySecond : ManyToManySecond
     {
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
     }
 
     private class MultipleNavigationsFirst
     {
         public static readonly PropertyInfo CollectionNavigationProperty =
-            typeof(MultipleNavigationsFirst).GetProperty("MultipleNavigationsSeconds", BindingFlags.Public | BindingFlags.Instance);
+            typeof(MultipleNavigationsFirst).GetProperty(
+                "MultipleNavigationsSeconds", BindingFlags.Public | BindingFlags.Instance)!;
 
         public static readonly PropertyInfo NonCollectionNavigationProperty =
-            typeof(MultipleNavigationsFirst).GetProperty("MultipleNavigationsSecond", BindingFlags.Public | BindingFlags.Instance);
+            typeof(MultipleNavigationsFirst).GetProperty(
+                "MultipleNavigationsSecond", BindingFlags.Public | BindingFlags.Instance)!;
 
         public int Id { get; set; }
 
-        public IEnumerable<MultipleNavigationsSecond> MultipleNavigationsSeconds { get; set; }
-        public MultipleNavigationsSecond MultipleNavigationsSecond { get; set; }
+        public IEnumerable<MultipleNavigationsSecond> MultipleNavigationsSeconds { get; set; } = null!;
+        public MultipleNavigationsSecond MultipleNavigationsSecond { get; set; } = null!;
     }
 
     private class MultipleNavigationsSecond
     {
         public int Id { get; set; }
 
-        public IEnumerable<MultipleNavigationsFirst> MultipleNavigationsFirsts { get; set; }
-        public MultipleNavigationsFirst MultipleNavigationsFirst { get; set; }
+        public IEnumerable<MultipleNavigationsFirst> MultipleNavigationsFirsts { get; set; } = null!;
+        public MultipleNavigationsFirst MultipleNavigationsFirst { get; set; } = null!;
 
         public static void IgnoreCollectionNavigation(IConventionEntityTypeBuilder entityTypeBuilder)
         {
@@ -1346,9 +1355,9 @@ public class RelationshipDiscoveryConventionTest
     {
         public int Id { get; set; }
 
-        public DerivedOne DerivedOne { get; set; }
-        public DerivedTwo DerivedTwo { get; set; }
-        public Base Base { get; set; }
+        public DerivedOne DerivedOne { get; set; } = null!;
+        public DerivedTwo DerivedTwo { get; set; } = null!;
+        public Base Base { get; set; } = null!;
 
         public static void IgnoreDerivedOneNavigation(IConventionEntityTypeBuilder entityTypeBuilder)
         {
@@ -1379,7 +1388,7 @@ public class RelationshipDiscoveryConventionTest
     {
         public int Id { get; set; }
 
-        public NavigationsToBaseAndDerived BaseNavigation { get; set; }
+        public NavigationsToBaseAndDerived BaseNavigation { get; set; } = null!;
 
         public static void IgnoreBaseNavigation(IConventionEntityTypeBuilder entityTypeBuilder)
         {
@@ -1392,7 +1401,7 @@ public class RelationshipDiscoveryConventionTest
 
     private class DerivedOne : Base
     {
-        public NavigationsToBaseAndDerived DerivedNavigation { get; set; }
+        public NavigationsToBaseAndDerived DerivedNavigation { get; set; } = null!;
 
         public static void IgnoreDerivedNavigation(IConventionEntityTypeBuilder entityTypeBuilder)
         {
@@ -1405,7 +1414,7 @@ public class RelationshipDiscoveryConventionTest
 
     private class DerivedTwo : Base
     {
-        public NavigationsToBaseAndDerived DerivedNavigation { get; set; }
+        public NavigationsToBaseAndDerived DerivedNavigation { get; set; } = null!;
 
         public static void IgnoreDerivedNavigation(IConventionEntityTypeBuilder entityTypeBuilder)
         {
@@ -1419,10 +1428,10 @@ public class RelationshipDiscoveryConventionTest
     private class SelfRef
     {
         public int Id { get; set; }
-        public SelfRef SelfRef1 { get; set; }
-        public SelfRef SelfRef2 { get; set; }
-        public IEnumerable<SelfRef> SelfRef3 { get; set; }
-        public IEnumerable<SelfRef> SelfRef4 { get; set; }
+        public SelfRef SelfRef1 { get; set; } = null!;
+        public SelfRef SelfRef2 { get; set; } = null!;
+        public IEnumerable<SelfRef> SelfRef3 { get; set; } = null!;
+        public IEnumerable<SelfRef> SelfRef4 { get; set; } = null!;
         public int SelfRefId { get; set; }
 
         public static void IgnoreNavigation2(IConventionEntityTypeBuilder entityTypeBuilder)
@@ -1453,7 +1462,7 @@ public class RelationshipDiscoveryConventionTest
     public class AmbiguousCardinalityOne : IEnumerable<AmbiguousCardinalityOne>
     {
         public int Id { get; set; }
-        public AmbiguousCardinalityTwo AmbiguousCardinalityTwo { get; set; }
+        public AmbiguousCardinalityTwo AmbiguousCardinalityTwo { get; set; } = null!;
 
         public static void IgnoreNavigation(IConventionEntityTypeBuilder entityTypeBuilder)
         {
@@ -1475,7 +1484,7 @@ public class RelationshipDiscoveryConventionTest
     public class AmbiguousCardinalityTwo : IEnumerable<AmbiguousCardinalityTwo>
     {
         public int Id { get; set; }
-        public AmbiguousCardinalityOne AmbiguousCardinalityOne { get; set; }
+        public AmbiguousCardinalityOne AmbiguousCardinalityOne { get; set; } = null!;
 
         public static void IgnoreNavigation(IConventionEntityTypeBuilder entityTypeBuilder)
         {

--- a/test/EFCore.Tests/Metadata/Conventions/ServicePropertyDiscoveryConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/ServicePropertyDiscoveryConventionTest.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System.ComponentModel.DataAnnotations.Schema;
 using Microsoft.EntityFrameworkCore.Infrastructure.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal;

--- a/test/EFCore.Tests/Metadata/Conventions/ValueGeneratorConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/ValueGeneratorConventionTest.cs
@@ -14,7 +14,7 @@ public class ValueGeneratorConventionTest
     {
         public int Id { get; set; }
         public int Number { get; set; }
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
     }
 
     private class ReferencedEntity
@@ -35,14 +35,14 @@ public class ValueGeneratorConventionTest
     public void RequiresValueGenerator_flag_is_set_for_key_properties_that_use_value_generation()
     {
         var modelBuilder = CreateInternalModelBuilder();
-        var entityBuilder = modelBuilder.Entity(typeof(SampleEntity), ConfigurationSource.Convention);
+        var entityBuilder = modelBuilder.Entity(typeof(SampleEntity), ConfigurationSource.Convention)!;
 
         var properties = new List<string> { "Id", "Name" };
 
-        entityBuilder.Property(properties[0], ConfigurationSource.Convention)
+        entityBuilder.Property(properties[0], ConfigurationSource.Convention)!
             .ValueGenerated(ValueGenerated.OnAdd, ConfigurationSource.Explicit);
 
-        var keyBuilder = entityBuilder.PrimaryKey(properties, ConfigurationSource.Convention);
+        var keyBuilder = entityBuilder.PrimaryKey(properties, ConfigurationSource.Convention)!;
 
         RunConvention(entityBuilder);
 
@@ -60,8 +60,8 @@ public class ValueGeneratorConventionTest
     {
         var modelBuilder = CreateInternalModelBuilder();
 
-        var principalEntityBuilder = modelBuilder.Entity(typeof(SampleEntity), ConfigurationSource.Convention);
-        var referencedEntityBuilder = modelBuilder.Entity(typeof(ReferencedEntity), ConfigurationSource.Convention);
+        var principalEntityBuilder = modelBuilder.Entity(typeof(SampleEntity), ConfigurationSource.Convention)!;
+        var referencedEntityBuilder = modelBuilder.Entity(typeof(ReferencedEntity), ConfigurationSource.Convention)!;
 
         var properties = new List<string> { "SampleEntityId" };
 
@@ -69,10 +69,10 @@ public class ValueGeneratorConventionTest
 
         referencedEntityBuilder.HasRelationship(
             principalEntityBuilder.Metadata,
-            referencedEntityBuilder.GetOrCreateProperties(properties, ConfigurationSource.Convention),
+            referencedEntityBuilder.GetOrCreateProperties(properties, ConfigurationSource.Convention)!,
             ConfigurationSource.Convention);
 
-        var keyBuilder = referencedEntityBuilder.PrimaryKey(properties, ConfigurationSource.Convention);
+        var keyBuilder = referencedEntityBuilder.PrimaryKey(properties, ConfigurationSource.Convention)!;
 
         RunConvention(referencedEntityBuilder);
 
@@ -87,21 +87,21 @@ public class ValueGeneratorConventionTest
     {
         var modelBuilder = CreateInternalModelBuilder();
 
-        var principalEntityBuilder = modelBuilder.Entity(typeof(SampleEntity), ConfigurationSource.Convention);
-        var referencedEntityBuilder = modelBuilder.Entity(typeof(ReferencedEntity), ConfigurationSource.Convention);
+        var principalEntityBuilder = modelBuilder.Entity(typeof(SampleEntity), ConfigurationSource.Convention)!;
+        var referencedEntityBuilder = modelBuilder.Entity(typeof(ReferencedEntity), ConfigurationSource.Convention)!;
 
         var properties = new List<string> { "Id", "SampleEntityId" };
-        referencedEntityBuilder.Property(properties[0], ConfigurationSource.Convention)
+        referencedEntityBuilder.Property(properties[0], ConfigurationSource.Convention)!
             .ValueGenerated(ValueGenerated.OnAdd, ConfigurationSource.Explicit);
-        referencedEntityBuilder.Property(properties[1], ConfigurationSource.Convention)
+        referencedEntityBuilder.Property(properties[1], ConfigurationSource.Convention)!
             .ValueGenerated(ValueGenerated.OnAdd, ConfigurationSource.Explicit);
 
         referencedEntityBuilder.HasRelationship(
             principalEntityBuilder.Metadata,
-            referencedEntityBuilder.GetOrCreateProperties([properties[1]], ConfigurationSource.Convention),
+            referencedEntityBuilder.GetOrCreateProperties([properties[1]], ConfigurationSource.Convention)!,
             ConfigurationSource.Convention);
 
-        var keyBuilder = referencedEntityBuilder.PrimaryKey(properties, ConfigurationSource.Convention);
+        var keyBuilder = referencedEntityBuilder.PrimaryKey(properties, ConfigurationSource.Convention)!;
 
         RunConvention(referencedEntityBuilder);
 
@@ -116,20 +116,20 @@ public class ValueGeneratorConventionTest
     {
         var modelBuilder = CreateInternalModelBuilder();
 
-        var principalEntityBuilder = modelBuilder.Entity(typeof(SampleEntity), ConfigurationSource.Convention);
-        var referencedEntityBuilder = modelBuilder.Entity(typeof(ReferencedEntity), ConfigurationSource.Convention);
+        var principalEntityBuilder = modelBuilder.Entity(typeof(SampleEntity), ConfigurationSource.Convention)!;
+        var referencedEntityBuilder = modelBuilder.Entity(typeof(ReferencedEntity), ConfigurationSource.Convention)!;
 
         var properties = new List<string> { "Id", "SampleEntityId" };
 
-        referencedEntityBuilder.Property(properties[0], ConfigurationSource.Convention)
+        referencedEntityBuilder.Property(properties[0], ConfigurationSource.Convention)!
             .ValueGenerated(ValueGenerated.OnAdd, ConfigurationSource.Explicit);
 
         referencedEntityBuilder.HasRelationship(
             principalEntityBuilder.Metadata,
-            referencedEntityBuilder.GetOrCreateProperties(properties, ConfigurationSource.Convention),
+            referencedEntityBuilder.GetOrCreateProperties(properties, ConfigurationSource.Convention)!,
             ConfigurationSource.Convention);
 
-        var keyBuilder = referencedEntityBuilder.PrimaryKey([properties[1]], ConfigurationSource.Convention);
+        var keyBuilder = referencedEntityBuilder.PrimaryKey([properties[1]], ConfigurationSource.Convention)!;
 
         RunConvention(referencedEntityBuilder);
 
@@ -143,14 +143,14 @@ public class ValueGeneratorConventionTest
     public void KeyConvention_does_not_override_ValueGenerated_when_configured_explicitly()
     {
         var modelBuilder = CreateInternalModelBuilder();
-        var entityBuilder = modelBuilder.Entity(typeof(SampleEntity), ConfigurationSource.Convention);
+        var entityBuilder = modelBuilder.Entity(typeof(SampleEntity), ConfigurationSource.Convention)!;
 
         var properties = new List<string> { "Id" };
 
-        entityBuilder.Property(properties[0], ConfigurationSource.Convention)
+        entityBuilder.Property(properties[0], ConfigurationSource.Convention)!
             .ValueGenerated(ValueGenerated.OnAdd, ConfigurationSource.Explicit);
 
-        var keyBuilder = entityBuilder.PrimaryKey(properties, ConfigurationSource.Convention);
+        var keyBuilder = entityBuilder.PrimaryKey(properties, ConfigurationSource.Convention)!;
 
         RunConvention(entityBuilder);
 
@@ -164,14 +164,14 @@ public class ValueGeneratorConventionTest
     {
         var modelBuilder = CreateInternalModelBuilder();
 
-        var principalEntityBuilder = modelBuilder.Entity(typeof(SampleEntity), ConfigurationSource.Convention);
-        var referencedEntityBuilder = modelBuilder.Entity(typeof(ReferencedEntity), ConfigurationSource.Convention);
+        var principalEntityBuilder = modelBuilder.Entity(typeof(SampleEntity), ConfigurationSource.Convention)!;
+        var referencedEntityBuilder = modelBuilder.Entity(typeof(ReferencedEntity), ConfigurationSource.Convention)!;
 
         var properties = new List<string> { "SampleEntityId" };
 
         referencedEntityBuilder.Property(properties[0], ConfigurationSource.Convention);
 
-        var keyBuilder = referencedEntityBuilder.PrimaryKey(properties, ConfigurationSource.Convention);
+        var keyBuilder = referencedEntityBuilder.PrimaryKey(properties, ConfigurationSource.Convention)!;
 
         RunConvention(referencedEntityBuilder);
 
@@ -181,8 +181,8 @@ public class ValueGeneratorConventionTest
 
         var foreignKeyBuilder = referencedEntityBuilder.HasRelationship(
             principalEntityBuilder.Metadata,
-            referencedEntityBuilder.GetOrCreateProperties(properties, ConfigurationSource.Convention),
-            ConfigurationSource.Convention);
+            referencedEntityBuilder.GetOrCreateProperties(properties, ConfigurationSource.Convention)!,
+            ConfigurationSource.Convention)!;
 
         RunConvention(foreignKeyBuilder);
 
@@ -195,14 +195,14 @@ public class ValueGeneratorConventionTest
     {
         var modelBuilder = CreateInternalModelBuilder();
 
-        var principalEntityBuilder = modelBuilder.Entity(typeof(SampleEntity), ConfigurationSource.Convention);
-        var referencedEntityBuilder = modelBuilder.Entity(typeof(ReferencedEntity), ConfigurationSource.Convention);
+        var principalEntityBuilder = modelBuilder.Entity(typeof(SampleEntity), ConfigurationSource.Convention)!;
+        var referencedEntityBuilder = modelBuilder.Entity(typeof(ReferencedEntity), ConfigurationSource.Convention)!;
 
         var properties = new List<string> { "SampleEntityId" };
 
         referencedEntityBuilder.Property(properties[0], ConfigurationSource.Convention);
 
-        var keyBuilder = referencedEntityBuilder.PrimaryKey(properties, ConfigurationSource.Convention);
+        var keyBuilder = referencedEntityBuilder.PrimaryKey(properties, ConfigurationSource.Convention)!;
 
         RunConvention(referencedEntityBuilder);
 
@@ -212,8 +212,8 @@ public class ValueGeneratorConventionTest
 
         var relationshipBuilder = referencedEntityBuilder.HasRelationship(
             principalEntityBuilder.Metadata,
-            referencedEntityBuilder.GetOrCreateProperties(properties, ConfigurationSource.Convention),
-            ConfigurationSource.Convention);
+            referencedEntityBuilder.GetOrCreateProperties(properties, ConfigurationSource.Convention)!,
+            ConfigurationSource.Convention)!;
 
         RunConvention(relationshipBuilder);
 
@@ -236,10 +236,10 @@ public class ValueGeneratorConventionTest
     public void Identity_is_set_for_primary_key()
     {
         var modelBuilder = CreateInternalModelBuilder();
-        var entityBuilder = modelBuilder.Entity(typeof(SampleEntity), ConfigurationSource.Convention);
+        var entityBuilder = modelBuilder.Entity(typeof(SampleEntity), ConfigurationSource.Convention)!;
 
         var keyBuilder = entityBuilder.PrimaryKey(
-            new List<string> { "Id" }, ConfigurationSource.Convention);
+            new List<string> { "Id" }, ConfigurationSource.Convention)!;
 
         RunConvention(entityBuilder);
 
@@ -252,10 +252,10 @@ public class ValueGeneratorConventionTest
     public void Identity_is_not_set_for_non_primary_key()
     {
         var modelBuilder = CreateInternalModelBuilder();
-        var entityBuilder = modelBuilder.Entity(typeof(SampleEntity), ConfigurationSource.Convention);
+        var entityBuilder = modelBuilder.Entity(typeof(SampleEntity), ConfigurationSource.Convention)!;
 
         var keyBuilder = entityBuilder.HasKey(
-            new List<string> { "Number" }, ConfigurationSource.Convention);
+            new List<string> { "Number" }, ConfigurationSource.Convention)!;
 
         RunConvention(entityBuilder);
 
@@ -268,10 +268,10 @@ public class ValueGeneratorConventionTest
     public void Identity_not_set_when_composite_primary_key()
     {
         var modelBuilder = CreateInternalModelBuilder();
-        var entityBuilder = modelBuilder.Entity(typeof(SampleEntity), ConfigurationSource.Convention);
+        var entityBuilder = modelBuilder.Entity(typeof(SampleEntity), ConfigurationSource.Convention)!;
 
         var keyBuilder = entityBuilder.PrimaryKey(
-            new List<string> { "Id", "Number" }, ConfigurationSource.Convention);
+            new List<string> { "Id", "Number" }, ConfigurationSource.Convention)!;
 
         RunConvention(entityBuilder);
 
@@ -285,10 +285,10 @@ public class ValueGeneratorConventionTest
     public void Identity_not_set_when_primary_key_property_is_string()
     {
         var modelBuilder = CreateInternalModelBuilder();
-        var entityBuilder = modelBuilder.Entity(typeof(SampleEntity), ConfigurationSource.Convention);
+        var entityBuilder = modelBuilder.Entity(typeof(SampleEntity), ConfigurationSource.Convention)!;
 
         var keyBuilder = entityBuilder.PrimaryKey(
-            new List<string> { "Name" }, ConfigurationSource.Convention);
+            new List<string> { "Name" }, ConfigurationSource.Convention)!;
 
         var property = keyBuilder.Metadata.Properties.First();
 
@@ -300,10 +300,10 @@ public class ValueGeneratorConventionTest
     public void Identity_not_set_when_primary_key_property_is_byte_array()
     {
         var modelBuilder = CreateInternalModelBuilder();
-        var entityBuilder = modelBuilder.Entity(typeof(SampleEntity), ConfigurationSource.Convention);
+        var entityBuilder = modelBuilder.Entity(typeof(SampleEntity), ConfigurationSource.Convention)!;
         entityBuilder.Property(typeof(byte[]), "binaryKey", ConfigurationSource.Explicit);
 
-        var keyBuilder = entityBuilder.PrimaryKey(["binaryKey"], ConfigurationSource.Convention);
+        var keyBuilder = entityBuilder.PrimaryKey(["binaryKey"], ConfigurationSource.Convention)!;
 
         var property = keyBuilder.Metadata.Properties.First();
 
@@ -315,10 +315,10 @@ public class ValueGeneratorConventionTest
     public void Identity_not_set_when_primary_key_property_is_enum()
     {
         var modelBuilder = CreateInternalModelBuilder();
-        var entityBuilder = modelBuilder.Entity(typeof(SampleEntity), ConfigurationSource.Convention);
+        var entityBuilder = modelBuilder.Entity(typeof(SampleEntity), ConfigurationSource.Convention)!;
         entityBuilder.Property(typeof(Eenom), "enumKey", ConfigurationSource.Explicit);
 
-        var keyBuilder = entityBuilder.PrimaryKey(["enumKey"], ConfigurationSource.Convention);
+        var keyBuilder = entityBuilder.PrimaryKey(["enumKey"], ConfigurationSource.Convention)!;
 
         var property = keyBuilder.Metadata.Properties.First();
 
@@ -330,10 +330,10 @@ public class ValueGeneratorConventionTest
     public void Identity_is_recomputed_when_primary_key_is_changed()
     {
         var modelBuilder = CreateInternalModelBuilder();
-        var entityBuilder = modelBuilder.Entity(typeof(SampleEntity), ConfigurationSource.Convention);
+        var entityBuilder = modelBuilder.Entity(typeof(SampleEntity), ConfigurationSource.Convention)!;
 
-        var idProperty = entityBuilder.Property(typeof(int), "Id", ConfigurationSource.Convention).Metadata;
-        var numberProperty = entityBuilder.Property(typeof(int), "Number", ConfigurationSource.Convention).Metadata;
+        var idProperty = entityBuilder.Property(typeof(int), "Id", ConfigurationSource.Convention)!.Metadata;
+        var numberProperty = entityBuilder.Property(typeof(int), "Number", ConfigurationSource.Convention)!.Metadata;
 
         Assert.Same(idProperty, entityBuilder.Metadata.FindProperty("Id"));
         Assert.Same(numberProperty, entityBuilder.Metadata.FindProperty("Number"));
@@ -361,13 +361,13 @@ public class ValueGeneratorConventionTest
     public void Convention_does_not_override_None_when_configured_explicitly()
     {
         var modelBuilder = CreateInternalModelBuilder();
-        var entityBuilder = modelBuilder.Entity(typeof(SampleEntity), ConfigurationSource.Convention);
+        var entityBuilder = modelBuilder.Entity(typeof(SampleEntity), ConfigurationSource.Convention)!;
 
-        entityBuilder.Property(typeof(int), "Id", ConfigurationSource.Convention)
+        entityBuilder.Property(typeof(int), "Id", ConfigurationSource.Convention)!
             .ValueGenerated(ValueGenerated.Never, ConfigurationSource.Explicit);
 
         var keyBuilder = entityBuilder.PrimaryKey(
-            new List<string> { "Id" }, ConfigurationSource.Convention);
+            new List<string> { "Id" }, ConfigurationSource.Convention)!;
 
         RunConvention(entityBuilder);
 
@@ -381,11 +381,11 @@ public class ValueGeneratorConventionTest
     {
         var modelBuilder = CreateInternalModelBuilder();
 
-        var principalEntityBuilder = modelBuilder.Entity(typeof(SampleEntity), ConfigurationSource.Convention);
-        var referencedEntityBuilder = modelBuilder.Entity(typeof(ReferencedEntity), ConfigurationSource.Convention);
+        var principalEntityBuilder = modelBuilder.Entity(typeof(SampleEntity), ConfigurationSource.Convention)!;
+        var referencedEntityBuilder = modelBuilder.Entity(typeof(ReferencedEntity), ConfigurationSource.Convention)!;
 
         var properties = new List<string> { "Id" };
-        var keyBuilder = referencedEntityBuilder.PrimaryKey(properties, ConfigurationSource.Convention);
+        var keyBuilder = referencedEntityBuilder.PrimaryKey(properties, ConfigurationSource.Convention)!;
 
         RunConvention(referencedEntityBuilder);
 
@@ -395,8 +395,8 @@ public class ValueGeneratorConventionTest
 
         var relationshipBuilder = referencedEntityBuilder.HasRelationship(
             principalEntityBuilder.Metadata,
-            referencedEntityBuilder.GetOrCreateProperties(properties, ConfigurationSource.Convention),
-            ConfigurationSource.Convention);
+            referencedEntityBuilder.GetOrCreateProperties(properties, ConfigurationSource.Convention)!,
+            ConfigurationSource.Convention)!;
 
         RunConvention(relationshipBuilder);
 
@@ -408,11 +408,11 @@ public class ValueGeneratorConventionTest
     {
         var modelBuilder = CreateInternalModelBuilder();
 
-        var principalEntityBuilder = modelBuilder.Entity(typeof(SampleEntity), ConfigurationSource.Convention);
-        var referencedEntityBuilder = modelBuilder.Entity(typeof(ReferencedEntity), ConfigurationSource.Convention);
+        var principalEntityBuilder = modelBuilder.Entity(typeof(SampleEntity), ConfigurationSource.Convention)!;
+        var referencedEntityBuilder = modelBuilder.Entity(typeof(ReferencedEntity), ConfigurationSource.Convention)!;
 
         var properties = new List<string> { "Id" };
-        var keyBuilder = referencedEntityBuilder.PrimaryKey(properties, ConfigurationSource.Convention);
+        var keyBuilder = referencedEntityBuilder.PrimaryKey(properties, ConfigurationSource.Convention)!;
 
         RunConvention(referencedEntityBuilder);
 
@@ -422,8 +422,8 @@ public class ValueGeneratorConventionTest
 
         var relationshipBuilder = referencedEntityBuilder.HasRelationship(
             principalEntityBuilder.Metadata,
-            referencedEntityBuilder.GetOrCreateProperties(properties, ConfigurationSource.Convention),
-            ConfigurationSource.Convention);
+            referencedEntityBuilder.GetOrCreateProperties(properties, ConfigurationSource.Convention)!,
+            ConfigurationSource.Convention)!;
 
         RunConvention(relationshipBuilder);
 

--- a/test/EFCore.Tests/Metadata/Internal/ClrCollectionAccessorFactoryTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/ClrCollectionAccessorFactoryTest.cs
@@ -127,7 +127,7 @@ public class ClrCollectionAccessorFactoryTest
         Func<MyEntity, IEnumerable<MyOtherEntity>> reader,
         bool initializeCollections = true)
     {
-        var accessor = ClrCollectionAccessorFactory.Instance.Create(CreateNavigation(navigationName));
+        var accessor = ClrCollectionAccessorFactory.Instance.Create(CreateNavigation(navigationName))!;
 
         var entity = new MyEntity(initializeCollections);
 
@@ -155,17 +155,17 @@ public class ClrCollectionAccessorFactoryTest
         var otherType = model.AddEntityType(typeof(MyEntityWithCustomComparer));
         var foreignKey = otherType.AddForeignKey(
             otherType.AddProperty("MyEntityId", typeof(int)),
-            entityType.SetPrimaryKey(entityType.AddProperty("Id", typeof(int))),
+            entityType.SetPrimaryKey(entityType.AddProperty("Id", typeof(int)))!,
             entityType);
 
         var navigation = foreignKey.SetPrincipalToDependent(
             typeof(MyEntity).GetProperty(
                 nameof(MyEntity.AsICollectionWithCustomComparer),
-                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance));
+                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance))!;
 
         RunConvention(navigation);
 
-        var accessor = ClrCollectionAccessorFactory.Instance.Create((INavigation)navigation);
+        var accessor = ClrCollectionAccessorFactory.Instance.Create((INavigation)navigation)!;
 
         var entity = new MyEntity(initialize: false);
         var value = new MyEntityWithCustomComparer { Id = 1 };
@@ -209,7 +209,7 @@ public class ClrCollectionAccessorFactoryTest
 
     private void Enumerable_backed_by_non_collection_throws(Action<IClrCollectionAccessor, MyEntity, MyOtherEntity> test)
     {
-        var accessor = ClrCollectionAccessorFactory.Instance.Create(CreateNavigation("AsIEnumerableNotCollection"));
+        var accessor = ClrCollectionAccessorFactory.Instance.Create(CreateNavigation("AsIEnumerableNotCollection"))!;
 
         var entity = new MyEntity(initialize: true);
         var value = new MyOtherEntity();
@@ -233,7 +233,7 @@ public class ClrCollectionAccessorFactoryTest
     [Fact]
     public void Initialization_for_navigation_without_backing_field_throws()
     {
-        var accessor = ClrCollectionAccessorFactory.Instance.Create(CreateNavigation("NoBackingFound"));
+        var accessor = ClrCollectionAccessorFactory.Instance.Create(CreateNavigation("NoBackingFound"))!;
 
         Assert.Equal(
             CoreStrings.NavigationNoSetter("NoBackingFound", typeof(MyEntity).Name),
@@ -244,7 +244,7 @@ public class ClrCollectionAccessorFactoryTest
     [Fact]
     public void Initialization_for_read_only_navigation_without_backing_field_throws()
     {
-        var accessor = ClrCollectionAccessorFactory.Instance.Create(CreateNavigation("ReadOnlyPropNoField"));
+        var accessor = ClrCollectionAccessorFactory.Instance.Create(CreateNavigation("ReadOnlyPropNoField"))!;
 
         Assert.Equal(
             CoreStrings.NavigationNoSetter("ReadOnlyPropNoField", typeof(MyEntity).Name),
@@ -263,7 +263,7 @@ public class ClrCollectionAccessorFactoryTest
     [Fact]
     public void Initialization_for_navigation_with_private_constructor_throws()
     {
-        var accessor = ClrCollectionAccessorFactory.Instance.Create(CreateNavigation("AsMyPrivateCollection"));
+        var accessor = ClrCollectionAccessorFactory.Instance.Create(CreateNavigation("AsMyPrivateCollection"))!;
 
         Assert.Equal(
             CoreStrings.NavigationCannotCreateType("AsMyPrivateCollection", typeof(MyEntity).Name, typeof(MyPrivateCollection).Name),
@@ -274,7 +274,7 @@ public class ClrCollectionAccessorFactoryTest
     [Fact]
     public void Initialization_for_navigation_with_internal_constructor_throws()
     {
-        var accessor = ClrCollectionAccessorFactory.Instance.Create(CreateNavigation("AsMyInternalCollection"));
+        var accessor = ClrCollectionAccessorFactory.Instance.Create(CreateNavigation("AsMyInternalCollection"))!;
 
         Assert.Equal(
             CoreStrings.NavigationCannotCreateType("AsMyInternalCollection", typeof(MyEntity).Name, typeof(MyInternalCollection).Name),
@@ -285,7 +285,7 @@ public class ClrCollectionAccessorFactoryTest
     [Fact]
     public void Initialization_for_navigation_without_parameterless_constructor_throws()
     {
-        var accessor = ClrCollectionAccessorFactory.Instance.Create(CreateNavigation("AsMyUnavailableCollection"));
+        var accessor = ClrCollectionAccessorFactory.Instance.Create(CreateNavigation("AsMyUnavailableCollection"))!;
 
         Assert.Equal(
             CoreStrings.NavigationCannotCreateType(
@@ -301,11 +301,11 @@ public class ClrCollectionAccessorFactoryTest
         var otherType = model.AddEntityType(typeof(MyOtherEntity));
         var foreignKey = otherType.AddForeignKey(
             otherType.AddProperty("MyEntityId", typeof(int)),
-            entityType.SetPrimaryKey(entityType.AddProperty("Id", typeof(int))),
+            entityType.SetPrimaryKey(entityType.AddProperty("Id", typeof(int)))!,
             entityType);
 
         var navigation = foreignKey.SetPrincipalToDependent(
-            typeof(MyEntity).GetProperty(navigationName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance));
+            typeof(MyEntity).GetProperty(navigationName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance))!;
 
         RunConvention(navigation);
 
@@ -327,28 +327,28 @@ public class ClrCollectionAccessorFactoryTest
     private class MyEntity
     {
         public static readonly PropertyInfo AsICollectionProperty = typeof(MyEntity).GetProperty(
-            nameof(AsICollection), BindingFlags.NonPublic | BindingFlags.Instance);
+            nameof(AsICollection), BindingFlags.NonPublic | BindingFlags.Instance)!;
 
-        private ICollection<MyOtherEntity> _asICollection;
-        private ICollection<MyEntityWithCustomComparer> _asICollectionOfEntitiesWithCustomComparer;
-        private IList<MyOtherEntity> _asIList;
-        private List<MyOtherEntity> _asList;
-        private MyCollection _myCollection;
-        private readonly ICollection<MyOtherEntity> _withNoBackingFieldFound;
-        private readonly ICollection<MyOtherEntity> _withNoSetter;
-        private ICollection<MyOtherEntity> _withNoGetter;
-        private IEnumerable<MyOtherEntity> _enumerable;
-        private IEnumerable<MyOtherEntity> _enumerableNotCollection;
-        private MyOtherEntity[] _array;
-        private MyPrivateCollection _privateCollection;
-        private MyInternalCollection _internalCollection;
-        private MyUnavailableCollection _unavailableCollection;
-        private readonly IEnumerable<MyOtherEntity> _readOnlyProp;
-        private readonly IEnumerable<MyOtherEntity> _readOnlyFieldProp;
-        private IEnumerable<MyOtherEntity> _writeOnlyProp;
-        private IEnumerable<MyOtherEntity> _fullPropNoFieldNotFound;
-        private readonly IEnumerable<MyOtherEntity> _readOnlyPropNoFieldNotFound;
-        private IEnumerable<MyOtherEntity> _writeOnlyPropNoFieldNotFound;
+        private ICollection<MyOtherEntity> _asICollection = null!;
+        private ICollection<MyEntityWithCustomComparer> _asICollectionOfEntitiesWithCustomComparer = null!;
+        private IList<MyOtherEntity> _asIList = null!;
+        private List<MyOtherEntity> _asList = null!;
+        private MyCollection _myCollection = null!;
+        private readonly ICollection<MyOtherEntity> _withNoBackingFieldFound = null!;
+        private readonly ICollection<MyOtherEntity> _withNoSetter = null!;
+        private ICollection<MyOtherEntity> _withNoGetter = null!;
+        private IEnumerable<MyOtherEntity> _enumerable = null!;
+        private IEnumerable<MyOtherEntity> _enumerableNotCollection = null!;
+        private MyOtherEntity[] _array = null!;
+        private MyPrivateCollection _privateCollection = null!;
+        private MyInternalCollection _internalCollection = null!;
+        private MyUnavailableCollection _unavailableCollection = null!;
+        private readonly IEnumerable<MyOtherEntity> _readOnlyProp = null!;
+        private readonly IEnumerable<MyOtherEntity> _readOnlyFieldProp = null!;
+        private IEnumerable<MyOtherEntity> _writeOnlyProp = null!;
+        private IEnumerable<MyOtherEntity> _fullPropNoFieldNotFound = null!;
+        private readonly IEnumerable<MyOtherEntity> _readOnlyPropNoFieldNotFound = null!;
+        private IEnumerable<MyOtherEntity> _writeOnlyPropNoFieldNotFound = null!;
 
         public MyEntity()
             : this(false)
@@ -461,12 +461,12 @@ public class ClrCollectionAccessorFactoryTest
             set => _unavailableCollection = value;
         }
 
-        internal IEnumerable<MyOtherEntity> AutoProp { get; set; }
+        internal IEnumerable<MyOtherEntity> AutoProp { get; set; } = null!;
 
         internal IEnumerable<MyOtherEntity> ReadOnlyProp
             => _readOnlyProp;
 
-        internal IEnumerable<MyOtherEntity> ReadOnlyAutoProp { get; }
+        internal IEnumerable<MyOtherEntity> ReadOnlyAutoProp { get; } = null!;
 
         internal IEnumerable<MyOtherEntity> ReadOnlyFieldProp
             => _readOnlyFieldProp;
@@ -503,7 +503,7 @@ public class ClrCollectionAccessorFactoryTest
     {
         public int Id { get; set; }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => obj is MyEntityWithCustomComparer other && Id == other.Id;
 
         public override int GetHashCode()

--- a/test/EFCore.Tests/Metadata/Internal/ClrIndexedCollectionAccessorFactoryTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/ClrIndexedCollectionAccessorFactoryTest.cs
@@ -27,7 +27,7 @@ public class ClrIndexedCollectionAccessorFactoryTest
     public void Can_get_item_from_collection()
     {
         var property = CreateComplexCollectionProperty<List<TestComplexType>>();
-        var accessor = ClrIndexedCollectionAccessorFactory.Instance.Create(property);
+        var accessor = ClrIndexedCollectionAccessorFactory.Instance.Create(property)!;
         var entity = new TestEntity<List<TestComplexType>>
         {
             Items =
@@ -47,7 +47,7 @@ public class ClrIndexedCollectionAccessorFactoryTest
 
         var genericValue = genericAccessor.Get(entity, 1);
 
-        Assert.Equal(((TestComplexType)value!).Number, genericValue.Number);
+        Assert.Equal(((TestComplexType)value!).Number, genericValue!.Number);
     }
 
     [Fact]
@@ -106,26 +106,26 @@ public class ClrIndexedCollectionAccessorFactoryTest
     public void Get_throws_for_null_entity()
     {
         var property = CreateComplexCollectionProperty<List<TestComplexType>>();
-        var accessor = ClrIndexedCollectionAccessorFactory.Instance.Create(property);
+        var accessor = ClrIndexedCollectionAccessorFactory.Instance.Create(property)!;
 
-        Assert.Throws<NullReferenceException>(() => accessor.Get(null, 0));
+        Assert.Throws<NullReferenceException>(() => accessor.Get(null!, 0));
     }
 
     [Fact]
     public void Set_throws_for_null_entity()
     {
         var property = CreateComplexCollectionProperty<List<TestComplexType>>();
-        var accessor = ClrIndexedCollectionAccessorFactory.Instance.Create(property);
+        var accessor = ClrIndexedCollectionAccessorFactory.Instance.Create(property)!;
         var newValue = new TestComplexType { Number = 42 };
 
-        Assert.Throws<NullReferenceException>(() => accessor.Set(null, 0, newValue, false));
+        Assert.Throws<NullReferenceException>(() => accessor.Set(null!, 0, newValue, false));
     }
 
     [Fact]
     public void Get_throws_for_index_out_of_range()
     {
         var property = CreateComplexCollectionProperty<List<TestComplexType>>();
-        var accessor = ClrIndexedCollectionAccessorFactory.Instance.Create(property);
+        var accessor = ClrIndexedCollectionAccessorFactory.Instance.Create(property)!;
         var entity = new TestEntity<List<TestComplexType>> { Items = [new TestComplexType { Number = 10 }] };
 
         Assert.Throws<ArgumentOutOfRangeException>(() => accessor.Get(entity, 5));
@@ -135,7 +135,7 @@ public class ClrIndexedCollectionAccessorFactoryTest
     public void Set_throws_for_index_out_of_range()
     {
         var property = CreateComplexCollectionProperty<List<TestComplexType>>();
-        var accessor = ClrIndexedCollectionAccessorFactory.Instance.Create(property);
+        var accessor = ClrIndexedCollectionAccessorFactory.Instance.Create(property)!;
         var entity = new TestEntity<List<TestComplexType>> { Items = [new TestComplexType { Number = 10 }] };
         var newValue = new TestComplexType { Number = 42 };
 
@@ -146,8 +146,8 @@ public class ClrIndexedCollectionAccessorFactoryTest
     public void Get_throws_for_null_collection()
     {
         var property = CreateComplexCollectionProperty<List<TestComplexType>>();
-        var accessor = ClrIndexedCollectionAccessorFactory.Instance.Create(property);
-        var entity = new TestEntity<List<TestComplexType>> { Items = null };
+        var accessor = ClrIndexedCollectionAccessorFactory.Instance.Create(property)!;
+        var entity = new TestEntity<List<TestComplexType>> { Items = null! };
 
         Assert.Throws<NullReferenceException>(() => accessor.Get(entity, 0));
     }
@@ -156,8 +156,8 @@ public class ClrIndexedCollectionAccessorFactoryTest
     public void Set_throws_for_null_collection()
     {
         var property = CreateComplexCollectionProperty<List<TestComplexType>>();
-        var accessor = ClrIndexedCollectionAccessorFactory.Instance.Create(property);
-        var entity = new TestEntity<List<TestComplexType>> { Items = null };
+        var accessor = ClrIndexedCollectionAccessorFactory.Instance.Create(property)!;
+        var entity = new TestEntity<List<TestComplexType>> { Items = null! };
         var newValue = new TestComplexType { Number = 42 };
 
         Assert.Throws<NullReferenceException>(() => accessor.Set(entity, 0, newValue, false));
@@ -167,7 +167,7 @@ public class ClrIndexedCollectionAccessorFactoryTest
     public void Throws_with_empty_collection()
     {
         var property = CreateComplexCollectionProperty<List<TestComplexType>>();
-        var accessor = ClrIndexedCollectionAccessorFactory.Instance.Create(property);
+        var accessor = ClrIndexedCollectionAccessorFactory.Instance.Create(property)!;
         var entity = new TestEntity<List<TestComplexType>> { Items = [] };
         var newValue = new TestComplexType { Number = 42 };
 
@@ -179,7 +179,7 @@ public class ClrIndexedCollectionAccessorFactoryTest
     public void Can_handle_arrays()
     {
         var property = CreateComplexCollectionProperty<TestComplexType[]>();
-        var accessor = ClrIndexedCollectionAccessorFactory.Instance.Create(property);
+        var accessor = ClrIndexedCollectionAccessorFactory.Instance.Create(property)!;
         var entity = new TestEntity<TestComplexType[]>
         {
             Items =
@@ -200,14 +200,14 @@ public class ClrIndexedCollectionAccessorFactoryTest
         var genericAccessor =
             Assert.IsType<ClrIndexedCollectionAccessor<TestEntity<TestComplexType[]>, TestComplexType[], TestComplexType>>(accessor);
 
-        var genericValue = genericAccessor.Get(entity, 1);
+        var genericValue = genericAccessor.Get(entity, 1)!;
         Assert.Equal(42, genericValue.Number);
 
         var anotherValue = new TestComplexType { Number = 99 };
         genericAccessor.Set(entity, 2, anotherValue, false);
         Assert.Equal(99, entity.Items[2].Number);
 
-        var updatedValue = genericAccessor.Get(entity, 2);
+        var updatedValue = genericAccessor.Get(entity, 2)!;
         Assert.Equal(99, updatedValue.Number);
     }
 
@@ -215,7 +215,7 @@ public class ClrIndexedCollectionAccessorFactoryTest
     public void Can_handle_custom_collections()
     {
         var property = CreateComplexCollectionProperty<MyList>();
-        var accessor = ClrIndexedCollectionAccessorFactory.Instance.Create(property);
+        var accessor = ClrIndexedCollectionAccessorFactory.Instance.Create(property)!;
         var entity = new TestEntity<MyList>
         {
             Items =
@@ -235,14 +235,14 @@ public class ClrIndexedCollectionAccessorFactoryTest
 
         var genericAccessor = Assert.IsType<ClrIndexedCollectionAccessor<TestEntity<MyList>, MyList, TestComplexType>>(accessor);
 
-        var genericValue = genericAccessor.Get(entity, 1);
+        var genericValue = genericAccessor.Get(entity, 1)!;
         Assert.Equal(42, genericValue.Number);
 
         var anotherValue = new TestComplexType { Number = 99 };
         genericAccessor.Set(entity, 2, anotherValue, false);
         Assert.Equal(99, entity.Items[2].Number);
 
-        var updatedValue = genericAccessor.Get(entity, 2);
+        var updatedValue = genericAccessor.Get(entity, 2)!;
         Assert.Equal(99, updatedValue.Number);
     }
 
@@ -250,7 +250,7 @@ public class ClrIndexedCollectionAccessorFactoryTest
     public void Can_handle_readonly_property()
     {
         var property = CreateReadOnlyComplexCollectionProperty();
-        var accessor = ClrIndexedCollectionAccessorFactory.Instance.Create(property);
+        var accessor = ClrIndexedCollectionAccessorFactory.Instance.Create(property)!;
         var entity = new TestEntityWithReadOnlyList(
         [
             new TestComplexType { Number = 10 },
@@ -269,7 +269,7 @@ public class ClrIndexedCollectionAccessorFactoryTest
     public void Can_handle_generic_list_types()
     {
         var property = CreateComplexCollectionProperty<List<TestComplexType>>();
-        var accessor = ClrIndexedCollectionAccessorFactory.Instance.Create(property);
+        var accessor = ClrIndexedCollectionAccessorFactory.Instance.Create(property)!;
         var entity = new TestEntity<List<TestComplexType>>
         {
             Items =
@@ -292,7 +292,7 @@ public class ClrIndexedCollectionAccessorFactoryTest
     public void Can_handle_IList_interface()
     {
         var property = CreateComplexCollectionProperty<IList<TestComplexType>>();
-        var accessor = ClrIndexedCollectionAccessorFactory.Instance.Create(property);
+        var accessor = ClrIndexedCollectionAccessorFactory.Instance.Create(property)!;
         var entity = new TestEntity<IList<TestComplexType>>
         {
             Items =
@@ -317,8 +317,8 @@ public class ClrIndexedCollectionAccessorFactoryTest
         entityTypeBuilder.ComplexCollection(typeof(T), nameof(TestEntity<>.Items));
 
         var model = modelBuilder.FinalizeModel();
-        var entityType = model.FindEntityType(typeof(TestEntity<T>));
-        return entityType.FindComplexProperty(nameof(TestEntity<T>.Items));
+        var entityType = model.FindEntityType(typeof(TestEntity<T>))!;
+        return entityType.FindComplexProperty(nameof(TestEntity<T>.Items))!;
     }
 
     private static IProperty CreateScalarProperty()
@@ -330,8 +330,8 @@ public class ClrIndexedCollectionAccessorFactoryTest
         var propertyBuilder = entityTypeBuilder.Property(propertyInfo.PropertyType, propertyInfo.Name);
 
         var model = modelBuilder.FinalizeModel();
-        var entityType = model.FindEntityType(typeof(TestEntity<List<TestComplexType>>));
-        return entityType.FindProperty(propertyInfo.Name);
+        var entityType = model.FindEntityType(typeof(TestEntity<List<TestComplexType>>))!;
+        return entityType.FindProperty(propertyInfo.Name)!;
     }
 
     private static IComplexProperty CreateReadOnlyComplexCollectionProperty()
@@ -343,15 +343,15 @@ public class ClrIndexedCollectionAccessorFactoryTest
         var complexPropertyBuilder = entityTypeBuilder.ComplexCollection(propertyInfo.PropertyType, propertyInfo.Name);
 
         var model = modelBuilder.FinalizeModel();
-        var entityType = model.FindEntityType(typeof(TestEntityWithReadOnlyList));
-        return entityType.FindComplexProperty(propertyInfo.Name);
+        var entityType = model.FindEntityType(typeof(TestEntityWithReadOnlyList))!;
+        return entityType.FindComplexProperty(propertyInfo.Name)!;
     }
 
     private class TestEntity<T>
     {
         public int Id { get; set; }
-        public string Name { get; set; }
-        public T Items { get; set; }
+        public string Name { get; set; } = null!;
+        public T Items { get; set; } = default!;
     }
 
     private class TestEntityWithReadOnlyList

--- a/test/EFCore.Tests/Metadata/Internal/ClrPropertyGetterFactoryTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/ClrPropertyGetterFactoryTest.cs
@@ -126,15 +126,15 @@ public class ClrPropertyGetterFactoryTest
         public bool HasSentinelValueUsingContainingEntity(object entity, IReadOnlyList<int> indices)
             => throw new NotImplementedException();
 
-        public string Name { get; }
-        public ITypeBase DeclaringType { get; }
-        public Type ClrType { get; }
+        public string Name { get; } = null!;
+        public ITypeBase DeclaringType { get; } = null!;
+        public Type ClrType { get; } = null!;
         public bool IsNullable { get; }
         public ValueGenerated ValueGenerated { get; }
         public bool IsConcurrencyToken { get; }
-        public object Sentinel { get; }
-        public PropertyInfo PropertyInfo { get; }
-        public FieldInfo FieldInfo { get; }
+        public object? Sentinel { get; }
+        public PropertyInfo? PropertyInfo { get; }
+        public FieldInfo? FieldInfo { get; }
 
         IReadOnlyTypeBase IReadOnlyPropertyBase.DeclaringType
             => throw new NotImplementedException();
@@ -150,7 +150,7 @@ public class ClrPropertyGetterFactoryTest
         modelBuilder.Entity<Customer>().Property(e => e.Id);
         var model = modelBuilder.FinalizeModel();
 
-        var idProperty = model.FindEntityType(typeof(Customer)).FindProperty(nameof(Customer.Id));
+        var idProperty = model.FindEntityType(typeof(Customer))!.FindProperty(nameof(Customer.Id))!;
 
         Assert.Equal(
             7, ClrPropertyGetterFactory.Instance.Create(idProperty).GetClrValueUsingContainingEntity(
@@ -160,7 +160,7 @@ public class ClrPropertyGetterFactoryTest
     [Fact]
     public void Delegate_getter_is_returned_for_property_info()
         => Assert.Equal(
-            7, ClrPropertyGetterFactory.Instance.Create(typeof(Customer).GetAnyProperty("Id")).GetClrValueUsingContainingEntity(
+            7, ClrPropertyGetterFactory.Instance.Create(typeof(Customer).GetAnyProperty("Id")!).GetClrValueUsingContainingEntity(
                 new Customer { Id = 7 }));
 
     [Fact]
@@ -181,7 +181,7 @@ public class ClrPropertyGetterFactoryTest
     public void Delegate_getter_is_returned_for_struct_property_info()
         => Assert.Equal(
             new Fuel(1.0),
-            ClrPropertyGetterFactory.Instance.Create(typeof(Customer).GetAnyProperty("Fuel")).GetClrValueUsingContainingEntity(
+            ClrPropertyGetterFactory.Instance.Create(typeof(Customer).GetAnyProperty("Fuel")!).GetClrValueUsingContainingEntity(
                 new Customer { Id = 7, Fuel = new Fuel(1.0) }));
 
     [Fact]

--- a/test/EFCore.Tests/Metadata/Internal/ClrPropertySetterFactoryTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/ClrPropertySetterFactoryTest.cs
@@ -21,26 +21,26 @@ public class ClrPropertySetterFactoryTest
 
     private class FakeProperty : Annotatable, IProperty, IClrPropertySetter
     {
-        public string Name { get; }
-        public ITypeBase DeclaringType { get; }
-        public Type ClrType { get; }
+        public string Name { get; } = null!;
+        public ITypeBase DeclaringType { get; } = null!;
+        public Type ClrType { get; } = null!;
         public bool IsNullable { get; }
         public bool IsReadOnlyBeforeSave { get; }
         public bool IsReadOnlyAfterSave { get; }
         public bool IsStoreGeneratedAlways { get; }
         public ValueGenerated ValueGenerated { get; }
         public bool IsConcurrencyToken { get; }
-        public object Sentinel { get; }
-        public PropertyInfo PropertyInfo { get; }
-        public FieldInfo FieldInfo { get; }
+        public object? Sentinel { get; }
+        public PropertyInfo? PropertyInfo { get; }
+        public FieldInfo? FieldInfo { get; }
 
         IReadOnlyTypeBase IReadOnlyPropertyBase.DeclaringType
             => throw new NotImplementedException();
 
-        public void SetClrValueUsingContainingEntity(object instance, IReadOnlyList<int> indices, object value)
+        public void SetClrValueUsingContainingEntity(object instance, IReadOnlyList<int> indices, object? value)
             => throw new NotImplementedException();
 
-        public object SetClrValue(object instance, object value)
+        public object SetClrValue(object instance, object? value)
             => throw new NotImplementedException();
 
         public IEnumerable<IForeignKey> GetContainingForeignKeys()
@@ -154,7 +154,7 @@ public class ClrPropertySetterFactoryTest
     {
         var customer = new Customer { Id = 7 };
 
-        ClrPropertySetterFactory.Instance.Create(typeof(Customer).GetAnyProperty("Id")).SetClrValueUsingContainingEntity(customer, 77);
+        ClrPropertySetterFactory.Instance.Create(typeof(Customer).GetAnyProperty("Id")!).SetClrValueUsingContainingEntity(customer, 77);
 
         Assert.Equal(77, customer.Id);
     }
@@ -242,7 +242,7 @@ public class ClrPropertySetterFactoryTest
     {
         var entityType = CreateModel().AddEntityType(typeof(ConcreteEntity1));
         var property = entityType.AddProperty(
-            typeof(ConcreteEntity1).GetProperty(nameof(ConcreteEntity1.VirtualPrivateProperty_Override)));
+            typeof(ConcreteEntity1).GetProperty(nameof(ConcreteEntity1.VirtualPrivateProperty_Override))!);
         var entity = new ConcreteEntity1();
 
         ClrPropertySetterFactory.Instance.Create((IProperty)property).SetClrValueUsingContainingEntity(entity, 100);
@@ -254,7 +254,7 @@ public class ClrPropertySetterFactoryTest
     {
         var entityType = CreateModel().AddEntityType(typeof(ConcreteEntity2));
         var property = entityType.AddProperty(
-            typeof(ConcreteEntity2).GetProperty(nameof(ConcreteEntity2.VirtualPrivateProperty_Override)));
+            typeof(ConcreteEntity2).GetProperty(nameof(ConcreteEntity2.VirtualPrivateProperty_Override))!);
         var entity = new ConcreteEntity2();
 
         ClrPropertySetterFactory.Instance.Create((IProperty)property).SetClrValueUsingContainingEntity(entity, 100);
@@ -266,7 +266,7 @@ public class ClrPropertySetterFactoryTest
     {
         var entityType = CreateModel().AddEntityType(typeof(ConcreteEntity1));
         var property = entityType.AddProperty(
-            typeof(ConcreteEntity1).GetProperty(nameof(ConcreteEntity1.VirtualPrivateProperty_NoOverride)));
+            typeof(ConcreteEntity1).GetProperty(nameof(ConcreteEntity1.VirtualPrivateProperty_NoOverride))!);
         var entity = new ConcreteEntity1();
 
         ClrPropertySetterFactory.Instance.Create((IProperty)property).SetClrValueUsingContainingEntity(entity, 100);
@@ -278,7 +278,7 @@ public class ClrPropertySetterFactoryTest
     {
         var entityType = CreateModel().AddEntityType(typeof(ConcreteEntity2));
         var property = entityType.AddProperty(
-            typeof(ConcreteEntity2).GetProperty(nameof(ConcreteEntity2.VirtualPrivateProperty_NoOverride)));
+            typeof(ConcreteEntity2).GetProperty(nameof(ConcreteEntity2.VirtualPrivateProperty_NoOverride))!);
         var entity = new ConcreteEntity2();
 
         ClrPropertySetterFactory.Instance.Create((IProperty)property).SetClrValueUsingContainingEntity(entity, 100);
@@ -289,7 +289,7 @@ public class ClrPropertySetterFactoryTest
     public void Delegate_setter_can_set_on_privatesetter_property_singlebasetype()
     {
         var entityType = CreateModel().AddEntityType(typeof(ConcreteEntity1));
-        var property = entityType.AddProperty(typeof(ConcreteEntity1).GetProperty(nameof(ConcreteEntity1.PrivateProperty)));
+        var property = entityType.AddProperty(typeof(ConcreteEntity1).GetProperty(nameof(ConcreteEntity1.PrivateProperty))!);
         var entity = new ConcreteEntity1();
 
         ClrPropertySetterFactory.Instance.Create((IProperty)property).SetClrValueUsingContainingEntity(entity, 100);
@@ -300,7 +300,7 @@ public class ClrPropertySetterFactoryTest
     public void Delegate_setter_can_set_on_privatesetter_property_multiplebasetypes()
     {
         var entityType = CreateModel().AddEntityType(typeof(ConcreteEntity2));
-        var property = entityType.AddProperty(typeof(ConcreteEntity2).GetProperty(nameof(ConcreteEntity2.PrivateProperty)));
+        var property = entityType.AddProperty(typeof(ConcreteEntity2).GetProperty(nameof(ConcreteEntity2.PrivateProperty))!);
         var entity = new ConcreteEntity2();
 
         ClrPropertySetterFactory.Instance.Create((IProperty)property).SetClrValueUsingContainingEntity(entity, 100);
@@ -311,12 +311,12 @@ public class ClrPropertySetterFactoryTest
     public void Delegate_setter_throws_if_no_setter_found()
     {
         var entityType = CreateModel().AddEntityType(typeof(ConcreteEntity1));
-        var property = entityType.AddProperty(typeof(ConcreteEntity1).GetProperty(nameof(ConcreteEntity1.NoSetterProperty)));
+        var property = entityType.AddProperty(typeof(ConcreteEntity1).GetProperty(nameof(ConcreteEntity1.NoSetterProperty))!);
 
         Assert.Throws<InvalidOperationException>(() => ClrPropertySetterFactory.Instance.Create((IProperty)property));
 
         entityType = CreateModel().AddEntityType(typeof(ConcreteEntity2));
-        property = entityType.AddProperty(typeof(ConcreteEntity2).GetProperty(nameof(ConcreteEntity2.NoSetterProperty)));
+        property = entityType.AddProperty(typeof(ConcreteEntity2).GetProperty(nameof(ConcreteEntity2.NoSetterProperty))!);
 
         Assert.Throws<InvalidOperationException>(() => ClrPropertySetterFactory.Instance.Create((IProperty)property));
     }
@@ -353,14 +353,14 @@ public class ClrPropertySetterFactoryTest
 
     private class Customer
     {
-        public static readonly PropertyInfo IdProperty = typeof(Customer).GetProperty(nameof(Id));
-        public static readonly PropertyInfo OptionalIntProperty = typeof(Customer).GetProperty(nameof(OptionalInt));
-        public static readonly PropertyInfo ContentProperty = typeof(Customer).GetProperty(nameof(Content));
-        public static readonly PropertyInfo FlagProperty = typeof(Customer).GetProperty(nameof(Flag));
-        public static readonly PropertyInfo OptionalFlagProperty = typeof(Customer).GetProperty(nameof(OptionalFlag));
+        public static readonly PropertyInfo IdProperty = typeof(Customer).GetProperty(nameof(Id))!;
+        public static readonly PropertyInfo OptionalIntProperty = typeof(Customer).GetProperty(nameof(OptionalInt))!;
+        public static readonly PropertyInfo ContentProperty = typeof(Customer).GetProperty(nameof(Content))!;
+        public static readonly PropertyInfo FlagProperty = typeof(Customer).GetProperty(nameof(Flag))!;
+        public static readonly PropertyInfo OptionalFlagProperty = typeof(Customer).GetProperty(nameof(OptionalFlag))!;
 
         public int Id { get; set; }
-        public string Content { get; set; }
+        public string Content { get; set; } = null!;
         public int? OptionalInt { get; set; }
         public Flag Flag { get; set; }
         public Flag? OptionalFlag { get; set; }

--- a/test/EFCore.Tests/Metadata/Internal/CollectionTypeFactoryTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/CollectionTypeFactoryTest.cs
@@ -102,7 +102,7 @@ public class CollectionTypeFactoryTest
     private class DummyNotifying : INotifyPropertyChanged
     {
 #pragma warning disable 67
-        public event PropertyChangedEventHandler PropertyChanged;
+        public event PropertyChangedEventHandler? PropertyChanged;
 #pragma warning restore 67
     }
 }

--- a/test/EFCore.Tests/Metadata/Internal/EntityTypeTest.BaseType.cs
+++ b/test/EFCore.Tests/Metadata/Internal/EntityTypeTest.BaseType.cs
@@ -12,13 +12,13 @@ public partial class EntityTypeTest
     {
         var model = (IConventionModel)CreateModel();
 
-        var a = model.AddEntityType(typeof(A).Name);
-        var b = model.AddEntityType(typeof(B).Name);
+        var a = model.AddEntityType(typeof(A).Name)!;
+        var b = model.AddEntityType(typeof(B).Name)!;
 
         Assert.Same(a, b.SetBaseType(a));
 
         var finalModel = model.FinalizeModel();
-        Assert.Same(finalModel.FindEntityType(typeof(A).Name), finalModel.FindEntityType(typeof(B).Name).BaseType);
+        Assert.Same(finalModel.FindEntityType(typeof(A).Name), finalModel.FindEntityType(typeof(B).Name)!.BaseType);
     }
 
     [Fact]
@@ -253,8 +253,8 @@ public partial class EntityTypeTest
         cType.BaseType = a;
 
         var builtModel = model.FinalizeModel();
-        var b = builtModel.FindEntityType(typeof(B));
-        var c = builtModel.FindEntityType(typeof(C));
+        var b = builtModel.FindEntityType(typeof(B))!;
+        var c = builtModel.FindEntityType(typeof(C))!;
 
         Assert.Equal(new[] { "E", "G" }, a.GetProperties().Select(p => p.Name).ToArray());
         Assert.Equal(new[] { "E", "G", "F", "H" }, b.GetProperties().Select(p => p.Name).ToArray());
@@ -290,8 +290,8 @@ public partial class EntityTypeTest
         cType.AddProperty("I", typeof(string));
 
         var builtModel = model.FinalizeModel();
-        var b = builtModel.FindEntityType(typeof(B));
-        var c = builtModel.FindEntityType(typeof(C));
+        var b = builtModel.FindEntityType(typeof(B))!;
+        var c = builtModel.FindEntityType(typeof(C))!;
 
         Assert.Equal(new[] { "E", "G" }, a.GetProperties().Select(p => p.Name).ToArray());
         Assert.Equal(new[] { "E", "G", "F", "H" }, b.GetProperties().Select(p => p.Name).ToArray());
@@ -346,9 +346,9 @@ public partial class EntityTypeTest
         cType.BaseType = aType;
 
         var builtModel = model.FinalizeModel();
-        var a = builtModel.FindEntityType(typeof(A));
-        var c = builtModel.FindEntityType(typeof(C));
-        var d = builtModel.FindEntityType(typeof(D));
+        var a = builtModel.FindEntityType(typeof(A))!;
+        var c = builtModel.FindEntityType(typeof(C))!;
+        var d = builtModel.FindEntityType(typeof(D))!;
 
         Assert.Equal(new[] { "E", "G" }, a.GetProperties().Select(p => p.Name).ToArray());
         Assert.Equal(new[] { "E", "G", "F", "H" }, c.GetProperties().Select(p => p.Name).ToArray());
@@ -516,7 +516,7 @@ public partial class EntityTypeTest
         bType.BaseType = a;
 
         var builtModel = model.FinalizeModel();
-        var b = builtModel.FindEntityType(typeof(B));
+        var b = builtModel.FindEntityType(typeof(B))!;
 
         Assert.Equal(
             [["E"], ["G"]],
@@ -527,8 +527,8 @@ public partial class EntityTypeTest
         Assert.Equal(new[] { "G", "E" }, a.GetProperties().Select(p => p.Name).ToArray());
         Assert.Equal(new[] { "G", "E", "F" }, b.GetProperties().Select(p => p.Name).ToArray());
         Assert.Equal([0, 1, 2], b.GetProperties().Select(p => p.GetIndex()));
-        Assert.Same(pk, b.FindProperty("G").FindContainingPrimaryKey());
-        Assert.Same(b.FindKey(b.FindProperty("G")), a.FindKey(a.FindProperty("G")));
+        Assert.Same(pk, b.FindProperty("G")!.FindContainingPrimaryKey());
+        Assert.Same(b.FindKey(b.FindProperty("G")!), a.FindKey(a.FindProperty("G")!));
     }
 
     [Fact]
@@ -545,8 +545,8 @@ public partial class EntityTypeTest
 
         b.BaseType = a;
 
-        a.SetPrimaryKey(a.FindProperty("G"));
-        a.AddKey(a.FindProperty("E"));
+        a.SetPrimaryKey(a.FindProperty("G")!);
+        a.AddKey(a.FindProperty("E")!);
 
         model.FinalizeModel();
 

--- a/test/EFCore.Tests/Metadata/Internal/EntityTypeTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/EntityTypeTest.cs
@@ -182,7 +182,7 @@ public partial class EntityTypeTest
         Assert.Same(key1, entityType.FindKey(key1.Properties));
         Assert.Same(key2, entityType.FindKey(key2.Properties));
 
-        Assert.Null(entityType.SetPrimaryKey((Property)null));
+        Assert.Null(entityType.SetPrimaryKey((Property?)null));
 
         Assert.Null(entityType.FindPrimaryKey());
         Assert.Equal(2, entityType.GetKeys().Count());
@@ -235,7 +235,7 @@ public partial class EntityTypeTest
         Assert.Same(key1, entityType.FindKey(key1.Properties));
         Assert.Same(key2, entityType.FindKey(key2.Properties));
 
-        Assert.Null(entityType.SetPrimaryKey((Property)null));
+        Assert.Null(entityType.SetPrimaryKey((Property?)null));
 
         Assert.Null(entityType.FindPrimaryKey());
         Assert.Equal(2, entityType.GetKeys().Count());
@@ -250,12 +250,12 @@ public partial class EntityTypeTest
         var model = CreateModel();
         var entityType = model.AddEntityType(typeof(Customer));
         var idProperty = entityType.AddProperty(Customer.IdProperty);
-        var customerPk = entityType.SetPrimaryKey(idProperty);
+        var customerPk = entityType.SetPrimaryKey(idProperty)!;
 
         var orderType = model.AddEntityType(typeof(Order));
         var fk = orderType.AddForeignKey(orderType.AddProperty(Order.CustomerIdProperty), customerPk, entityType);
 
-        entityType.SetPrimaryKey((Property)null);
+        entityType.SetPrimaryKey((Property?)null);
 
         Assert.Single(entityType.GetKeys());
         Assert.Same(customerPk, entityType.FindKey(idProperty));
@@ -269,7 +269,7 @@ public partial class EntityTypeTest
         var model = CreateModel();
         var entityType = model.AddEntityType(typeof(Customer));
         var idProperty = entityType.AddProperty(Customer.IdProperty);
-        var customerPk = entityType.SetPrimaryKey(idProperty);
+        var customerPk = entityType.SetPrimaryKey(idProperty)!;
 
         var orderType = model.AddEntityType(typeof(Order));
         var fk = orderType.AddForeignKey(orderType.AddProperty(Order.CustomerIdProperty), customerPk, entityType);
@@ -393,8 +393,8 @@ public partial class EntityTypeTest
         Assert.False(idProperty.IsKey());
         Assert.Empty(idProperty.GetContainingKeys());
 
-        var key1 = entityType.SetPrimaryKey([idProperty, nameProperty]);
-        var key2 = entityType.AddKey(idProperty);
+        var key1 = entityType.SetPrimaryKey([idProperty, nameProperty])!;
+        var key2 = entityType.AddKey(idProperty)!;
 
         Assert.True(((Key)key1).IsInModel);
         Assert.True(((Key)key2).IsInModel);
@@ -848,7 +848,7 @@ public partial class EntityTypeTest
         var entityType = CreateEmptyModel().AddEntityType("Customer");
         var idProperty = entityType.AddProperty("id", typeof(int));
         var fkProperty = entityType.AddProperty("fk", typeof(int));
-        var fk = entityType.AddForeignKey(fkProperty, entityType.SetPrimaryKey(idProperty), entityType);
+        var fk = entityType.AddForeignKey(fkProperty, entityType.SetPrimaryKey(idProperty)!, entityType);
 
         Assert.Same(fk, entityType.GetReferencingForeignKeys().Single());
     }
@@ -864,8 +864,8 @@ public partial class EntityTypeTest
         var foreignKeyProperty = orderType.AddProperty(Order.CustomerIdProperty);
         var customerForeignKey = orderType.AddForeignKey(foreignKeyProperty, customerKey, customerType);
 
-        var customerNavigation = customerForeignKey.SetDependentToPrincipal(Order.CustomerProperty);
-        var ordersNavigation = customerForeignKey.SetPrincipalToDependent(Customer.OrdersProperty);
+        var customerNavigation = customerForeignKey.SetDependentToPrincipal(Order.CustomerProperty)!;
+        var ordersNavigation = customerForeignKey.SetPrincipalToDependent(Customer.OrdersProperty)!;
 
         Assert.Equal(nameof(Order.Customer), customerNavigation.Name);
         Assert.Same(orderType, customerNavigation.DeclaringEntityType);
@@ -886,13 +886,13 @@ public partial class EntityTypeTest
         Assert.Same(customerNavigation, orderType.GetNavigations().Single());
         Assert.Same(ordersNavigation, customerType.GetNavigations().Single());
 
-        Assert.Same(customerNavigation, customerForeignKey.SetDependentToPrincipal((string)null));
-        Assert.Null(customerForeignKey.SetDependentToPrincipal((string)null));
+        Assert.Same(customerNavigation, customerForeignKey.SetDependentToPrincipal((string?)null));
+        Assert.Null(customerForeignKey.SetDependentToPrincipal((string?)null));
         Assert.Empty(orderType.GetNavigations());
         Assert.Empty(((IReadOnlyEntityType)orderType).GetNavigations());
 
-        Assert.Same(ordersNavigation, customerForeignKey.SetPrincipalToDependent((string)null));
-        Assert.Null(customerForeignKey.SetPrincipalToDependent((string)null));
+        Assert.Same(ordersNavigation, customerForeignKey.SetPrincipalToDependent((string?)null));
+        Assert.Null(customerForeignKey.SetPrincipalToDependent((string?)null));
         Assert.Empty(customerType.GetNavigations());
         Assert.Empty(((IReadOnlyEntityType)customerType).GetNavigations());
     }
@@ -907,7 +907,7 @@ public partial class EntityTypeTest
         var orderType = model.AddEntityType(typeof(Order));
         var foreignKeyProperty = orderType.AddProperty(Order.CustomerIdProperty);
         var customerForeignKey = orderType.AddForeignKey(foreignKeyProperty, customerKey, customerType);
-        var customerNavigation = customerForeignKey.SetDependentToPrincipal(Order.CustomerProperty);
+        var customerNavigation = customerForeignKey.SetDependentToPrincipal(Order.CustomerProperty)!;
 
         Assert.Equal(nameof(Order.Customer), customerNavigation.Name);
         Assert.Same(orderType, customerNavigation.DeclaringEntityType);
@@ -930,7 +930,7 @@ public partial class EntityTypeTest
         var orderType = model.AddEntityType(typeof(Order));
         var foreignKeyProperty = orderType.AddProperty(Order.CustomerIdProperty);
         var customerForeignKey = orderType.AddForeignKey(foreignKeyProperty, customerKey, customerType);
-        var customerNavigation = customerForeignKey.SetDependentToPrincipal(Order.CustomerProperty);
+        var customerNavigation = customerForeignKey.SetDependentToPrincipal(Order.CustomerProperty)!;
 
         Assert.Same(customerNavigation, orderType.FindNavigation(nameof(Order.Customer)));
         Assert.Same(customerNavigation, orderType.FindNavigation(nameof(Order.Customer)));
@@ -1056,7 +1056,7 @@ public partial class EntityTypeTest
         var foreignKeyProperty = orderType.AddProperty(Order.CustomerIdProperty);
         var customerForeignKey = orderType.AddForeignKey(foreignKeyProperty, customerKey, customerType);
 
-        var ordersNavigation = customerForeignKey.SetPrincipalToDependent(Customer.OrdersProperty);
+        var ordersNavigation = customerForeignKey.SetPrincipalToDependent(Customer.OrdersProperty)!;
 
         Assert.Equal(nameof(Customer.Orders), ordersNavigation.Name);
         Assert.Same(customerType, ordersNavigation.DeclaringEntityType);
@@ -1113,7 +1113,7 @@ public partial class EntityTypeTest
         var foreignKeyProperty = orderType.AddProperty(Order.CustomerIdProperty);
         var customerForeignKey = orderType.AddForeignKey(foreignKeyProperty, customerKey, customerType);
 
-        var customerNavigation = customerForeignKey.SetDependentToPrincipal(Order.CustomerProperty);
+        var customerNavigation = customerForeignKey.SetDependentToPrincipal(Order.CustomerProperty)!;
 
         Assert.Equal("Customer", customerNavigation.Name);
         Assert.Same(orderType, customerNavigation.DeclaringEntityType);
@@ -1130,7 +1130,7 @@ public partial class EntityTypeTest
         var entityType = model.AddEntityType(typeof(SelfRef));
         var fkProperty = entityType.AddProperty(SelfRef.ForeignKeyProperty);
         var principalKeyProperty = entityType.AddProperty(SelfRef.IdProperty);
-        var referencedKey = entityType.SetPrimaryKey(principalKeyProperty);
+        var referencedKey = entityType.SetPrimaryKey(principalKeyProperty)!;
         var fk = entityType.AddForeignKey(fkProperty, referencedKey, entityType);
         fk.IsUnique = true;
 
@@ -1148,7 +1148,7 @@ public partial class EntityTypeTest
         var entityType = model.AddEntityType(typeof(SelfRef));
         var fkProperty = entityType.AddProperty(SelfRef.ForeignKeyProperty);
         var principalKeyProperty = entityType.AddProperty(SelfRef.IdProperty);
-        var referencedKey = entityType.SetPrimaryKey(principalKeyProperty);
+        var referencedKey = entityType.SetPrimaryKey(principalKeyProperty)!;
         var fk = entityType.AddForeignKey(fkProperty, referencedKey, entityType);
         fk.IsUnique = true;
 
@@ -1173,8 +1173,8 @@ public partial class EntityTypeTest
         var specialCustomerForeignKeyProperty = specialOrderType.AddProperty(Order.CustomerIdProperty);
         var specialCustomerForeignKey = specialOrderType.AddForeignKey(specialCustomerForeignKeyProperty, customerKey, customerType);
 
-        var navigation2 = customerForeignKey.SetPrincipalToDependent(Customer.OrdersProperty);
-        var navigation1 = specialCustomerForeignKey.SetPrincipalToDependent(SpecialCustomer.DerivedOrdersProperty);
+        var navigation2 = customerForeignKey.SetPrincipalToDependent(Customer.OrdersProperty)!;
+        var navigation1 = specialCustomerForeignKey.SetPrincipalToDependent(SpecialCustomer.DerivedOrdersProperty)!;
 
         Assert.True(new[] { navigation1, navigation2 }.SequenceEqual(customerType.GetNavigations()));
         Assert.True(new[] { navigation1, navigation2 }.SequenceEqual(((IReadOnlyEntityType)customerType).GetNavigations()));
@@ -1185,8 +1185,8 @@ public partial class EntityTypeTest
     {
         var model = BuildProductModel();
 
-        var category = model.FindEntityType(typeof(Product)).GetNavigations().Single(e => e.Name == "Category");
-        var products = model.FindEntityType(typeof(Category)).GetNavigations().Single(e => e.Name == "Products");
+        var category = model.FindEntityType(typeof(Product))!.GetNavigations().Single(e => e.Name == "Category");
+        var products = model.FindEntityType(typeof(Category))!.GetNavigations().Single(e => e.Name == "Products");
 
         Assert.Same(category, products.Inverse);
         Assert.Same(products, category.Inverse);
@@ -1197,8 +1197,8 @@ public partial class EntityTypeTest
     {
         var model = BuildProductModel();
 
-        var category = model.FindEntityType(typeof(Product)).GetNavigations().Single(e => e.Name == "FeaturedProductCategory");
-        var product = model.FindEntityType(typeof(Category)).GetNavigations().Single(e => e.Name == "FeaturedProduct");
+        var category = model.FindEntityType(typeof(Product))!.GetNavigations().Single(e => e.Name == "FeaturedProductCategory");
+        var product = model.FindEntityType(typeof(Category))!.GetNavigations().Single(e => e.Name == "FeaturedProduct");
 
         Assert.Same(category, product.Inverse);
         Assert.Same(product, category.Inverse);
@@ -1209,8 +1209,8 @@ public partial class EntityTypeTest
     {
         var model = BuildProductModel();
 
-        var productType = model.FindEntityType(typeof(Product));
-        var categoryType = model.FindEntityType(typeof(Category));
+        var productType = model.FindEntityType(typeof(Product))!;
+        var categoryType = model.FindEntityType(typeof(Category))!;
 
         var category = productType.GetNavigations().Single(e => e.Name == "Category");
         var products = categoryType.GetNavigations().Single(e => e.Name == "Products");
@@ -1222,22 +1222,22 @@ public partial class EntityTypeTest
     [Fact]
     public void Returns_null_when_no_inverse()
     {
-        var products = BuildProductModel(createCategory: false).FindEntityType(typeof(Category)).GetNavigations()
+        var products = BuildProductModel(createCategory: false).FindEntityType(typeof(Category))!.GetNavigations()
             .Single(e => e.Name == "Products");
 
         Assert.Null(products.Inverse);
 
-        var category = BuildProductModel(createProducts: false).FindEntityType(typeof(Product)).GetNavigations()
+        var category = BuildProductModel(createProducts: false).FindEntityType(typeof(Product))!.GetNavigations()
             .Single(e => e.Name == "Category");
 
         Assert.Null(category.Inverse);
 
-        var featuredCategory = BuildProductModel(createFeaturedProduct: false).FindEntityType(typeof(Product)).GetNavigations()
+        var featuredCategory = BuildProductModel(createFeaturedProduct: false).FindEntityType(typeof(Product))!.GetNavigations()
             .Single(e => e.Name == "FeaturedProductCategory");
 
         Assert.Null(featuredCategory.Inverse);
 
-        var featuredProduct = BuildProductModel(createFeaturedProductCategory: false).FindEntityType(typeof(Category)).GetNavigations()
+        var featuredProduct = BuildProductModel(createFeaturedProductCategory: false).FindEntityType(typeof(Category))!.GetNavigations()
             .Single(e => e.Name == "FeaturedProduct");
 
         Assert.Null(featuredProduct.Inverse);
@@ -1263,13 +1263,13 @@ public partial class EntityTypeTest
             e.Ignore(c => c.FeaturedProduct);
         });
 
-        var categoryType = model.FindEntityType(typeof(Category));
-        var productType = model.FindEntityType(typeof(Product));
+        var categoryType = model.FindEntityType(typeof(Category))!;
+        var productType = model.FindEntityType(typeof(Product))!;
 
         var categoryFk = productType.AddForeignKey(
-            productType.FindProperty("CategoryId"), categoryType.FindPrimaryKey(), categoryType);
+            productType.FindProperty("CategoryId")!, categoryType.FindPrimaryKey()!, categoryType);
         var featuredProductFk = categoryType.AddForeignKey(
-            categoryType.FindProperty("FeaturedProductId"), productType.FindPrimaryKey(), productType);
+            categoryType.FindProperty("FeaturedProductId")!, productType.FindPrimaryKey()!, productType);
         featuredProductFk.IsUnique = true;
 
         if (createProducts)
@@ -1698,7 +1698,7 @@ public partial class EntityTypeTest
         entityType.AddIndex([property1], "NamedIndex");
         Assert.Single(entityType.GetIndexes());
 
-        var index = ((EntityType)entityType).RemoveIndex("NamedIndex");
+        var index = ((EntityType)entityType).RemoveIndex("NamedIndex")!;
 
         Assert.Equal("NamedIndex", index.Name);
         Assert.Empty(entityType.GetIndexes());
@@ -1813,8 +1813,8 @@ public partial class EntityTypeTest
         public static readonly PropertyInfo RaisinProperty
             = typeof(HiddenFieldBase).GetRuntimeProperties().Single(p => p.Name == nameof(Raisin));
 
-        private string _date;
-        private string Raisin { get; set; }
+        private string _date = null!;
+        private string Raisin { get; set; } = null!;
 
         public DateTime Date
         {
@@ -1872,7 +1872,7 @@ public partial class EntityTypeTest
     {
         var entityType = (IConventionEntityType)CreateModel().AddEntityType(typeof(Customer));
 
-        var property = entityType.AddProperty(nameof(Customer.Name), typeof(int), setTypeConfigurationSource: false);
+        var property = entityType.AddProperty(nameof(Customer.Name), typeof(int), setTypeConfigurationSource: false)!;
 
         Assert.Equal(typeof(string), property.ClrType);
     }
@@ -1924,7 +1924,7 @@ public partial class EntityTypeTest
     {
         var model = CreateModel();
         var customerType = model.AddEntityType(typeof(Customer));
-        var customerPk = customerType.SetPrimaryKey(customerType.AddProperty(Customer.IdProperty));
+        var customerPk = customerType.SetPrimaryKey(customerType.AddProperty(Customer.IdProperty))!;
 
         var orderType = model.AddEntityType(typeof(Order));
         var customerFk = orderType.AddProperty(Order.CustomerIdProperty);
@@ -2033,9 +2033,9 @@ public partial class EntityTypeTest
         entityType.AddProperty(Customer.IdProperty);
         entityType.AddProperty("Mane_", typeof(int));
 
-        Assert.False(entityType.FindProperty("Name").IsShadowProperty());
-        Assert.False(entityType.FindProperty("Id").IsShadowProperty());
-        Assert.True(entityType.FindProperty("Mane_").IsShadowProperty());
+        Assert.False(entityType.FindProperty("Name")!.IsShadowProperty());
+        Assert.False(entityType.FindProperty("Id")!.IsShadowProperty());
+        Assert.True(entityType.FindProperty("Mane_")!.IsShadowProperty());
     }
 
     [Fact]
@@ -2147,7 +2147,7 @@ public partial class EntityTypeTest
         Assert.Empty(mutatbleEntityType.GetProperties());
 
         var conventionEntityType = (IConventionEntityType)mutatbleEntityType;
-        var conventionProperty = conventionEntityType.AddIndexerProperty("Country", typeof(string));
+        var conventionProperty = conventionEntityType.AddIndexerProperty("Country", typeof(string))!;
 
         Assert.False(conventionProperty.IsShadowProperty());
         Assert.True(conventionProperty.IsIndexerProperty());
@@ -2221,15 +2221,15 @@ public partial class EntityTypeTest
             eb.Property<int>("Mane_");
         });
 
-        var entityType = (IRuntimeEntityType)modelBuilder.FinalizeModel().FindEntityType(typeof(Customer));
+        var entityType = (IRuntimeEntityType)modelBuilder.FinalizeModel().FindEntityType(typeof(Customer))!;
 
-        Assert.Equal(0, entityType.FindProperty("Id_").GetIndex());
-        Assert.Equal(1, entityType.FindProperty("Mane_").GetIndex());
-        Assert.Equal(2, entityType.FindProperty("Name").GetIndex());
+        Assert.Equal(0, entityType.FindProperty("Id_")!.GetIndex());
+        Assert.Equal(1, entityType.FindProperty("Mane_")!.GetIndex());
+        Assert.Equal(2, entityType.FindProperty("Name")!.GetIndex());
 
-        Assert.Equal(0, entityType.FindProperty("Id_").GetShadowIndex());
-        Assert.Equal(1, entityType.FindProperty("Mane_").GetShadowIndex());
-        Assert.Equal(-1, entityType.FindProperty("Name").GetShadowIndex());
+        Assert.Equal(0, entityType.FindProperty("Id_")!.GetShadowIndex());
+        Assert.Equal(1, entityType.FindProperty("Mane_")!.GetShadowIndex());
+        Assert.Equal(-1, entityType.FindProperty("Name")!.GetShadowIndex());
 
         Assert.Equal(2, entityType.ShadowPropertyCount);
     }
@@ -2238,7 +2238,7 @@ public partial class EntityTypeTest
     public void Attempting_to_set_store_generated_value_for_non_generated_property_throws()
     {
         using var context = new Levels();
-        var property = context.Model.FindEntityType(typeof(Level1)).GetProperty("Prop1");
+        var property = context.Model.FindEntityType(typeof(Level1))!.GetProperty("Prop1");
 
         Assert.Equal(-1, property.GetStoreGeneratedIndex());
 
@@ -2253,33 +2253,33 @@ public partial class EntityTypeTest
     public void Indexes_for_derived_types_are_calculated_correctly()
     {
         using var context = new Levels();
-        var type = (IRuntimeEntityType)context.Model.FindEntityType(typeof(Level1));
+        var type = (IRuntimeEntityType)context.Model.FindEntityType(typeof(Level1))!;
 
-        Assert.Equal(0, type.FindProperty("Id").GetIndex());
-        Assert.Equal(1, type.FindProperty("Level1ReferenceId").GetIndex());
-        Assert.Equal(2, type.FindProperty("Prop1").GetIndex());
-        Assert.Equal(0, type.FindNavigation("Level1Collection").GetIndex());
-        Assert.Equal(1, type.FindNavigation("Level1Reference").GetIndex());
+        Assert.Equal(0, type.FindProperty("Id")!.GetIndex());
+        Assert.Equal(1, type.FindProperty("Level1ReferenceId")!.GetIndex());
+        Assert.Equal(2, type.FindProperty("Prop1")!.GetIndex());
+        Assert.Equal(0, type.FindNavigation("Level1Collection")!.GetIndex());
+        Assert.Equal(1, type.FindNavigation("Level1Reference")!.GetIndex());
 
-        Assert.Equal(-1, type.FindProperty("Id").GetShadowIndex());
-        Assert.Equal(0, type.FindProperty("Level1ReferenceId").GetShadowIndex());
-        Assert.Equal(-1, type.FindProperty("Prop1").GetShadowIndex());
+        Assert.Equal(-1, type.FindProperty("Id")!.GetShadowIndex());
+        Assert.Equal(0, type.FindProperty("Level1ReferenceId")!.GetShadowIndex());
+        Assert.Equal(-1, type.FindProperty("Prop1")!.GetShadowIndex());
 
-        Assert.Equal(0, type.FindProperty("Id").GetOriginalValueIndex());
-        Assert.Equal(1, type.FindProperty("Level1ReferenceId").GetOriginalValueIndex());
-        Assert.Equal(2, type.FindProperty("Prop1").GetOriginalValueIndex());
+        Assert.Equal(0, type.FindProperty("Id")!.GetOriginalValueIndex());
+        Assert.Equal(1, type.FindProperty("Level1ReferenceId")!.GetOriginalValueIndex());
+        Assert.Equal(2, type.FindProperty("Prop1")!.GetOriginalValueIndex());
 
-        Assert.Equal(0, type.FindProperty("Id").GetRelationshipIndex());
-        Assert.Equal(1, type.FindProperty("Level1ReferenceId").GetRelationshipIndex());
-        Assert.Equal(-1, type.FindProperty("Prop1").GetRelationshipIndex());
-        Assert.Equal(2, type.FindNavigation("Level1Collection").GetRelationshipIndex());
-        Assert.Equal(3, type.FindNavigation("Level1Reference").GetRelationshipIndex());
+        Assert.Equal(0, type.FindProperty("Id")!.GetRelationshipIndex());
+        Assert.Equal(1, type.FindProperty("Level1ReferenceId")!.GetRelationshipIndex());
+        Assert.Equal(-1, type.FindProperty("Prop1")!.GetRelationshipIndex());
+        Assert.Equal(2, type.FindNavigation("Level1Collection")!.GetRelationshipIndex());
+        Assert.Equal(3, type.FindNavigation("Level1Reference")!.GetRelationshipIndex());
 
-        Assert.Equal(0, type.FindProperty("Id").GetStoreGeneratedIndex());
-        Assert.Equal(1, type.FindProperty("Level1ReferenceId").GetStoreGeneratedIndex());
-        Assert.Equal(-1, type.FindProperty("Prop1").GetStoreGeneratedIndex());
-        Assert.Equal(-1, type.FindNavigation("Level1Collection").GetStoreGeneratedIndex());
-        Assert.Equal(-1, type.FindNavigation("Level1Reference").GetStoreGeneratedIndex());
+        Assert.Equal(0, type.FindProperty("Id")!.GetStoreGeneratedIndex());
+        Assert.Equal(1, type.FindProperty("Level1ReferenceId")!.GetStoreGeneratedIndex());
+        Assert.Equal(-1, type.FindProperty("Prop1")!.GetStoreGeneratedIndex());
+        Assert.Equal(-1, type.FindNavigation("Level1Collection")!.GetStoreGeneratedIndex());
+        Assert.Equal(-1, type.FindNavigation("Level1Reference")!.GetStoreGeneratedIndex());
 
         Assert.Equal(4, type.PropertyCount);
         Assert.Equal(2, type.NavigationCount);
@@ -2288,49 +2288,49 @@ public partial class EntityTypeTest
         Assert.Equal(4, type.RelationshipPropertyCount);
         Assert.Equal(2, type.StoreGeneratedCount);
 
-        type = (IRuntimeEntityType)context.Model.FindEntityType(typeof(Level2));
+        type = (IRuntimeEntityType)context.Model.FindEntityType(typeof(Level2))!;
 
-        Assert.Equal(0, type.FindProperty("Id").GetIndex());
-        Assert.Equal(1, type.FindProperty("Level1ReferenceId").GetIndex());
-        Assert.Equal(2, type.FindProperty("Prop1").GetIndex());
-        Assert.Equal(4, type.FindProperty("Level2ReferenceId").GetIndex());
-        Assert.Equal(5, type.FindProperty("Prop2").GetIndex());
-        Assert.Equal(0, type.FindNavigation("Level1Collection").GetIndex());
-        Assert.Equal(1, type.FindNavigation("Level1Reference").GetIndex());
-        Assert.Equal(2, type.FindNavigation("Level2Collection").GetIndex());
-        Assert.Equal(3, type.FindNavigation("Level2Reference").GetIndex());
+        Assert.Equal(0, type.FindProperty("Id")!.GetIndex());
+        Assert.Equal(1, type.FindProperty("Level1ReferenceId")!.GetIndex());
+        Assert.Equal(2, type.FindProperty("Prop1")!.GetIndex());
+        Assert.Equal(4, type.FindProperty("Level2ReferenceId")!.GetIndex());
+        Assert.Equal(5, type.FindProperty("Prop2")!.GetIndex());
+        Assert.Equal(0, type.FindNavigation("Level1Collection")!.GetIndex());
+        Assert.Equal(1, type.FindNavigation("Level1Reference")!.GetIndex());
+        Assert.Equal(2, type.FindNavigation("Level2Collection")!.GetIndex());
+        Assert.Equal(3, type.FindNavigation("Level2Reference")!.GetIndex());
 
-        Assert.Equal(-1, type.FindProperty("Id").GetShadowIndex());
-        Assert.Equal(0, type.FindProperty("Level1ReferenceId").GetShadowIndex());
-        Assert.Equal(-1, type.FindProperty("Prop1").GetShadowIndex());
-        Assert.Equal(2, type.FindProperty("Level2ReferenceId").GetShadowIndex());
-        Assert.Equal(-1, type.FindProperty("Prop2").GetShadowIndex());
+        Assert.Equal(-1, type.FindProperty("Id")!.GetShadowIndex());
+        Assert.Equal(0, type.FindProperty("Level1ReferenceId")!.GetShadowIndex());
+        Assert.Equal(-1, type.FindProperty("Prop1")!.GetShadowIndex());
+        Assert.Equal(2, type.FindProperty("Level2ReferenceId")!.GetShadowIndex());
+        Assert.Equal(-1, type.FindProperty("Prop2")!.GetShadowIndex());
 
-        Assert.Equal(0, type.FindProperty("Id").GetOriginalValueIndex());
-        Assert.Equal(1, type.FindProperty("Level1ReferenceId").GetOriginalValueIndex());
-        Assert.Equal(2, type.FindProperty("Prop1").GetOriginalValueIndex());
-        Assert.Equal(4, type.FindProperty("Level2ReferenceId").GetOriginalValueIndex());
-        Assert.Equal(5, type.FindProperty("Prop2").GetOriginalValueIndex());
+        Assert.Equal(0, type.FindProperty("Id")!.GetOriginalValueIndex());
+        Assert.Equal(1, type.FindProperty("Level1ReferenceId")!.GetOriginalValueIndex());
+        Assert.Equal(2, type.FindProperty("Prop1")!.GetOriginalValueIndex());
+        Assert.Equal(4, type.FindProperty("Level2ReferenceId")!.GetOriginalValueIndex());
+        Assert.Equal(5, type.FindProperty("Prop2")!.GetOriginalValueIndex());
 
-        Assert.Equal(0, type.FindProperty("Id").GetRelationshipIndex());
-        Assert.Equal(1, type.FindProperty("Level1ReferenceId").GetRelationshipIndex());
-        Assert.Equal(-1, type.FindProperty("Prop1").GetRelationshipIndex());
-        Assert.Equal(2, type.FindNavigation("Level1Collection").GetRelationshipIndex());
-        Assert.Equal(3, type.FindNavigation("Level1Reference").GetRelationshipIndex());
-        Assert.Equal(4, type.FindProperty("Level2ReferenceId").GetRelationshipIndex());
-        Assert.Equal(-1, type.FindProperty("Prop2").GetRelationshipIndex());
-        Assert.Equal(5, type.FindNavigation("Level2Collection").GetRelationshipIndex());
-        Assert.Equal(6, type.FindNavigation("Level2Reference").GetRelationshipIndex());
+        Assert.Equal(0, type.FindProperty("Id")!.GetRelationshipIndex());
+        Assert.Equal(1, type.FindProperty("Level1ReferenceId")!.GetRelationshipIndex());
+        Assert.Equal(-1, type.FindProperty("Prop1")!.GetRelationshipIndex());
+        Assert.Equal(2, type.FindNavigation("Level1Collection")!.GetRelationshipIndex());
+        Assert.Equal(3, type.FindNavigation("Level1Reference")!.GetRelationshipIndex());
+        Assert.Equal(4, type.FindProperty("Level2ReferenceId")!.GetRelationshipIndex());
+        Assert.Equal(-1, type.FindProperty("Prop2")!.GetRelationshipIndex());
+        Assert.Equal(5, type.FindNavigation("Level2Collection")!.GetRelationshipIndex());
+        Assert.Equal(6, type.FindNavigation("Level2Reference")!.GetRelationshipIndex());
 
-        Assert.Equal(0, type.FindProperty("Id").GetStoreGeneratedIndex());
-        Assert.Equal(1, type.FindProperty("Level1ReferenceId").GetStoreGeneratedIndex());
-        Assert.Equal(-1, type.FindProperty("Prop1").GetStoreGeneratedIndex());
-        Assert.Equal(2, type.FindProperty("Level2ReferenceId").GetStoreGeneratedIndex());
-        Assert.Equal(-1, type.FindProperty("Prop2").GetStoreGeneratedIndex());
-        Assert.Equal(-1, type.FindNavigation("Level1Collection").GetStoreGeneratedIndex());
-        Assert.Equal(-1, type.FindNavigation("Level1Reference").GetStoreGeneratedIndex());
-        Assert.Equal(-1, type.FindNavigation("Level2Collection").GetStoreGeneratedIndex());
-        Assert.Equal(-1, type.FindNavigation("Level2Reference").GetStoreGeneratedIndex());
+        Assert.Equal(0, type.FindProperty("Id")!.GetStoreGeneratedIndex());
+        Assert.Equal(1, type.FindProperty("Level1ReferenceId")!.GetStoreGeneratedIndex());
+        Assert.Equal(-1, type.FindProperty("Prop1")!.GetStoreGeneratedIndex());
+        Assert.Equal(2, type.FindProperty("Level2ReferenceId")!.GetStoreGeneratedIndex());
+        Assert.Equal(-1, type.FindProperty("Prop2")!.GetStoreGeneratedIndex());
+        Assert.Equal(-1, type.FindNavigation("Level1Collection")!.GetStoreGeneratedIndex());
+        Assert.Equal(-1, type.FindNavigation("Level1Reference")!.GetStoreGeneratedIndex());
+        Assert.Equal(-1, type.FindNavigation("Level2Collection")!.GetStoreGeneratedIndex());
+        Assert.Equal(-1, type.FindNavigation("Level2Reference")!.GetStoreGeneratedIndex());
 
         Assert.Equal(6, type.PropertyCount);
         Assert.Equal(4, type.NavigationCount);
@@ -2339,65 +2339,65 @@ public partial class EntityTypeTest
         Assert.Equal(7, type.RelationshipPropertyCount);
         Assert.Equal(3, type.StoreGeneratedCount);
 
-        type = (IRuntimeEntityType)context.Model.FindEntityType(typeof(Level3));
+        type = (IRuntimeEntityType)context.Model.FindEntityType(typeof(Level3))!;
 
-        Assert.Equal(0, type.FindProperty("Id").GetIndex());
-        Assert.Equal(1, type.FindProperty("Level1ReferenceId").GetIndex());
-        Assert.Equal(2, type.FindProperty("Prop1").GetIndex());
-        Assert.Equal(4, type.FindProperty("Level2ReferenceId").GetIndex());
-        Assert.Equal(5, type.FindProperty("Prop2").GetIndex());
-        Assert.Equal(6, type.FindProperty("Level3ReferenceId").GetIndex());
-        Assert.Equal(7, type.FindProperty("Prop3").GetIndex());
-        Assert.Equal(0, type.FindNavigation("Level1Collection").GetIndex());
-        Assert.Equal(1, type.FindNavigation("Level1Reference").GetIndex());
-        Assert.Equal(2, type.FindNavigation("Level2Collection").GetIndex());
-        Assert.Equal(3, type.FindNavigation("Level2Reference").GetIndex());
-        Assert.Equal(4, type.FindNavigation("Level3Collection").GetIndex());
-        Assert.Equal(5, type.FindNavigation("Level3Reference").GetIndex());
+        Assert.Equal(0, type.FindProperty("Id")!.GetIndex());
+        Assert.Equal(1, type.FindProperty("Level1ReferenceId")!.GetIndex());
+        Assert.Equal(2, type.FindProperty("Prop1")!.GetIndex());
+        Assert.Equal(4, type.FindProperty("Level2ReferenceId")!.GetIndex());
+        Assert.Equal(5, type.FindProperty("Prop2")!.GetIndex());
+        Assert.Equal(6, type.FindProperty("Level3ReferenceId")!.GetIndex());
+        Assert.Equal(7, type.FindProperty("Prop3")!.GetIndex());
+        Assert.Equal(0, type.FindNavigation("Level1Collection")!.GetIndex());
+        Assert.Equal(1, type.FindNavigation("Level1Reference")!.GetIndex());
+        Assert.Equal(2, type.FindNavigation("Level2Collection")!.GetIndex());
+        Assert.Equal(3, type.FindNavigation("Level2Reference")!.GetIndex());
+        Assert.Equal(4, type.FindNavigation("Level3Collection")!.GetIndex());
+        Assert.Equal(5, type.FindNavigation("Level3Reference")!.GetIndex());
 
-        Assert.Equal(-1, type.FindProperty("Id").GetShadowIndex());
-        Assert.Equal(0, type.FindProperty("Level1ReferenceId").GetShadowIndex());
-        Assert.Equal(-1, type.FindProperty("Prop1").GetShadowIndex());
-        Assert.Equal(2, type.FindProperty("Level2ReferenceId").GetShadowIndex());
-        Assert.Equal(-1, type.FindProperty("Prop2").GetShadowIndex());
-        Assert.Equal(3, type.FindProperty("Level3ReferenceId").GetShadowIndex());
-        Assert.Equal(-1, type.FindProperty("Prop3").GetShadowIndex());
+        Assert.Equal(-1, type.FindProperty("Id")!.GetShadowIndex());
+        Assert.Equal(0, type.FindProperty("Level1ReferenceId")!.GetShadowIndex());
+        Assert.Equal(-1, type.FindProperty("Prop1")!.GetShadowIndex());
+        Assert.Equal(2, type.FindProperty("Level2ReferenceId")!.GetShadowIndex());
+        Assert.Equal(-1, type.FindProperty("Prop2")!.GetShadowIndex());
+        Assert.Equal(3, type.FindProperty("Level3ReferenceId")!.GetShadowIndex());
+        Assert.Equal(-1, type.FindProperty("Prop3")!.GetShadowIndex());
 
-        Assert.Equal(0, type.FindProperty("Id").GetOriginalValueIndex());
-        Assert.Equal(1, type.FindProperty("Level1ReferenceId").GetOriginalValueIndex());
-        Assert.Equal(2, type.FindProperty("Prop1").GetOriginalValueIndex());
-        Assert.Equal(4, type.FindProperty("Level2ReferenceId").GetOriginalValueIndex());
-        Assert.Equal(5, type.FindProperty("Prop2").GetOriginalValueIndex());
-        Assert.Equal(6, type.FindProperty("Level3ReferenceId").GetOriginalValueIndex());
-        Assert.Equal(7, type.FindProperty("Prop3").GetOriginalValueIndex());
+        Assert.Equal(0, type.FindProperty("Id")!.GetOriginalValueIndex());
+        Assert.Equal(1, type.FindProperty("Level1ReferenceId")!.GetOriginalValueIndex());
+        Assert.Equal(2, type.FindProperty("Prop1")!.GetOriginalValueIndex());
+        Assert.Equal(4, type.FindProperty("Level2ReferenceId")!.GetOriginalValueIndex());
+        Assert.Equal(5, type.FindProperty("Prop2")!.GetOriginalValueIndex());
+        Assert.Equal(6, type.FindProperty("Level3ReferenceId")!.GetOriginalValueIndex());
+        Assert.Equal(7, type.FindProperty("Prop3")!.GetOriginalValueIndex());
 
-        Assert.Equal(0, type.FindProperty("Id").GetRelationshipIndex());
-        Assert.Equal(1, type.FindProperty("Level1ReferenceId").GetRelationshipIndex());
-        Assert.Equal(-1, type.FindProperty("Prop1").GetRelationshipIndex());
-        Assert.Equal(2, type.FindNavigation("Level1Collection").GetRelationshipIndex());
-        Assert.Equal(3, type.FindNavigation("Level1Reference").GetRelationshipIndex());
-        Assert.Equal(4, type.FindProperty("Level2ReferenceId").GetRelationshipIndex());
-        Assert.Equal(-1, type.FindProperty("Prop2").GetRelationshipIndex());
-        Assert.Equal(5, type.FindNavigation("Level2Collection").GetRelationshipIndex());
-        Assert.Equal(6, type.FindNavigation("Level2Reference").GetRelationshipIndex());
-        Assert.Equal(7, type.FindProperty("Level3ReferenceId").GetRelationshipIndex());
-        Assert.Equal(-1, type.FindProperty("Prop3").GetRelationshipIndex());
-        Assert.Equal(8, type.FindNavigation("Level3Collection").GetRelationshipIndex());
-        Assert.Equal(9, type.FindNavigation("Level3Reference").GetRelationshipIndex());
+        Assert.Equal(0, type.FindProperty("Id")!.GetRelationshipIndex());
+        Assert.Equal(1, type.FindProperty("Level1ReferenceId")!.GetRelationshipIndex());
+        Assert.Equal(-1, type.FindProperty("Prop1")!.GetRelationshipIndex());
+        Assert.Equal(2, type.FindNavigation("Level1Collection")!.GetRelationshipIndex());
+        Assert.Equal(3, type.FindNavigation("Level1Reference")!.GetRelationshipIndex());
+        Assert.Equal(4, type.FindProperty("Level2ReferenceId")!.GetRelationshipIndex());
+        Assert.Equal(-1, type.FindProperty("Prop2")!.GetRelationshipIndex());
+        Assert.Equal(5, type.FindNavigation("Level2Collection")!.GetRelationshipIndex());
+        Assert.Equal(6, type.FindNavigation("Level2Reference")!.GetRelationshipIndex());
+        Assert.Equal(7, type.FindProperty("Level3ReferenceId")!.GetRelationshipIndex());
+        Assert.Equal(-1, type.FindProperty("Prop3")!.GetRelationshipIndex());
+        Assert.Equal(8, type.FindNavigation("Level3Collection")!.GetRelationshipIndex());
+        Assert.Equal(9, type.FindNavigation("Level3Reference")!.GetRelationshipIndex());
 
-        Assert.Equal(0, type.FindProperty("Id").GetStoreGeneratedIndex());
-        Assert.Equal(1, type.FindProperty("Level1ReferenceId").GetStoreGeneratedIndex());
-        Assert.Equal(-1, type.FindProperty("Prop1").GetStoreGeneratedIndex());
-        Assert.Equal(2, type.FindProperty("Level2ReferenceId").GetStoreGeneratedIndex());
-        Assert.Equal(-1, type.FindProperty("Prop2").GetStoreGeneratedIndex());
-        Assert.Equal(3, type.FindProperty("Level3ReferenceId").GetStoreGeneratedIndex());
-        Assert.Equal(-1, type.FindProperty("Prop3").GetStoreGeneratedIndex());
-        Assert.Equal(-1, type.FindNavigation("Level1Collection").GetStoreGeneratedIndex());
-        Assert.Equal(-1, type.FindNavigation("Level1Reference").GetStoreGeneratedIndex());
-        Assert.Equal(-1, type.FindNavigation("Level2Collection").GetStoreGeneratedIndex());
-        Assert.Equal(-1, type.FindNavigation("Level2Reference").GetStoreGeneratedIndex());
-        Assert.Equal(-1, type.FindNavigation("Level3Collection").GetStoreGeneratedIndex());
-        Assert.Equal(-1, type.FindNavigation("Level3Reference").GetStoreGeneratedIndex());
+        Assert.Equal(0, type.FindProperty("Id")!.GetStoreGeneratedIndex());
+        Assert.Equal(1, type.FindProperty("Level1ReferenceId")!.GetStoreGeneratedIndex());
+        Assert.Equal(-1, type.FindProperty("Prop1")!.GetStoreGeneratedIndex());
+        Assert.Equal(2, type.FindProperty("Level2ReferenceId")!.GetStoreGeneratedIndex());
+        Assert.Equal(-1, type.FindProperty("Prop2")!.GetStoreGeneratedIndex());
+        Assert.Equal(3, type.FindProperty("Level3ReferenceId")!.GetStoreGeneratedIndex());
+        Assert.Equal(-1, type.FindProperty("Prop3")!.GetStoreGeneratedIndex());
+        Assert.Equal(-1, type.FindNavigation("Level1Collection")!.GetStoreGeneratedIndex());
+        Assert.Equal(-1, type.FindNavigation("Level1Reference")!.GetStoreGeneratedIndex());
+        Assert.Equal(-1, type.FindNavigation("Level2Collection")!.GetStoreGeneratedIndex());
+        Assert.Equal(-1, type.FindNavigation("Level2Reference")!.GetStoreGeneratedIndex());
+        Assert.Equal(-1, type.FindNavigation("Level3Collection")!.GetStoreGeneratedIndex());
+        Assert.Equal(-1, type.FindNavigation("Level3Reference")!.GetStoreGeneratedIndex());
 
         Assert.Equal(8, type.PropertyCount);
         Assert.Equal(6, type.NavigationCount);
@@ -2428,13 +2428,13 @@ public partial class EntityTypeTest
     public void Can_get_all_properties_and_navigations()
     {
         var entityType = CreateEmptyModel().AddEntityType(nameof(SelfRef));
-        var pk = entityType.SetPrimaryKey(entityType.AddProperty(nameof(SelfRef.Id), typeof(int)));
+        var pk = entityType.SetPrimaryKey(entityType.AddProperty(nameof(SelfRef.Id), typeof(int)))!;
         var fkProp = entityType.AddProperty(nameof(SelfRef.SelfRefId), typeof(int?));
 
         var fk = entityType.AddForeignKey([fkProp], pk, entityType);
         fk.IsUnique = true;
-        var dependentToPrincipal = fk.SetDependentToPrincipal(nameof(SelfRef.SelfRef2));
-        var principalToDependent = fk.SetPrincipalToDependent(nameof(SelfRef.SelfRef1));
+        var dependentToPrincipal = fk.SetDependentToPrincipal(nameof(SelfRef.SelfRef2))!;
+        var principalToDependent = fk.SetPrincipalToDependent(nameof(SelfRef.SelfRef1))!;
 
         Assert.Equal(
             new IReadOnlyPropertyBase[] { pk.Properties.Single(), fkProp, principalToDependent, dependentToPrincipal },
@@ -2447,42 +2447,42 @@ public partial class EntityTypeTest
         using var context = new SideBySide();
         var model = context.Model;
 
-        var parent = (IRuntimeEntityType)model.FindEntityType(typeof(Parent1Entity));
+        var parent = (IRuntimeEntityType)model.FindEntityType(typeof(Parent1Entity))!;
         var indexes = GetIndexes(parent.GetSnapshottableMembers());
         Assert.Equal(2, indexes.Count);
         // Order: Index, Shadow, Original, StoreGenerated, Relationship
         Assert.Equal((0, -1, 0, 0, 0), indexes[nameof(Parent1Entity.Id)]);
         Assert.Equal((0, -1, -1, -1, 1), indexes[nameof(Parent1Entity.Children)]);
 
-        indexes = GetIndexes(model.FindEntityType(typeof(ChildEntity), nameof(Parent1Entity.Children), parent).GetProperties());
+        indexes = GetIndexes(model.FindEntityType(typeof(ChildEntity), nameof(Parent1Entity.Children), parent)!.GetProperties());
         Assert.Equal(3, indexes.Count);
         // Order: Index, Shadow, Original, StoreGenerated, Relationship
         Assert.Equal((0, 0, 0, 0, 0), indexes[nameof(Parent1Entity) + "Id"]);
         Assert.Equal((1, 1, 1, 1, 1), indexes["Id"]);
         Assert.Equal((2, -1, 2, -1, -1), indexes[nameof(ChildEntity.Name)]);
 
-        parent = (IRuntimeEntityType)model.FindEntityType(typeof(Parent2Entity));
+        parent = (IRuntimeEntityType)model.FindEntityType(typeof(Parent2Entity))!;
         indexes = GetIndexes(parent.GetSnapshottableMembers());
         Assert.Equal(2, indexes.Count);
         // Order: Index, Shadow, Original, StoreGenerated, Relationship
         Assert.Equal((0, -1, 0, 0, 0), indexes[nameof(Parent2Entity.Id)]);
         Assert.Equal((0, -1, -1, -1, 1), indexes[nameof(Parent2Entity.Children)]);
 
-        indexes = GetIndexes(model.FindEntityType(typeof(ChildEntity), nameof(Parent2Entity.Children), parent).GetProperties());
+        indexes = GetIndexes(model.FindEntityType(typeof(ChildEntity), nameof(Parent2Entity.Children), parent)!.GetProperties());
         Assert.Equal(3, indexes.Count);
         // Order: Index, Shadow, Original, StoreGenerated, Relationship
         Assert.Equal((0, 0, 0, 0, 0), indexes[nameof(Parent2Entity) + "Id"]);
         Assert.Equal((1, 1, 1, 1, 1), indexes["Id"]);
         Assert.Equal((2, -1, 2, -1, -1), indexes[nameof(ChildEntity.Name)]);
 
-        parent = (IRuntimeEntityType)model.FindEntityType(typeof(Parent3Entity));
+        parent = (IRuntimeEntityType)model.FindEntityType(typeof(Parent3Entity))!;
         indexes = GetIndexes(parent.GetSnapshottableMembers());
         Assert.Equal(2, indexes.Count);
         // Order: Index, Shadow, Original, StoreGenerated, Relationship
         Assert.Equal((0, -1, 0, 0, 0), indexes[nameof(Parent3Entity.Id)]);
         Assert.Equal((0, -1, -1, -1, 1), indexes[nameof(Parent3Entity.Children)]);
 
-        indexes = GetIndexes(model.FindEntityType(typeof(ChildEntity), nameof(Parent3Entity.Children), parent).GetProperties());
+        indexes = GetIndexes(model.FindEntityType(typeof(ChildEntity), nameof(Parent3Entity.Children), parent)!.GetProperties());
         Assert.Equal(3, indexes.Count);
         // Order: Index, Shadow, Original, StoreGenerated, Relationship
         Assert.Equal((0, 0, 0, 0, 0), indexes[nameof(Parent3Entity) + "Id"]);
@@ -2519,24 +2519,24 @@ public partial class EntityTypeTest
     private class Parent1Entity
     {
         public Guid Id { get; set; }
-        public ICollection<ChildEntity> Children { get; set; }
+        public ICollection<ChildEntity> Children { get; set; } = null!;
     }
 
     private class Parent2Entity
     {
         public Guid Id { get; set; }
-        public ICollection<ChildEntity> Children { get; set; }
+        public ICollection<ChildEntity> Children { get; set; } = null!;
     }
 
     private class Parent3Entity
     {
         public Guid Id { get; set; }
-        public ICollection<ChildEntity> Children { get; set; }
+        public ICollection<ChildEntity> Children { get; set; } = null!;
     }
 
     private class ChildEntity
     {
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
     }
 
     [Fact]
@@ -2562,7 +2562,7 @@ public partial class EntityTypeTest
     public void Change_tracking_from_model_is_used_by_default_regardless_of_CLR_type()
     {
         var model = BuildFullNotificationEntityModel();
-        var entityType = model.FindEntityType(typeof(FullNotificationEntity));
+        var entityType = model.FindEntityType(typeof(FullNotificationEntity))!;
 
         Assert.Equal(ChangeTrackingStrategy.Snapshot, entityType.GetChangeTrackingStrategy());
 
@@ -2590,7 +2590,7 @@ public partial class EntityTypeTest
         var model = BuildFullNotificationEntityModel();
         model.SetChangeTrackingStrategy(ChangeTrackingStrategy.ChangedNotifications);
 
-        var entityType = model.FindEntityType(typeof(FullNotificationEntity));
+        var entityType = model.FindEntityType(typeof(FullNotificationEntity))!;
 
         Assert.Equal(ChangeTrackingStrategy.ChangedNotifications, entityType.GetChangeTrackingStrategy());
 
@@ -2803,29 +2803,29 @@ public partial class EntityTypeTest
     private class Application
     {
         public Guid Id { get; protected set; }
-        public Attitude Attitude { get; set; }
-        public Rejection Rejection { get; set; }
+        public Attitude Attitude { get; set; } = null!;
+        public Rejection Rejection { get; set; } = null!;
     }
 
     private class ApplicationVersion
     {
         public Guid Id { get; protected set; }
-        public Attitude Attitude { get; set; }
+        public Attitude Attitude { get; set; } = null!;
     }
 
     private class Rejection
     {
-        public FirstTest FirstTest { get; set; }
+        public FirstTest FirstTest { get; set; } = null!;
     }
 
     private class Attitude
     {
-        public FirstTest FirstTest { get; set; }
+        public FirstTest FirstTest { get; set; } = null!;
     }
 
     private class FirstTest
     {
-        public SpecialistStaff Tester { get; set; }
+        public SpecialistStaff Tester { get; set; } = null!;
     }
 
     private class SpecialistStaff;
@@ -2834,16 +2834,16 @@ public partial class EntityTypeTest
     public void All_properties_have_original_value_indexes_when_using_snapshot_change_tracking()
     {
         var model = BuildFullNotificationEntityModel();
-        model.FindEntityType(typeof(FullNotificationEntity))
+        model.FindEntityType(typeof(FullNotificationEntity))!
             .SetChangeTrackingStrategy(ChangeTrackingStrategy.Snapshot);
-        var entityType = (IRuntimeEntityType)model.FinalizeModel().FindEntityType(typeof(FullNotificationEntity));
+        var entityType = (IRuntimeEntityType)model.FinalizeModel().FindEntityType(typeof(FullNotificationEntity))!;
 
-        Assert.Equal(0, entityType.FindProperty("Id").GetOriginalValueIndex());
-        Assert.Equal(1, entityType.FindProperty("AnotherEntityId").GetOriginalValueIndex());
-        Assert.Equal(2, entityType.FindProperty("Index").GetOriginalValueIndex());
-        Assert.Equal(3, entityType.FindProperty("Name").GetOriginalValueIndex());
-        Assert.Equal(4, entityType.FindProperty("Token").GetOriginalValueIndex());
-        Assert.Equal(5, entityType.FindProperty("UniqueIndex").GetOriginalValueIndex());
+        Assert.Equal(0, entityType.FindProperty("Id")!.GetOriginalValueIndex());
+        Assert.Equal(1, entityType.FindProperty("AnotherEntityId")!.GetOriginalValueIndex());
+        Assert.Equal(2, entityType.FindProperty("Index")!.GetOriginalValueIndex());
+        Assert.Equal(3, entityType.FindProperty("Name")!.GetOriginalValueIndex());
+        Assert.Equal(4, entityType.FindProperty("Token")!.GetOriginalValueIndex());
+        Assert.Equal(5, entityType.FindProperty("UniqueIndex")!.GetOriginalValueIndex());
 
         Assert.Equal(6, entityType.OriginalValueCount);
     }
@@ -2852,18 +2852,18 @@ public partial class EntityTypeTest
     public void All_relationship_properties_have_relationship_indexes_when_using_snapshot_change_tracking()
     {
         var model = BuildFullNotificationEntityModel();
-        model.FindEntityType(typeof(FullNotificationEntity))
+        model.FindEntityType(typeof(FullNotificationEntity))!
             .SetChangeTrackingStrategy(ChangeTrackingStrategy.Snapshot);
-        var entityType = (IRuntimeEntityType)model.FinalizeModel().FindEntityType(typeof(FullNotificationEntity));
+        var entityType = (IRuntimeEntityType)model.FinalizeModel().FindEntityType(typeof(FullNotificationEntity))!;
 
-        Assert.Equal(0, entityType.FindProperty("Id").GetRelationshipIndex());
-        Assert.Equal(1, entityType.FindProperty("AnotherEntityId").GetRelationshipIndex());
-        Assert.Equal(-1, entityType.FindProperty("Index").GetRelationshipIndex());
-        Assert.Equal(-1, entityType.FindProperty("Name").GetRelationshipIndex());
-        Assert.Equal(-1, entityType.FindProperty("Token").GetRelationshipIndex());
-        Assert.Equal(-1, entityType.FindProperty("UniqueIndex").GetRelationshipIndex());
-        Assert.Equal(2, entityType.FindNavigation("CollectionNav").GetRelationshipIndex());
-        Assert.Equal(3, entityType.FindNavigation("ReferenceNav").GetRelationshipIndex());
+        Assert.Equal(0, entityType.FindProperty("Id")!.GetRelationshipIndex());
+        Assert.Equal(1, entityType.FindProperty("AnotherEntityId")!.GetRelationshipIndex());
+        Assert.Equal(-1, entityType.FindProperty("Index")!.GetRelationshipIndex());
+        Assert.Equal(-1, entityType.FindProperty("Name")!.GetRelationshipIndex());
+        Assert.Equal(-1, entityType.FindProperty("Token")!.GetRelationshipIndex());
+        Assert.Equal(-1, entityType.FindProperty("UniqueIndex")!.GetRelationshipIndex());
+        Assert.Equal(2, entityType.FindNavigation("CollectionNav")!.GetRelationshipIndex());
+        Assert.Equal(3, entityType.FindNavigation("ReferenceNav")!.GetRelationshipIndex());
 
         Assert.Equal(4, entityType.RelationshipPropertyCount);
     }
@@ -2872,16 +2872,16 @@ public partial class EntityTypeTest
     public void All_properties_have_original_value_indexes_when_using_changed_only_tracking()
     {
         var model = BuildFullNotificationEntityModel();
-        model.FindEntityType(typeof(FullNotificationEntity))
+        model.FindEntityType(typeof(FullNotificationEntity))!
             .SetChangeTrackingStrategy(ChangeTrackingStrategy.ChangedNotifications);
-        var entityType = (IRuntimeEntityType)model.FinalizeModel().FindEntityType(typeof(FullNotificationEntity));
+        var entityType = (IRuntimeEntityType)model.FinalizeModel().FindEntityType(typeof(FullNotificationEntity))!;
 
-        Assert.Equal(0, entityType.FindProperty("Id").GetOriginalValueIndex());
-        Assert.Equal(1, entityType.FindProperty("AnotherEntityId").GetOriginalValueIndex());
-        Assert.Equal(2, entityType.FindProperty("Index").GetOriginalValueIndex());
-        Assert.Equal(3, entityType.FindProperty("Name").GetOriginalValueIndex());
-        Assert.Equal(4, entityType.FindProperty("Token").GetOriginalValueIndex());
-        Assert.Equal(5, entityType.FindProperty("UniqueIndex").GetOriginalValueIndex());
+        Assert.Equal(0, entityType.FindProperty("Id")!.GetOriginalValueIndex());
+        Assert.Equal(1, entityType.FindProperty("AnotherEntityId")!.GetOriginalValueIndex());
+        Assert.Equal(2, entityType.FindProperty("Index")!.GetOriginalValueIndex());
+        Assert.Equal(3, entityType.FindProperty("Name")!.GetOriginalValueIndex());
+        Assert.Equal(4, entityType.FindProperty("Token")!.GetOriginalValueIndex());
+        Assert.Equal(5, entityType.FindProperty("UniqueIndex")!.GetOriginalValueIndex());
 
         Assert.Equal(6, entityType.OriginalValueCount);
     }
@@ -2890,18 +2890,18 @@ public partial class EntityTypeTest
     public void Collections_dont_have_relationship_indexes_when_using_changed_only_change_tracking()
     {
         var model = BuildFullNotificationEntityModel();
-        model.FindEntityType(typeof(FullNotificationEntity))
+        model.FindEntityType(typeof(FullNotificationEntity))!
             .SetChangeTrackingStrategy(ChangeTrackingStrategy.ChangedNotifications);
-        var entityType = (IRuntimeEntityType)model.FinalizeModel().FindEntityType(typeof(FullNotificationEntity));
+        var entityType = (IRuntimeEntityType)model.FinalizeModel().FindEntityType(typeof(FullNotificationEntity))!;
 
-        Assert.Equal(0, entityType.FindProperty("Id").GetRelationshipIndex());
-        Assert.Equal(1, entityType.FindProperty("AnotherEntityId").GetRelationshipIndex());
-        Assert.Equal(-1, entityType.FindProperty("Index").GetRelationshipIndex());
-        Assert.Equal(-1, entityType.FindProperty("Name").GetRelationshipIndex());
-        Assert.Equal(-1, entityType.FindProperty("Token").GetRelationshipIndex());
-        Assert.Equal(-1, entityType.FindProperty("UniqueIndex").GetRelationshipIndex());
-        Assert.Equal(-1, entityType.FindNavigation("CollectionNav").GetRelationshipIndex());
-        Assert.Equal(2, entityType.FindNavigation("ReferenceNav").GetRelationshipIndex());
+        Assert.Equal(0, entityType.FindProperty("Id")!.GetRelationshipIndex());
+        Assert.Equal(1, entityType.FindProperty("AnotherEntityId")!.GetRelationshipIndex());
+        Assert.Equal(-1, entityType.FindProperty("Index")!.GetRelationshipIndex());
+        Assert.Equal(-1, entityType.FindProperty("Name")!.GetRelationshipIndex());
+        Assert.Equal(-1, entityType.FindProperty("Token")!.GetRelationshipIndex());
+        Assert.Equal(-1, entityType.FindProperty("UniqueIndex")!.GetRelationshipIndex());
+        Assert.Equal(-1, entityType.FindNavigation("CollectionNav")!.GetRelationshipIndex());
+        Assert.Equal(2, entityType.FindNavigation("ReferenceNav")!.GetRelationshipIndex());
 
         Assert.Equal(3, entityType.RelationshipPropertyCount);
     }
@@ -2910,16 +2910,16 @@ public partial class EntityTypeTest
     public void Only_concurrency_index_and_key_properties_have_original_value_indexes_when_using_full_notifications()
     {
         var model = BuildFullNotificationEntityModel();
-        model.FindEntityType(typeof(FullNotificationEntity))
+        model.FindEntityType(typeof(FullNotificationEntity))!
             .SetChangeTrackingStrategy(ChangeTrackingStrategy.ChangingAndChangedNotifications);
-        var entityType = (IRuntimeEntityType)model.FinalizeModel().FindEntityType(typeof(FullNotificationEntity));
+        var entityType = (IRuntimeEntityType)model.FinalizeModel().FindEntityType(typeof(FullNotificationEntity))!;
 
-        Assert.Equal(0, entityType.FindProperty("Id").GetOriginalValueIndex());
-        Assert.Equal(1, entityType.FindProperty("AnotherEntityId").GetOriginalValueIndex());
-        Assert.Equal(-1, entityType.FindProperty("Name").GetOriginalValueIndex());
-        Assert.Equal(-1, entityType.FindProperty("Index").GetOriginalValueIndex());
-        Assert.Equal(2, entityType.FindProperty("Token").GetOriginalValueIndex());
-        Assert.Equal(3, entityType.FindProperty("UniqueIndex").GetOriginalValueIndex());
+        Assert.Equal(0, entityType.FindProperty("Id")!.GetOriginalValueIndex());
+        Assert.Equal(1, entityType.FindProperty("AnotherEntityId")!.GetOriginalValueIndex());
+        Assert.Equal(-1, entityType.FindProperty("Name")!.GetOriginalValueIndex());
+        Assert.Equal(-1, entityType.FindProperty("Index")!.GetOriginalValueIndex());
+        Assert.Equal(2, entityType.FindProperty("Token")!.GetOriginalValueIndex());
+        Assert.Equal(3, entityType.FindProperty("UniqueIndex")!.GetOriginalValueIndex());
 
         Assert.Equal(4, entityType.OriginalValueCount);
     }
@@ -2928,18 +2928,18 @@ public partial class EntityTypeTest
     public void Collections_dont_have_relationship_indexes_when_using_full_notifications()
     {
         var model = BuildFullNotificationEntityModel();
-        model.FindEntityType(typeof(FullNotificationEntity))
+        model.FindEntityType(typeof(FullNotificationEntity))!
             .SetChangeTrackingStrategy(ChangeTrackingStrategy.ChangingAndChangedNotifications);
-        var entityType = (IRuntimeEntityType)model.FinalizeModel().FindEntityType(typeof(FullNotificationEntity));
+        var entityType = (IRuntimeEntityType)model.FinalizeModel().FindEntityType(typeof(FullNotificationEntity))!;
 
-        Assert.Equal(0, entityType.FindProperty("Id").GetRelationshipIndex());
-        Assert.Equal(1, entityType.FindProperty("AnotherEntityId").GetRelationshipIndex());
-        Assert.Equal(-1, entityType.FindProperty("Index").GetRelationshipIndex());
-        Assert.Equal(-1, entityType.FindProperty("Name").GetRelationshipIndex());
-        Assert.Equal(-1, entityType.FindProperty("Token").GetRelationshipIndex());
-        Assert.Equal(-1, entityType.FindProperty("UniqueIndex").GetRelationshipIndex());
-        Assert.Equal(-1, entityType.FindNavigation("CollectionNav").GetRelationshipIndex());
-        Assert.Equal(2, entityType.FindNavigation("ReferenceNav").GetRelationshipIndex());
+        Assert.Equal(0, entityType.FindProperty("Id")!.GetRelationshipIndex());
+        Assert.Equal(1, entityType.FindProperty("AnotherEntityId")!.GetRelationshipIndex());
+        Assert.Equal(-1, entityType.FindProperty("Index")!.GetRelationshipIndex());
+        Assert.Equal(-1, entityType.FindProperty("Name")!.GetRelationshipIndex());
+        Assert.Equal(-1, entityType.FindProperty("Token")!.GetRelationshipIndex());
+        Assert.Equal(-1, entityType.FindProperty("UniqueIndex")!.GetRelationshipIndex());
+        Assert.Equal(-1, entityType.FindNavigation("CollectionNav")!.GetRelationshipIndex());
+        Assert.Equal(2, entityType.FindNavigation("ReferenceNav")!.GetRelationshipIndex());
 
         Assert.Equal(3, entityType.RelationshipPropertyCount);
     }
@@ -2948,16 +2948,16 @@ public partial class EntityTypeTest
     public void All_properties_have_original_value_indexes_when_full_notifications_with_original_values()
     {
         var model = BuildFullNotificationEntityModel();
-        model.FindEntityType(typeof(FullNotificationEntity))
+        model.FindEntityType(typeof(FullNotificationEntity))!
             .SetChangeTrackingStrategy(ChangeTrackingStrategy.ChangingAndChangedNotificationsWithOriginalValues);
-        var entityType = (IRuntimeEntityType)model.FinalizeModel().FindEntityType(typeof(FullNotificationEntity));
+        var entityType = (IRuntimeEntityType)model.FinalizeModel().FindEntityType(typeof(FullNotificationEntity))!;
 
-        Assert.Equal(0, entityType.FindProperty("Id").GetOriginalValueIndex());
-        Assert.Equal(1, entityType.FindProperty("AnotherEntityId").GetOriginalValueIndex());
-        Assert.Equal(2, entityType.FindProperty("Index").GetOriginalValueIndex());
-        Assert.Equal(3, entityType.FindProperty("Name").GetOriginalValueIndex());
-        Assert.Equal(4, entityType.FindProperty("Token").GetOriginalValueIndex());
-        Assert.Equal(5, entityType.FindProperty("UniqueIndex").GetOriginalValueIndex());
+        Assert.Equal(0, entityType.FindProperty("Id")!.GetOriginalValueIndex());
+        Assert.Equal(1, entityType.FindProperty("AnotherEntityId")!.GetOriginalValueIndex());
+        Assert.Equal(2, entityType.FindProperty("Index")!.GetOriginalValueIndex());
+        Assert.Equal(3, entityType.FindProperty("Name")!.GetOriginalValueIndex());
+        Assert.Equal(4, entityType.FindProperty("Token")!.GetOriginalValueIndex());
+        Assert.Equal(5, entityType.FindProperty("UniqueIndex")!.GetOriginalValueIndex());
 
         Assert.Equal(6, entityType.OriginalValueCount);
     }
@@ -2966,18 +2966,18 @@ public partial class EntityTypeTest
     public void Collections_dont_have_relationship_indexes_when_full_notifications_with_original_values()
     {
         var model = BuildFullNotificationEntityModel();
-        model.FindEntityType(typeof(FullNotificationEntity))
+        model.FindEntityType(typeof(FullNotificationEntity))!
             .SetChangeTrackingStrategy(ChangeTrackingStrategy.ChangingAndChangedNotificationsWithOriginalValues);
-        var entityType = (IRuntimeEntityType)model.FinalizeModel().FindEntityType(typeof(FullNotificationEntity));
+        var entityType = (IRuntimeEntityType)model.FinalizeModel().FindEntityType(typeof(FullNotificationEntity))!;
 
-        Assert.Equal(0, entityType.FindProperty("Id").GetRelationshipIndex());
-        Assert.Equal(1, entityType.FindProperty("AnotherEntityId").GetRelationshipIndex());
-        Assert.Equal(-1, entityType.FindProperty("Index").GetRelationshipIndex());
-        Assert.Equal(-1, entityType.FindProperty("Name").GetRelationshipIndex());
-        Assert.Equal(-1, entityType.FindProperty("Token").GetRelationshipIndex());
-        Assert.Equal(-1, entityType.FindProperty("UniqueIndex").GetRelationshipIndex());
-        Assert.Equal(-1, entityType.FindNavigation("CollectionNav").GetRelationshipIndex());
-        Assert.Equal(2, entityType.FindNavigation("ReferenceNav").GetRelationshipIndex());
+        Assert.Equal(0, entityType.FindProperty("Id")!.GetRelationshipIndex());
+        Assert.Equal(1, entityType.FindProperty("AnotherEntityId")!.GetRelationshipIndex());
+        Assert.Equal(-1, entityType.FindProperty("Index")!.GetRelationshipIndex());
+        Assert.Equal(-1, entityType.FindProperty("Name")!.GetRelationshipIndex());
+        Assert.Equal(-1, entityType.FindProperty("Token")!.GetRelationshipIndex());
+        Assert.Equal(-1, entityType.FindProperty("UniqueIndex")!.GetRelationshipIndex());
+        Assert.Equal(-1, entityType.FindNavigation("CollectionNav")!.GetRelationshipIndex());
+        Assert.Equal(2, entityType.FindNavigation("ReferenceNav")!.GetRelationshipIndex());
 
         Assert.Equal(3, entityType.RelationshipPropertyCount);
     }
@@ -2989,7 +2989,7 @@ public partial class EntityTypeTest
 
         var typeName = "<>f__AnonymousType01Child";
         model.AddEntityType(typeName);
-        var entityType = model.FinalizeModel().FindEntityType(typeName);
+        var entityType = model.FinalizeModel().FindEntityType(typeName)!;
 
         Assert.Equal(typeName, entityType.ShortName());
     }
@@ -3008,7 +3008,7 @@ public partial class EntityTypeTest
 
         model.AddEntityType(type);
 
-        var entityType = model.FinalizeModel().FindEntityType(typeName);
+        var entityType = model.FinalizeModel().FindEntityType(typeName)!;
 
         Assert.Equal(typeName[2..], entityType.ShortName());
     }
@@ -3027,7 +3027,7 @@ public partial class EntityTypeTest
 
         model.AddEntityType(type);
 
-        var entityType = model.FinalizeModel().FindEntityType(typeName);
+        var entityType = model.FinalizeModel().FindEntityType(typeName)!;
 
         Assert.Equal("__AnonymousType01Child", entityType.ShortName());
     }
@@ -3050,7 +3050,7 @@ public partial class EntityTypeTest
 
         model.AddEntityType(type);
 
-        var entityType = model.FinalizeModel().FindEntityType(clrName);
+        var entityType = model.FinalizeModel().FindEntityType(clrName)!;
 
         Assert.Equal(expectedShortName, entityType.ShortName());
     }
@@ -3073,7 +3073,7 @@ public partial class EntityTypeTest
 
         model.AddEntityType(type);
 
-        var entityType = model.FinalizeModel().FindEntityType(clrName);
+        var entityType = model.FinalizeModel().FindEntityType(clrName)!;
 
         Assert.Equal(expectedShortName, entityType.ShortName());
     }
@@ -3106,7 +3106,7 @@ public partial class EntityTypeTest
 
         model.AddEntityType(type);
 
-        var entityType = model.FinalizeModel().FindEntityType(clrName);
+        var entityType = model.FinalizeModel().FindEntityType(clrName)!;
 
         Assert.Equal(expectedDisplayName, entityType.DisplayName());
     }
@@ -3137,7 +3137,7 @@ public partial class EntityTypeTest
 
         model.AddEntityType(type);
 
-        var entityType = model.FinalizeModel().FindEntityType(clrName);
+        var entityType = model.FinalizeModel().FindEntityType(clrName)!;
 
         Assert.Equal(expectedDisplayName, entityType.DisplayName());
     }
@@ -3161,7 +3161,7 @@ public partial class EntityTypeTest
 
         model.AddEntityType(type);
 
-        var entityType = model.FinalizeModel().FindEntityType(clrName);
+        var entityType = model.FinalizeModel().FindEntityType(clrName)!;
 
         Assert.Equal(expectedDisplayName, entityType.DisplayName());
     }
@@ -3177,48 +3177,48 @@ public partial class EntityTypeTest
     private readonly IMutableModel _model = BuildModel();
 
     private IMutableEntityType DependentType
-        => _model.FindEntityType(typeof(DependentEntity));
+        => _model.FindEntityType(typeof(DependentEntity))!;
 
     private IMutableEntityType PrincipalType
-        => _model.FindEntityType(typeof(PrincipalEntity));
+        => _model.FindEntityType(typeof(PrincipalEntity))!;
 
     private class PrincipalEntity
     {
         public int PeeKay { get; set; }
-        public IEnumerable<DependentEntity> AnotherNav { get; set; }
+        public IEnumerable<DependentEntity> AnotherNav { get; set; } = null!;
     }
 
     private class DependentEntity
     {
-        public PrincipalEntity Navigator { get; set; }
-        public PrincipalEntity AnotherNav { get; set; }
+        public PrincipalEntity Navigator { get; set; } = null!;
+        public PrincipalEntity AnotherNav { get; set; } = null!;
     }
 
     private class A
     {
-        public static readonly PropertyInfo EProperty = typeof(A).GetProperty("E");
-        public static readonly PropertyInfo GProperty = typeof(A).GetProperty("G");
+        public static readonly PropertyInfo EProperty = typeof(A).GetProperty("E")!;
+        public static readonly PropertyInfo GProperty = typeof(A).GetProperty("G")!;
 
-        public string E { get; set; }
-        public string G { get; set; }
+        public string E { get; set; } = null!;
+        public string G { get; set; } = null!;
     }
 
     private class B : A
     {
-        public static readonly PropertyInfo FProperty = typeof(B).GetProperty("F");
-        public static readonly PropertyInfo HProperty = typeof(B).GetProperty("H");
+        public static readonly PropertyInfo FProperty = typeof(B).GetProperty("F")!;
+        public static readonly PropertyInfo HProperty = typeof(B).GetProperty("H")!;
 
-        public string F { get; set; }
-        public string H { get; set; }
+        public string F { get; set; } = null!;
+        public string H { get; set; } = null!;
     }
 
     private class C : A
     {
-        public static readonly PropertyInfo FProperty = typeof(C).GetProperty("F");
-        public static readonly PropertyInfo HProperty = typeof(C).GetProperty("H");
+        public static readonly PropertyInfo FProperty = typeof(C).GetProperty("F")!;
+        public static readonly PropertyInfo HProperty = typeof(C).GetProperty("H")!;
 
-        public string F { get; set; }
-        public string H { get; set; }
+        public string F { get; set; } = null!;
+        public string H { get; set; } = null!;
     }
 
     private class D : C;
@@ -3227,22 +3227,22 @@ public partial class EntityTypeTest
     {
         public int Id { get; set; }
         public int Prop1 { get; set; }
-        public Level1 Level1Reference { get; set; }
-        public ICollection<Level1> Level1Collection { get; set; }
+        public Level1 Level1Reference { get; set; } = null!;
+        public ICollection<Level1> Level1Collection { get; set; } = null!;
     }
 
     private class Level2 : Level1
     {
         public int Prop2 { get; set; }
-        public Level2 Level2Reference { get; set; }
-        public ICollection<Level2> Level2Collection { get; set; }
+        public Level2 Level2Reference { get; set; } = null!;
+        public ICollection<Level2> Level2Collection { get; set; } = null!;
     }
 
     private class Level3 : Level2
     {
         public int Prop3 { get; set; }
-        public Level3 Level3Reference { get; set; }
-        public ICollection<Level3> Level3Collection { get; set; }
+        public Level3 Level3Reference { get; set; } = null!;
+        public ICollection<Level3> Level3Collection { get; set; } = null!;
     }
 
     private class BaseType
@@ -3252,105 +3252,105 @@ public partial class EntityTypeTest
 
     private class Customer : BaseType
     {
-        public static readonly PropertyInfo IdProperty = typeof(BaseType).GetProperty(nameof(Id));
-        public static readonly PropertyInfo NameProperty = typeof(Customer).GetProperty(nameof(Name));
-        public static readonly PropertyInfo OrdersProperty = typeof(Customer).GetProperty(nameof(Orders));
-        public static readonly PropertyInfo MoreOrdersProperty = typeof(Customer).GetProperty(nameof(MoreOrders));
-        public static readonly PropertyInfo NotCollectionOrdersProperty = typeof(Customer).GetProperty(nameof(NotCollectionOrders));
+        public static readonly PropertyInfo IdProperty = typeof(BaseType).GetProperty(nameof(Id))!;
+        public static readonly PropertyInfo NameProperty = typeof(Customer).GetProperty(nameof(Name))!;
+        public static readonly PropertyInfo OrdersProperty = typeof(Customer).GetProperty(nameof(Orders))!;
+        public static readonly PropertyInfo MoreOrdersProperty = typeof(Customer).GetProperty(nameof(MoreOrders))!;
+        public static readonly PropertyInfo NotCollectionOrdersProperty = typeof(Customer).GetProperty(nameof(NotCollectionOrders))!;
 
         public int AlternateId { get; set; }
         public Guid Unique { get; set; }
-        public string Name { get; set; }
-        public string Mane { get; set; }
+        public string Name { get; set; } = null!;
+        public string Mane { get; set; } = null!;
 
         public object this[string name]
         {
-            get => null;
+            get => null!;
             set { }
         }
 
-        public ICollection<Order> Orders { get; set; }
-        public ICollection<Order> MoreOrders { get; set; }
+        public ICollection<Order> Orders { get; set; } = null!;
+        public ICollection<Order> MoreOrders { get; set; } = null!;
 
-        public IEnumerable<Order> EnumerableOrders { get; set; }
-        public Order NotCollectionOrders { get; set; }
+        public IEnumerable<Order> EnumerableOrders { get; set; } = null!;
+        public Order NotCollectionOrders { get; set; } = null!;
     }
 
     private class SpecialCustomer : Customer
     {
-        public static readonly PropertyInfo DerivedOrdersProperty = typeof(SpecialCustomer).GetProperty(nameof(DerivedOrders));
+        public static readonly PropertyInfo DerivedOrdersProperty = typeof(SpecialCustomer).GetProperty(nameof(DerivedOrders))!;
 
-        public IEnumerable<SpecialOrder> DerivedOrders { get; set; }
+        public IEnumerable<SpecialOrder> DerivedOrders { get; set; } = null!;
     }
 
     private class VerySpecialCustomer : SpecialCustomer;
 
     private class Order : BaseType
     {
-        public static readonly PropertyInfo IdProperty = typeof(Order).GetProperty(nameof(Id));
-        public static readonly PropertyInfo CustomerProperty = typeof(Order).GetProperty(nameof(Customer));
-        public static readonly PropertyInfo CustomerIdProperty = typeof(Order).GetProperty(nameof(CustomerId));
-        public static readonly PropertyInfo CustomerUniqueProperty = typeof(Order).GetProperty(nameof(CustomerUnique));
-        public static readonly PropertyInfo RelatedOrderProperty = typeof(Order).GetProperty(nameof(RelatedOrder));
-        public static readonly PropertyInfo ProductsProperty = typeof(Order).GetProperty(nameof(Products));
+        public static readonly PropertyInfo IdProperty = typeof(Order).GetProperty(nameof(Id))!;
+        public static readonly PropertyInfo CustomerProperty = typeof(Order).GetProperty(nameof(Customer))!;
+        public static readonly PropertyInfo CustomerIdProperty = typeof(Order).GetProperty(nameof(CustomerId))!;
+        public static readonly PropertyInfo CustomerUniqueProperty = typeof(Order).GetProperty(nameof(CustomerUnique))!;
+        public static readonly PropertyInfo RelatedOrderProperty = typeof(Order).GetProperty(nameof(RelatedOrder))!;
+        public static readonly PropertyInfo ProductsProperty = typeof(Order).GetProperty(nameof(Products))!;
 
         public int CustomerId { get; set; }
         public Guid CustomerUnique { get; set; }
-        public Customer Customer { get; set; }
+        public Customer Customer { get; set; } = null!;
 
-        public Order RelatedOrder { get; set; }
-        public virtual ICollection<Product> Products { get; set; }
+        public Order RelatedOrder { get; set; } = null!;
+        public virtual ICollection<Product> Products { get; set; } = null!;
     }
 
     private class SpecialOrder : Order
     {
-        public static readonly PropertyInfo DerivedCustomerProperty = typeof(SpecialOrder).GetProperty(nameof(DerivedCustomer));
+        public static readonly PropertyInfo DerivedCustomerProperty = typeof(SpecialOrder).GetProperty(nameof(DerivedCustomer))!;
 
-        public SpecialCustomer DerivedCustomer { get; set; }
+        public SpecialCustomer DerivedCustomer { get; set; } = null!;
     }
 
     private class VerySpecialOrder : SpecialOrder;
 
     private class OrderProduct
     {
-        public static readonly PropertyInfo OrderIdProperty = typeof(OrderProduct).GetProperty(nameof(OrderId));
-        public static readonly PropertyInfo ProductIdProperty = typeof(OrderProduct).GetProperty(nameof(ProductId));
+        public static readonly PropertyInfo OrderIdProperty = typeof(OrderProduct).GetProperty(nameof(OrderId))!;
+        public static readonly PropertyInfo ProductIdProperty = typeof(OrderProduct).GetProperty(nameof(ProductId))!;
 
         public int OrderId { get; set; }
         public int ProductId { get; set; }
-        public virtual Order Order { get; set; }
-        public virtual Product Product { get; set; }
+        public virtual Order Order { get; set; } = null!;
+        public virtual Product Product { get; set; } = null!;
     }
 
     private class Category
     {
-        public static readonly PropertyInfo ProductsProperty = typeof(Category).GetProperty(nameof(Products));
-        public static readonly PropertyInfo FeaturedProductProperty = typeof(Category).GetProperty(nameof(FeaturedProduct));
+        public static readonly PropertyInfo ProductsProperty = typeof(Category).GetProperty(nameof(Products))!;
+        public static readonly PropertyInfo FeaturedProductProperty = typeof(Category).GetProperty(nameof(FeaturedProduct))!;
 
         public int Id { get; set; }
 
         public int FeaturedProductId { get; set; }
-        public Product FeaturedProduct { get; set; }
+        public Product FeaturedProduct { get; set; } = null!;
 
-        public ICollection<Product> Products { get; set; }
+        public ICollection<Product> Products { get; set; } = null!;
     }
 
     private class Product
     {
-        public static readonly PropertyInfo CategoryProperty = typeof(Product).GetProperty(nameof(Category));
-        public static readonly PropertyInfo IdProperty = typeof(Product).GetProperty(nameof(Id));
+        public static readonly PropertyInfo CategoryProperty = typeof(Product).GetProperty(nameof(Category))!;
+        public static readonly PropertyInfo IdProperty = typeof(Product).GetProperty(nameof(Id))!;
 
         public static readonly PropertyInfo FeaturedProductCategoryProperty =
-            typeof(Product).GetProperty(nameof(FeaturedProductCategory));
+            typeof(Product).GetProperty(nameof(FeaturedProductCategory))!;
 
         public int Id { get; set; }
 
-        public Category FeaturedProductCategory { get; set; }
+        public Category FeaturedProductCategory { get; set; } = null!;
 
         public int CategoryId { get; set; }
-        public Category Category { get; set; }
+        public Category Category { get; set; } = null!;
 
-        public virtual ICollection<Order> Orders { get; set; }
+        public virtual ICollection<Order> Orders { get; set; } = null!;
     }
 
     private static IMutableModel BuildFullNotificationEntityModel()
@@ -3380,19 +3380,19 @@ public partial class EntityTypeTest
     private class FullNotificationEntity : INotifyPropertyChanging, INotifyPropertyChanged
     {
         public int Id { get; set; }
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
         public int Token { get; set; }
         public int Index { get; set; }
         public int UniqueIndex { get; set; }
 
-        public AnotherEntity ReferenceNav { get; set; }
+        public AnotherEntity ReferenceNav { get; set; } = null!;
         public int AnotherEntityId { get; set; }
 
-        public ICollection<AnotherEntity> CollectionNav { get; set; }
+        public ICollection<AnotherEntity> CollectionNav { get; set; } = null!;
 
 #pragma warning disable 67
-        public event PropertyChangingEventHandler PropertyChanging;
-        public event PropertyChangedEventHandler PropertyChanged;
+        public event PropertyChangingEventHandler? PropertyChanging;
+        public event PropertyChangedEventHandler? PropertyChanged;
 #pragma warning restore 67
     }
 
@@ -3405,24 +3405,24 @@ public partial class EntityTypeTest
     private class ChangedOnlyEntity : INotifyPropertyChanged
     {
         public int Id { get; set; }
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
 
 #pragma warning disable 67
-        public event PropertyChangedEventHandler PropertyChanged;
+        public event PropertyChangedEventHandler? PropertyChanged;
 #pragma warning restore 67
     }
 
     private class SelfRef
     {
-        public static readonly PropertyInfo IdProperty = typeof(SelfRef).GetProperty("Id");
-        public static readonly PropertyInfo ForeignKeyProperty = typeof(SelfRef).GetProperty("ForeignKey");
-        public static readonly PropertyInfo SelfRef1Property = typeof(SelfRef).GetProperty(nameof(SelfRef1));
-        public static readonly PropertyInfo SelfRef2Property = typeof(SelfRef).GetProperty(nameof(SelfRef2));
-        public static readonly PropertyInfo SelfRefIdProperty = typeof(SelfRef).GetProperty("SelfRefId");
+        public static readonly PropertyInfo IdProperty = typeof(SelfRef).GetProperty("Id")!;
+        public static readonly PropertyInfo ForeignKeyProperty = typeof(SelfRef).GetProperty("ForeignKey")!;
+        public static readonly PropertyInfo SelfRef1Property = typeof(SelfRef).GetProperty(nameof(SelfRef1))!;
+        public static readonly PropertyInfo SelfRef2Property = typeof(SelfRef).GetProperty(nameof(SelfRef2))!;
+        public static readonly PropertyInfo SelfRefIdProperty = typeof(SelfRef).GetProperty("SelfRefId")!;
 
         public int Id { get; set; }
-        public SelfRef SelfRef1 { get; set; }
-        public SelfRef SelfRef2 { get; set; }
+        public SelfRef SelfRef1 { get; set; } = null!;
+        public SelfRef SelfRef2 { get; set; } = null!;
         public int? SelfRefId { get; set; }
         public int ForeignKey { get; set; }
     }

--- a/test/EFCore.Tests/Metadata/Internal/ForeignKeyTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/ForeignKeyTest.cs
@@ -43,11 +43,11 @@ public class ForeignKeyTest
 
         Assert.Equal(
             CoreStrings.ModelReadOnly,
-            Assert.Throws<InvalidOperationException>(() => foreignKey.SetDependentToPrincipal((string)null)).Message);
+            Assert.Throws<InvalidOperationException>(() => foreignKey.SetDependentToPrincipal((string?)null)).Message);
 
         Assert.Equal(
             CoreStrings.ModelReadOnly,
-            Assert.Throws<InvalidOperationException>(() => foreignKey.SetPrincipalToDependent((string)null)).Message);
+            Assert.Throws<InvalidOperationException>(() => foreignKey.SetPrincipalToDependent((string?)null)).Message);
 
         Assert.Equal(
             CoreStrings.ModelReadOnly,
@@ -58,12 +58,12 @@ public class ForeignKeyTest
     public void Can_create_foreign_key()
     {
         var entityType = (IConventionEntityType)CreateModel().AddEntityType("E");
-        var dependentProp = entityType.AddProperty("P", typeof(int));
-        var principalProp = entityType.AddProperty("Id", typeof(int));
+        var dependentProp = entityType.AddProperty("P", typeof(int))!;
+        var principalProp = entityType.AddProperty("Id", typeof(int))!;
         entityType.SetPrimaryKey(principalProp);
 
         var foreignKey = entityType.AddForeignKey(
-            [dependentProp], entityType.FindPrimaryKey(), entityType);
+            [dependentProp], entityType.FindPrimaryKey()!, entityType)!;
         foreignKey.SetIsUnique(true);
 
         Assert.Same(entityType, foreignKey.PrincipalEntityType);
@@ -87,7 +87,7 @@ public class ForeignKeyTest
         var dependentEntityType = model.AddEntityType("D");
         var fk = dependentEntityType.AddProperty("Fk", typeof(int));
 
-        var principalKey = dependentEntityType.SetPrimaryKey(fk);
+        var principalKey = dependentEntityType.SetPrimaryKey(fk)!;
 
         Assert.Equal(
             CoreStrings.ForeignKeyReferencedEntityKeyMismatch("{'Fk'}", "R (Dictionary<string, object>)"),
@@ -112,7 +112,7 @@ public class ForeignKeyTest
             CoreStrings.ForeignKeyCountMismatch(
                 "{'P1', 'P2'}", "D (Dictionary<string, object>)", "{'Id'}", "P (Dictionary<string, object>)"),
             Assert.Throws<InvalidOperationException>(() => dependentEntityType.AddForeignKey(
-                    [dependentProperty1, dependentProperty2], principalEntityType.FindPrimaryKey(), principalEntityType))
+                    [dependentProperty1, dependentProperty2], principalEntityType.FindPrimaryKey()!, principalEntityType))
                 .Message);
     }
 
@@ -135,7 +135,7 @@ public class ForeignKeyTest
                 "{'P1' : int, 'P2' : string}", "D (Dictionary<string, object>)", "{'Id1' : int, 'Id2' : int}",
                 "P (Dictionary<string, object>)"),
             Assert.Throws<InvalidOperationException>(() => dependentEntityType.AddForeignKey(
-                    [dependentProperty1, dependentProperty2], principalEntityType.FindPrimaryKey(), principalEntityType))
+                    [dependentProperty1, dependentProperty2], principalEntityType.FindPrimaryKey()!, principalEntityType))
                 .Message);
     }
 
@@ -167,7 +167,7 @@ public class ForeignKeyTest
         entityType.SetPrimaryKey(property);
         var dependentProp = entityType.AddProperty("P", typeof(int));
 
-        var foreignKey = entityType.AddForeignKey([dependentProp], entityType.FindPrimaryKey(), entityType);
+        var foreignKey = entityType.AddForeignKey([dependentProp], entityType.FindPrimaryKey()!, entityType);
 
         Assert.False(dependentProp.IsNullable);
         Assert.True(foreignKey.IsRequired);
@@ -182,7 +182,7 @@ public class ForeignKeyTest
         entityType.SetPrimaryKey(property);
         var dependentProp = entityType.AddProperty("P", typeof(int?));
 
-        var foreignKey = entityType.AddForeignKey([dependentProp], entityType.FindPrimaryKey(), entityType);
+        var foreignKey = entityType.AddForeignKey([dependentProp], entityType.FindPrimaryKey()!, entityType);
 
         Assert.True(dependentProp.IsNullable);
         Assert.False(foreignKey.IsRequired);
@@ -202,7 +202,7 @@ public class ForeignKeyTest
         var dependentProp1 = entityType.AddProperty("P1", typeof(int));
         var dependentProp2 = entityType.AddProperty("P2", typeof(string));
 
-        var foreignKey = entityType.AddForeignKey([dependentProp1, dependentProp2], entityType.FindPrimaryKey(), entityType);
+        var foreignKey = entityType.AddForeignKey([dependentProp1, dependentProp2], entityType.FindPrimaryKey()!, entityType);
 
         Assert.False(foreignKey.IsRequired);
 
@@ -224,7 +224,7 @@ public class ForeignKeyTest
         var dependentProp1 = entityType.AddProperty("P1", typeof(int));
         var dependentProp2 = entityType.AddProperty("P2", typeof(string));
 
-        var foreignKey = entityType.AddForeignKey([dependentProp1, dependentProp2], entityType.FindPrimaryKey(), entityType);
+        var foreignKey = entityType.AddForeignKey([dependentProp1, dependentProp2], entityType.FindPrimaryKey()!, entityType);
         foreignKey.IsRequired = true;
 
         Assert.True(foreignKey.IsRequired);
@@ -247,7 +247,7 @@ public class ForeignKeyTest
         var dependentProp2 = entityType.AddProperty("P2", typeof(string));
         dependentProp2.IsNullable = false;
 
-        var foreignKey = entityType.AddForeignKey([dependentProp1, dependentProp2], entityType.FindPrimaryKey(), entityType);
+        var foreignKey = entityType.AddForeignKey([dependentProp1, dependentProp2], entityType.FindPrimaryKey()!, entityType);
         foreignKey.IsRequired = false;
 
         Assert.False(foreignKey.IsRequired);
@@ -272,7 +272,7 @@ public class ForeignKeyTest
         var model = CreateModel();
         var principalEntityType = model.AddEntityType(typeof(OneToManyPrincipal));
         var property = principalEntityType.AddProperty(NavigationBase.IdProperty);
-        var pk = principalEntityType.SetPrimaryKey(property);
+        var pk = principalEntityType.SetPrimaryKey(property)!;
 
         var dependentEntityType = model.AddEntityType(typeof(OneToManyDependent));
         var fkProp = dependentEntityType.AddProperty(NavigationBase.IdProperty);
@@ -288,7 +288,7 @@ public class ForeignKeyTest
 
         var baseEntityType = model.AddEntityType(typeof(NavigationBase));
         var property1 = baseEntityType.AddProperty(NavigationBase.IdProperty);
-        var pk = baseEntityType.SetPrimaryKey(property1);
+        var pk = baseEntityType.SetPrimaryKey(property1)!;
 
         var principalEntityType = model.AddEntityType(typeof(OneToManyPrincipal));
         principalEntityType.BaseType = baseEntityType;
@@ -307,7 +307,7 @@ public class ForeignKeyTest
 
         var baseEntityType = model.AddEntityType(typeof(NavigationBase));
         var property1 = baseEntityType.AddProperty(NavigationBase.IdProperty);
-        var pk = baseEntityType.SetPrimaryKey(property1);
+        var pk = baseEntityType.SetPrimaryKey(property1)!;
 
         var dependentEntityType = model.AddEntityType(typeof(OneToManyDependent));
         dependentEntityType.BaseType = baseEntityType;
@@ -318,30 +318,30 @@ public class ForeignKeyTest
 
     public abstract class NavigationBase
     {
-        public static readonly PropertyInfo IdProperty = typeof(NavigationBase).GetProperty(nameof(Id));
+        public static readonly PropertyInfo IdProperty = typeof(NavigationBase).GetProperty(nameof(Id))!;
 
         public static readonly PropertyInfo OneToManyDependentsProperty =
-            typeof(NavigationBase).GetProperty(nameof(OneToManyDependents));
+            typeof(NavigationBase).GetProperty(nameof(OneToManyDependents))!;
 
-        public static readonly PropertyInfo OneToManyPrincipalProperty = typeof(NavigationBase).GetProperty(nameof(OneToManyPrincipal));
+        public static readonly PropertyInfo OneToManyPrincipalProperty = typeof(NavigationBase).GetProperty(nameof(OneToManyPrincipal))!;
 
         public int Id { get; set; }
-        public IEnumerable<OneToManyDependent> OneToManyDependents { get; set; }
-        public OneToManyPrincipal OneToManyPrincipal { get; set; }
+        public IEnumerable<OneToManyDependent> OneToManyDependents { get; set; } = null!;
+        public OneToManyPrincipal OneToManyPrincipal { get; set; } = null!;
     }
 
     public class OneToManyPrincipal : NavigationBase
     {
-        public IEnumerable<OneToManyDependent> Deception { get; set; }
+        public IEnumerable<OneToManyDependent> Deception { get; set; } = null!;
     }
 
     public class DerivedOneToManyPrincipal : OneToManyPrincipal;
 
     public class OneToManyDependent : NavigationBase
     {
-        public static readonly PropertyInfo DeceptionProperty = typeof(OneToManyDependent).GetProperty(nameof(Deception));
+        public static readonly PropertyInfo DeceptionProperty = typeof(OneToManyDependent).GetProperty(nameof(Deception))!;
 
-        public OneToManyPrincipal Deception { get; set; }
+        public OneToManyPrincipal Deception { get; set; } = null!;
     }
 
     public class DerivedOneToManyDependent : OneToManyDependent;
@@ -355,7 +355,7 @@ public class ForeignKeyTest
         var newFkProp = foreignKey1.DeclaringEntityType.AddProperty("FkProp", typeof(int));
         var foreignKey2 = foreignKey1.DeclaringEntityType.AddForeignKey(
             [newFkProp],
-            foreignKey1.PrincipalEntityType.FindPrimaryKey(),
+            foreignKey1.PrincipalEntityType.FindPrimaryKey()!,
             foreignKey1.PrincipalEntityType);
 
         Assert.Equal(
@@ -377,7 +377,7 @@ public class ForeignKeyTest
         var newFkProp = foreignKey1.DeclaringEntityType.AddProperty("FkProp", typeof(int));
         var foreignKey2 = foreignKey1.DeclaringEntityType.AddForeignKey(
             [newFkProp],
-            foreignKey1.PrincipalEntityType.FindPrimaryKey(),
+            foreignKey1.PrincipalEntityType.FindPrimaryKey()!,
             foreignKey1.PrincipalEntityType);
 
         Assert.Equal(
@@ -408,7 +408,7 @@ public class ForeignKeyTest
     public void IsUnique_throws_for_incompatible_required_dependent()
     {
         var foreignKey = CreateOneToManyFK();
-        foreignKey.SetPrincipalToDependent((string)null);
+        foreignKey.SetPrincipalToDependent((string?)null);
         foreignKey.IsUnique = true;
         foreignKey.IsRequiredDependent = true;
 
@@ -422,7 +422,7 @@ public class ForeignKeyTest
     private IMutableForeignKey CreateSelfRefFK(bool useAltKey = false)
     {
         var entityType = CreateModel().AddEntityType(typeof(SelfRef));
-        var pk = entityType.SetPrimaryKey(entityType.AddProperty(SelfRef.IdProperty));
+        var pk = entityType.SetPrimaryKey(entityType.AddProperty(SelfRef.IdProperty))!;
 
         var property = entityType.AddProperty("AltId", typeof(int));
         var principalKey = useAltKey
@@ -438,14 +438,14 @@ public class ForeignKeyTest
 
     private class SelfRef
     {
-        public static readonly PropertyInfo IdProperty = typeof(SelfRef).GetProperty("Id");
-        public static readonly PropertyInfo SelfRefIdProperty = typeof(SelfRef).GetProperty(nameof(SelfRefId));
-        public static readonly PropertyInfo SelfRefPrincipalProperty = typeof(SelfRef).GetProperty(nameof(SelfRefPrincipal));
-        public static readonly PropertyInfo SelfRefDependentProperty = typeof(SelfRef).GetProperty(nameof(SelfRefDependent));
+        public static readonly PropertyInfo IdProperty = typeof(SelfRef).GetProperty("Id")!;
+        public static readonly PropertyInfo SelfRefIdProperty = typeof(SelfRef).GetProperty(nameof(SelfRefId))!;
+        public static readonly PropertyInfo SelfRefPrincipalProperty = typeof(SelfRef).GetProperty(nameof(SelfRefPrincipal))!;
+        public static readonly PropertyInfo SelfRefDependentProperty = typeof(SelfRef).GetProperty(nameof(SelfRefDependent))!;
 
         public int Id { get; set; }
-        public SelfRef SelfRefPrincipal { get; set; }
-        public SelfRef SelfRefDependent { get; set; }
+        public SelfRef SelfRefPrincipal { get; set; } = null!;
+        public SelfRef SelfRefDependent { get; set; } = null!;
         public int? SelfRefId { get; set; }
     }
 
@@ -584,7 +584,7 @@ public class ForeignKeyTest
                 "S",
                 "E (Dictionary<string, object>)",
                 "E (Dictionary<string, object>)"),
-            Assert.Throws<InvalidOperationException>(() => foreignKey.SetPrincipalToDependent((string)null)).Message);
+            Assert.Throws<InvalidOperationException>(() => foreignKey.SetPrincipalToDependent((string?)null)).Message);
     }
 
     [Fact]
@@ -675,10 +675,18 @@ public class ForeignKeyTest
                 derivedDependent.DisplayName(), fk.DeclaringEntityType.DisplayName(), fk.PrincipalEntityType.DisplayName()),
             Assert.Throws<InvalidOperationException>(() => fk.FindNavigationsTo(derivedDependent)).Message);
 
-        Assert.Equal(new[] { fk.PrincipalToDependent }.Where(n => n != null), fk.FindNavigationsFromInHierarchy(derivedPrincipal));
-        Assert.Equal(new[] { fk.DependentToPrincipal }.Where(n => n != null), fk.FindNavigationsFromInHierarchy(derivedDependent));
-        Assert.Equal(new[] { fk.DependentToPrincipal }.Where(n => n != null), fk.FindNavigationsToInHierarchy(derivedPrincipal));
-        Assert.Equal(new[] { fk.PrincipalToDependent }.Where(n => n != null), fk.FindNavigationsToInHierarchy(derivedDependent));
+        Assert.Equal(
+            new[] { fk.PrincipalToDependent! }.Where(n => n != null), fk.FindNavigationsFromInHierarchy(derivedPrincipal));
+        Assert.Equal(
+            new[] { fk.DependentToPrincipal! }.Where(n => n != null), fk.FindNavigationsFromInHierarchy(derivedDependent));
+        Assert.Equal(
+            new[] { fk.DependentToPrincipal! }.Where(n => n != null), fk.FindNavigationsToInHierarchy(derivedPrincipal));
+        Assert.Equal(
+            new[] { fk.PrincipalToDependent! }.Where(n => n != null), fk.FindNavigationsToInHierarchy(derivedDependent));
+        Assert.Equal(new[] { fk.PrincipalToDependent }.OfType<Navigation>(), fk.FindNavigationsFromInHierarchy(derivedPrincipal));
+        Assert.Equal(new[] { fk.DependentToPrincipal }.OfType<Navigation>(), fk.FindNavigationsFromInHierarchy(derivedDependent));
+        Assert.Equal(new[] { fk.DependentToPrincipal }.OfType<Navigation>(), fk.FindNavigationsToInHierarchy(derivedPrincipal));
+        Assert.Equal(new[] { fk.PrincipalToDependent }.OfType<Navigation>(), fk.FindNavigationsToInHierarchy(derivedDependent));
     }
 
     [Fact]
@@ -690,29 +698,29 @@ public class ForeignKeyTest
         Assert.Same(fk.DeclaringEntityType, fk.GetRelatedEntityType(fk.PrincipalEntityType));
 
         Assert.Equal(
-            [fk.PrincipalToDependent, fk.DependentToPrincipal],
+            [fk.PrincipalToDependent!, fk.DependentToPrincipal!],
             fk.FindNavigationsFrom(fk.PrincipalEntityType).ToArray());
         Assert.Equal(
-            [fk.PrincipalToDependent, fk.DependentToPrincipal],
+            [fk.PrincipalToDependent!, fk.DependentToPrincipal!],
             fk.FindNavigationsFrom(fk.DeclaringEntityType).ToArray());
         Assert.Equal(
-            [fk.PrincipalToDependent, fk.DependentToPrincipal],
+            [fk.PrincipalToDependent!, fk.DependentToPrincipal!],
             fk.FindNavigationsTo(fk.PrincipalEntityType).ToArray());
         Assert.Equal(
-            [fk.PrincipalToDependent, fk.DependentToPrincipal],
+            [fk.PrincipalToDependent!, fk.DependentToPrincipal!],
             fk.FindNavigationsTo(fk.DeclaringEntityType).ToArray());
 
         Assert.Equal(
-            [fk.PrincipalToDependent, fk.DependentToPrincipal],
+            [fk.PrincipalToDependent!, fk.DependentToPrincipal!],
             fk.FindNavigationsFromInHierarchy(fk.PrincipalEntityType).ToArray());
         Assert.Equal(
-            [fk.PrincipalToDependent, fk.DependentToPrincipal],
+            [fk.PrincipalToDependent!, fk.DependentToPrincipal!],
             fk.FindNavigationsFromInHierarchy(fk.DeclaringEntityType).ToArray());
         Assert.Equal(
-            [fk.PrincipalToDependent, fk.DependentToPrincipal],
+            [fk.PrincipalToDependent!, fk.DependentToPrincipal!],
             fk.FindNavigationsToInHierarchy(fk.PrincipalEntityType).ToArray());
         Assert.Equal(
-            [fk.PrincipalToDependent, fk.DependentToPrincipal],
+            [fk.PrincipalToDependent!, fk.DependentToPrincipal!],
             fk.FindNavigationsToInHierarchy(fk.DeclaringEntityType).ToArray());
     }
 
@@ -729,16 +737,28 @@ public class ForeignKeyTest
         Assert.Same(fk.PrincipalToDependent, fk.FindNavigationsTo(fk.DeclaringEntityType).SingleOrDefault());
 
         Assert.Equal(
-            new[] { fk.PrincipalToDependent, fk.DependentToPrincipal }.Where(n => n != null),
+            new[] { fk.PrincipalToDependent!, fk.DependentToPrincipal! }.Where(n => n != null),
             fk.FindNavigationsFromInHierarchy(fk.PrincipalEntityType));
         Assert.Equal(
-            new[] { fk.PrincipalToDependent, fk.DependentToPrincipal }.Where(n => n != null),
+            new[] { fk.PrincipalToDependent, fk.DependentToPrincipal }.OfType<Navigation>(),
+            fk.FindNavigationsFromInHierarchy(fk.PrincipalEntityType));
+        Assert.Equal(
+            new[] { fk.PrincipalToDependent!, fk.DependentToPrincipal! }.Where(n => n != null),
             fk.FindNavigationsFromInHierarchy(fk.DeclaringEntityType));
         Assert.Equal(
-            new[] { fk.PrincipalToDependent, fk.DependentToPrincipal }.Where(n => n != null),
+            new[] { fk.PrincipalToDependent, fk.DependentToPrincipal }.OfType<Navigation>(),
+            fk.FindNavigationsFromInHierarchy(fk.DeclaringEntityType));
+        Assert.Equal(
+            new[] { fk.PrincipalToDependent!, fk.DependentToPrincipal! }.Where(n => n != null),
             fk.FindNavigationsToInHierarchy(fk.PrincipalEntityType));
         Assert.Equal(
-            new[] { fk.PrincipalToDependent, fk.DependentToPrincipal }.Where(n => n != null),
+            new[] { fk.PrincipalToDependent, fk.DependentToPrincipal }.OfType<Navigation>(),
+            fk.FindNavigationsToInHierarchy(fk.PrincipalEntityType));
+        Assert.Equal(
+            new[] { fk.PrincipalToDependent!, fk.DependentToPrincipal! }.Where(n => n != null),
+            fk.FindNavigationsToInHierarchy(fk.DeclaringEntityType));
+        Assert.Equal(
+            new[] { fk.PrincipalToDependent, fk.DependentToPrincipal }.OfType<Navigation>(),
             fk.FindNavigationsToInHierarchy(fk.DeclaringEntityType));
     }
 
@@ -798,10 +818,10 @@ public class ForeignKeyTest
     public void IsConstrained_defaults_to_true()
     {
         var entityType = (IConventionEntityType)CreateModel().AddEntityType("E");
-        var dependentProp = entityType.AddProperty("P", typeof(int));
-        var principalProp = entityType.AddProperty("Id", typeof(int));
+        var dependentProp = entityType.AddProperty("P", typeof(int))!;
+        var principalProp = entityType.AddProperty("Id", typeof(int))!;
         entityType.SetPrimaryKey(principalProp);
-        var foreignKey = entityType.AddForeignKey([dependentProp], entityType.FindPrimaryKey(), entityType);
+        var foreignKey = entityType.AddForeignKey([dependentProp], entityType.FindPrimaryKey()!, entityType)!;
 
         Assert.True(foreignKey.IsConstrained);
         Assert.Null(foreignKey.GetIsConstrainedConfigurationSource());
@@ -811,10 +831,10 @@ public class ForeignKeyTest
     public void Can_set_and_reset_IsConstrained()
     {
         var entityType = (IConventionEntityType)CreateModel().AddEntityType("E");
-        var dependentProp = entityType.AddProperty("P", typeof(int));
-        var principalProp = entityType.AddProperty("Id", typeof(int));
+        var dependentProp = entityType.AddProperty("P", typeof(int))!;
+        var principalProp = entityType.AddProperty("Id", typeof(int))!;
         entityType.SetPrimaryKey(principalProp);
-        var foreignKey = entityType.AddForeignKey([dependentProp], entityType.FindPrimaryKey(), entityType);
+        var foreignKey = entityType.AddForeignKey([dependentProp], entityType.FindPrimaryKey()!, entityType)!;
 
         foreignKey.SetIsConstrained(false);
 

--- a/test/EFCore.Tests/Metadata/Internal/IndexTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/IndexTest.cs
@@ -35,11 +35,11 @@ public class IndexTest
     [Fact]
     public void Gets_expected_default_values()
     {
-        var entityType = ((IConventionModel)CreateModel()).AddEntityType(typeof(Customer));
-        var property1 = entityType.AddProperty(Customer.IdProperty);
-        var property2 = entityType.AddProperty(Customer.NameProperty);
+        var entityType = ((IConventionModel)CreateModel()).AddEntityType(typeof(Customer))!;
+        var property1 = entityType.AddProperty(Customer.IdProperty)!;
+        var property2 = entityType.AddProperty(Customer.NameProperty)!;
 
-        var index = entityType.AddIndex([property1, property2]);
+        var index = entityType.AddIndex([property1, property2])!;
 
         Assert.True(new[] { property1, property2 }.SequenceEqual(index.Properties));
         Assert.False(index.IsUnique);
@@ -107,16 +107,16 @@ public class IndexTest
 
     private class Customer
     {
-        public static readonly PropertyInfo IdProperty = typeof(Customer).GetProperty("Id");
-        public static readonly PropertyInfo NameProperty = typeof(Customer).GetProperty("Name");
+        public static readonly PropertyInfo IdProperty = typeof(Customer).GetProperty("Id")!;
+        public static readonly PropertyInfo NameProperty = typeof(Customer).GetProperty("Name")!;
 
         public int Id { get; set; }
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
     }
 
     private class Order
     {
-        public static readonly PropertyInfo IdProperty = typeof(Order).GetProperty("Id");
+        public static readonly PropertyInfo IdProperty = typeof(Order).GetProperty("Id")!;
 
         public int Id { get; set; }
     }
@@ -124,27 +124,27 @@ public class IndexTest
     private sealed class Blog
     {
         public int Id { get; set; }
-        public string Title { get; set; }
+        public string Title { get; set; } = null!;
         public List<Post> Posts { get; set; } = [];
-        public Address Owner { get; set; }
+        public Address Owner { get; set; } = null!;
     }
 
     private sealed class Post
     {
-        public string Title { get; set; }
+        public string Title { get; set; } = null!;
         public int Rating { get; set; }
         public List<Comment> Comments { get; } = [];
     }
 
     private sealed class Comment
     {
-        public string Text { get; set; }
+        public string Text { get; set; } = null!;
     }
 
     private sealed class Address
     {
-        public string City { get; set; }
-        public string Country { get; set; }
+        public string City { get; set; } = null!;
+        public string Country { get; set; } = null!;
     }
 
     private static ModelBuilder CreateComplexModelBuilder()
@@ -527,7 +527,7 @@ public class IndexTest
         var entityType = (EntityType)modelBuilder.Model.FindEntityType(typeof(Blog))!;
         var titleProp = (PropertyBase)entityType.FindComplexProperty("Posts")!.ComplexType.FindProperty("Title")!;
 
-        var original = entityType.AddIndex([titleProp], [[5]], "IX_Reattach", ConfigurationSource.Explicit);
+        var original = entityType.AddIndex([titleProp], [[5]], "IX_Reattach", ConfigurationSource.Explicit)!;
         original.SetIsUnique(true, ConfigurationSource.Explicit);
 
         var detached = InternalEntityTypeBuilder.DetachIndex(original);
@@ -552,7 +552,7 @@ public class IndexTest
         var entityType = (EntityType)modelBuilder.Model.FindEntityType(typeof(Blog))!;
         var titleProp = (PropertyBase)entityType.FindComplexProperty("Posts")!.ComplexType.FindProperty("Title")!;
 
-        var original = entityType.AddIndex([titleProp], [[null]], ConfigurationSource.Explicit);
+        var original = entityType.AddIndex([titleProp], [[null]], ConfigurationSource.Explicit)!;
 
         var detached = InternalEntityTypeBuilder.DetachIndex(original);
         Assert.Null(entityType.FindIndex([titleProp], [[null]]));
@@ -575,7 +575,7 @@ public class IndexTest
         var textProp = (PropertyBase)entityType.FindComplexProperty("Posts")!.ComplexType
             .FindComplexProperty("Comments")!.ComplexType.FindProperty("Text")!;
 
-        var original = entityType.AddIndex([textProp], [[0, 1]], "IX_NestedReattach", ConfigurationSource.Explicit);
+        var original = entityType.AddIndex([textProp], [[0, 1]], "IX_NestedReattach", ConfigurationSource.Explicit)!;
 
         var detached = InternalEntityTypeBuilder.DetachIndex(original);
         var reattached = detached.Attach(entityType.Builder);
@@ -599,7 +599,7 @@ public class IndexTest
         var entityType = (EntityType)modelBuilder.Model.FindEntityType(typeof(Blog))!;
         var postsProp = (PropertyBase)entityType.FindComplexProperty("Posts")!;
 
-        var original = entityType.AddIndex([postsProp], [[7]], "IX_LeafCollectionReattach", ConfigurationSource.Explicit);
+        var original = entityType.AddIndex([postsProp], [[7]], "IX_LeafCollectionReattach", ConfigurationSource.Explicit)!;
 
         var detached = InternalEntityTypeBuilder.DetachIndex(original);
         var reattached = detached.Attach(entityType.Builder);
@@ -622,7 +622,7 @@ public class IndexTest
         var entityType = (EntityType)modelBuilder.Model.FindEntityType(typeof(Blog))!;
         var postsProp = (PropertyBase)entityType.FindComplexProperty("Posts")!;
 
-        var original = entityType.AddIndex([postsProp], [[null]], ConfigurationSource.Explicit);
+        var original = entityType.AddIndex([postsProp], [[null]], ConfigurationSource.Explicit)!;
 
         var detached = InternalEntityTypeBuilder.DetachIndex(original);
         var reattached = detached.Attach(entityType.Builder);

--- a/test/EFCore.Tests/Metadata/Internal/InternalEntityTypeBuilderTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/InternalEntityTypeBuilderTest.cs
@@ -22,21 +22,21 @@ public class InternalEntityTypeBuilderTest
         var dependentEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
 
         var relationshipBuilder = dependentEntityBuilder.HasRelationship(principalEntityBuilder.Metadata, ConfigurationSource.Explicit)
-            .HasNavigation(
+            !.HasNavigation(
                 Order.CustomerProperty.Name,
                 pointsToPrincipal: true,
-                ConfigurationSource.Explicit).HasNavigation(
+                ConfigurationSource.Explicit)!.HasNavigation(
                 Customer.OrdersProperty.Name,
                 pointsToPrincipal: false,
-                ConfigurationSource.Explicit);
+                ConfigurationSource.Explicit)!;
 
         Assert.NotNull(relationshipBuilder);
         Assert.Same(
             relationshipBuilder,
-            dependentEntityBuilder.HasRelationship(principalEntityBuilder.Metadata, ConfigurationSource.Convention).HasNavigation(
+            dependentEntityBuilder.HasRelationship(principalEntityBuilder.Metadata, ConfigurationSource.Convention)!.HasNavigation(
                 Order.CustomerProperty.Name,
                 pointsToPrincipal: true,
-                ConfigurationSource.Convention).HasNavigation(
+                ConfigurationSource.Convention)!.HasNavigation(
                 Customer.OrdersProperty.Name,
                 pointsToPrincipal: false,
                 ConfigurationSource.Convention));
@@ -53,7 +53,7 @@ public class InternalEntityTypeBuilderTest
             principalEntityBuilder.Metadata,
             null,
             Customer.OrdersProperty.Name,
-            ConfigurationSource.DataAnnotation);
+            ConfigurationSource.DataAnnotation)!;
 
         Assert.NotNull(relationshipBuilder);
         var pkProperty = relationshipBuilder.Metadata.PrincipalKey.Properties.Single();
@@ -93,9 +93,9 @@ public class InternalEntityTypeBuilderTest
 
         var relationshipBuilder = dependentEntityBuilder.HasRelationship(
             principalEntityBuilder.Metadata,
-            (string)null,
+            (string?)null,
             null,
-            ConfigurationSource.DataAnnotation);
+            ConfigurationSource.DataAnnotation)!;
 
         Assert.NotNull(relationshipBuilder);
         var pkProperty = relationshipBuilder.Metadata.PrincipalKey.Properties.Single();
@@ -120,7 +120,7 @@ public class InternalEntityTypeBuilderTest
             principalEntityBuilder.Metadata,
             nameof(Order.Customer),
             null,
-            ConfigurationSource.DataAnnotation);
+            ConfigurationSource.DataAnnotation)!;
 
         Assert.NotNull(relationshipBuilder);
         var pkProperty = relationshipBuilder.Metadata.PrincipalKey.Properties.Single();
@@ -171,23 +171,23 @@ public class InternalEntityTypeBuilderTest
         var dependentEntityBuilder = modelBuilder.Entity("Value", ConfigurationSource.Explicit);
 
         var relationshipBuilder = dependentEntityBuilder.HasRelationship(principalEntityBuilder.Metadata, ConfigurationSource.Explicit)
-            .HasNavigation(
+            !.HasNavigation(
                 "Count",
                 pointsToPrincipal: true,
                 ConfigurationSource.Explicit)
-            .HasNavigation(
+            !.HasNavigation(
                 "Values",
                 pointsToPrincipal: false,
-                ConfigurationSource.Explicit);
+                ConfigurationSource.Explicit)!;
 
         var fk = relationshipBuilder.Metadata;
-        Assert.Same(dependentEntityBuilder.Metadata.FindIndexerPropertyInfo(), fk.DependentToPrincipal.PropertyInfo);
-        Assert.Same(principalEntityBuilder.Metadata.FindIndexerPropertyInfo(), fk.PrincipalToDependent.PropertyInfo);
+        Assert.Same(dependentEntityBuilder.Metadata.FindIndexerPropertyInfo(), fk.DependentToPrincipal!.PropertyInfo);
+        Assert.Same(principalEntityBuilder.Metadata.FindIndexerPropertyInfo(), fk.PrincipalToDependent!.PropertyInfo);
 
         var skipNavigationBuilder = principalEntityBuilder.HasSkipNavigation(
             MemberIdentity.Create("Keys"),
             dependentEntityBuilder.Metadata,
-            ConfigurationSource.Explicit);
+            ConfigurationSource.Explicit)!;
 
         Assert.Same(dependentEntityBuilder.Metadata.FindIndexerPropertyInfo(), skipNavigationBuilder.Metadata.PropertyInfo);
     }
@@ -203,9 +203,9 @@ public class InternalEntityTypeBuilderTest
         var relationshipBuilder = orderEntityBuilder.HasRelationship(
             customerEntityBuilder.Metadata.Name,
             ["ShadowCustomerId"],
-            ConfigurationSource.Convention);
+            ConfigurationSource.Convention)!;
 
-        var shadowProperty = orderEntityBuilder.Metadata.FindProperty("ShadowCustomerId");
+        var shadowProperty = orderEntityBuilder.Metadata.FindProperty("ShadowCustomerId")!;
         Assert.NotNull(shadowProperty);
         Assert.True(shadowProperty.IsShadowProperty());
         Assert.Equal(shadowProperty, relationshipBuilder.Metadata.Properties.First());
@@ -219,9 +219,9 @@ public class InternalEntityTypeBuilderTest
         var orderEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
 
         var relationshipBuilder = orderEntityBuilder.HasRelationship(
-            customerEntityBuilder.Metadata.Name, ["ShadowCustomerId"], ConfigurationSource.Convention);
+            customerEntityBuilder.Metadata.Name, ["ShadowCustomerId"], ConfigurationSource.Convention)!;
 
-        var shadowProperty = orderEntityBuilder.Metadata.FindProperty("ShadowCustomerId");
+        var shadowProperty = orderEntityBuilder.Metadata.FindProperty("ShadowCustomerId")!;
         Assert.True(shadowProperty.IsShadowProperty());
         Assert.Equal(shadowProperty, relationshipBuilder.Metadata.Properties.First());
 
@@ -260,9 +260,9 @@ public class InternalEntityTypeBuilderTest
         var relationshipBuilder = orderEntityBuilder.HasRelationship(
             customerEntityBuilder.Metadata.Name,
             ["ShadowCustomerId"],
-            ConfigurationSource.Convention);
+            ConfigurationSource.Convention)!;
 
-        var shadowProperty = orderEntityBuilder.Metadata.FindProperty("ShadowCustomerId");
+        var shadowProperty = orderEntityBuilder.Metadata.FindProperty("ShadowCustomerId")!;
         Assert.NotNull(shadowProperty);
         Assert.True(shadowProperty.IsShadowProperty());
         Assert.Equal(shadowProperty, relationshipBuilder.Metadata.Properties.First());
@@ -273,7 +273,7 @@ public class InternalEntityTypeBuilderTest
     {
         var modelBuilder = CreateModelBuilder();
         var principalEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
-        var primaryKey = principalEntityBuilder.PrimaryKey([nameof(Customer.Id)], ConfigurationSource.Convention).Metadata;
+        var primaryKey = principalEntityBuilder.PrimaryKey([nameof(Customer.Id)], ConfigurationSource.Convention)!.Metadata;
         var entityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
         var derivedEntityBuilder = modelBuilder.Entity(typeof(SpecialOrder), ConfigurationSource.Convention);
         derivedEntityBuilder.HasBaseType(entityBuilder.Metadata, ConfigurationSource.Convention);
@@ -284,7 +284,7 @@ public class InternalEntityTypeBuilderTest
                     [Order.IdProperty.Name],
                     primaryKey,
                     ConfigurationSource.DataAnnotation)
-                .IsUnique(true, ConfigurationSource.DataAnnotation));
+                !.IsUnique(true, ConfigurationSource.DataAnnotation));
 
         entityBuilder.HasRelationship(
             principalEntityBuilder.Metadata.Name,
@@ -298,7 +298,7 @@ public class InternalEntityTypeBuilderTest
             principalEntityBuilder.Metadata.Name,
             [Order.IdProperty.Name],
             primaryKey,
-            ConfigurationSource.Convention);
+            ConfigurationSource.Convention)!;
 
         Assert.Single(entityBuilder.Metadata.GetForeignKeys());
         Assert.Empty(derivedEntityBuilder.Metadata.GetDeclaredForeignKeys());
@@ -311,7 +311,7 @@ public class InternalEntityTypeBuilderTest
     {
         var modelBuilder = CreateModelBuilder();
         var principalEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
-        var principalKey = principalEntityBuilder.HasKey([Customer.IdProperty], ConfigurationSource.Explicit).Metadata;
+        var principalKey = principalEntityBuilder.HasKey([Customer.IdProperty], ConfigurationSource.Explicit)!.Metadata;
         var dependentEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
         dependentEntityBuilder.Property(typeof(int), Order.IdProperty.Name, ConfigurationSource.Convention);
         dependentEntityBuilder.HasRelationship(
@@ -327,16 +327,16 @@ public class InternalEntityTypeBuilderTest
             principalEntityBuilder.Metadata.Name,
             [Order.IdProperty.Name],
             principalKey,
-            ConfigurationSource.DataAnnotation);
+            ConfigurationSource.DataAnnotation)!;
 
         Assert.Same(derivedDependentEntityBuilder.Metadata.GetForeignKeys().Single(), relationshipBuilder.Metadata);
         Assert.Same(dependentEntityBuilder.Metadata, relationshipBuilder.Metadata.DeclaringEntityType);
 
-        relationshipBuilder = relationshipBuilder.IsUnique(true, ConfigurationSource.Convention);
+        relationshipBuilder = relationshipBuilder.IsUnique(true, ConfigurationSource.Convention)!;
         Assert.True(relationshipBuilder.Metadata.IsUnique);
         Assert.Null(
             relationshipBuilder.HasForeignKey(
-                [dependentEntityBuilder.Property(Order.CustomerIdProperty, ConfigurationSource.Convention).Metadata],
+                [dependentEntityBuilder.Property(Order.CustomerIdProperty, ConfigurationSource.Convention)!.Metadata],
                 ConfigurationSource.Convention));
     }
 
@@ -345,9 +345,9 @@ public class InternalEntityTypeBuilderTest
     {
         var modelBuilder = CreateModelBuilder();
         var principalEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
-        var primaryKey = principalEntityBuilder.PrimaryKey([Customer.IdProperty], ConfigurationSource.Convention).Metadata;
-        var shadowKeyProperty = principalEntityBuilder.Property(typeof(int), "ShadowId", ConfigurationSource.Convention);
-        var alternateKey = principalEntityBuilder.HasKey([shadowKeyProperty.Metadata.Name], ConfigurationSource.Convention)
+        var primaryKey = principalEntityBuilder.PrimaryKey([Customer.IdProperty], ConfigurationSource.Convention)!.Metadata;
+        var shadowKeyProperty = principalEntityBuilder.Property(typeof(int), "ShadowId", ConfigurationSource.Convention)!;
+        var alternateKey = principalEntityBuilder.HasKey([shadowKeyProperty.Metadata.Name], ConfigurationSource.Convention)!
             .Metadata;
         var dependentEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
         dependentEntityBuilder.Property(typeof(int), Order.IdProperty.Name, ConfigurationSource.Convention);
@@ -355,22 +355,22 @@ public class InternalEntityTypeBuilderTest
         var fk1 = dependentEntityBuilder.HasRelationship(
             principalEntityBuilder.Metadata.Name,
             [Order.IdProperty.Name],
-            ConfigurationSource.DataAnnotation).Metadata;
+            ConfigurationSource.DataAnnotation)!.Metadata;
         var newFk1 = dependentEntityBuilder.HasRelationship(
             principalEntityBuilder.Metadata.Name,
             [Order.IdProperty.Name],
             alternateKey,
-            ConfigurationSource.Explicit).Metadata;
+            ConfigurationSource.Explicit)!.Metadata;
 
         var fk2 = dependentEntityBuilder.HasRelationship(
             principalEntityBuilder.Metadata.Name,
             [Order.IdProperty.Name],
-            ConfigurationSource.DataAnnotation).Metadata;
+            ConfigurationSource.DataAnnotation)!.Metadata;
         var newFk2 = dependentEntityBuilder.HasRelationship(
             principalEntityBuilder.Metadata.Name,
             [Order.IdProperty.Name],
             primaryKey,
-            ConfigurationSource.Explicit).Metadata;
+            ConfigurationSource.Explicit)!.Metadata;
 
         Assert.NotSame(fk1, newFk1);
         Assert.Same(fk1, fk2);
@@ -404,7 +404,7 @@ public class InternalEntityTypeBuilderTest
             basePrincipalEntityBuilder.Metadata,
             Order.CustomerProperty.Name,
             Customer.OrdersProperty.Name,
-            ConfigurationSource.Convention);
+            ConfigurationSource.Convention)!;
 
         Assert.Same(relationship.Metadata, dependentEntityBuilder.Metadata.GetForeignKeys().Single());
         Assert.Same(relationship.Metadata, principalEntityBuilder.Metadata.GetNavigations().Single().ForeignKey);
@@ -442,11 +442,11 @@ public class InternalEntityTypeBuilderTest
             principalEntityBuilder.Metadata,
             Order.CustomerProperty.Name,
             null,
-            ConfigurationSource.DataAnnotation);
+            ConfigurationSource.DataAnnotation)!;
 
         Assert.Same(baseDependentEntityBuilder.Metadata, relationshipBuilder.Metadata.DeclaringEntityType);
         Assert.Null(relationshipBuilder.Metadata.PrincipalToDependent);
-        Assert.Equal(Order.CustomerProperty.Name, relationshipBuilder.Metadata.DependentToPrincipal.Name);
+        Assert.Equal(Order.CustomerProperty.Name, relationshipBuilder.Metadata.DependentToPrincipal!.Name);
         Assert.Empty(principalEntityBuilder.Metadata.GetNavigations());
         Assert.Same(relationshipBuilder.Metadata, dependentEntityBuilder.Metadata.GetForeignKeys().Single());
     }
@@ -460,8 +460,8 @@ public class InternalEntityTypeBuilderTest
 
         var relationshipBuilder = dependentEntityBuilder.HasRelationship(
             principalEntityBuilder.Metadata,
-            [dependentEntityBuilder.Property(Order.CustomerIdProperty, ConfigurationSource.Convention).Metadata],
-            ConfigurationSource.Convention);
+            [dependentEntityBuilder.Property(Order.CustomerIdProperty, ConfigurationSource.Convention)!.Metadata],
+            ConfigurationSource.Convention)!;
         Assert.NotNull(relationshipBuilder);
 
         Assert.Empty(dependentEntityBuilder.Metadata.GetIndexes());
@@ -486,7 +486,7 @@ public class InternalEntityTypeBuilderTest
             .HasRelationship(
                 customerEntityTypeBuilder.Metadata.Name,
                 [Order.IdProperty.Name, SpecialOrder.SpecialtyProperty.Name],
-                ConfigurationSource.DataAnnotation);
+                ConfigurationSource.DataAnnotation)!;
 
         Assert.Empty(entityBuilder.Metadata.GetForeignKeys());
         Assert.Same(derivedEntityBuilder.Metadata.GetDeclaredForeignKeys().Single(), relationshipBuilder.Metadata);
@@ -506,10 +506,10 @@ public class InternalEntityTypeBuilderTest
         var relationshipBuilder = dependentEntityBuilder.HasRelationship(
             principalEntityBuilder.Metadata,
             [
-                dependentEntityBuilder.Property(Order.CustomerIdProperty, ConfigurationSource.Convention).Metadata,
-                dependentEntityBuilder.Property(Order.CustomerUniqueProperty, ConfigurationSource.Convention).Metadata
+                dependentEntityBuilder.Property(Order.CustomerIdProperty, ConfigurationSource.Convention)!.Metadata,
+                dependentEntityBuilder.Property(Order.CustomerUniqueProperty, ConfigurationSource.Convention)!.Metadata
             ],
-            ConfigurationSource.DataAnnotation);
+            ConfigurationSource.DataAnnotation)!;
         Assert.NotNull(relationshipBuilder);
 
         Assert.Null(dependentEntityBuilder.HasNoRelationship(relationshipBuilder.Metadata, ConfigurationSource.Convention));
@@ -530,8 +530,8 @@ public class InternalEntityTypeBuilderTest
 
         var relationshipBuilder = dependentEntityBuilder.HasRelationship(
             principalEntityBuilder.Metadata,
-            [dependentEntityBuilder.Property(Order.CustomerIdProperty, ConfigurationSource.Convention).Metadata],
-            ConfigurationSource.DataAnnotation);
+            [dependentEntityBuilder.Property(Order.CustomerIdProperty, ConfigurationSource.Convention)!.Metadata],
+            ConfigurationSource.DataAnnotation)!;
         Assert.NotNull(relationshipBuilder);
 
         Assert.Equal(
@@ -549,15 +549,15 @@ public class InternalEntityTypeBuilderTest
         var modelBuilder = CreateModelBuilder();
         var principalEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
         var dependentEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
-        var shadowProperty = dependentEntityBuilder.Property(typeof(Guid), "Shadow", ConfigurationSource.Convention);
+        var shadowProperty = dependentEntityBuilder.Property(typeof(Guid), "Shadow", ConfigurationSource.Convention)!;
 
         var relationshipBuilder = dependentEntityBuilder.HasRelationship(
             principalEntityBuilder.Metadata,
             [
-                dependentEntityBuilder.Property(Order.CustomerIdProperty, ConfigurationSource.Convention).Metadata,
+                dependentEntityBuilder.Property(Order.CustomerIdProperty, ConfigurationSource.Convention)!.Metadata,
                 shadowProperty.Metadata
             ],
-            ConfigurationSource.Convention);
+            ConfigurationSource.Convention)!;
         Assert.NotNull(relationshipBuilder);
 
         Assert.NotNull(dependentEntityBuilder.HasNoRelationship(relationshipBuilder.Metadata, ConfigurationSource.DataAnnotation));
@@ -577,8 +577,8 @@ public class InternalEntityTypeBuilderTest
 
         Test_removing_relationship_does_not_remove_contained_shadow_properties_if_referenced_elsewhere((entityBuilder, property)
             => entityBuilder.HasRelationship(
-                typeof(Customer).FullName,
-                [entityBuilder.Property(typeof(int), "Shadow2", ConfigurationSource.Convention).Metadata.Name, property.Name],
+                typeof(Customer).FullName!,
+                [entityBuilder.Property(typeof(int), "Shadow2", ConfigurationSource.Convention)!.Metadata.Name, property.Name],
                 ConfigurationSource.Convention));
 
         Test_removing_relationship_does_not_remove_contained_shadow_properties_if_referenced_elsewhere((entityBuilder, property)
@@ -586,18 +586,18 @@ public class InternalEntityTypeBuilderTest
     }
 
     private void Test_removing_relationship_does_not_remove_contained_shadow_properties_if_referenced_elsewhere(
-        Func<InternalEntityTypeBuilder, Property, object> shadowConfig)
+        Func<InternalEntityTypeBuilder, Property, object?> shadowConfig)
     {
         var modelBuilder = CreateModelBuilder();
         var principalEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
         var dependentEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
-        var shadowProperty = dependentEntityBuilder.Property(typeof(Guid), "Shadow", ConfigurationSource.Convention);
+        var shadowProperty = dependentEntityBuilder.Property(typeof(Guid), "Shadow", ConfigurationSource.Convention)!;
         Assert.NotNull(shadowConfig(dependentEntityBuilder, shadowProperty.Metadata));
 
         var relationshipBuilder = dependentEntityBuilder.HasRelationship(
             principalEntityBuilder.Metadata,
             [
-                dependentEntityBuilder.Property(Order.CustomerIdProperty, ConfigurationSource.Convention).Metadata,
+                dependentEntityBuilder.Property(Order.CustomerIdProperty, ConfigurationSource.Convention)!.Metadata,
                 shadowProperty.Metadata
             ],
             ConfigurationSource.Convention);
@@ -617,7 +617,7 @@ public class InternalEntityTypeBuilderTest
         var modelBuilder = CreateModelBuilder();
         var entityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
 
-        var indexBuilder = entityBuilder.HasIndex([Order.IdProperty, Order.CustomerIdProperty], ConfigurationSource.Explicit);
+        var indexBuilder = entityBuilder.HasIndex([Order.IdProperty, Order.CustomerIdProperty], ConfigurationSource.Explicit)!;
 
         Assert.NotNull(indexBuilder);
         Assert.Same(
@@ -632,7 +632,7 @@ public class InternalEntityTypeBuilderTest
         var entityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
 
         var indexBuilder = entityBuilder.HasIndex(
-            [Order.IdProperty.Name, Order.CustomerIdProperty.Name], ConfigurationSource.Convention);
+            [Order.IdProperty.Name, Order.CustomerIdProperty.Name], ConfigurationSource.Convention)!;
 
         Assert.NotNull(indexBuilder);
         Assert.Same(
@@ -646,7 +646,7 @@ public class InternalEntityTypeBuilderTest
         var entityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
 
         var indexBuilder = entityBuilder.HasIndex(
-            [Order.IdProperty.Name, Order.CustomerIdProperty.Name], ConfigurationSource.Convention);
+            [Order.IdProperty.Name, Order.CustomerIdProperty.Name], ConfigurationSource.Convention)!;
 
         Assert.NotNull(indexBuilder);
         Assert.Same(
@@ -661,7 +661,7 @@ public class InternalEntityTypeBuilderTest
         var entityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
 
         var indexBuilder = entityBuilder.HasIndex(
-            [Order.IdProperty, Order.CustomerIdProperty], "TestIndex", ConfigurationSource.Explicit);
+            [Order.IdProperty, Order.CustomerIdProperty], "TestIndex", ConfigurationSource.Explicit)!;
 
         Assert.NotNull(indexBuilder);
         Assert.Same(
@@ -677,7 +677,7 @@ public class InternalEntityTypeBuilderTest
         var entityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
 
         var indexBuilder = entityBuilder.HasIndex(
-            [Order.IdProperty.Name, Order.CustomerIdProperty.Name], "TestIndex", ConfigurationSource.Convention);
+            [Order.IdProperty.Name, Order.CustomerIdProperty.Name], "TestIndex", ConfigurationSource.Convention)!;
 
         Assert.NotNull(indexBuilder);
         Assert.Same(
@@ -692,7 +692,7 @@ public class InternalEntityTypeBuilderTest
         var entityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
 
         var indexBuilder = entityBuilder.HasIndex(
-            [Order.IdProperty.Name, Order.CustomerIdProperty.Name], "TestIndex", ConfigurationSource.Convention);
+            [Order.IdProperty.Name, Order.CustomerIdProperty.Name], "TestIndex", ConfigurationSource.Convention)!;
 
         Assert.NotNull(indexBuilder);
         Assert.Same(
@@ -707,7 +707,7 @@ public class InternalEntityTypeBuilderTest
         var entityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
 
         var indexBuilder = entityBuilder.HasIndex(
-            [Order.IdProperty.Name, Order.CustomerIdProperty.Name], "NamedIndex", ConfigurationSource.Convention);
+            [Order.IdProperty.Name, Order.CustomerIdProperty.Name], "NamedIndex", ConfigurationSource.Convention)!;
 
         Assert.NotNull(indexBuilder);
         Assert.Equal(
@@ -728,7 +728,7 @@ public class InternalEntityTypeBuilderTest
         derivedEntityBuilder.Property(Order.CustomerIdProperty, ConfigurationSource.Convention);
 
         var indexBuilder = baseEntityBuilder.HasIndex(
-            [Order.IdProperty.Name, Order.CustomerIdProperty.Name], "NamedIndex", ConfigurationSource.Convention);
+            [Order.IdProperty.Name, Order.CustomerIdProperty.Name], "NamedIndex", ConfigurationSource.Convention)!;
 
         Assert.NotNull(indexBuilder);
         Assert.Equal(
@@ -748,7 +748,7 @@ public class InternalEntityTypeBuilderTest
         derivedEntityBuilder.Property(Order.CustomerIdProperty, ConfigurationSource.Convention);
 
         var indexBuilder = derivedEntityBuilder.HasIndex(
-            [Order.IdProperty.Name, Order.CustomerIdProperty.Name], "NamedIndex", ConfigurationSource.Convention);
+            [Order.IdProperty.Name, Order.CustomerIdProperty.Name], "NamedIndex", ConfigurationSource.Convention)!;
 
         Assert.NotNull(indexBuilder);
         Assert.Equal(
@@ -767,7 +767,7 @@ public class InternalEntityTypeBuilderTest
         derivedEntityBuilder.Property(Order.IdProperty, ConfigurationSource.Convention);
         derivedEntityBuilder.HasIndex([Order.IdProperty.Name], ConfigurationSource.DataAnnotation);
 
-        var indexBuilder = entityBuilder.HasIndex([Order.IdProperty.Name], ConfigurationSource.Convention);
+        var indexBuilder = entityBuilder.HasIndex([Order.IdProperty.Name], ConfigurationSource.Convention)!;
         Assert.Same(indexBuilder.Metadata.Properties.Single(), entityBuilder.Metadata.FindProperty(Order.IdProperty.Name));
         Assert.Same(indexBuilder.Metadata, entityBuilder.Metadata.FindIndex((IReadOnlyProperty)indexBuilder.Metadata.Properties.Single()));
         Assert.Empty(derivedEntityBuilder.Metadata.GetDeclaredIndexes());
@@ -783,9 +783,9 @@ public class InternalEntityTypeBuilderTest
         derivedEntityBuilder.Property(Order.IdProperty, ConfigurationSource.Convention);
         derivedEntityBuilder.HasIndex([Order.IdProperty.Name], "IndexToPromote", ConfigurationSource.DataAnnotation);
 
-        var indexBuilder = entityBuilder.HasIndex([Order.IdProperty.Name], "IndexToPromote", ConfigurationSource.Convention);
+        var indexBuilder = entityBuilder.HasIndex([Order.IdProperty.Name], "IndexToPromote", ConfigurationSource.Convention)!;
         Assert.Same(indexBuilder.Metadata.Properties.Single(), entityBuilder.Metadata.FindProperty(Order.IdProperty.Name));
-        Assert.Same(indexBuilder.Metadata, entityBuilder.Metadata.FindIndex(indexBuilder.Metadata.Name));
+        Assert.Same(indexBuilder.Metadata, entityBuilder.Metadata.FindIndex(indexBuilder.Metadata.Name!));
         Assert.Empty(derivedEntityBuilder.Metadata.GetDeclaredIndexes());
     }
 
@@ -798,9 +798,9 @@ public class InternalEntityTypeBuilderTest
         derivedEntityBuilder.HasBaseType(entityBuilder.Metadata, ConfigurationSource.Convention);
         derivedEntityBuilder.Property(Order.IdProperty, ConfigurationSource.Convention);
         derivedEntityBuilder.HasIndex([Order.IdProperty.Name], ConfigurationSource.DataAnnotation)
-            .IsUnique(true, ConfigurationSource.Convention);
+            !.IsUnique(true, ConfigurationSource.Convention);
 
-        var indexBuilder = entityBuilder.HasIndex([Order.IdProperty.Name], ConfigurationSource.Convention);
+        var indexBuilder = entityBuilder.HasIndex([Order.IdProperty.Name], ConfigurationSource.Convention)!;
         Assert.Same(indexBuilder.Metadata.Properties.Single(), entityBuilder.Metadata.FindProperty(Order.IdProperty.Name));
         Assert.Same(indexBuilder.Metadata, entityBuilder.Metadata.FindIndex((IReadOnlyProperty)indexBuilder.Metadata.Properties.Single()));
         Assert.True(indexBuilder.Metadata.IsUnique);
@@ -816,11 +816,11 @@ public class InternalEntityTypeBuilderTest
         derivedEntityBuilder.HasBaseType(entityBuilder.Metadata, ConfigurationSource.Convention);
         derivedEntityBuilder.Property(Order.IdProperty, ConfigurationSource.Convention);
         derivedEntityBuilder.HasIndex([Order.IdProperty.Name], "IndexToPromote", ConfigurationSource.DataAnnotation)
-            .IsUnique(true, ConfigurationSource.Convention);
+            !.IsUnique(true, ConfigurationSource.Convention);
 
-        var indexBuilder = entityBuilder.HasIndex([Order.IdProperty.Name], "IndexToPromote", ConfigurationSource.Convention);
+        var indexBuilder = entityBuilder.HasIndex([Order.IdProperty.Name], "IndexToPromote", ConfigurationSource.Convention)!;
         Assert.Same(indexBuilder.Metadata.Properties.Single(), entityBuilder.Metadata.FindProperty(Order.IdProperty.Name));
-        Assert.Same(indexBuilder.Metadata, entityBuilder.Metadata.FindIndex(indexBuilder.Metadata.Name));
+        Assert.Same(indexBuilder.Metadata, entityBuilder.Metadata.FindIndex(indexBuilder.Metadata.Name!));
         Assert.True(indexBuilder.Metadata.IsUnique);
         Assert.Empty(derivedEntityBuilder.Metadata.GetDeclaredIndexes());
     }
@@ -836,7 +836,7 @@ public class InternalEntityTypeBuilderTest
         var derivedEntityBuilder = modelBuilder.Entity(typeof(SpecialOrder), ConfigurationSource.Convention);
         derivedEntityBuilder.HasBaseType(entityBuilder.Metadata, ConfigurationSource.Convention);
 
-        var indexBuilder = derivedEntityBuilder.HasIndex([Order.IdProperty.Name], ConfigurationSource.DataAnnotation);
+        var indexBuilder = derivedEntityBuilder.HasIndex([Order.IdProperty.Name], ConfigurationSource.DataAnnotation)!;
 
         Assert.Same(entityBuilder.Metadata.GetIndexes().Single(), indexBuilder.Metadata);
         Assert.NotNull(indexBuilder.IsUnique(true, ConfigurationSource.Convention));
@@ -853,7 +853,7 @@ public class InternalEntityTypeBuilderTest
         var derivedEntityBuilder = modelBuilder.Entity(typeof(SpecialOrder), ConfigurationSource.Convention);
         derivedEntityBuilder.HasBaseType(entityBuilder.Metadata, ConfigurationSource.Convention);
 
-        var indexBuilder = derivedEntityBuilder.HasIndex([Order.IdProperty.Name], ConfigurationSource.DataAnnotation);
+        var indexBuilder = derivedEntityBuilder.HasIndex([Order.IdProperty.Name], ConfigurationSource.DataAnnotation)!;
 
         Assert.Empty(entityBuilder.Metadata.GetIndexes());
         Assert.Same(derivedEntityBuilder.Metadata.GetDeclaredIndexes().Single(), indexBuilder.Metadata);
@@ -872,7 +872,7 @@ public class InternalEntityTypeBuilderTest
         derivedEntityBuilder.HasBaseType(entityBuilder.Metadata, ConfigurationSource.Convention);
 
         var indexBuilder = derivedEntityBuilder.HasIndex(
-            [Order.IdProperty.Name, SpecialOrder.SpecialtyProperty.Name], ConfigurationSource.DataAnnotation);
+            [Order.IdProperty.Name, SpecialOrder.SpecialtyProperty.Name], ConfigurationSource.DataAnnotation)!;
 
         Assert.Empty(entityBuilder.Metadata.GetIndexes());
         Assert.Same(derivedEntityBuilder.Metadata.GetDeclaredIndexes().Single(), indexBuilder.Metadata);
@@ -912,7 +912,7 @@ public class InternalEntityTypeBuilderTest
             .PrimaryKey([Customer.IdProperty, Customer.UniqueProperty], ConfigurationSource.Explicit);
         var entityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
 
-        var index = entityBuilder.HasIndex([Order.CustomerIdProperty.Name], ConfigurationSource.DataAnnotation);
+        var index = entityBuilder.HasIndex([Order.CustomerIdProperty.Name], ConfigurationSource.DataAnnotation)!;
         Assert.NotNull(index);
 
         Assert.Null(entityBuilder.HasNoIndex(index.Metadata, ConfigurationSource.Convention));
@@ -927,10 +927,10 @@ public class InternalEntityTypeBuilderTest
     {
         var modelBuilder = CreateModelBuilder();
         var entityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
-        var shadowProperty = entityBuilder.Property(typeof(Guid), "Shadow", ConfigurationSource.Convention);
+        var shadowProperty = entityBuilder.Property(typeof(Guid), "Shadow", ConfigurationSource.Convention)!;
 
         var index = entityBuilder.HasIndex(
-            [Order.CustomerIdProperty.Name, shadowProperty.Metadata.Name], ConfigurationSource.Convention);
+            [Order.CustomerIdProperty.Name, shadowProperty.Metadata.Name], ConfigurationSource.Convention)!;
         Assert.NotNull(index);
 
         Assert.NotNull(entityBuilder.HasNoIndex(index.Metadata, ConfigurationSource.DataAnnotation));
@@ -950,7 +950,7 @@ public class InternalEntityTypeBuilderTest
 
         Test_removing_index_does_not_remove_contained_shadow_properties_if_referenced_elsewhere((entityBuilder, property)
             => entityBuilder.HasRelationship(
-                typeof(Customer).FullName,
+                typeof(Customer).FullName!,
                 [Order.CustomerIdProperty.Name, property.Name],
                 ConfigurationSource.Convention));
 
@@ -960,18 +960,18 @@ public class InternalEntityTypeBuilderTest
     }
 
     private void Test_removing_index_does_not_remove_contained_shadow_properties_if_referenced_elsewhere(
-        Func<InternalEntityTypeBuilder, Property, object> shadowConfig)
+        Func<InternalEntityTypeBuilder, Property, object?> shadowConfig)
     {
         var modelBuilder = CreateModelBuilder();
         modelBuilder
             .Entity(typeof(Customer), ConfigurationSource.Explicit)
             .PrimaryKey([Customer.IdProperty, Customer.UniqueProperty], ConfigurationSource.Explicit);
         var entityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
-        var shadowProperty = entityBuilder.Property(typeof(Guid), "Shadow", ConfigurationSource.Convention);
+        var shadowProperty = entityBuilder.Property(typeof(Guid), "Shadow", ConfigurationSource.Convention)!;
         Assert.NotNull(shadowConfig(entityBuilder, shadowProperty.Metadata));
 
         var index = entityBuilder.HasIndex(
-            [Order.CustomerIdProperty.Name, shadowProperty.Metadata.Name], ConfigurationSource.Convention);
+            [Order.CustomerIdProperty.Name, shadowProperty.Metadata.Name], ConfigurationSource.Convention)!;
         Assert.NotNull(index);
 
         Assert.NotNull(entityBuilder.HasNoIndex(index.Metadata, ConfigurationSource.DataAnnotation));
@@ -986,7 +986,7 @@ public class InternalEntityTypeBuilderTest
         var modelBuilder = CreateModelBuilder();
         var entityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
 
-        var keyBuilder = entityBuilder.HasKey([Order.IdProperty, Order.CustomerIdProperty], ConfigurationSource.DataAnnotation);
+        var keyBuilder = entityBuilder.HasKey([Order.IdProperty, Order.CustomerIdProperty], ConfigurationSource.DataAnnotation)!;
 
         Assert.NotNull(keyBuilder);
         Assert.Same(
@@ -1001,7 +1001,7 @@ public class InternalEntityTypeBuilderTest
         var entityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
 
         var keyBuilder = entityBuilder.PrimaryKey(
-            [Order.IdProperty.Name, Order.CustomerIdProperty.Name], ConfigurationSource.Convention);
+            [Order.IdProperty.Name, Order.CustomerIdProperty.Name], ConfigurationSource.Convention)!;
 
         Assert.NotNull(keyBuilder);
         Assert.Same(
@@ -1014,7 +1014,7 @@ public class InternalEntityTypeBuilderTest
         var modelBuilder = CreateModelBuilder();
         var entityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
 
-        entityBuilder.Property(Order.CustomerUniqueProperty, ConfigurationSource.Convention)
+        entityBuilder.Property(Order.CustomerUniqueProperty, ConfigurationSource.Convention)!
             .IsRequired(false, ConfigurationSource.DataAnnotation);
 
         Assert.Null(entityBuilder.PrimaryKey([Order.IdProperty, Order.CustomerUniqueProperty], ConfigurationSource.Convention));
@@ -1022,16 +1022,16 @@ public class InternalEntityTypeBuilderTest
         Assert.NotNull(
             entityBuilder.PrimaryKey([Order.IdProperty, Order.CustomerUniqueProperty], ConfigurationSource.DataAnnotation));
 
-        Assert.False(((IReadOnlyEntityType)entityBuilder.Metadata).FindProperty(Order.CustomerUniqueProperty).IsNullable);
+        Assert.False(((IReadOnlyEntityType)entityBuilder.Metadata).FindProperty(Order.CustomerUniqueProperty)!.IsNullable);
 
         Assert.Null(
-            entityBuilder.Property(Order.CustomerUniqueProperty, ConfigurationSource.Convention)
+            entityBuilder.Property(Order.CustomerUniqueProperty, ConfigurationSource.Convention)!
                 .IsRequired(false, ConfigurationSource.Convention));
         Assert.NotNull(
-            entityBuilder.Property(Order.CustomerUniqueProperty, ConfigurationSource.Convention)
+            entityBuilder.Property(Order.CustomerUniqueProperty, ConfigurationSource.Convention)!
                 .IsRequired(false, ConfigurationSource.DataAnnotation));
 
-        Assert.True(((IReadOnlyEntityType)entityBuilder.Metadata).FindProperty(Order.CustomerUniqueProperty).IsNullable);
+        Assert.True(((IReadOnlyEntityType)entityBuilder.Metadata).FindProperty(Order.CustomerUniqueProperty)!.IsNullable);
         Assert.Null(entityBuilder.Metadata.FindPrimaryKey());
     }
 
@@ -1131,7 +1131,7 @@ public class InternalEntityTypeBuilderTest
         var modelBuilder = CreateModelBuilder();
         var entityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
 
-        var key = entityBuilder.HasKey([Order.CustomerIdProperty.Name], ConfigurationSource.DataAnnotation);
+        var key = entityBuilder.HasKey([Order.CustomerIdProperty.Name], ConfigurationSource.DataAnnotation)!;
         Assert.NotNull(key);
 
         Assert.Null(entityBuilder.HasNoKey(key.Metadata, ConfigurationSource.Convention));
@@ -1146,10 +1146,10 @@ public class InternalEntityTypeBuilderTest
     {
         var modelBuilder = CreateModelBuilder();
         var entityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
-        var shadowProperty = entityBuilder.Property(typeof(Guid), "Shadow", ConfigurationSource.Convention);
+        var shadowProperty = entityBuilder.Property(typeof(Guid), "Shadow", ConfigurationSource.Convention)!;
 
         var key = entityBuilder.HasKey(
-            [Order.CustomerIdProperty.Name, shadowProperty.Metadata.Name], ConfigurationSource.Convention);
+            [Order.CustomerIdProperty.Name, shadowProperty.Metadata.Name], ConfigurationSource.Convention)!;
         Assert.NotNull(key);
 
         Assert.NotNull(entityBuilder.HasNoKey(key.Metadata, ConfigurationSource.DataAnnotation));
@@ -1163,7 +1163,7 @@ public class InternalEntityTypeBuilderTest
     {
         Test_removing_key_does_not_remove_contained_shadow_properties_if_referenced_elsewhere((entityBuilder, property)
             => entityBuilder.PrimaryKey(
-                [entityBuilder.Property(typeof(int), "Shadow2", ConfigurationSource.Convention).Metadata.Name, property.Name],
+                [entityBuilder.Property(typeof(int), "Shadow2", ConfigurationSource.Convention)!.Metadata.Name, property.Name],
                 ConfigurationSource.Convention));
 
         Test_removing_key_does_not_remove_contained_shadow_properties_if_referenced_elsewhere((entityBuilder, property)
@@ -1171,7 +1171,7 @@ public class InternalEntityTypeBuilderTest
 
         Test_removing_key_does_not_remove_contained_shadow_properties_if_referenced_elsewhere((entityBuilder, property)
             => entityBuilder.HasRelationship(
-                typeof(Customer).FullName,
+                typeof(Customer).FullName!,
                 [Order.CustomerIdProperty.Name, property.Name],
                 ConfigurationSource.Convention));
 
@@ -1180,17 +1180,17 @@ public class InternalEntityTypeBuilderTest
     }
 
     private void Test_removing_key_does_not_remove_contained_shadow_properties_if_referenced_elsewhere(
-        Func<InternalEntityTypeBuilder, Property, object> shadowConfig)
+        Func<InternalEntityTypeBuilder, Property, object?> shadowConfig)
     {
         var modelBuilder = CreateModelBuilder();
         modelBuilder
             .Entity(typeof(Customer), ConfigurationSource.Explicit)
             .PrimaryKey([Customer.IdProperty, Customer.UniqueProperty], ConfigurationSource.Explicit);
         var entityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
-        var shadowProperty = entityBuilder.Property(typeof(Guid), "Shadow", ConfigurationSource.Convention);
+        var shadowProperty = entityBuilder.Property(typeof(Guid), "Shadow", ConfigurationSource.Convention)!;
 
         var key = entityBuilder.HasKey(
-            [Order.CustomerIdProperty.Name, shadowProperty.Metadata.Name], ConfigurationSource.Convention);
+            [Order.CustomerIdProperty.Name, shadowProperty.Metadata.Name], ConfigurationSource.Convention)!;
         Assert.NotNull(key);
 
         Assert.NotNull(shadowConfig(entityBuilder, shadowProperty.Metadata));
@@ -1259,7 +1259,7 @@ public class InternalEntityTypeBuilderTest
         Assert.Equal(ConfigurationSource.DataAnnotation, entityType.GetIsKeylessConfigurationSource());
         Assert.NotEmpty(entityType.GetKeys());
 
-        var shadowProperty = entityBuilder.Property(typeof(Guid), "Shadow", ConfigurationSource.Convention);
+        var shadowProperty = entityBuilder.Property(typeof(Guid), "Shadow", ConfigurationSource.Convention)!;
         Assert.NotNull(entityBuilder.HasKey([shadowProperty.Metadata.Name], ConfigurationSource.Convention));
 
         Assert.Null(entityBuilder.HasNoKey(ConfigurationSource.Convention));
@@ -1283,7 +1283,7 @@ public class InternalEntityTypeBuilderTest
         var entityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
 
         var keyBuilder = entityBuilder.PrimaryKey(
-            [Order.IdProperty, Order.CustomerIdProperty], ConfigurationSource.DataAnnotation);
+            [Order.IdProperty, Order.CustomerIdProperty], ConfigurationSource.DataAnnotation)!;
 
         Assert.NotNull(keyBuilder);
         Assert.Same(
@@ -1300,7 +1300,7 @@ public class InternalEntityTypeBuilderTest
         var entityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
 
         var keyBuilder = entityBuilder.HasKey(
-            [Order.IdProperty.Name, Order.CustomerIdProperty.Name], ConfigurationSource.Convention);
+            [Order.IdProperty.Name, Order.CustomerIdProperty.Name], ConfigurationSource.Convention)!;
 
         Assert.NotNull(keyBuilder);
         Assert.Same(
@@ -1360,7 +1360,7 @@ public class InternalEntityTypeBuilderTest
 
         Assert.NotNull(entityBuilder.PrimaryKey([Order.CustomerIdProperty.Name], ConfigurationSource.Convention));
 
-        Assert.Equal(Order.CustomerIdProperty.Name, entityBuilder.Metadata.FindPrimaryKey().Properties.Single().Name);
+        Assert.Equal(Order.CustomerIdProperty.Name, entityBuilder.Metadata.FindPrimaryKey()!.Properties.Single().Name);
     }
 
     [Fact]
@@ -1392,18 +1392,18 @@ public class InternalEntityTypeBuilderTest
         var entityType = entityBuilder.Metadata;
 
         var compositeKeyBuilder = entityBuilder.PrimaryKey(
-            [Order.IdProperty, Order.CustomerIdProperty], ConfigurationSource.Convention);
-        var simpleKeyBuilder = entityBuilder.PrimaryKey([Order.IdProperty], ConfigurationSource.Convention);
+            [Order.IdProperty, Order.CustomerIdProperty], ConfigurationSource.Convention)!;
+        var simpleKeyBuilder = entityBuilder.PrimaryKey([Order.IdProperty], ConfigurationSource.Convention)!;
 
         Assert.NotNull(simpleKeyBuilder);
         Assert.NotEqual(compositeKeyBuilder, simpleKeyBuilder);
         Assert.Equal(Order.IdProperty.Name, entityType.GetKeys().Single().Properties.Single().Name);
 
-        var simpleKeyBuilder2 = entityBuilder.HasKey([Order.IdProperty], ConfigurationSource.Explicit);
+        var simpleKeyBuilder2 = entityBuilder.HasKey([Order.IdProperty], ConfigurationSource.Explicit)!;
         Assert.Same(simpleKeyBuilder, simpleKeyBuilder2);
 
         var compositeKeyBuilder2 = entityBuilder.PrimaryKey(
-            [Order.IdProperty, Order.CustomerIdProperty], ConfigurationSource.Convention);
+            [Order.IdProperty, Order.CustomerIdProperty], ConfigurationSource.Convention)!;
         Assert.NotNull(compositeKeyBuilder2);
         Assert.NotEqual(compositeKeyBuilder, compositeKeyBuilder2);
         Assert.Same(compositeKeyBuilder2.Metadata, entityBuilder.Metadata.FindPrimaryKey());
@@ -1427,8 +1427,8 @@ public class InternalEntityTypeBuilderTest
 
         entityType.SetPrimaryKey(
             [
-                entityType.AddProperty(Order.IdProperty, ConfigurationSource.Explicit),
-                entityType.AddProperty(Order.CustomerIdProperty, ConfigurationSource.Explicit)
+                entityType.AddProperty(Order.IdProperty, ConfigurationSource.Explicit)!,
+                entityType.AddProperty(Order.CustomerIdProperty, ConfigurationSource.Explicit)!
             ],
             ConfigurationSource.Explicit);
 
@@ -1438,11 +1438,11 @@ public class InternalEntityTypeBuilderTest
 
         Assert.Equal(
             new[] { Order.IdProperty.Name, Order.CustomerIdProperty.Name },
-            entityType.FindPrimaryKey().Properties.Select(p => p.Name).ToArray());
+            entityType.FindPrimaryKey()!.Properties.Select(p => p.Name).ToArray());
 
         Assert.NotNull(entityBuilder.PrimaryKey([Order.IdProperty], ConfigurationSource.Explicit));
 
-        Assert.Equal(Order.IdProperty.Name, entityType.FindPrimaryKey().Properties.Single().Name);
+        Assert.Equal(Order.IdProperty.Name, entityType.FindPrimaryKey()!.Properties.Single().Name);
     }
 
     [Fact]
@@ -1452,15 +1452,15 @@ public class InternalEntityTypeBuilderTest
         var dependentEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
         var principalEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
         var keyBuilder = principalEntityBuilder.PrimaryKey(
-            [Customer.IdProperty, Customer.UniqueProperty], ConfigurationSource.Convention);
-        var fkProperty1 = dependentEntityBuilder.Property(Order.CustomerIdProperty, ConfigurationSource.Convention).Metadata;
-        var fkProperty2 = dependentEntityBuilder.Property(Order.CustomerUniqueProperty, ConfigurationSource.Convention).Metadata;
+            [Customer.IdProperty, Customer.UniqueProperty], ConfigurationSource.Convention)!;
+        var fkProperty1 = dependentEntityBuilder.Property(Order.CustomerIdProperty, ConfigurationSource.Convention)!.Metadata;
+        var fkProperty2 = dependentEntityBuilder.Property(Order.CustomerUniqueProperty, ConfigurationSource.Convention)!.Metadata;
 
-        dependentEntityBuilder.HasRelationship(principalEntityBuilder.Metadata, ConfigurationSource.DataAnnotation)
-            .HasPrincipalKey(keyBuilder.Metadata.Properties, ConfigurationSource.DataAnnotation)
+        dependentEntityBuilder.HasRelationship(principalEntityBuilder.Metadata, ConfigurationSource.DataAnnotation)!
+            .HasPrincipalKey(keyBuilder.Metadata.Properties, ConfigurationSource.DataAnnotation)!
             .HasForeignKey([fkProperty1, fkProperty2], ConfigurationSource.Explicit);
 
-        keyBuilder = principalEntityBuilder.PrimaryKey([Customer.IdProperty], ConfigurationSource.DataAnnotation);
+        keyBuilder = principalEntityBuilder.PrimaryKey([Customer.IdProperty], ConfigurationSource.DataAnnotation)!;
 
         Assert.Same(keyBuilder.Metadata, principalEntityBuilder.Metadata.FindPrimaryKey());
         var fk = dependentEntityBuilder.Metadata.GetForeignKeys().Single();
@@ -1473,7 +1473,7 @@ public class InternalEntityTypeBuilderTest
         var modelBuilder = CreateModelBuilder();
         var dependentEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
         var principalEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
-        dependentEntityBuilder.HasRelationship(principalEntityBuilder.Metadata, ConfigurationSource.DataAnnotation)
+        dependentEntityBuilder.HasRelationship(principalEntityBuilder.Metadata, ConfigurationSource.DataAnnotation)!
             .HasForeignKey([Order.CustomerIdProperty, Order.CustomerUniqueProperty], ConfigurationSource.DataAnnotation);
 
         Assert.Null(principalEntityBuilder.Metadata.FindPrimaryKey());
@@ -1481,7 +1481,7 @@ public class InternalEntityTypeBuilderTest
             nameof(Customer.Id), dependentEntityBuilder.Metadata.GetForeignKeys().Single().PrincipalKey.Properties.First().Name);
 
         var keyBuilder = principalEntityBuilder.PrimaryKey(
-            [Customer.IdProperty, Customer.UniqueProperty], ConfigurationSource.Convention);
+            [Customer.IdProperty, Customer.UniqueProperty], ConfigurationSource.Convention)!;
 
         Assert.Same(keyBuilder.Metadata, dependentEntityBuilder.Metadata.GetForeignKeys().Single().PrincipalKey);
         Assert.Same(keyBuilder.Metadata, principalEntityBuilder.Metadata.GetKeys().Single());
@@ -1494,11 +1494,11 @@ public class InternalEntityTypeBuilderTest
         var dependentEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
         var principalEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
         var existingKeyBuilder = principalEntityBuilder.HasKey(
-            [Customer.IdProperty, Customer.UniqueProperty], ConfigurationSource.Convention);
-        dependentEntityBuilder.HasRelationship(principalEntityBuilder.Metadata, ConfigurationSource.Explicit)
+            [Customer.IdProperty, Customer.UniqueProperty], ConfigurationSource.Convention)!;
+        dependentEntityBuilder.HasRelationship(principalEntityBuilder.Metadata, ConfigurationSource.Explicit)!
             .HasPrincipalKey(existingKeyBuilder.Metadata.Properties, ConfigurationSource.Explicit);
 
-        var keyBuilder = principalEntityBuilder.PrimaryKey([Customer.IdProperty], ConfigurationSource.Explicit);
+        var keyBuilder = principalEntityBuilder.PrimaryKey([Customer.IdProperty], ConfigurationSource.Explicit)!;
 
         Assert.Same(existingKeyBuilder.Metadata, dependentEntityBuilder.Metadata.GetForeignKeys().Single().PrincipalKey);
         Assert.Equal(2, principalEntityBuilder.Metadata.GetKeys().Count());
@@ -1511,7 +1511,7 @@ public class InternalEntityTypeBuilderTest
         var modelBuilder = CreateModelBuilder();
         var entityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
 
-        var propertyBuilder = entityBuilder.Property(Order.IdProperty, ConfigurationSource.Explicit);
+        var propertyBuilder = entityBuilder.Property(Order.IdProperty, ConfigurationSource.Explicit)!;
 
         Assert.NotNull(propertyBuilder);
         Assert.Same(propertyBuilder, entityBuilder.Property(typeof(int), Order.IdProperty.Name, ConfigurationSource.Explicit));
@@ -1523,7 +1523,7 @@ public class InternalEntityTypeBuilderTest
         var modelBuilder = CreateModelBuilder();
         var entityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
 
-        var propertyBuilder = entityBuilder.Property(Order.IdProperty.Name, ConfigurationSource.DataAnnotation);
+        var propertyBuilder = entityBuilder.Property(Order.IdProperty.Name, ConfigurationSource.DataAnnotation)!;
 
         Assert.NotNull(propertyBuilder);
         Assert.Same(propertyBuilder, entityBuilder.Property(Order.IdProperty, ConfigurationSource.DataAnnotation));
@@ -1535,7 +1535,7 @@ public class InternalEntityTypeBuilderTest
         var modelBuilder = CreateModelBuilder();
         var entityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
 
-        var propertyBuilder = entityBuilder.Property(Order.IdProperty, ConfigurationSource.DataAnnotation);
+        var propertyBuilder = entityBuilder.Property(Order.IdProperty, ConfigurationSource.DataAnnotation)!;
         Assert.NotNull(propertyBuilder);
 
         Assert.Same(
@@ -1570,7 +1570,7 @@ public class InternalEntityTypeBuilderTest
         var entityBuilder = modelBuilder.Entity(typeof(EntityWithComplexProperty), ConfigurationSource.Explicit);
 
         var originalComplexBuilder = entityBuilder.ComplexProperty(
-            EntityWithComplexProperty.DetailsProperty, complexTypeName: null, collection: false, ConfigurationSource.Explicit);
+            EntityWithComplexProperty.DetailsProperty, complexTypeName: null, collection: false, ConfigurationSource.Explicit)!;
         Assert.NotNull(originalComplexBuilder);
         var stale = originalComplexBuilder.Metadata;
 
@@ -1578,7 +1578,7 @@ public class InternalEntityTypeBuilderTest
         Assert.False(stale.IsInModel);
 
         var newComplexBuilder = entityBuilder.ComplexProperty(
-            EntityWithComplexProperty.DetailsProperty, complexTypeName: null, collection: false, ConfigurationSource.Explicit);
+            EntityWithComplexProperty.DetailsProperty, complexTypeName: null, collection: false, ConfigurationSource.Explicit)!;
         Assert.NotNull(newComplexBuilder);
         Assert.NotSame(stale, newComplexBuilder.Metadata);
 
@@ -1590,15 +1590,15 @@ public class InternalEntityTypeBuilderTest
     private class EntityWithComplexProperty
     {
         public static readonly PropertyInfo DetailsProperty =
-            typeof(EntityWithComplexProperty).GetProperty(nameof(Details));
+            typeof(EntityWithComplexProperty).GetProperty(nameof(Details))!;
 
         public int Id { get; set; }
-        public ComplexDetails Details { get; set; }
+        public ComplexDetails Details { get; set; } = null!;
     }
 
     private class ComplexDetails
     {
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
     }
 
     [Fact]
@@ -1608,7 +1608,7 @@ public class InternalEntityTypeBuilderTest
         var entityBuilder = modelBuilder.Entity(typeof(IndexedClass), ConfigurationSource.Explicit);
 
         var propertyBuilder = entityBuilder.IndexerProperty(
-            typeof(string), IndexedClass.IndexerPropertyName, ConfigurationSource.DataAnnotation);
+            typeof(string), IndexedClass.IndexerPropertyName, ConfigurationSource.DataAnnotation)!;
 
         Assert.NotNull(propertyBuilder);
     }
@@ -1620,7 +1620,7 @@ public class InternalEntityTypeBuilderTest
         var entityBuilder = modelBuilder.Entity(typeof(IndexedClass), ConfigurationSource.Explicit);
 
         var propertyBuilder = entityBuilder.IndexerProperty(
-            typeof(string), IndexedClass.IndexerPropertyName, ConfigurationSource.DataAnnotation);
+            typeof(string), IndexedClass.IndexerPropertyName, ConfigurationSource.DataAnnotation)!;
 
         Assert.NotNull(propertyBuilder);
         Assert.Same(
@@ -1641,14 +1641,14 @@ public class InternalEntityTypeBuilderTest
         var entityBuilder = modelBuilder.Entity(typeof(IndexedClass), ConfigurationSource.Explicit);
 
         var propertyBuilder = entityBuilder.IndexerProperty(
-            typeof(string), IndexedClass.IndexerPropertyName, ConfigurationSource.Convention);
+            typeof(string), IndexedClass.IndexerPropertyName, ConfigurationSource.Convention)!;
 
         Assert.NotNull(propertyBuilder);
         Assert.True(propertyBuilder.Metadata.IsIndexerProperty());
         Assert.False(propertyBuilder.Metadata.IsShadowProperty());
 
         var replacedPropertyBuilder = entityBuilder.Property(
-            typeof(int), IndexedClass.IndexerPropertyName, ConfigurationSource.DataAnnotation);
+            typeof(int), IndexedClass.IndexerPropertyName, ConfigurationSource.DataAnnotation)!;
 
         Assert.NotNull(replacedPropertyBuilder);
         Assert.NotSame(propertyBuilder, replacedPropertyBuilder);
@@ -1663,13 +1663,13 @@ public class InternalEntityTypeBuilderTest
         var entityBuilder = modelBuilder.Entity(typeof(IndexedClass), ConfigurationSource.Explicit);
 
         var shadowPropertyBuilder = entityBuilder.Property(
-            typeof(int), IndexedClass.IndexerPropertyName, ConfigurationSource.Convention);
+            typeof(int), IndexedClass.IndexerPropertyName, ConfigurationSource.Convention)!;
 
         Assert.NotNull(shadowPropertyBuilder);
         Assert.True(shadowPropertyBuilder.Metadata.IsShadowProperty());
 
         var replacedPropertyBuilder = entityBuilder.IndexerProperty(
-            typeof(string), IndexedClass.IndexerPropertyName, ConfigurationSource.DataAnnotation);
+            typeof(string), IndexedClass.IndexerPropertyName, ConfigurationSource.DataAnnotation)!;
 
         Assert.NotNull(replacedPropertyBuilder);
         Assert.NotSame(shadowPropertyBuilder, replacedPropertyBuilder);
@@ -1696,10 +1696,10 @@ public class InternalEntityTypeBuilderTest
         var principalEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
         var dependentEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
 
-        dependentEntityBuilder.HasRelationship(principalEntityBuilder.Metadata, ConfigurationSource.Explicit).HasNavigation(
+        dependentEntityBuilder.HasRelationship(principalEntityBuilder.Metadata, ConfigurationSource.Explicit)!.HasNavigation(
             Order.CustomerProperty.Name,
             pointsToPrincipal: true,
-            ConfigurationSource.Explicit).HasNavigation(
+            ConfigurationSource.Explicit)!.HasNavigation(
             Customer.OrdersProperty.Name,
             pointsToPrincipal: false,
             ConfigurationSource.Explicit);
@@ -1730,15 +1730,15 @@ public class InternalEntityTypeBuilderTest
         var entityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
         var derivedEntityBuilder = modelBuilder.Entity(typeof(SpecialOrder), ConfigurationSource.Convention);
         derivedEntityBuilder.HasBaseType(entityBuilder.Metadata, ConfigurationSource.Convention);
-        var derivedProperty = derivedEntityBuilder.Property(typeof(int), "byte", ConfigurationSource.DataAnnotation);
+        var derivedProperty = derivedEntityBuilder.Property(typeof(int), "byte", ConfigurationSource.DataAnnotation)!;
         derivedProperty.IsConcurrencyToken(true, ConfigurationSource.Convention);
         derivedProperty.HasMaxLength(1, ConfigurationSource.Explicit);
         var derivedEntityBuilder2 = modelBuilder.Entity(typeof(BackOrder), ConfigurationSource.Convention);
         derivedEntityBuilder2.HasBaseType(entityBuilder.Metadata, ConfigurationSource.Convention);
-        var derivedProperty2 = derivedEntityBuilder2.Property(typeof(byte), "byte", ConfigurationSource.Convention);
+        var derivedProperty2 = derivedEntityBuilder2.Property(typeof(byte), "byte", ConfigurationSource.Convention)!;
         derivedProperty2.HasMaxLength(2, ConfigurationSource.Convention);
 
-        var propertyBuilder = entityBuilder.Property(typeof(int), "byte", ConfigurationSource.Convention);
+        var propertyBuilder = entityBuilder.Property(typeof(int), "byte", ConfigurationSource.Convention)!;
         Assert.Same(propertyBuilder.Metadata, entityBuilder.Metadata.FindProperty("byte"));
         Assert.Null(entityBuilder.Ignore("byte", ConfigurationSource.Convention));
         Assert.Empty(derivedEntityBuilder.Metadata.GetDeclaredProperties());
@@ -1753,14 +1753,14 @@ public class InternalEntityTypeBuilderTest
     {
         var modelBuilder = CreateModelBuilder();
         var entityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
-        entityBuilder.Property(typeof(int), nameof(SpecialOrder.Specialty), ConfigurationSource.Explicit)
+        entityBuilder.Property(typeof(int), nameof(SpecialOrder.Specialty), ConfigurationSource.Explicit)!
             .IsConcurrencyToken(false, ConfigurationSource.Convention);
 
         var derivedEntityBuilder = modelBuilder.Entity(typeof(SpecialOrder), ConfigurationSource.Convention);
         derivedEntityBuilder.HasBaseType(entityBuilder.Metadata, ConfigurationSource.Convention);
 
         var propertyBuilder = derivedEntityBuilder.Property(
-            typeof(int), nameof(SpecialOrder.Specialty), ConfigurationSource.DataAnnotation);
+            typeof(int), nameof(SpecialOrder.Specialty), ConfigurationSource.DataAnnotation)!;
 
         Assert.Same(entityBuilder.Metadata.FindProperty(nameof(SpecialOrder.Specialty)), propertyBuilder.Metadata);
         Assert.NotNull(propertyBuilder.IsConcurrencyToken(true, ConfigurationSource.Convention));
@@ -1771,7 +1771,7 @@ public class InternalEntityTypeBuilderTest
 
         Assert.Null(entityBuilder.Metadata.FindPrimaryKey());
         Assert.NotNull(entityBuilder.PrimaryKey([propertyBuilder.Metadata.Name], ConfigurationSource.Explicit));
-        propertyBuilder = derivedEntityBuilder.Property(typeof(string), nameof(SpecialOrder.Specialty), ConfigurationSource.Explicit);
+        propertyBuilder = derivedEntityBuilder.Property(typeof(string), nameof(SpecialOrder.Specialty), ConfigurationSource.Explicit)!;
 
         Assert.Same(typeof(string), propertyBuilder.Metadata.ClrType);
         Assert.Same(entityBuilder.Metadata, propertyBuilder.Metadata.DeclaringType);
@@ -1785,21 +1785,21 @@ public class InternalEntityTypeBuilderTest
         var principalEntityBuilder = modelBuilder.Entity(nameof(Customer), ConfigurationSource.Explicit);
         var principalKey = principalEntityBuilder.HasKey(
         [
-            principalEntityBuilder.Property(typeof(int), "Id", ConfigurationSource.Explicit).Metadata,
-            principalEntityBuilder.Property(typeof(int), "AlternateId", ConfigurationSource.Explicit).Metadata
-        ], ConfigurationSource.Explicit).Metadata;
+            principalEntityBuilder.Property(typeof(int), "Id", ConfigurationSource.Explicit)!.Metadata,
+            principalEntityBuilder.Property(typeof(int), "AlternateId", ConfigurationSource.Explicit)!.Metadata
+        ], ConfigurationSource.Explicit)!.Metadata;
         var dependentEntityBuilder = modelBuilder.Entity(nameof(Order), ConfigurationSource.Explicit);
         var foreignKey = dependentEntityBuilder.HasRelationship(
             principalEntityBuilder.Metadata,
             [
-                dependentEntityBuilder.Property(typeof(int), "AlternateId", ConfigurationSource.Convention).Metadata,
-                dependentEntityBuilder.Property(typeof(int), "AlternateId1", ConfigurationSource.Convention).Metadata
+                dependentEntityBuilder.Property(typeof(int), "AlternateId", ConfigurationSource.Convention)!.Metadata,
+                dependentEntityBuilder.Property(typeof(int), "AlternateId1", ConfigurationSource.Convention)!.Metadata
             ],
-            principalKey, ConfigurationSource.Convention).Metadata;
+            principalKey, ConfigurationSource.Convention)!.Metadata;
 
         Assert.True(dependentEntityBuilder.ShouldReuniquifyTemporaryProperties(foreignKey));
 
-        var newFkProperties = foreignKey.Builder.HasForeignKey((IReadOnlyList<Property>)null, ConfigurationSource.Convention)
+        var newFkProperties = foreignKey.Builder.HasForeignKey((IReadOnlyList<Property>?)null, ConfigurationSource.Convention)!
             .Metadata.Properties;
 
         Assert.Equal("CustomerId", newFkProperties[0].Name);
@@ -1814,21 +1814,21 @@ public class InternalEntityTypeBuilderTest
         var principalEntityBuilder = modelBuilder.Entity(nameof(Customer), ConfigurationSource.Explicit);
         var principalKey = principalEntityBuilder.HasKey(
         [
-            principalEntityBuilder.Property(typeof(int), "Id", ConfigurationSource.Explicit).Metadata,
-            principalEntityBuilder.Property(typeof(Guid), "AlternateId", ConfigurationSource.Explicit).Metadata
-        ], ConfigurationSource.Explicit).Metadata;
+            principalEntityBuilder.Property(typeof(int), "Id", ConfigurationSource.Explicit)!.Metadata,
+            principalEntityBuilder.Property(typeof(Guid), "AlternateId", ConfigurationSource.Explicit)!.Metadata
+        ], ConfigurationSource.Explicit)!.Metadata;
         var dependentEntityBuilder = modelBuilder.Entity(nameof(Order), ConfigurationSource.Explicit);
         var foreignKey = dependentEntityBuilder.HasRelationship(
             principalEntityBuilder.Metadata,
             [
-                dependentEntityBuilder.Property(typeof(int), "AlternateId", ConfigurationSource.Convention).Metadata,
-                dependentEntityBuilder.Property(typeof(Guid), "Id", ConfigurationSource.Convention).Metadata
+                dependentEntityBuilder.Property(typeof(int), "AlternateId", ConfigurationSource.Convention)!.Metadata,
+                dependentEntityBuilder.Property(typeof(Guid), "Id", ConfigurationSource.Convention)!.Metadata
             ],
-            principalKey, ConfigurationSource.Convention).Metadata;
+            principalKey, ConfigurationSource.Convention)!.Metadata;
 
         Assert.True(dependentEntityBuilder.ShouldReuniquifyTemporaryProperties(foreignKey));
 
-        var newFkProperties = foreignKey.Builder.HasForeignKey((IReadOnlyList<Property>)null, ConfigurationSource.Convention)
+        var newFkProperties = foreignKey.Builder.HasForeignKey((IReadOnlyList<Property>?)null, ConfigurationSource.Convention)!
             .Metadata.Properties;
 
         Assert.Equal("CustomerId", newFkProperties[0].Name);
@@ -1843,21 +1843,21 @@ public class InternalEntityTypeBuilderTest
         var principalEntityBuilder = modelBuilder.Entity(nameof(Customer), ConfigurationSource.Explicit);
         var principalKey = principalEntityBuilder.HasKey(
         [
-            principalEntityBuilder.Property(typeof(int), "Id", ConfigurationSource.Explicit).Metadata,
-            principalEntityBuilder.Property(typeof(int), "Unique", ConfigurationSource.Explicit).Metadata
-        ], ConfigurationSource.Explicit).Metadata;
+            principalEntityBuilder.Property(typeof(int), "Id", ConfigurationSource.Explicit)!.Metadata,
+            principalEntityBuilder.Property(typeof(int), "Unique", ConfigurationSource.Explicit)!.Metadata
+        ], ConfigurationSource.Explicit)!.Metadata;
         var dependentEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
         var foreignKey = dependentEntityBuilder.HasRelationship(
             principalEntityBuilder.Metadata,
             [
-                dependentEntityBuilder.Property(typeof(int), "Id1", ConfigurationSource.Convention).Metadata,
-                dependentEntityBuilder.Property(typeof(int), "Id2", ConfigurationSource.Convention).Metadata
+                dependentEntityBuilder.Property(typeof(int), "Id1", ConfigurationSource.Convention)!.Metadata,
+                dependentEntityBuilder.Property(typeof(int), "Id2", ConfigurationSource.Convention)!.Metadata
             ],
-            principalKey, ConfigurationSource.Convention).Metadata;
+            principalKey, ConfigurationSource.Convention)!.Metadata;
 
         Assert.True(dependentEntityBuilder.ShouldReuniquifyTemporaryProperties(foreignKey));
 
-        var newFkProperties = foreignKey.Builder.HasForeignKey((IReadOnlyList<Property>)null, ConfigurationSource.Convention)
+        var newFkProperties = foreignKey.Builder.HasForeignKey((IReadOnlyList<Property>?)null, ConfigurationSource.Convention)!
             .Metadata.Properties;
 
         Assert.Equal("CustomerId1", newFkProperties[0].Name);
@@ -1896,8 +1896,8 @@ public class InternalEntityTypeBuilderTest
             ignoredOnType, ignoreConfigurationSource, addConfigurationSource, ignoredFirst, setBaseFirst,
             et => et.Metadata.FindProperty(Order.CustomerIdProperty.Name) != null,
             et => et.Property(Order.CustomerIdProperty, addConfigurationSource) != null,
-            modelBuilder => modelBuilder.Entity(typeof(Order), ConfigurationSource.Convention).HasRelationship(
-                modelBuilder.Entity(typeof(Customer), ConfigurationSource.Convention).Metadata,
+            modelBuilder => modelBuilder.Entity(typeof(Order), ConfigurationSource.Convention)!.HasRelationship(
+                modelBuilder.Entity(typeof(Customer), ConfigurationSource.Convention)!.Metadata,
                 Order.CustomerProperty,
                 Customer.OrdersProperty,
                 ConfigurationSource.Convention),
@@ -1917,9 +1917,9 @@ public class InternalEntityTypeBuilderTest
         var testModelBuilder = CreateConventionlessModelBuilder();
         var modelBuilder = (InternalModelBuilder)testModelBuilder.GetInfrastructure();
         configureModel(modelBuilder);
-        var customerTypeBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Convention);
+        var customerTypeBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Convention)!;
         customerTypeBuilder.PrimaryKey([Customer.IdProperty], ConfigurationSource.Convention);
-        var productTypeBuilder = modelBuilder.Entity(typeof(Product), ConfigurationSource.Convention);
+        var productTypeBuilder = modelBuilder.Entity(typeof(Product), ConfigurationSource.Convention)!;
         productTypeBuilder.PrimaryKey([Product.IdProperty], ConfigurationSource.Convention);
         customerTypeBuilder.Ignore(Customer.NotCollectionOrdersProperty.Name, ConfigurationSource.Convention);
         customerTypeBuilder.Ignore(Customer.SpecialOrdersProperty.Name, ConfigurationSource.Convention);
@@ -1930,8 +1930,8 @@ public class InternalEntityTypeBuilderTest
             ConfigureOrdersHierarchy(modelBuilder);
         }
 
-        var ignoredEntityTypeBuilder = modelBuilder.Entity(ignoredOnType, ConfigurationSource.Convention);
-        var addedEntityTypeBuilder = modelBuilder.Entity(typeof(SpecialOrder), ConfigurationSource.Convention);
+        var ignoredEntityTypeBuilder = modelBuilder.Entity(ignoredOnType, ConfigurationSource.Convention)!;
+        var addedEntityTypeBuilder = modelBuilder.Entity(typeof(SpecialOrder), ConfigurationSource.Convention)!;
 
         var exceptionExpected = ignoredOnType == typeof(ExtraSpecialOrder)
             && (ignoreConfigurationSource == ConfigurationSource.Explicit
@@ -2001,11 +2001,11 @@ public class InternalEntityTypeBuilderTest
 
     private void ConfigureOrdersHierarchy(InternalModelBuilder modelBuilder)
     {
-        modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit)
+        modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit)!
             .PrimaryKey([Order.IdProperty], ConfigurationSource.Explicit);
-        var entityBuilder = modelBuilder.Entity(typeof(SpecialOrder), ConfigurationSource.Explicit);
+        var entityBuilder = modelBuilder.Entity(typeof(SpecialOrder), ConfigurationSource.Explicit)!;
         entityBuilder.HasBaseType(typeof(Order), ConfigurationSource.Explicit);
-        var derivedEntityBuilder = modelBuilder.Entity(typeof(ExtraSpecialOrder), ConfigurationSource.Explicit);
+        var derivedEntityBuilder = modelBuilder.Entity(typeof(ExtraSpecialOrder), ConfigurationSource.Explicit)!;
         derivedEntityBuilder.HasBaseType(typeof(SpecialOrder), ConfigurationSource.Explicit);
     }
 
@@ -2028,21 +2028,21 @@ public class InternalEntityTypeBuilderTest
         var modelBuilder = CreateModelBuilder();
         var principalEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
         var key = principalEntityBuilder.PrimaryKey(
-            [Customer.IdProperty, Customer.UniqueProperty], ConfigurationSource.Explicit);
+            [Customer.IdProperty, Customer.UniqueProperty], ConfigurationSource.Explicit)!;
         var dependentEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
 
         var relationshipBuilder =
             dependentEntityBuilder.HasRelationship(
-                    principalEntityBuilder.Metadata, (string)null, null, ConfigurationSource.DataAnnotation)
+                    principalEntityBuilder.Metadata, (string?)null, null, ConfigurationSource.DataAnnotation)!
                 .HasForeignKey(
                 [
-                    dependentEntityBuilder.Property(Order.CustomerIdProperty, ConfigurationSource.Convention).Metadata,
-                    dependentEntityBuilder.Property(Order.CustomerUniqueProperty, ConfigurationSource.Convention).Metadata
-                ], ConfigurationSource.DataAnnotation)
-                .HasPrincipalKey(key.Metadata.Properties, ConfigurationSource.DataAnnotation)
-                .IsUnique(true, ConfigurationSource.DataAnnotation)
-                .IsRequired(true, ConfigurationSource.DataAnnotation)
-                .OnDelete(DeleteBehavior.Cascade, ConfigurationSource.DataAnnotation);
+                    dependentEntityBuilder.Property(Order.CustomerIdProperty, ConfigurationSource.Convention)!.Metadata,
+                    dependentEntityBuilder.Property(Order.CustomerUniqueProperty, ConfigurationSource.Convention)!.Metadata
+                ], ConfigurationSource.DataAnnotation)!
+                .HasPrincipalKey(key.Metadata.Properties, ConfigurationSource.DataAnnotation)!
+                .IsUnique(true, ConfigurationSource.DataAnnotation)!
+                .IsRequired(true, ConfigurationSource.DataAnnotation)!
+                .OnDelete(DeleteBehavior.Cascade, ConfigurationSource.DataAnnotation)!;
         var fk = relationshipBuilder.Metadata;
 
         Assert.NotNull(dependentEntityBuilder.Ignore(Order.CustomerIdProperty.Name, ConfigurationSource.Explicit));
@@ -2075,8 +2075,8 @@ public class InternalEntityTypeBuilderTest
         dependentEntityBuilder.HasRelationship(
             principalEntityBuilder.Metadata,
             [
-                dependentEntityBuilder.Property(Order.CustomerIdProperty, ConfigurationSource.Convention).Metadata,
-                dependentEntityBuilder.Property(Order.CustomerUniqueProperty, ConfigurationSource.Convention).Metadata
+                dependentEntityBuilder.Property(Order.CustomerIdProperty, ConfigurationSource.Convention)!.Metadata,
+                dependentEntityBuilder.Property(Order.CustomerUniqueProperty, ConfigurationSource.Convention)!.Metadata
             ],
             ConfigurationSource.DataAnnotation);
 
@@ -2247,7 +2247,7 @@ public class InternalEntityTypeBuilderTest
         var modelBuilder = CreateModelBuilder();
         var principalEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
         var key = principalEntityBuilder.PrimaryKey(
-            [Customer.IdProperty, Customer.UniqueProperty], ConfigurationSource.Convention);
+            [Customer.IdProperty, Customer.UniqueProperty], ConfigurationSource.Convention)!;
         var dependentEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
 
         var principalType = principalEntityBuilder.Metadata;
@@ -2257,13 +2257,13 @@ public class InternalEntityTypeBuilderTest
                 principalEntityBuilder.Metadata,
                 Order.CustomerProperty.Name,
                 Customer.OrdersProperty.Name,
-                ConfigurationSource.Convention)
+                ConfigurationSource.Convention)!
             .HasForeignKey(
             [
-                dependentEntityBuilder.Property(Order.CustomerIdProperty, ConfigurationSource.Convention).Metadata,
-                dependentEntityBuilder.Property(Order.CustomerUniqueProperty, ConfigurationSource.Convention).Metadata
-            ], ConfigurationSource.Convention)
-            .HasPrincipalKey(key.Metadata.Properties, ConfigurationSource.Convention)
+                dependentEntityBuilder.Property(Order.CustomerIdProperty, ConfigurationSource.Convention)!.Metadata,
+                dependentEntityBuilder.Property(Order.CustomerUniqueProperty, ConfigurationSource.Convention)!.Metadata
+            ], ConfigurationSource.Convention)!
+            .HasPrincipalKey(key.Metadata.Properties, ConfigurationSource.Convention)!
             .Metadata;
 
         Assert.NotNull(principalEntityBuilder.Ignore(Customer.UniqueProperty.Name, ConfigurationSource.DataAnnotation));
@@ -2279,8 +2279,8 @@ public class InternalEntityTypeBuilderTest
         Assert.Equal(
             [Customer.IdProperty.Name, newFk.PrincipalKey.Properties.Single().Name],
             principalType.GetProperties().Select(p => p.Name));
-        Assert.Equal(Order.CustomerProperty.Name, newFk.DependentToPrincipal.Name);
-        Assert.Equal(Customer.OrdersProperty.Name, newFk.PrincipalToDependent.Name);
+        Assert.Equal(Order.CustomerProperty.Name, newFk.DependentToPrincipal!.Name);
+        Assert.Equal(Customer.OrdersProperty.Name, newFk.PrincipalToDependent!.Name);
     }
 
     [Fact]
@@ -2304,7 +2304,7 @@ public class InternalEntityTypeBuilderTest
         var principalEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
         var dependentEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
         var foreignKeyBuilder = dependentEntityBuilder.HasRelationship(
-            principalEntityBuilder.Metadata, ConfigurationSource.DataAnnotation);
+            principalEntityBuilder.Metadata, ConfigurationSource.DataAnnotation)!;
 
         Assert.True(
             dependentEntityBuilder.CanHaveNavigation(
@@ -2313,7 +2313,7 @@ public class InternalEntityTypeBuilderTest
         foreignKeyBuilder = foreignKeyBuilder.HasNavigation(
             Order.CustomerProperty.Name,
             pointsToPrincipal: true,
-            ConfigurationSource.DataAnnotation);
+            ConfigurationSource.DataAnnotation)!;
 
         Assert.True(
             dependentEntityBuilder.CanHaveNavigation(
@@ -2325,23 +2325,23 @@ public class InternalEntityTypeBuilderTest
         foreignKeyBuilder = foreignKeyBuilder.HasNavigation(
             Customer.OrdersProperty.Name,
             pointsToPrincipal: false,
-            ConfigurationSource.DataAnnotation);
+            ConfigurationSource.DataAnnotation)!;
 
         Assert.True(
             principalEntityBuilder.CanHaveNavigation(
                 Customer.OrdersProperty.Name, Customer.OrdersProperty.GetMemberType(), ConfigurationSource.Explicit));
 
         var newForeignKeyBuilder = dependentEntityBuilder
-            .HasRelationship(principalEntityBuilder.Metadata, ConfigurationSource.Convention).HasNavigation(
+            .HasRelationship(principalEntityBuilder.Metadata, ConfigurationSource.Convention)!.HasNavigation(
                 Customer.OrdersProperty.Name,
                 pointsToPrincipal: false,
-                ConfigurationSource.Convention);
+                ConfigurationSource.Convention)!;
         Assert.Same(foreignKeyBuilder, newForeignKeyBuilder);
-        newForeignKeyBuilder = principalEntityBuilder.HasRelationship(dependentEntityBuilder.Metadata, ConfigurationSource.Convention)
+        newForeignKeyBuilder = principalEntityBuilder.HasRelationship(dependentEntityBuilder.Metadata, ConfigurationSource.Convention)!
             .HasNavigation(
                 Order.CustomerProperty.Name,
                 pointsToPrincipal: false,
-                ConfigurationSource.Convention);
+            ConfigurationSource.Convention)!;
         Assert.Same(foreignKeyBuilder, newForeignKeyBuilder);
 
         Assert.Same(foreignKeyBuilder.Metadata, dependentEntityBuilder.Metadata.GetForeignKeys().Single());
@@ -2381,7 +2381,7 @@ public class InternalEntityTypeBuilderTest
             ignoredOnType, ignoreConfigurationSource, addConfigurationSource, ignoredFirst, setBaseFirst,
             et => et.Metadata.FindNavigation(Order.CustomerProperty.Name) != null,
             et => et.HasRelationship(
-                    et.ModelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit).Metadata,
+                    et.ModelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit)!.Metadata,
                     Order.CustomerProperty,
                     Customer.OrdersProperty,
                     addConfigurationSource)
@@ -2397,7 +2397,7 @@ public class InternalEntityTypeBuilderTest
         var derivedEntityBuilder = modelBuilder.Entity(typeof(SpecialCustomer), ConfigurationSource.Explicit);
         derivedEntityBuilder.HasBaseType(baseEntityBuilder.Metadata, ConfigurationSource.Convention);
 
-        baseEntityBuilder.HasRelationship(derivedEntityBuilder.Metadata, ConfigurationSource.Explicit).HasNavigation(
+        baseEntityBuilder.HasRelationship(derivedEntityBuilder.Metadata, ConfigurationSource.Explicit)!.HasNavigation(
             nameof(Customer.SpecialCustomer),
             pointsToPrincipal: true,
             ConfigurationSource.Explicit);
@@ -2406,7 +2406,7 @@ public class InternalEntityTypeBuilderTest
             baseEntityBuilder.Metadata,
             nameof(SpecialCustomer.Customer),
             nameof(Customer.SpecialCustomer),
-            ConfigurationSource.Convention);
+            ConfigurationSource.Convention)!;
 
         Assert.NotNull(derivedRelationship);
 
@@ -2422,7 +2422,7 @@ public class InternalEntityTypeBuilderTest
         var customerEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
         var orderEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
 
-        var relationshipBuilder = orderEntityBuilder.HasRelationship(customerEntityBuilder.Metadata, ConfigurationSource.Convention);
+        var relationshipBuilder = orderEntityBuilder.HasRelationship(customerEntityBuilder.Metadata, ConfigurationSource.Convention)!;
 
         Assert.NotNull(relationshipBuilder);
         Assert.NotSame(
@@ -2462,11 +2462,11 @@ public class InternalEntityTypeBuilderTest
             et => et.Metadata.FindSkipNavigation(nameof(Order.Products)) != null,
             et => et.HasSkipNavigation(
                     MemberIdentity.Create(Order.ProductsProperty),
-                    et.ModelBuilder.Entity(typeof(Product), ConfigurationSource.Explicit).Metadata,
+                    et.ModelBuilder.Entity(typeof(Product), ConfigurationSource.Explicit)!.Metadata,
                     addConfigurationSource)
                 != null,
-            modelBuilder => modelBuilder.Entity(typeof(Order), ConfigurationSource.Convention).HasRelationship(
-                modelBuilder.Entity(typeof(Customer), ConfigurationSource.Convention).Metadata,
+            modelBuilder => modelBuilder.Entity(typeof(Order), ConfigurationSource.Convention)!.HasRelationship(
+                modelBuilder.Entity(typeof(Customer), ConfigurationSource.Convention)!.Metadata,
                 Order.CustomerProperty,
                 Customer.OrdersProperty,
                 ConfigurationSource.Convention),
@@ -2598,7 +2598,7 @@ public class InternalEntityTypeBuilderTest
 
         AssertDeclaringType(
             modelBuilder.Entity(typeof(ExtraSpecialOrder), ConfigurationSource.Convention),
-            expectedDeclaringType,
+            expectedDeclaringType!,
             expectedMemberType);
     }
 
@@ -2619,7 +2619,7 @@ public class InternalEntityTypeBuilderTest
                 return entityTypeBuilder.ServiceProperty(Order.ProductsProperty, configurationSource) != null;
             case MemberType.Navigation:
                 return entityTypeBuilder.HasRelationship(
-                        entityTypeBuilder.ModelBuilder.Entity(typeof(Product), ConfigurationSource.Explicit).Metadata,
+                        entityTypeBuilder.ModelBuilder.Entity(typeof(Product), ConfigurationSource.Explicit)!.Metadata,
                         Order.ProductsProperty,
                         null,
                         configurationSource)
@@ -2627,7 +2627,7 @@ public class InternalEntityTypeBuilderTest
             case MemberType.SkipNavigation:
                 return entityTypeBuilder.HasSkipNavigation(
                         MemberIdentity.Create(Order.ProductsProperty),
-                        entityTypeBuilder.ModelBuilder.Entity(typeof(Product), ConfigurationSource.Explicit).Metadata,
+                        entityTypeBuilder.ModelBuilder.Entity(typeof(Product), ConfigurationSource.Explicit)!.Metadata,
                         configurationSource)
                     != null;
         }
@@ -2657,16 +2657,16 @@ public class InternalEntityTypeBuilderTest
             GetDeclaringType(entityTypeBuilder, MemberType.SkipNavigation));
     }
 
-    private EntityType GetDeclaringType(
+    private EntityType? GetDeclaringType(
         InternalEntityTypeBuilder entityTypeBuilder,
         MemberType memberType)
     {
         switch (memberType)
         {
             case MemberType.Property:
-                return (EntityType)entityTypeBuilder.Metadata.FindProperty(nameof(Order.Products))?.DeclaringType;
+                return (EntityType?)entityTypeBuilder.Metadata.FindProperty(nameof(Order.Products))?.DeclaringType;
             case MemberType.ComplexProperty:
-                return (EntityType)entityTypeBuilder.Metadata.FindComplexProperty(nameof(Order.Products))?.DeclaringType;
+                return (EntityType?)entityTypeBuilder.Metadata.FindComplexProperty(nameof(Order.Products))?.DeclaringType;
             case MemberType.ServiceProperty:
                 return entityTypeBuilder.Metadata.FindServiceProperty(nameof(Order.Products))?.DeclaringEntityType;
             case MemberType.Navigation:
@@ -2763,7 +2763,7 @@ public class InternalEntityTypeBuilderTest
         Assert.Empty(principalEntityBuilder.Metadata.GetForeignKeys());
         var fk = dependentEntityBuilder.Metadata.GetForeignKeys().Single();
         Assert.Null(fk.DependentToPrincipal?.Name);
-        Assert.Equal(Customer.OrdersProperty.Name, fk.PrincipalToDependent.Name);
+        Assert.Equal(Customer.OrdersProperty.Name, fk.PrincipalToDependent!.Name);
     }
 
     [Fact]
@@ -2782,7 +2782,7 @@ public class InternalEntityTypeBuilderTest
         Assert.Empty(principalEntityBuilder.Metadata.GetForeignKeys());
         var fk = dependentEntityBuilder.Metadata.GetForeignKeys().Single();
         Assert.Null(fk.PrincipalToDependent?.Name);
-        Assert.Equal(Order.CustomerProperty.Name, fk.DependentToPrincipal.Name);
+        Assert.Equal(Order.CustomerProperty.Name, fk.DependentToPrincipal!.Name);
     }
 
     [Fact]
@@ -2793,11 +2793,11 @@ public class InternalEntityTypeBuilderTest
         var dependentEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
 
         var orderRelationship = dependentEntityBuilder.HasRelationship(
-            principalEntityBuilder.Metadata, Order.CustomerProperty.Name, null, ConfigurationSource.DataAnnotation);
+            principalEntityBuilder.Metadata, Order.CustomerProperty.Name, null, ConfigurationSource.DataAnnotation)!;
         Assert.NotNull(orderRelationship);
         var customerRelationship = dependentEntityBuilder.HasRelationship(
                 principalEntityBuilder.Metadata, null, Customer.NotCollectionOrdersProperty.Name, ConfigurationSource.Convention)
-            .HasEntityTypes(principalEntityBuilder.Metadata, dependentEntityBuilder.Metadata, ConfigurationSource.Convention);
+            !.HasEntityTypes(principalEntityBuilder.Metadata, dependentEntityBuilder.Metadata, ConfigurationSource.Convention)!;
         Assert.NotNull(customerRelationship);
 
         Assert.Null(
@@ -2808,8 +2808,8 @@ public class InternalEntityTypeBuilderTest
         var orderFk = dependentEntityBuilder.Metadata.GetNavigations().Single().ForeignKey;
         var customerFk = principalEntityBuilder.Metadata.GetNavigations().Single().ForeignKey;
         Assert.Null(orderFk.PrincipalToDependent);
-        Assert.Equal(Order.CustomerProperty.Name, orderFk.DependentToPrincipal.Name);
-        Assert.Equal(Customer.NotCollectionOrdersProperty.Name, customerFk.PrincipalToDependent.Name);
+        Assert.Equal(Order.CustomerProperty.Name, orderFk.DependentToPrincipal!.Name);
+        Assert.Equal(Customer.NotCollectionOrdersProperty.Name, customerFk.PrincipalToDependent!.Name);
         Assert.Null(customerFk.DependentToPrincipal);
     }
 
@@ -2821,11 +2821,11 @@ public class InternalEntityTypeBuilderTest
         var dependentEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
 
         var orderRelationship = dependentEntityBuilder.HasRelationship(
-            principalEntityBuilder.Metadata, Order.CustomerProperty, null, ConfigurationSource.Convention);
+            principalEntityBuilder.Metadata, Order.CustomerProperty, null, ConfigurationSource.Convention)!;
         Assert.NotNull(orderRelationship);
         var customerRelationship = dependentEntityBuilder.HasRelationship(
                 principalEntityBuilder.Metadata, null, Customer.NotCollectionOrdersProperty, ConfigurationSource.DataAnnotation)
-            .HasEntityTypes(principalEntityBuilder.Metadata, dependentEntityBuilder.Metadata, ConfigurationSource.DataAnnotation);
+            !.HasEntityTypes(principalEntityBuilder.Metadata, dependentEntityBuilder.Metadata, ConfigurationSource.DataAnnotation)!;
         Assert.NotNull(customerRelationship);
 
         Assert.Null(
@@ -2834,8 +2834,8 @@ public class InternalEntityTypeBuilderTest
                 ConfigurationSource.Convention));
 
         Assert.Null(orderRelationship.Metadata.PrincipalToDependent);
-        Assert.Equal(Order.CustomerProperty.Name, orderRelationship.Metadata.DependentToPrincipal.Name);
-        Assert.Equal(Customer.NotCollectionOrdersProperty.Name, customerRelationship.Metadata.PrincipalToDependent.Name);
+        Assert.Equal(Order.CustomerProperty.Name, orderRelationship.Metadata.DependentToPrincipal!.Name);
+        Assert.Equal(Customer.NotCollectionOrdersProperty.Name, customerRelationship.Metadata.PrincipalToDependent!.Name);
         Assert.Null(customerRelationship.Metadata.DependentToPrincipal);
     }
 
@@ -2845,35 +2845,35 @@ public class InternalEntityTypeBuilderTest
         var modelBuilder = CreateModelBuilder();
         var customerEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
         var orderEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
-        var fkProperty = orderEntityBuilder.Property(Order.IdProperty, ConfigurationSource.Explicit).Metadata;
-        var key = customerEntityBuilder.PrimaryKey([Customer.IdProperty], ConfigurationSource.Explicit).Metadata;
+        var fkProperty = orderEntityBuilder.Property(Order.IdProperty, ConfigurationSource.Explicit)!.Metadata;
+        var key = customerEntityBuilder.PrimaryKey([Customer.IdProperty], ConfigurationSource.Explicit)!.Metadata;
 
         var orderRelationship = orderEntityBuilder.HasRelationship(
-            customerEntityBuilder.Metadata, Order.CustomerProperty.Name, null, ConfigurationSource.Convention);
+            customerEntityBuilder.Metadata, Order.CustomerProperty.Name, null, ConfigurationSource.Convention)!;
         Assert.NotNull(orderRelationship);
         var customerRelationship = orderEntityBuilder.HasRelationship(
-            customerEntityBuilder.Metadata, null, Customer.NotCollectionOrdersProperty.Name, ConfigurationSource.Convention);
+            customerEntityBuilder.Metadata, null, Customer.NotCollectionOrdersProperty.Name, ConfigurationSource.Convention)!;
         Assert.NotNull(customerRelationship);
         var fkRelationship = orderEntityBuilder.HasRelationship(
                 customerEntityBuilder.Metadata, [fkProperty], key, ConfigurationSource.DataAnnotation)
-            .IsUnique(false, ConfigurationSource.DataAnnotation);
+            !.IsUnique(false, ConfigurationSource.DataAnnotation)!;
         Assert.NotNull(fkRelationship);
         Assert.Same(
             fkRelationship.Metadata, orderEntityBuilder.Metadata.GetForeignKeys()
                 .Single(fk => fk.DependentToPrincipal == null && fk.PrincipalToDependent == null));
-        var fk1 = orderEntityBuilder.Metadata.FindNavigation(Order.CustomerProperty.Name).ForeignKey;
+        var fk1 = orderEntityBuilder.Metadata.FindNavigation(Order.CustomerProperty.Name)!.ForeignKey;
         Assert.NotSame(fkRelationship.Metadata, fk1);
-        var fk2 = customerEntityBuilder.Metadata.FindNavigation(Customer.NotCollectionOrdersProperty.Name).ForeignKey;
+        var fk2 = customerEntityBuilder.Metadata.FindNavigation(Customer.NotCollectionOrdersProperty.Name)!.ForeignKey;
         Assert.NotSame(fkRelationship.Metadata, fk2);
         Assert.NotSame(fk1, fk2);
 
-        orderEntityBuilder.HasRelationship(customerEntityBuilder.Metadata, ConfigurationSource.Convention).HasNavigation(
+        orderEntityBuilder.HasRelationship(customerEntityBuilder.Metadata, ConfigurationSource.Convention)!.HasNavigation(
                 Order.CustomerProperty.Name,
                 pointsToPrincipal: true,
-                ConfigurationSource.Convention).HasNavigation(
+                ConfigurationSource.Convention)!.HasNavigation(
                 Customer.NotCollectionOrdersProperty.Name,
                 pointsToPrincipal: false,
-                ConfigurationSource.Convention)
+                ConfigurationSource.Convention)!
             .HasForeignKey([fkProperty], ConfigurationSource.Convention)
             ?.HasPrincipalKey(key.Properties, ConfigurationSource.Convention);
 
@@ -2896,11 +2896,11 @@ public class InternalEntityTypeBuilderTest
         Assert.Null(modelBuilder.Ignore(entityBuilder.Metadata.Name, ConfigurationSource.Convention));
         Assert.Same(
             derivedEntityBuilder,
-            derivedEntityBuilder.HasBaseType((Type)null, ConfigurationSource.DataAnnotation));
+            derivedEntityBuilder.HasBaseType((Type?)null, ConfigurationSource.DataAnnotation));
         Assert.Same(
             derivedEntityBuilder,
             derivedEntityBuilder.HasBaseType(entityBuilder.Metadata, ConfigurationSource.Explicit));
-        Assert.Null(derivedEntityBuilder.HasBaseType((string)null, ConfigurationSource.Convention));
+        Assert.Null(derivedEntityBuilder.HasBaseType((string?)null, ConfigurationSource.Convention));
         Assert.Same(entityBuilder.Metadata, derivedEntityBuilder.Metadata.BaseType);
     }
 
@@ -2913,8 +2913,8 @@ public class InternalEntityTypeBuilderTest
         derivedEntityBuilder.Metadata.SetBaseType(entityBuilder.Metadata, ConfigurationSource.Explicit);
 
         Assert.Same(derivedEntityBuilder, derivedEntityBuilder.HasBaseType(entityBuilder.Metadata, ConfigurationSource.Convention));
-        Assert.Null(derivedEntityBuilder.HasBaseType((EntityType)null, ConfigurationSource.Convention));
-        Assert.Same(derivedEntityBuilder, derivedEntityBuilder.HasBaseType((EntityType)null, ConfigurationSource.Explicit));
+        Assert.Null(derivedEntityBuilder.HasBaseType((EntityType?)null, ConfigurationSource.Convention));
+        Assert.Same(derivedEntityBuilder, derivedEntityBuilder.HasBaseType((EntityType?)null, ConfigurationSource.Explicit));
         Assert.Null(derivedEntityBuilder.Metadata.BaseType);
     }
 
@@ -2966,7 +2966,7 @@ public class InternalEntityTypeBuilderTest
                 principalEntityBuilder.Metadata, Order.CustomerProperty.Name, null, ConfigurationSource.Explicit));
 
         var derivedPrincipalEntityBuilder = modelBuilder.Entity(typeof(SpecialCustomer), ConfigurationSource.Explicit)
-            .HasBaseType((string)null, ConfigurationSource.Explicit);
+            .HasBaseType((string?)null, ConfigurationSource.Explicit)!;
         var derivedDependentEntityBuilder = modelBuilder.Entity(typeof(SpecialOrder), ConfigurationSource.Convention);
         Assert.NotNull(
             derivedDependentEntityBuilder.HasRelationship(
@@ -2991,11 +2991,11 @@ public class InternalEntityTypeBuilderTest
         var modelBuilder = CreateModelBuilder();
         var dependentEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
         dependentEntityBuilder.HasRelationship(
-            typeof(Customer).FullName, [Order.CustomerIdProperty.Name], ConfigurationSource.Explicit);
+            typeof(Customer).FullName!, [Order.CustomerIdProperty.Name], ConfigurationSource.Explicit);
 
         var derivedDependentEntityBuilder = modelBuilder.Entity(typeof(SpecialOrder), ConfigurationSource.Convention);
         derivedDependentEntityBuilder.HasRelationship(
-            typeof(Customer).FullName, [Order.CustomerIdProperty.Name], ConfigurationSource.Explicit);
+            typeof(Customer).FullName!, [Order.CustomerIdProperty.Name], ConfigurationSource.Explicit);
 
         Assert.Same(
             derivedDependentEntityBuilder,
@@ -3014,7 +3014,7 @@ public class InternalEntityTypeBuilderTest
         var derivedEntityBuilder = modelBuilder.Entity(typeof(SpecialOrder), ConfigurationSource.Convention);
         derivedEntityBuilder.Property(Order.IdProperty, ConfigurationSource.Convention);
         derivedEntityBuilder.HasIndex([Order.IdProperty.Name], ConfigurationSource.DataAnnotation)
-            .IsUnique(true, ConfigurationSource.Convention);
+            !.IsUnique(true, ConfigurationSource.Convention);
         Assert.Single(derivedEntityBuilder.Metadata.GetDeclaredIndexes());
 
         Assert.Same(
@@ -3034,13 +3034,13 @@ public class InternalEntityTypeBuilderTest
         var dependentEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
 
         var derivedPrincipalEntityBuilder = modelBuilder.Entity(typeof(SpecialCustomer), ConfigurationSource.Convention);
-        var derivedIdProperty = derivedPrincipalEntityBuilder.Property(Customer.IdProperty, ConfigurationSource.Convention).Metadata;
+        var derivedIdProperty = derivedPrincipalEntityBuilder.Property(Customer.IdProperty, ConfigurationSource.Convention)!.Metadata;
 
         dependentEntityBuilder.HasRelationship(
                 derivedPrincipalEntityBuilder.Metadata,
                 Order.CustomerProperty.Name,
                 Customer.OrdersProperty.Name,
-                ConfigurationSource.Convention)
+                ConfigurationSource.Convention)!
             .HasPrincipalKey([derivedIdProperty], ConfigurationSource.Convention);
         Assert.Single(derivedPrincipalEntityBuilder.Metadata.GetDeclaredKeys());
 
@@ -3053,8 +3053,8 @@ public class InternalEntityTypeBuilderTest
         Assert.Empty(derivedPrincipalEntityBuilder.Metadata.GetForeignKeys());
         Assert.Empty(principalEntityBuilder.Metadata.GetReferencingForeignKeys());
         var fk = derivedPrincipalEntityBuilder.Metadata.GetReferencingForeignKeys().Single();
-        Assert.Equal(Order.CustomerProperty.Name, fk.DependentToPrincipal.Name);
-        Assert.Equal(Customer.OrdersProperty.Name, fk.PrincipalToDependent.Name);
+        Assert.Equal(Order.CustomerProperty.Name, fk.DependentToPrincipal!.Name);
+        Assert.Equal(Customer.OrdersProperty.Name, fk.PrincipalToDependent!.Name);
     }
 
     [Fact]
@@ -3066,13 +3066,13 @@ public class InternalEntityTypeBuilderTest
         var dependentEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
 
         var derivedDependentEntityBuilder = modelBuilder.Entity(typeof(SpecialOrder), ConfigurationSource.Convention);
-        var derivedIdProperty = derivedDependentEntityBuilder.Property(Order.IdProperty, ConfigurationSource.Convention).Metadata;
+        var derivedIdProperty = derivedDependentEntityBuilder.Property(Order.IdProperty, ConfigurationSource.Convention)!.Metadata;
 
         derivedDependentEntityBuilder.HasRelationship(
                 principalEntityBuilder.Metadata,
                 Order.CustomerProperty.Name,
                 Customer.SpecialOrdersProperty.Name,
-                ConfigurationSource.DataAnnotation)
+                ConfigurationSource.DataAnnotation)!
             .HasForeignKey([derivedIdProperty], ConfigurationSource.DataAnnotation);
 
         Assert.Same(
@@ -3081,8 +3081,8 @@ public class InternalEntityTypeBuilderTest
         Assert.Empty(dependentEntityBuilder.Metadata.GetForeignKeys());
         Assert.Empty(dependentEntityBuilder.Metadata.GetDeclaredProperties());
         var fk = derivedDependentEntityBuilder.Metadata.GetForeignKeys().Single();
-        Assert.Equal(Order.CustomerProperty.Name, fk.DependentToPrincipal.Name);
-        Assert.Equal(Customer.SpecialOrdersProperty.Name, fk.PrincipalToDependent.Name);
+        Assert.Equal(Order.CustomerProperty.Name, fk.DependentToPrincipal!.Name);
+        Assert.Equal(Customer.SpecialOrdersProperty.Name, fk.PrincipalToDependent!.Name);
         Assert.Equal(Order.IdProperty.Name, fk.Properties.Single().Name);
     }
 
@@ -3096,13 +3096,13 @@ public class InternalEntityTypeBuilderTest
         dependentEntityBuilder.PrimaryKey([Order.IdProperty], ConfigurationSource.Explicit);
         var derivedDependentEntityBuilder = modelBuilder.Entity(typeof(SpecialOrder), ConfigurationSource.Convention);
         derivedDependentEntityBuilder.PrimaryKey([Order.IdProperty], ConfigurationSource.Convention);
-        var derivedIdProperty = derivedDependentEntityBuilder.Property(Order.IdProperty, ConfigurationSource.Convention).Metadata;
+        var derivedIdProperty = derivedDependentEntityBuilder.Property(Order.IdProperty, ConfigurationSource.Convention)!.Metadata;
 
         derivedDependentEntityBuilder.HasRelationship(
                 principalEntityBuilder.Metadata,
                 Order.CustomerProperty.Name,
                 Customer.SpecialOrdersProperty.Name,
-                ConfigurationSource.Explicit)
+                ConfigurationSource.Explicit)!
             .HasForeignKey([derivedIdProperty], ConfigurationSource.Convention);
 
         Assert.Same(
@@ -3110,8 +3110,8 @@ public class InternalEntityTypeBuilderTest
             derivedDependentEntityBuilder.HasBaseType(dependentEntityBuilder.Metadata, ConfigurationSource.DataAnnotation));
         Assert.Empty(dependentEntityBuilder.Metadata.GetForeignKeys());
         var fk = derivedDependentEntityBuilder.Metadata.GetForeignKeys().Single();
-        Assert.Equal(Order.CustomerProperty.Name, fk.DependentToPrincipal.Name);
-        Assert.Equal(Customer.SpecialOrdersProperty.Name, fk.PrincipalToDependent.Name);
+        Assert.Equal(Order.CustomerProperty.Name, fk.DependentToPrincipal!.Name);
+        Assert.Equal(Customer.SpecialOrdersProperty.Name, fk.PrincipalToDependent!.Name);
         Assert.NotEqual(Order.IdProperty.Name, fk.Properties.Single().Name);
         Assert.Single(dependentEntityBuilder.Metadata.GetDeclaredProperties());
     }
@@ -3161,13 +3161,13 @@ public class InternalEntityTypeBuilderTest
 
         var shadowProperty = entityType.AddPrimitiveCollection("Shadow", typeof(List<int>), typeof(int));
         Assert.NotNull(shadowProperty);
-        Assert.Equal(typeof(int), shadowProperty.GetElementType().ClrType);
+        Assert.Equal(typeof(int), shadowProperty.GetElementType()!.ClrType);
         Assert.True(shadowProperty.IsPrimitiveCollection);
 
         var memberProperty = entityType.AddPrimitiveCollection(
             nameof(Order.Numbers), typeof(List<int>), Order.NumbersProperty, typeof(int));
         Assert.NotNull(memberProperty);
-        Assert.Equal(typeof(int), memberProperty.GetElementType().ClrType);
+        Assert.Equal(typeof(int), memberProperty.GetElementType()!.ClrType);
         Assert.True(memberProperty.IsPrimitiveCollection);
         Assert.Same(Order.NumbersProperty, memberProperty.GetIdentifyingMemberInfo());
     }
@@ -3204,32 +3204,32 @@ public class InternalEntityTypeBuilderTest
     {
         IConventionEntityTypeBuilder typeBuilder = CreateModelBuilder().Entity(typeof(Order), ConfigurationSource.Convention);
         Assert.NotNull(typeBuilder.HasDiscriminator());
-        Assert.Equal("Discriminator", typeBuilder.Metadata.FindDiscriminatorProperty().Name);
-        Assert.Equal(typeof(string), typeBuilder.Metadata.FindDiscriminatorProperty().ClrType);
+        Assert.Equal("Discriminator", typeBuilder.Metadata.FindDiscriminatorProperty()!.Name);
+        Assert.Equal(typeof(string), typeBuilder.Metadata.FindDiscriminatorProperty()!.ClrType);
 
         Assert.NotNull(typeBuilder.HasNoDiscriminator());
         Assert.Null(typeBuilder.Metadata.FindDiscriminatorProperty());
         Assert.Empty(typeBuilder.Metadata.GetProperties());
 
         Assert.NotNull(typeBuilder.HasDiscriminator("Splod", typeof(int?)));
-        Assert.Equal("Splod", typeBuilder.Metadata.FindDiscriminatorProperty().Name);
-        Assert.Equal(typeof(int?), typeBuilder.Metadata.FindDiscriminatorProperty().ClrType);
+        Assert.Equal("Splod", typeBuilder.Metadata.FindDiscriminatorProperty()!.Name);
+        Assert.Equal(typeof(int?), typeBuilder.Metadata.FindDiscriminatorProperty()!.ClrType);
         Assert.Equal("Splod", typeBuilder.Metadata.GetProperties().Single().Name);
 
         Assert.NotNull(typeBuilder.HasDiscriminator(Order.CustomerUniqueProperty, fromDataAnnotation: true));
-        Assert.Equal(Order.CustomerUniqueProperty.Name, typeBuilder.Metadata.FindDiscriminatorProperty().Name);
-        Assert.Equal(typeof(Guid?), typeBuilder.Metadata.FindDiscriminatorProperty().ClrType);
+        Assert.Equal(Order.CustomerUniqueProperty.Name, typeBuilder.Metadata.FindDiscriminatorProperty()!.Name);
+        Assert.Equal(typeof(Guid?), typeBuilder.Metadata.FindDiscriminatorProperty()!.ClrType);
         Assert.Equal(Order.CustomerUniqueProperty.Name, typeBuilder.Metadata.GetProperties().Single().Name);
 
         Assert.Null(typeBuilder.HasDiscriminator("Splew", typeof(int?)));
-        Assert.Equal(Order.CustomerUniqueProperty.Name, typeBuilder.Metadata.FindDiscriminatorProperty().Name);
-        Assert.Equal(typeof(Guid?), typeBuilder.Metadata.FindDiscriminatorProperty().ClrType);
+        Assert.Equal(Order.CustomerUniqueProperty.Name, typeBuilder.Metadata.FindDiscriminatorProperty()!.Name);
+        Assert.Equal(typeof(Guid?), typeBuilder.Metadata.FindDiscriminatorProperty()!.ClrType);
         Assert.Equal(Order.CustomerUniqueProperty.Name, typeBuilder.Metadata.GetProperties().Single().Name);
 
         Assert.NotNull(typeBuilder.HasDiscriminator(typeof(int), fromDataAnnotation: true));
         Assert.Null(typeBuilder.HasDiscriminator(typeof(long)));
-        Assert.Equal("Discriminator", typeBuilder.Metadata.FindDiscriminatorProperty().Name);
-        Assert.Equal(typeof(int), typeBuilder.Metadata.FindDiscriminatorProperty().ClrType);
+        Assert.Equal("Discriminator", typeBuilder.Metadata.FindDiscriminatorProperty()!.Name);
+        Assert.Equal(typeof(int), typeBuilder.Metadata.FindDiscriminatorProperty()!.ClrType);
 
         Assert.Null(typeBuilder.HasNoDiscriminator());
     }
@@ -3241,12 +3241,12 @@ public class InternalEntityTypeBuilderTest
         typeBuilder.Ignore("Splod", true);
 
         Assert.NotNull(typeBuilder.HasDiscriminator("Splew", typeof(string)));
-        Assert.Equal("Splew", typeBuilder.Metadata.FindDiscriminatorProperty().Name);
-        Assert.Equal(typeof(string), typeBuilder.Metadata.FindDiscriminatorProperty().ClrType);
+        Assert.Equal("Splew", typeBuilder.Metadata.FindDiscriminatorProperty()!.Name);
+        Assert.Equal(typeof(string), typeBuilder.Metadata.FindDiscriminatorProperty()!.ClrType);
 
         Assert.Null(typeBuilder.HasDiscriminator("Splod", typeof(int?)));
-        Assert.Equal("Splew", typeBuilder.Metadata.FindDiscriminatorProperty().Name);
-        Assert.Equal(typeof(string), typeBuilder.Metadata.FindDiscriminatorProperty().ClrType);
+        Assert.Equal("Splew", typeBuilder.Metadata.FindDiscriminatorProperty()!.Name);
+        Assert.Equal(typeof(string), typeBuilder.Metadata.FindDiscriminatorProperty()!.ClrType);
     }
 
     [Fact]
@@ -3263,15 +3263,15 @@ public class InternalEntityTypeBuilderTest
     public void Can_access_discriminator_value()
     {
         IConventionEntityTypeBuilder typeBuilder = CreateModelBuilder().Entity("Splot", ConfigurationSource.Convention);
-        var derivedTypeBuilder = typeBuilder.ModelBuilder.Entity("Splod");
+        var derivedTypeBuilder = typeBuilder.ModelBuilder.Entity("Splod")!;
         derivedTypeBuilder.HasBaseType(typeBuilder.Metadata, fromDataAnnotation: true);
-        var otherDerivedTypeBuilder = typeBuilder.ModelBuilder.Entity("Splow");
+        var otherDerivedTypeBuilder = typeBuilder.ModelBuilder.Entity("Splow")!;
 
         Assert.NotNull(typeBuilder.HasDiscriminator());
         Assert.Single(typeBuilder.Metadata.GetDeclaredProperties());
         Assert.Empty(derivedTypeBuilder.Metadata.GetDeclaredProperties());
 
-        var discriminatorBuilder = typeBuilder.HasDiscriminator("Splowed", typeof(int?));
+        var discriminatorBuilder = typeBuilder.HasDiscriminator("Splowed", typeof(int?))!;
         Assert.NotNull(discriminatorBuilder.HasValue(typeBuilder.Metadata, 1));
         Assert.NotNull(discriminatorBuilder.HasValue(otherDerivedTypeBuilder.Metadata, 2));
         Assert.NotNull(discriminatorBuilder.HasValue(derivedTypeBuilder.Metadata, 3));
@@ -3279,35 +3279,35 @@ public class InternalEntityTypeBuilderTest
         Assert.Same(typeBuilder.Metadata, otherDerivedTypeBuilder.Metadata.BaseType);
         Assert.Equal(1, typeBuilder.Metadata.GetDiscriminatorValue());
         Assert.Equal(
-            2, typeBuilder.ModelBuilder.Entity("Splow")
+            2, typeBuilder.ModelBuilder.Entity("Splow")!
                 .Metadata.GetDiscriminatorValue());
         Assert.Equal(
-            3, typeBuilder.ModelBuilder.Entity("Splod")
+            3, typeBuilder.ModelBuilder.Entity("Splod")!
                 .Metadata.GetDiscriminatorValue());
-        Assert.Same(typeBuilder.Metadata, typeBuilder.ModelBuilder.Metadata.FindEntityType("Splow").BaseType);
+        Assert.Same(typeBuilder.Metadata, typeBuilder.ModelBuilder.Metadata.FindEntityType("Splow")!.BaseType);
 
-        discriminatorBuilder = typeBuilder.HasDiscriminator(fromDataAnnotation: true);
+        discriminatorBuilder = typeBuilder.HasDiscriminator(fromDataAnnotation: true)!;
         Assert.NotNull(discriminatorBuilder.HasValue(typeBuilder.Metadata, 4, fromDataAnnotation: true));
         Assert.NotNull(discriminatorBuilder.HasValue(otherDerivedTypeBuilder.Metadata, 5, fromDataAnnotation: true));
         Assert.NotNull(discriminatorBuilder.HasValue(derivedTypeBuilder.Metadata, 6, fromDataAnnotation: true));
         Assert.Equal(4, typeBuilder.Metadata.GetDiscriminatorValue());
         Assert.Equal(
-            5, typeBuilder.ModelBuilder.Entity("Splow")
+            5, typeBuilder.ModelBuilder.Entity("Splow")!
                 .Metadata.GetDiscriminatorValue());
         Assert.Equal(
-            6, typeBuilder.ModelBuilder.Entity("Splod")
+            6, typeBuilder.ModelBuilder.Entity("Splod")!
                 .Metadata.GetDiscriminatorValue());
 
-        discriminatorBuilder = typeBuilder.HasDiscriminator();
+        discriminatorBuilder = typeBuilder.HasDiscriminator()!;
         Assert.Null(discriminatorBuilder.HasValue(typeBuilder.Metadata, 1));
         Assert.Null(discriminatorBuilder.HasValue(otherDerivedTypeBuilder.Metadata, 2));
         Assert.Null(discriminatorBuilder.HasValue(derivedTypeBuilder.Metadata, 3));
         Assert.Equal(4, typeBuilder.Metadata.GetDiscriminatorValue());
         Assert.Equal(
-            5, typeBuilder.ModelBuilder.Entity("Splow")
+            5, typeBuilder.ModelBuilder.Entity("Splow")!
                 .Metadata.GetDiscriminatorValue());
         Assert.Equal(
-            6, typeBuilder.ModelBuilder.Entity("Splod")
+            6, typeBuilder.ModelBuilder.Entity("Splod")!
                 .Metadata.GetDiscriminatorValue());
 
         Assert.NotNull(typeBuilder.HasNoDiscriminator(fromDataAnnotation: true));
@@ -3320,51 +3320,51 @@ public class InternalEntityTypeBuilderTest
     public void Changing_discriminator_type_removes_values()
     {
         IConventionEntityTypeBuilder typeBuilder = CreateModelBuilder().Entity("Splot", ConfigurationSource.Convention);
-        var derivedTypeBuilder = typeBuilder.ModelBuilder.Entity("Splod");
+        var derivedTypeBuilder = typeBuilder.ModelBuilder.Entity("Splod")!;
         derivedTypeBuilder.HasBaseType(typeBuilder.Metadata, fromDataAnnotation: true);
-        var otherDerivedTypeBuilder = typeBuilder.ModelBuilder.Entity("Splow");
+        var otherDerivedTypeBuilder = typeBuilder.ModelBuilder.Entity("Splow")!;
 
         Assert.NotNull(typeBuilder.HasDiscriminator());
         Assert.Single(typeBuilder.Metadata.GetDeclaredProperties());
         Assert.Empty(derivedTypeBuilder.Metadata.GetDeclaredProperties());
 
-        var discriminatorBuilder = typeBuilder.HasDiscriminator("Splowed", typeof(int));
+        var discriminatorBuilder = typeBuilder.HasDiscriminator("Splowed", typeof(int))!;
         Assert.NotNull(discriminatorBuilder.HasValue(typeBuilder.Metadata, 1));
         Assert.NotNull(discriminatorBuilder.HasValue(otherDerivedTypeBuilder.Metadata, 2));
         Assert.NotNull(discriminatorBuilder.HasValue(derivedTypeBuilder.Metadata, 3));
 
-        discriminatorBuilder = typeBuilder.HasDiscriminator("Splowed", typeof(string));
+        discriminatorBuilder = typeBuilder.HasDiscriminator("Splowed", typeof(string))!;
         Assert.Null(typeBuilder.Metadata[CoreAnnotationNames.DiscriminatorValue]);
         Assert.Null(
-            typeBuilder.ModelBuilder.Entity("Splow")
+            typeBuilder.ModelBuilder.Entity("Splow")!
                 .Metadata[CoreAnnotationNames.DiscriminatorValue]);
         Assert.Null(
-            typeBuilder.ModelBuilder.Entity("Splod")
+            typeBuilder.ModelBuilder.Entity("Splod")!
                 .Metadata[CoreAnnotationNames.DiscriminatorValue]);
         Assert.NotNull(discriminatorBuilder.HasValue(typeBuilder.Metadata, "4"));
         Assert.NotNull(discriminatorBuilder.HasValue(otherDerivedTypeBuilder.Metadata, "5"));
         Assert.NotNull(discriminatorBuilder.HasValue(derivedTypeBuilder.Metadata, "6"));
 
-        discriminatorBuilder = typeBuilder.HasDiscriminator("Splotted", typeof(string));
+        discriminatorBuilder = typeBuilder.HasDiscriminator("Splotted", typeof(string))!;
 
         Assert.NotNull(discriminatorBuilder);
         Assert.Equal("4", typeBuilder.Metadata.GetDiscriminatorValue());
         Assert.Equal(
-            "5", typeBuilder.ModelBuilder.Entity("Splow")
+            "5", typeBuilder.ModelBuilder.Entity("Splow")!
                 .Metadata.GetDiscriminatorValue());
         Assert.Equal(
-            "6", typeBuilder.ModelBuilder.Entity("Splod")
+            "6", typeBuilder.ModelBuilder.Entity("Splod")!
                 .Metadata.GetDiscriminatorValue());
 
-        discriminatorBuilder = typeBuilder.HasDiscriminator(typeof(int));
+        discriminatorBuilder = typeBuilder.HasDiscriminator(typeof(int))!;
 
         Assert.NotNull(discriminatorBuilder);
         Assert.Null(typeBuilder.Metadata[CoreAnnotationNames.DiscriminatorValue]);
         Assert.Null(
-            typeBuilder.ModelBuilder.Entity("Splow")
+            typeBuilder.ModelBuilder.Entity("Splow")!
                 .Metadata[CoreAnnotationNames.DiscriminatorValue]);
         Assert.Null(
-            typeBuilder.ModelBuilder.Entity("Splod")
+            typeBuilder.ModelBuilder.Entity("Splod")!
                 .Metadata[CoreAnnotationNames.DiscriminatorValue]);
     }
 
@@ -3374,21 +3374,21 @@ public class InternalEntityTypeBuilderTest
         IConventionEntityTypeBuilder typeBuilder = CreateModelBuilder().Entity(typeof(Splot), ConfigurationSource.Convention);
 
         var discriminatorBuilder = new DiscriminatorBuilder<int?>(
-            (DiscriminatorBuilder)typeBuilder.HasDiscriminator(Splot.SplowedProperty));
+            (DiscriminatorBuilder)typeBuilder.HasDiscriminator(Splot.SplowedProperty)!);
         Assert.NotNull(discriminatorBuilder.HasValue(typeof(Splot), 1));
         Assert.NotNull(discriminatorBuilder.HasValue(typeof(Splow), 2));
         Assert.NotNull(discriminatorBuilder.HasValue(typeof(Splod), 3));
 
-        var splow = typeBuilder.ModelBuilder.Entity(typeof(Splow)).Metadata;
-        var splod = typeBuilder.ModelBuilder.Entity(typeof(Splod)).Metadata;
+        var splow = typeBuilder.ModelBuilder.Entity(typeof(Splow))!.Metadata;
+        var splod = typeBuilder.ModelBuilder.Entity(typeof(Splod))!.Metadata;
         Assert.Equal(1, typeBuilder.Metadata.GetDiscriminatorValue());
         Assert.Equal(2, splow.GetDiscriminatorValue());
         Assert.Equal(
-            3, typeBuilder.ModelBuilder.Entity(typeof(Splod))
+            3, typeBuilder.ModelBuilder.Entity(typeof(Splod))!
                 .Metadata.GetDiscriminatorValue());
 
         discriminatorBuilder = new DiscriminatorBuilder<int?>(
-            (DiscriminatorBuilder)typeBuilder.HasDiscriminator(fromDataAnnotation: true));
+            (DiscriminatorBuilder)typeBuilder.HasDiscriminator(fromDataAnnotation: true)!);
         Assert.NotNull(discriminatorBuilder.HasValue(typeof(Splot), 4));
         Assert.NotNull(discriminatorBuilder.HasValue(typeof(Splow), 5));
         Assert.NotNull(discriminatorBuilder.HasValue(typeof(Splod), 6));
@@ -3396,7 +3396,7 @@ public class InternalEntityTypeBuilderTest
         Assert.Equal(5, splow.GetDiscriminatorValue());
         Assert.Equal(6, splod.GetDiscriminatorValue());
 
-        var conventionDiscriminatorBuilder = typeBuilder.HasDiscriminator();
+        var conventionDiscriminatorBuilder = typeBuilder.HasDiscriminator()!;
         Assert.Null(conventionDiscriminatorBuilder.HasValue(typeBuilder.Metadata, 1));
         Assert.Null(conventionDiscriminatorBuilder.HasValue(splow, 2));
         Assert.Null(conventionDiscriminatorBuilder.HasValue(splod, 3));
@@ -3409,11 +3409,11 @@ public class InternalEntityTypeBuilderTest
     public void DiscriminatorValue_throws_if_base_cannot_be_set()
     {
         IConventionModelBuilder modelBuilder = CreateModelBuilder();
-        var typeBuilder = modelBuilder.Entity("Splot");
-        var nonDerivedTypeBuilder = modelBuilder.Entity("Splow");
-        nonDerivedTypeBuilder.HasBaseType(modelBuilder.Entity("Splod").Metadata, true);
+        var typeBuilder = modelBuilder.Entity("Splot")!;
+        var nonDerivedTypeBuilder = modelBuilder.Entity("Splow")!;
+        nonDerivedTypeBuilder.HasBaseType(modelBuilder.Entity("Splod")!.Metadata, true);
 
-        var discriminatorBuilder = typeBuilder.HasDiscriminator();
+        var discriminatorBuilder = typeBuilder.HasDiscriminator()!;
         Assert.Equal(
             CoreStrings.DiscriminatorEntityTypeNotDerived("Splow (Dictionary<string, object>)", "Splot (Dictionary<string, object>)"),
             Assert.Throws<InvalidOperationException>(() => discriminatorBuilder.HasValue(nonDerivedTypeBuilder.Metadata, "1")).Message);
@@ -3432,25 +3432,25 @@ public class InternalEntityTypeBuilderTest
 
         entityBuilder.HasQueryFilter(new QueryFilter(filterExpression, ConfigurationSource.Explicit));
         entityBuilder.HasQueryFilter(new QueryFilter(filterExpression2, ConfigurationSource.Explicit));
-        Assert.NotEqual(filterExpression, entityBuilder.Metadata.FindDeclaredQueryFilter(null).Expression);
+        Assert.NotEqual(filterExpression, entityBuilder.Metadata.FindDeclaredQueryFilter(null)!.Expression);
 
         entityBuilder.HasQueryFilter(new QueryFilter(filterExpression3, ConfigurationSource.DataAnnotation));
-        Assert.Same(filterExpression2, entityBuilder.Metadata.FindDeclaredQueryFilter(null).Expression);
+        Assert.Same(filterExpression2, entityBuilder.Metadata.FindDeclaredQueryFilter(null)!.Expression);
 
         entityBuilder.HasQueryFilter(new QueryFilter(filterExpression4, ConfigurationSource.Convention));
-        Assert.Same(filterExpression2, entityBuilder.Metadata.FindDeclaredQueryFilter(null).Expression);
+        Assert.Same(filterExpression2, entityBuilder.Metadata.FindDeclaredQueryFilter(null)!.Expression);
 
         modelBuilder = CreateModelBuilder();
         entityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Convention);
         entityBuilder.HasQueryFilter(new QueryFilter(filterExpression4, ConfigurationSource.Convention));
         entityBuilder.HasQueryFilter(new QueryFilter(filterExpression3, ConfigurationSource.Convention));
-        Assert.NotEqual(filterExpression4, entityBuilder.Metadata.FindDeclaredQueryFilter(null).Expression);
+        Assert.NotEqual(filterExpression4, entityBuilder.Metadata.FindDeclaredQueryFilter(null)!.Expression);
 
         entityBuilder.HasQueryFilter(new QueryFilter(filterExpression2, ConfigurationSource.DataAnnotation));
-        Assert.NotEqual(filterExpression3, entityBuilder.Metadata.FindDeclaredQueryFilter(null).Expression);
+        Assert.NotEqual(filterExpression3, entityBuilder.Metadata.FindDeclaredQueryFilter(null)!.Expression);
 
         entityBuilder.HasQueryFilter(new QueryFilter(filterExpression, ConfigurationSource.Explicit));
-        Assert.NotEqual(filterExpression2, entityBuilder.Metadata.FindDeclaredQueryFilter(null).Expression);
+        Assert.NotEqual(filterExpression2, entityBuilder.Metadata.FindDeclaredQueryFilter(null)!.Expression);
     }
 
     [Fact]
@@ -3467,25 +3467,25 @@ public class InternalEntityTypeBuilderTest
 
         entityBuilder.HasQueryFilter(new QueryFilter(filterKey, filterExpression, ConfigurationSource.Explicit));
         entityBuilder.HasQueryFilter(new QueryFilter(filterKey, filterExpression2, ConfigurationSource.Explicit));
-        Assert.NotEqual(filterExpression, entityBuilder.Metadata.FindDeclaredQueryFilter(filterKey).Expression);
+        Assert.NotEqual(filterExpression, entityBuilder.Metadata.FindDeclaredQueryFilter(filterKey)!.Expression);
 
         entityBuilder.HasQueryFilter(new QueryFilter(filterKey, filterExpression3, ConfigurationSource.DataAnnotation));
-        Assert.Same(filterExpression2, entityBuilder.Metadata.FindDeclaredQueryFilter(filterKey).Expression);
+        Assert.Same(filterExpression2, entityBuilder.Metadata.FindDeclaredQueryFilter(filterKey)!.Expression);
 
         entityBuilder.HasQueryFilter(new QueryFilter(filterKey, filterExpression4, ConfigurationSource.Convention));
-        Assert.Same(filterExpression2, entityBuilder.Metadata.FindDeclaredQueryFilter(filterKey).Expression);
+        Assert.Same(filterExpression2, entityBuilder.Metadata.FindDeclaredQueryFilter(filterKey)!.Expression);
 
         modelBuilder = CreateModelBuilder();
         entityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Convention);
         entityBuilder.HasQueryFilter(new QueryFilter(filterKey, filterExpression4, ConfigurationSource.Convention));
         entityBuilder.HasQueryFilter(new QueryFilter(filterKey, filterExpression3, ConfigurationSource.Convention));
-        Assert.NotEqual(filterExpression4, entityBuilder.Metadata.FindDeclaredQueryFilter(filterKey).Expression);
+        Assert.NotEqual(filterExpression4, entityBuilder.Metadata.FindDeclaredQueryFilter(filterKey)!.Expression);
 
         entityBuilder.HasQueryFilter(new QueryFilter(filterKey, filterExpression2, ConfigurationSource.DataAnnotation));
-        Assert.NotEqual(filterExpression3, entityBuilder.Metadata.FindDeclaredQueryFilter(filterKey).Expression);
+        Assert.NotEqual(filterExpression3, entityBuilder.Metadata.FindDeclaredQueryFilter(filterKey)!.Expression);
 
         entityBuilder.HasQueryFilter(new QueryFilter(filterKey, filterExpression, ConfigurationSource.Explicit));
-        Assert.NotEqual(filterExpression2, entityBuilder.Metadata.FindDeclaredQueryFilter(filterKey).Expression);
+        Assert.NotEqual(filterExpression2, entityBuilder.Metadata.FindDeclaredQueryFilter(filterKey)!.Expression);
     }
 
     [Fact]
@@ -3501,7 +3501,7 @@ public class InternalEntityTypeBuilderTest
 
         // Convention sets a named query filter
         entityBuilder.HasQueryFilter(new QueryFilter(filterKey, conventionFilter, ConfigurationSource.Convention));
-        Assert.Same(conventionFilter, entityBuilder.Metadata.FindDeclaredQueryFilter(filterKey).Expression);
+        Assert.Same(conventionFilter, entityBuilder.Metadata.FindDeclaredQueryFilter(filterKey)!.Expression);
         Assert.Equal(ConfigurationSource.Convention, entityBuilder.Metadata.GetQueryFilterConfigurationSource(filterKey));
 
         // Public API should be able to override it
@@ -3509,18 +3509,33 @@ public class InternalEntityTypeBuilderTest
         publicBuilder.HasQueryFilter(filterKey, explicitFilter);
 
         // Verify the filter was replaced with the explicit one
-        Assert.Same(explicitFilter, entityBuilder.Metadata.FindDeclaredQueryFilter(filterKey).Expression);
+        Assert.Same(explicitFilter, entityBuilder.Metadata.FindDeclaredQueryFilter(filterKey)!.Expression);
         Assert.Equal(ConfigurationSource.Explicit, entityBuilder.Metadata.GetQueryFilterConfigurationSource(filterKey));
     }
 
     private static TestLogger<DbLoggerCategory.Model, TestLoggingDefinitions> CreateTestLogger()
         => new() { EnabledFor = LogLevel.Warning };
 
-    private InternalModelBuilder CreateModelBuilder(Model model = null)
+    private NonNullableInternalModelBuilder CreateModelBuilder(Model? model = null)
         => new(model ?? new Model());
 
+    private sealed class NonNullableInternalModelBuilder(Model model) : InternalModelBuilder(model)
+    {
+        public override InternalEntityTypeBuilder Entity(
+            string name,
+            ConfigurationSource configurationSource,
+            bool? shouldBeOwned = false)
+            => base.Entity(name, configurationSource, shouldBeOwned)!;
+
+        public override InternalEntityTypeBuilder Entity(
+            Type type,
+            ConfigurationSource configurationSource,
+            bool? shouldBeOwned = null)
+            => base.Entity(type, configurationSource, shouldBeOwned)!;
+    }
+
     protected virtual TestHelpers.TestModelBuilder CreateConventionlessModelBuilder(
-        Action<ModelConfigurationBuilder> configure = null,
+        Action<ModelConfigurationBuilder>? configure = null,
         bool sensitiveDataLoggingEnabled = false)
         => InMemoryTestHelpers.Instance.CreateConventionBuilder(
             configureConventions: configurationBuilder =>
@@ -3543,26 +3558,26 @@ public class InternalEntityTypeBuilderTest
 
     private class Order
     {
-        public static readonly PropertyInfo IdProperty = typeof(Order).GetProperty(nameof(Id));
-        public static readonly PropertyInfo CustomerIdProperty = typeof(Order).GetProperty(nameof(CustomerId));
-        public static readonly PropertyInfo CustomerUniqueProperty = typeof(Order).GetProperty(nameof(CustomerUnique));
-        public static readonly PropertyInfo CustomerProperty = typeof(Order).GetProperty(nameof(Customer));
-        public static readonly PropertyInfo ContextProperty = typeof(Order).GetProperty(nameof(Context));
-        public static readonly PropertyInfo ProductsProperty = typeof(Order).GetProperty(nameof(Products));
-        public static readonly PropertyInfo NumbersProperty = typeof(Order).GetProperty(nameof(Numbers));
+        public static readonly PropertyInfo IdProperty = typeof(Order).GetProperty(nameof(Id))!;
+        public static readonly PropertyInfo CustomerIdProperty = typeof(Order).GetProperty(nameof(CustomerId))!;
+        public static readonly PropertyInfo CustomerUniqueProperty = typeof(Order).GetProperty(nameof(CustomerUnique))!;
+        public static readonly PropertyInfo CustomerProperty = typeof(Order).GetProperty(nameof(Customer))!;
+        public static readonly PropertyInfo ContextProperty = typeof(Order).GetProperty(nameof(Context))!;
+        public static readonly PropertyInfo ProductsProperty = typeof(Order).GetProperty(nameof(Products))!;
+        public static readonly PropertyInfo NumbersProperty = typeof(Order).GetProperty(nameof(Numbers))!;
 
         public int Id { get; set; }
         public int CustomerId { get; set; }
         public Guid? CustomerUnique { get; set; }
-        public Customer Customer { get; set; }
-        public DbContext Context { get; set; }
-        public ICollection<Product> Products { get; set; }
-        public List<int> Numbers { get; set; }
+        public Customer Customer { get; set; } = null!;
+        public DbContext Context { get; set; } = null!;
+        public ICollection<Product> Products { get; set; } = null!;
+        public List<int> Numbers { get; set; } = null!;
     }
 
     private class SpecialOrder : Order, IEnumerable<Order>
     {
-        public static readonly PropertyInfo SpecialtyProperty = typeof(SpecialOrder).GetProperty("Specialty");
+        public static readonly PropertyInfo SpecialtyProperty = typeof(SpecialOrder).GetProperty("Specialty")!;
 
         public IEnumerator<Order> GetEnumerator()
         {
@@ -3572,7 +3587,7 @@ public class InternalEntityTypeBuilderTest
         IEnumerator IEnumerable.GetEnumerator()
             => GetEnumerator();
 
-        public string Specialty { get; set; }
+        public string Specialty { get; set; } = null!;
     }
 
     private class ExtraSpecialOrder : SpecialOrder;
@@ -3581,43 +3596,43 @@ public class InternalEntityTypeBuilderTest
 
     private class Customer
     {
-        public static readonly PropertyInfo IdProperty = typeof(Customer).GetProperty(nameof(Id));
-        public static readonly PropertyInfo UniqueProperty = typeof(Customer).GetProperty(nameof(Unique));
-        public static readonly PropertyInfo OrdersProperty = typeof(Customer).GetProperty(nameof(Orders));
-        public static readonly PropertyInfo NotCollectionOrdersProperty = typeof(Customer).GetProperty(nameof(NotCollectionOrders));
-        public static readonly PropertyInfo SpecialOrdersProperty = typeof(Customer).GetProperty(nameof(SpecialOrders));
+        public static readonly PropertyInfo IdProperty = typeof(Customer).GetProperty(nameof(Id))!;
+        public static readonly PropertyInfo UniqueProperty = typeof(Customer).GetProperty(nameof(Unique))!;
+        public static readonly PropertyInfo OrdersProperty = typeof(Customer).GetProperty(nameof(Orders))!;
+        public static readonly PropertyInfo NotCollectionOrdersProperty = typeof(Customer).GetProperty(nameof(NotCollectionOrders))!;
+        public static readonly PropertyInfo SpecialOrdersProperty = typeof(Customer).GetProperty(nameof(SpecialOrders))!;
 
         public int Id { get; set; }
         public Guid Unique { get; set; }
-        public ICollection<Order> Orders { get; set; }
-        public Order NotCollectionOrders { get; set; }
-        public ICollection<SpecialOrder> SpecialOrders { get; set; }
-        internal SpecialCustomer SpecialCustomer { get; set; }
+        public ICollection<Order> Orders { get; set; } = null!;
+        public Order NotCollectionOrders { get; set; } = null!;
+        public ICollection<SpecialOrder> SpecialOrders { get; set; } = null!;
+        internal SpecialCustomer SpecialCustomer { get; set; } = null!;
     }
 
     private class SpecialCustomer : Customer
     {
-        internal Customer Customer { get; set; }
+        internal Customer Customer { get; set; } = null!;
     }
 
     private class OrderProduct
     {
-        public static readonly PropertyInfo OrderIdProperty = typeof(OrderProduct).GetProperty(nameof(OrderId));
-        public static readonly PropertyInfo ProductIdProperty = typeof(OrderProduct).GetProperty(nameof(ProductId));
+        public static readonly PropertyInfo OrderIdProperty = typeof(OrderProduct).GetProperty(nameof(OrderId))!;
+        public static readonly PropertyInfo ProductIdProperty = typeof(OrderProduct).GetProperty(nameof(ProductId))!;
 
         public int OrderId { get; set; }
         public int ProductId { get; set; }
-        public virtual Order Order { get; set; }
-        public virtual Product Product { get; set; }
+        public virtual Order Order { get; set; } = null!;
+        public virtual Product Product { get; set; } = null!;
     }
 
     private class Product
     {
-        public static readonly PropertyInfo IdProperty = typeof(Product).GetProperty(nameof(Id));
+        public static readonly PropertyInfo IdProperty = typeof(Product).GetProperty(nameof(Id))!;
 
         public int Id { get; set; }
 
-        public virtual ICollection<Order> Orders { get; set; }
+        public virtual ICollection<Order> Orders { get; set; } = null!;
     }
 
     private class SpecialProduct : Product;
@@ -3626,7 +3641,7 @@ public class InternalEntityTypeBuilderTest
 
     private class Splot
     {
-        public static readonly PropertyInfo SplowedProperty = typeof(Splot).GetProperty("Splowed");
+        public static readonly PropertyInfo SplowedProperty = typeof(Splot).GetProperty("Splowed")!;
 
         public int? Splowed { get; set; }
     }
@@ -3641,7 +3656,7 @@ public class InternalEntityTypeBuilderTest
 
         public object this[string name]
         {
-            get => null;
+            get => null!;
             set { }
         }
     }

--- a/test/EFCore.Tests/Metadata/Internal/InternalForeignKeyBuilderTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/InternalForeignKeyBuilderTest.cs
@@ -16,13 +16,13 @@ public class InternalForeignKeyBuilderTest
     public void Facets_are_configured_with_the_specified_source()
     {
         var modelBuilder = CreateInternalModelBuilder();
-        var principalEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
+        var principalEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit)!;
         var key = principalEntityBuilder.PrimaryKey(
-            [Customer.IdProperty, Customer.UniqueProperty], ConfigurationSource.Convention);
-        var dependentEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
+            [Customer.IdProperty, Customer.UniqueProperty], ConfigurationSource.Convention)!;
+        var dependentEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit)!;
 
         var relationshipBuilder = dependentEntityBuilder.HasRelationship(
-            principalEntityBuilder.Metadata, ConfigurationSource.Convention);
+            principalEntityBuilder.Metadata, ConfigurationSource.Convention)!;
 
         var fk = relationshipBuilder.Metadata;
         Assert.Equal(ConfigurationSource.Convention, fk.GetConfigurationSource());
@@ -37,29 +37,29 @@ public class InternalForeignKeyBuilderTest
         Assert.Null(fk.GetIsUniqueConfigurationSource());
         Assert.Null(fk.GetDeleteBehaviorConfigurationSource());
 
-        relationshipBuilder = relationshipBuilder.PrincipalEntityType(principalEntityBuilder.Metadata, ConfigurationSource.Explicit)
-            .HasPrincipalKey(key.Metadata.Properties, ConfigurationSource.Explicit).HasNavigation(
+        relationshipBuilder = relationshipBuilder.PrincipalEntityType(principalEntityBuilder.Metadata, ConfigurationSource.Explicit)!
+            .HasPrincipalKey(key.Metadata.Properties, ConfigurationSource.Explicit)!.HasNavigation(
                 Order.CustomerProperty.Name,
                 pointsToPrincipal: true,
-                ConfigurationSource.Explicit).HasNavigation(
+                ConfigurationSource.Explicit)!.HasNavigation(
                 Customer.OrdersProperty.Name,
                 pointsToPrincipal: false,
-                ConfigurationSource.Explicit)
-            .IsUnique(false, ConfigurationSource.Explicit)
-            .IsRequired(false, ConfigurationSource.Explicit)
-            .IsRequiredDependent(false, ConfigurationSource.Explicit)
-            .IsOwnership(false, ConfigurationSource.Explicit)
-            .OnDelete(DeleteBehavior.Cascade, ConfigurationSource.Explicit)
+                ConfigurationSource.Explicit)!
+            .IsUnique(false, ConfigurationSource.Explicit)!
+            .IsRequired(false, ConfigurationSource.Explicit)!
+            .IsRequiredDependent(false, ConfigurationSource.Explicit)!
+            .IsOwnership(false, ConfigurationSource.Explicit)!
+            .OnDelete(DeleteBehavior.Cascade, ConfigurationSource.Explicit)!
             .HasForeignKey(
             [
-                dependentEntityBuilder.Property(Order.CustomerIdProperty, ConfigurationSource.Convention).Metadata,
-                dependentEntityBuilder.Property(Order.CustomerUniqueProperty, ConfigurationSource.Convention).Metadata
-            ], ConfigurationSource.Explicit);
+                dependentEntityBuilder.Property(Order.CustomerIdProperty, ConfigurationSource.Convention)!.Metadata,
+                dependentEntityBuilder.Property(Order.CustomerUniqueProperty, ConfigurationSource.Convention)!.Metadata
+            ], ConfigurationSource.Explicit)!;
 
         Assert.Null(
             relationshipBuilder.HasForeignKey(
                 [Order.IdProperty, Order.CustomerUniqueProperty], ConfigurationSource.DataAnnotation));
-        var shadowId = principalEntityBuilder.Property(typeof(int), "ShadowId", ConfigurationSource.Convention).Metadata;
+        var shadowId = principalEntityBuilder.Property(typeof(int), "ShadowId", ConfigurationSource.Convention)!.Metadata;
         Assert.Null(
             relationshipBuilder.HasPrincipalKey(
                 [shadowId.Name, Customer.UniqueProperty.Name], ConfigurationSource.DataAnnotation));
@@ -73,12 +73,12 @@ public class InternalForeignKeyBuilderTest
                 relationshipBuilder.Metadata.PrincipalEntityType, ConfigurationSource.DataAnnotation));
         Assert.Null(
             relationshipBuilder.HasNavigation(
-                (string)null,
+                (string?)null,
                 pointsToPrincipal: true,
                 ConfigurationSource.DataAnnotation));
         Assert.Null(
             relationshipBuilder.HasNavigation(
-                (string)null,
+                (string?)null,
                 pointsToPrincipal: false,
                 ConfigurationSource.DataAnnotation));
     }
@@ -87,12 +87,12 @@ public class InternalForeignKeyBuilderTest
     public void Existing_facets_are_configured_explicitly()
     {
         var modelBuilder = CreateInternalModelBuilder();
-        var principalEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
+        var principalEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit)!;
         principalEntityBuilder.PrimaryKey([Customer.IdProperty, Customer.UniqueProperty], ConfigurationSource.Convention);
-        var dependentEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
+        var dependentEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit)!;
 
         var foreignKey = dependentEntityBuilder.HasRelationship(
-            principalEntityBuilder.Metadata, ConfigurationSource.Explicit).Metadata;
+            principalEntityBuilder.Metadata, ConfigurationSource.Explicit)!.Metadata;
 
         foreignKey.UpdatePropertiesConfigurationSource(ConfigurationSource.Explicit);
         foreignKey.UpdatePrincipalKeyConfigurationSource(ConfigurationSource.Explicit);
@@ -123,20 +123,20 @@ public class InternalForeignKeyBuilderTest
     public void Read_only_facets_are_configured_explicitly_by_default()
     {
         var modelBuilder = CreateInternalModelBuilder();
-        var customerEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
+        var customerEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit)!;
         var customerKeyBuilder = customerEntityBuilder.PrimaryKey(
-            [Customer.IdProperty, Customer.UniqueProperty], ConfigurationSource.Explicit);
-        var orderEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
+            [Customer.IdProperty, Customer.UniqueProperty], ConfigurationSource.Explicit)!;
+        var orderEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit)!;
 
         var foreignKey = orderEntityBuilder.Metadata.AddForeignKey(
             [
-                orderEntityBuilder.Property(Order.CustomerIdProperty, ConfigurationSource.Convention).Metadata,
-                orderEntityBuilder.Property(Order.CustomerUniqueProperty, ConfigurationSource.Convention).Metadata
+                orderEntityBuilder.Property(Order.CustomerIdProperty, ConfigurationSource.Convention)!.Metadata,
+                orderEntityBuilder.Property(Order.CustomerUniqueProperty, ConfigurationSource.Convention)!.Metadata
             ],
             customerKeyBuilder.Metadata,
             customerEntityBuilder.Metadata,
             ConfigurationSource.Explicit,
-            ConfigurationSource.Explicit);
+            ConfigurationSource.Explicit)!;
 
         Assert.Equal(ConfigurationSource.Explicit, foreignKey.GetPropertiesConfigurationSource());
         Assert.Equal(ConfigurationSource.Explicit, foreignKey.GetPrincipalKeyConfigurationSource());
@@ -147,19 +147,19 @@ public class InternalForeignKeyBuilderTest
     public void ForeignKey_returns_same_instance_for_same_properties()
     {
         var modelBuilder = CreateInternalModelBuilder();
-        var customerEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
-        var orderEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
+        var customerEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit)!;
+        var orderEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit)!;
 
         var relationshipBuilder = orderEntityBuilder
-            .HasRelationship(customerEntityBuilder.Metadata, ConfigurationSource.Convention)
+            .HasRelationship(customerEntityBuilder.Metadata, ConfigurationSource.Convention)!
             .HasForeignKey(
-                [Order.CustomerIdProperty.Name, Order.CustomerUniqueProperty.Name], ConfigurationSource.DataAnnotation);
+                [Order.CustomerIdProperty.Name, Order.CustomerUniqueProperty.Name], ConfigurationSource.DataAnnotation)!;
 
         Assert.NotNull(relationshipBuilder);
         Assert.Same(
             relationshipBuilder, orderEntityBuilder
-                .HasRelationship(customerEntityBuilder.Metadata, ConfigurationSource.Convention)
-                .HasForeignKey([Order.CustomerIdProperty, Order.CustomerUniqueProperty], ConfigurationSource.DataAnnotation)
+                .HasRelationship(customerEntityBuilder.Metadata, ConfigurationSource.Convention)!
+                .HasForeignKey([Order.CustomerIdProperty, Order.CustomerUniqueProperty], ConfigurationSource.DataAnnotation)!
                 .HasPrincipalKey(relationshipBuilder.Metadata.PrincipalKey.Properties, ConfigurationSource.Convention));
     }
 
@@ -167,17 +167,17 @@ public class InternalForeignKeyBuilderTest
     public void ForeignKey_uses_same_relationship_if_conflicting_properties_configured_with_lower_source()
     {
         var modelBuilder = CreateInternalModelBuilder();
-        var customerEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
-        var orderEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
+        var customerEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit)!;
+        var orderEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit)!;
 
         var relationshipBuilder = orderEntityBuilder
-            .HasRelationship(customerEntityBuilder.Metadata, ConfigurationSource.DataAnnotation)
-            .HasForeignKey([Order.CustomerIdProperty.Name, Order.CustomerUniqueProperty.Name], ConfigurationSource.Convention);
+            .HasRelationship(customerEntityBuilder.Metadata, ConfigurationSource.DataAnnotation)!
+            .HasForeignKey([Order.CustomerIdProperty.Name, Order.CustomerUniqueProperty.Name], ConfigurationSource.Convention)!;
 
         Assert.NotNull(relationshipBuilder);
         Assert.Same(
             relationshipBuilder, orderEntityBuilder
-                .HasRelationship(customerEntityBuilder.Metadata, ConfigurationSource.DataAnnotation)
+                .HasRelationship(customerEntityBuilder.Metadata, ConfigurationSource.DataAnnotation)!
                 .HasForeignKey([Order.CustomerIdProperty, Order.CustomerUniqueProperty], ConfigurationSource.DataAnnotation));
 
         Assert.Single(orderEntityBuilder.Metadata.GetForeignKeys());
@@ -187,20 +187,20 @@ public class InternalForeignKeyBuilderTest
     public void ForeignKey_can_be_set_independently_from_requiredness()
     {
         var modelBuilder = CreateInternalModelBuilder();
-        var customerEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
-        var orderEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
+        var customerEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit)!;
+        var orderEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit)!;
 
-        var relationshipBuilder = orderEntityBuilder.HasRelationship(customerEntityBuilder.Metadata, ConfigurationSource.Convention);
-        relationshipBuilder = relationshipBuilder.IsRequired(false, ConfigurationSource.DataAnnotation);
+        var relationshipBuilder = orderEntityBuilder.HasRelationship(customerEntityBuilder.Metadata, ConfigurationSource.Convention)!;
+        relationshipBuilder = relationshipBuilder.IsRequired(false, ConfigurationSource.DataAnnotation)!;
 
-        var nullableId = orderEntityBuilder.Property(typeof(int?), "NullableId", ConfigurationSource.Explicit);
-        relationshipBuilder = relationshipBuilder.HasForeignKey([nullableId.Metadata.Name], ConfigurationSource.Convention);
+        var nullableId = orderEntityBuilder.Property(typeof(int?), "NullableId", ConfigurationSource.Explicit)!;
+        relationshipBuilder = relationshipBuilder.HasForeignKey([nullableId.Metadata.Name], ConfigurationSource.Convention)!;
         Assert.False(((IReadOnlyForeignKey)relationshipBuilder.Metadata).IsRequired);
         Assert.Equal(
             [nullableId.Metadata.Name],
             relationshipBuilder.Metadata.Properties.Select(p => p.Name));
 
-        relationshipBuilder = relationshipBuilder.HasForeignKey([Order.CustomerIdProperty], ConfigurationSource.Convention);
+        relationshipBuilder = relationshipBuilder.HasForeignKey([Order.CustomerIdProperty], ConfigurationSource.Convention)!;
         Assert.False(((IReadOnlyForeignKey)relationshipBuilder.Metadata).IsRequired);
         Assert.Equal(
             [Order.CustomerIdProperty.Name],
@@ -211,13 +211,13 @@ public class InternalForeignKeyBuilderTest
     public void ForeignKey_overrides_incompatible_lower_or_equal_source_principal_key()
     {
         var modelBuilder = CreateInternalModelBuilder();
-        var customerEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
-        var orderEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
+        var customerEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit)!;
+        var orderEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit)!;
 
-        var relationshipBuilder = orderEntityBuilder.HasRelationship(customerEntityBuilder.Metadata, ConfigurationSource.Convention);
-        relationshipBuilder = relationshipBuilder.HasPrincipalKey([Customer.IdProperty], ConfigurationSource.DataAnnotation);
+        var relationshipBuilder = orderEntityBuilder.HasRelationship(customerEntityBuilder.Metadata, ConfigurationSource.Convention)!;
+        relationshipBuilder = relationshipBuilder.HasPrincipalKey([Customer.IdProperty], ConfigurationSource.DataAnnotation)!;
 
-        relationshipBuilder = relationshipBuilder.HasForeignKey([Order.CustomerIdProperty], ConfigurationSource.Convention);
+        relationshipBuilder = relationshipBuilder.HasForeignKey([Order.CustomerIdProperty], ConfigurationSource.Convention)!;
         Assert.Equal(
             [Customer.IdProperty.Name],
             relationshipBuilder.Metadata.PrincipalKey.Properties.Select(p => p.Name));
@@ -234,7 +234,7 @@ public class InternalForeignKeyBuilderTest
             relationshipBuilder.Metadata.Properties.Select(p => p.Name));
 
         relationshipBuilder = relationshipBuilder.HasForeignKey(
-            [Order.CustomerUniqueProperty], ConfigurationSource.DataAnnotation);
+            [Order.CustomerUniqueProperty], ConfigurationSource.DataAnnotation)!;
         Assert.NotEqual(
             [Customer.IdProperty.Name],
             relationshipBuilder.Metadata.PrincipalKey.Properties.Select(p => p.Name));
@@ -247,15 +247,15 @@ public class InternalForeignKeyBuilderTest
     public void ForeignKey_creates_shadow_properties_if_corresponding_principal_key_property_is_non_shadow()
     {
         var modelBuilder = CreateInternalModelBuilder();
-        var customerEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
-        var orderEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
+        var customerEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit)!;
+        var orderEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit)!;
 
         var relationshipBuilder = orderEntityBuilder.HasRelationship(customerEntityBuilder.Metadata, ConfigurationSource.Convention)
-            .HasPrincipalKey([Customer.IdProperty], ConfigurationSource.DataAnnotation);
+            !.HasPrincipalKey([Customer.IdProperty], ConfigurationSource.DataAnnotation)!;
 
-        relationshipBuilder = relationshipBuilder.HasForeignKey(["ShadowCustomerId"], ConfigurationSource.Convention);
+        relationshipBuilder = relationshipBuilder.HasForeignKey(["ShadowCustomerId"], ConfigurationSource.Convention)!;
 
-        var shadowProperty = orderEntityBuilder.Metadata.FindProperty("ShadowCustomerId");
+        var shadowProperty = orderEntityBuilder.Metadata.FindProperty("ShadowCustomerId")!;
         Assert.NotNull(shadowProperty);
         Assert.True(shadowProperty.IsShadowProperty());
         Assert.Equal(shadowProperty, relationshipBuilder.Metadata.Properties.First());
@@ -265,11 +265,11 @@ public class InternalForeignKeyBuilderTest
     public void ForeignKey_creates_shadow_properties_if_principal_entity_has_no_PK()
     {
         var modelBuilder = CreateInternalModelBuilder();
-        var customerEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
-        var orderEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
+        var customerEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit)!;
+        var orderEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit)!;
 
         var relationshipBuilder = orderEntityBuilder.HasRelationship(customerEntityBuilder.Metadata, ConfigurationSource.Convention)
-            .HasForeignKey(["ShadowCustomerId", "ShadowCustomerUnique"], ConfigurationSource.Convention);
+            !.HasForeignKey(["ShadowCustomerId", "ShadowCustomerUnique"], ConfigurationSource.Convention)!;
 
         var shadowProperty1 = relationshipBuilder.Metadata.Properties.First();
         Assert.True(shadowProperty1.IsShadowProperty());
@@ -287,13 +287,13 @@ public class InternalForeignKeyBuilderTest
     public void ForeignKey_creates_shadow_properties_if_corresponding_principal_key_property_is_shadow()
     {
         var modelBuilder = CreateInternalModelBuilder();
-        var customerEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
-        var orderEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
+        var customerEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit)!;
+        var orderEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit)!;
 
         var relationshipBuilder = orderEntityBuilder.HasRelationship(customerEntityBuilder.Metadata, ConfigurationSource.Convention)
-            .HasForeignKey(["ShadowCustomerId"], ConfigurationSource.Convention);
+            !.HasForeignKey(["ShadowCustomerId"], ConfigurationSource.Convention)!;
 
-        var shadowProperty = orderEntityBuilder.Metadata.FindProperty("ShadowCustomerId");
+        var shadowProperty = orderEntityBuilder.Metadata.FindProperty("ShadowCustomerId")!;
         Assert.True(shadowProperty.IsShadowProperty());
         Assert.Equal(shadowProperty, relationshipBuilder.Metadata.Properties.First());
     }
@@ -302,16 +302,16 @@ public class InternalForeignKeyBuilderTest
     public void PrincipalKey_does_not_return_same_instance_for_same_properties()
     {
         var modelBuilder = CreateInternalModelBuilder();
-        var customerEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
-        var orderEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
+        var customerEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit)!;
+        var orderEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit)!;
 
-        var relationshipBuilder = customerEntityBuilder.HasRelationship(orderEntityBuilder.Metadata, ConfigurationSource.DataAnnotation)
+        var relationshipBuilder = customerEntityBuilder.HasRelationship(orderEntityBuilder.Metadata, ConfigurationSource.DataAnnotation)!
             .HasPrincipalKey(
-                [Order.CustomerIdProperty.Name, Order.CustomerUniqueProperty.Name], ConfigurationSource.DataAnnotation);
+            [Order.CustomerIdProperty.Name, Order.CustomerUniqueProperty.Name], ConfigurationSource.DataAnnotation)!;
 
         Assert.NotNull(relationshipBuilder);
         Assert.NotSame(
-            relationshipBuilder, customerEntityBuilder.HasRelationship(orderEntityBuilder.Metadata, ConfigurationSource.DataAnnotation)
+            relationshipBuilder, customerEntityBuilder.HasRelationship(orderEntityBuilder.Metadata, ConfigurationSource.DataAnnotation)!
                 .HasPrincipalKey(
                     [Order.CustomerIdProperty.Name, Order.CustomerUniqueProperty.Name], ConfigurationSource.DataAnnotation));
 
@@ -322,13 +322,13 @@ public class InternalForeignKeyBuilderTest
     public void PrincipalKey_overrides_incompatible_lower_or_equal_source_dependent_properties()
     {
         var modelBuilder = CreateInternalModelBuilder();
-        var customerEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
+        var customerEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit)!;
         customerEntityBuilder.PrimaryKey([Customer.IdProperty], ConfigurationSource.Explicit);
-        var orderEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
+        var orderEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit)!;
 
-        var relationshipBuilder = orderEntityBuilder.HasRelationship(customerEntityBuilder.Metadata, ConfigurationSource.Convention)
-            .HasForeignKey([Order.CustomerIdProperty, Order.CustomerUniqueProperty], ConfigurationSource.DataAnnotation)
-            .HasPrincipalKey([Customer.IdProperty, Customer.UniqueProperty], ConfigurationSource.Convention);
+        var relationshipBuilder = orderEntityBuilder.HasRelationship(customerEntityBuilder.Metadata, ConfigurationSource.Convention)!
+            .HasForeignKey([Order.CustomerIdProperty, Order.CustomerUniqueProperty], ConfigurationSource.DataAnnotation)!
+            .HasPrincipalKey([Customer.IdProperty, Customer.UniqueProperty], ConfigurationSource.Convention)!;
         Assert.Equal(
             [Customer.IdProperty.Name, Customer.UniqueProperty.Name],
             relationshipBuilder.Metadata.PrincipalKey.Properties.Select(p => p.Name));
@@ -344,7 +344,7 @@ public class InternalForeignKeyBuilderTest
             [Order.CustomerIdProperty.Name, Order.CustomerUniqueProperty.Name],
             relationshipBuilder.Metadata.Properties.Select(p => p.Name));
 
-        relationshipBuilder = relationshipBuilder.HasPrincipalKey([Customer.IdProperty], ConfigurationSource.DataAnnotation);
+        relationshipBuilder = relationshipBuilder.HasPrincipalKey([Customer.IdProperty], ConfigurationSource.DataAnnotation)!;
         Assert.Equal(
             [Customer.IdProperty.Name],
             relationshipBuilder.Metadata.PrincipalKey.Properties.Select(p => p.Name));
@@ -357,16 +357,16 @@ public class InternalForeignKeyBuilderTest
     public void Can_only_override_lower_or_equal_source_Unique()
     {
         var modelBuilder = CreateInternalModelBuilder();
-        var customerEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
-        var orderEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
+        var customerEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit)!;
+        var orderEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit)!;
 
-        var relationshipBuilder = orderEntityBuilder.HasRelationship(customerEntityBuilder.Metadata, ConfigurationSource.Convention);
+        var relationshipBuilder = orderEntityBuilder.HasRelationship(customerEntityBuilder.Metadata, ConfigurationSource.Convention)!;
         Assert.False(relationshipBuilder.Metadata.IsUnique);
 
-        relationshipBuilder = relationshipBuilder.IsUnique(true, ConfigurationSource.Convention);
+        relationshipBuilder = relationshipBuilder.IsUnique(true, ConfigurationSource.Convention)!;
         Assert.True(relationshipBuilder.Metadata.IsUnique);
 
-        relationshipBuilder = relationshipBuilder.IsUnique(false, ConfigurationSource.DataAnnotation);
+        relationshipBuilder = relationshipBuilder.IsUnique(false, ConfigurationSource.DataAnnotation)!;
         Assert.False(relationshipBuilder.Metadata.IsUnique);
 
         Assert.Null(relationshipBuilder.IsUnique(true, ConfigurationSource.Convention));
@@ -377,41 +377,41 @@ public class InternalForeignKeyBuilderTest
     public void Can_only_override_existing_Unique_value_explicitly()
     {
         var modelBuilder = CreateInternalModelBuilder();
-        var customerEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
+        var customerEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit)!;
         var customerKeyBuilder = customerEntityBuilder.PrimaryKey(
-            [Customer.IdProperty, Customer.UniqueProperty], ConfigurationSource.Explicit);
-        var orderEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
+            [Customer.IdProperty, Customer.UniqueProperty], ConfigurationSource.Explicit)!;
+        var orderEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit)!;
 
         var foreignKey = orderEntityBuilder.Metadata.AddForeignKey(
             [
-                orderEntityBuilder.Property(Order.CustomerIdProperty, ConfigurationSource.Convention).Metadata,
-                orderEntityBuilder.Property(Order.CustomerUniqueProperty, ConfigurationSource.Convention).Metadata
+                orderEntityBuilder.Property(Order.CustomerIdProperty, ConfigurationSource.Convention)!.Metadata,
+                orderEntityBuilder.Property(Order.CustomerUniqueProperty, ConfigurationSource.Convention)!.Metadata
             ],
             customerKeyBuilder.Metadata,
             customerEntityBuilder.Metadata,
             ConfigurationSource.Explicit,
-            ConfigurationSource.Explicit);
+            ConfigurationSource.Explicit)!;
         foreignKey.IsUnique = true;
 
         Assert.Equal(ConfigurationSource.Explicit, foreignKey.GetIsUniqueConfigurationSource());
 
         var relationshipBuilder = orderEntityBuilder
-            .HasRelationship(customerEntityBuilder.Metadata, foreignKey.Properties, ConfigurationSource.Convention);
+            .HasRelationship(customerEntityBuilder.Metadata, foreignKey.Properties, ConfigurationSource.Convention)!;
         Assert.Same(foreignKey, relationshipBuilder.Metadata);
 
         relationshipBuilder = relationshipBuilder
-            .HasPrincipalKey(customerKeyBuilder.Metadata.Properties, ConfigurationSource.Convention);
+            .HasPrincipalKey(customerKeyBuilder.Metadata.Properties, ConfigurationSource.Convention)!;
         Assert.Same(foreignKey, relationshipBuilder.Metadata);
         Assert.True(((IReadOnlyForeignKey)relationshipBuilder.Metadata).IsUnique);
 
         Assert.Null(relationshipBuilder.IsUnique(false, ConfigurationSource.Convention));
         Assert.True(((IReadOnlyForeignKey)relationshipBuilder.Metadata).IsUnique);
 
-        relationshipBuilder = relationshipBuilder.IsUnique(true, ConfigurationSource.Convention);
+        relationshipBuilder = relationshipBuilder.IsUnique(true, ConfigurationSource.Convention)!;
         Assert.NotNull(relationshipBuilder);
         Assert.True(((IReadOnlyForeignKey)relationshipBuilder.Metadata).IsUnique);
 
-        relationshipBuilder = relationshipBuilder.IsUnique(false, ConfigurationSource.Explicit);
+        relationshipBuilder = relationshipBuilder.IsUnique(false, ConfigurationSource.Explicit)!;
         Assert.NotNull(relationshipBuilder);
         Assert.False(((IReadOnlyForeignKey)relationshipBuilder.Metadata).IsUnique);
     }
@@ -420,15 +420,15 @@ public class InternalForeignKeyBuilderTest
     public void Unique_overrides_incompatible_lower_or_equal_source_principalToDependent()
     {
         var modelBuilder = CreateInternalModelBuilder();
-        var customerEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
-        var orderEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
+        var customerEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit)!;
+        var orderEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit)!;
 
         var relationshipBuilder = orderEntityBuilder.HasRelationship(
             customerEntityBuilder.Metadata, nameof(Order.Customer), nameof(Customer.NotCollectionOrders),
-            ConfigurationSource.DataAnnotation);
+            ConfigurationSource.DataAnnotation)!;
         Assert.True(relationshipBuilder.Metadata.IsUnique);
 
-        relationshipBuilder = relationshipBuilder.IsUnique(true, ConfigurationSource.Convention);
+        relationshipBuilder = relationshipBuilder.IsUnique(true, ConfigurationSource.Convention)!;
         Assert.True(relationshipBuilder.Metadata.IsUnique);
         Assert.NotNull(relationshipBuilder.Metadata.PrincipalToDependent);
 
@@ -436,7 +436,7 @@ public class InternalForeignKeyBuilderTest
         Assert.True(relationshipBuilder.Metadata.IsUnique);
         Assert.NotNull(relationshipBuilder.Metadata.PrincipalToDependent);
 
-        relationshipBuilder = relationshipBuilder.IsUnique(false, ConfigurationSource.DataAnnotation);
+        relationshipBuilder = relationshipBuilder.IsUnique(false, ConfigurationSource.DataAnnotation)!;
         Assert.False(relationshipBuilder.Metadata.IsUnique);
         Assert.Null(relationshipBuilder.Metadata.PrincipalToDependent);
     }
@@ -445,16 +445,16 @@ public class InternalForeignKeyBuilderTest
     public void Can_only_override_lower_or_equal_source_Required()
     {
         var modelBuilder = CreateInternalModelBuilder();
-        var customerEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
-        var orderEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
+        var customerEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit)!;
+        var orderEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit)!;
 
-        var relationshipBuilder = orderEntityBuilder.HasRelationship(customerEntityBuilder.Metadata, ConfigurationSource.Convention);
+        var relationshipBuilder = orderEntityBuilder.HasRelationship(customerEntityBuilder.Metadata, ConfigurationSource.Convention)!;
         Assert.False(relationshipBuilder.Metadata.IsRequired);
 
-        relationshipBuilder = relationshipBuilder.IsRequired(true, ConfigurationSource.Convention);
+        relationshipBuilder = relationshipBuilder.IsRequired(true, ConfigurationSource.Convention)!;
         Assert.True(relationshipBuilder.Metadata.IsRequired);
 
-        relationshipBuilder = relationshipBuilder.IsRequired(false, ConfigurationSource.DataAnnotation);
+        relationshipBuilder = relationshipBuilder.IsRequired(false, ConfigurationSource.DataAnnotation)!;
         Assert.False(relationshipBuilder.Metadata.IsRequired);
 
         Assert.Null(relationshipBuilder.IsRequired(true, ConfigurationSource.Convention));
@@ -465,32 +465,32 @@ public class InternalForeignKeyBuilderTest
     public void Can_set_Required_independently_from_nullability()
     {
         var modelBuilder = CreateInternalModelBuilder();
-        var customerEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
-        var pk = customerEntityBuilder.PrimaryKey([Customer.IdProperty, Customer.UniqueProperty], ConfigurationSource.Explicit)
+        var customerEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit)!;
+        var pk = customerEntityBuilder.PrimaryKey([Customer.IdProperty, Customer.UniqueProperty], ConfigurationSource.Explicit)!
             .Metadata;
-        var orderEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
-        var customerIdProperty = orderEntityBuilder.Property(Order.CustomerIdProperty, ConfigurationSource.Convention).Metadata;
-        var customerUniqueProperty = orderEntityBuilder.Property(Order.CustomerUniqueProperty, ConfigurationSource.Convention).Metadata;
+        var orderEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit)!;
+        var customerIdProperty = orderEntityBuilder.Property(Order.CustomerIdProperty, ConfigurationSource.Convention)!.Metadata;
+        var customerUniqueProperty = orderEntityBuilder.Property(Order.CustomerUniqueProperty, ConfigurationSource.Convention)!.Metadata;
         var fk = orderEntityBuilder.Metadata.AddForeignKey(
             [customerIdProperty, customerUniqueProperty],
             pk,
             customerEntityBuilder.Metadata,
             ConfigurationSource.Explicit,
-            ConfigurationSource.Explicit);
+            ConfigurationSource.Explicit)!;
 
         var relationshipBuilder = orderEntityBuilder.HasRelationship(
-            customerEntityBuilder.Metadata, fk.Properties, ConfigurationSource.Explicit);
-        relationshipBuilder = relationshipBuilder.IsRequired(false, ConfigurationSource.Convention);
+            customerEntityBuilder.Metadata, fk.Properties, ConfigurationSource.Explicit)!;
+        relationshipBuilder = relationshipBuilder.IsRequired(false, ConfigurationSource.Convention)!;
         Assert.False(((IReadOnlyForeignKey)relationshipBuilder.Metadata).IsRequired);
         Assert.False(customerIdProperty.IsNullable);
         Assert.True(customerUniqueProperty.IsNullable);
 
-        relationshipBuilder = relationshipBuilder.IsRequired(true, ConfigurationSource.Convention);
+        relationshipBuilder = relationshipBuilder.IsRequired(true, ConfigurationSource.Convention)!;
         Assert.True(((IReadOnlyForeignKey)relationshipBuilder.Metadata).IsRequired);
         Assert.False(customerIdProperty.IsNullable);
         Assert.True(customerUniqueProperty.IsNullable);
 
-        relationshipBuilder = relationshipBuilder.IsRequired(false, ConfigurationSource.Explicit);
+        relationshipBuilder = relationshipBuilder.IsRequired(false, ConfigurationSource.Explicit)!;
         Assert.NotNull(relationshipBuilder);
         fk = relationshipBuilder.Metadata;
         Assert.False(fk.IsRequired);
@@ -504,29 +504,29 @@ public class InternalForeignKeyBuilderTest
     public void Can_set_Required_false_on_non_nullable_properties()
     {
         var modelBuilder = CreateInternalModelBuilder();
-        var customerEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
-        var orderEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
+        var customerEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit)!;
+        var orderEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit)!;
 
-        var relationshipBuilder = orderEntityBuilder.HasRelationship(customerEntityBuilder.Metadata, ConfigurationSource.Convention);
-        relationshipBuilder = relationshipBuilder.HasForeignKey([Order.CustomerIdProperty], ConfigurationSource.DataAnnotation);
+        var relationshipBuilder = orderEntityBuilder.HasRelationship(customerEntityBuilder.Metadata, ConfigurationSource.Convention)!;
+        relationshipBuilder = relationshipBuilder.HasForeignKey([Order.CustomerIdProperty], ConfigurationSource.DataAnnotation)!;
         Assert.False(relationshipBuilder.Metadata.IsRequired);
         Assert.Equal(
             [Order.CustomerIdProperty.Name],
             relationshipBuilder.Metadata.Properties.Select(p => p.Name));
 
-        relationshipBuilder = relationshipBuilder.IsRequired(true, ConfigurationSource.Convention);
+        relationshipBuilder = relationshipBuilder.IsRequired(true, ConfigurationSource.Convention)!;
         Assert.True(relationshipBuilder.Metadata.IsRequired);
         Assert.Equal(
             [Order.CustomerIdProperty.Name],
             relationshipBuilder.Metadata.Properties.Select(p => p.Name));
 
-        relationshipBuilder = relationshipBuilder.IsRequired(false, ConfigurationSource.Convention);
+        relationshipBuilder = relationshipBuilder.IsRequired(false, ConfigurationSource.Convention)!;
         Assert.False(relationshipBuilder.Metadata.IsRequired);
         Assert.Equal(
             [Order.CustomerIdProperty.Name],
             relationshipBuilder.Metadata.Properties.Select(p => p.Name));
 
-        relationshipBuilder = relationshipBuilder.IsRequired(false, ConfigurationSource.DataAnnotation);
+        relationshipBuilder = relationshipBuilder.IsRequired(false, ConfigurationSource.DataAnnotation)!;
         Assert.False(relationshipBuilder.Metadata.IsRequired);
         Assert.Equal(
             [Order.CustomerIdProperty.Name],
@@ -537,17 +537,17 @@ public class InternalForeignKeyBuilderTest
     public void Can_only_override_lower_or_equal_source_RequiredDependent()
     {
         var modelBuilder = CreateInternalModelBuilder();
-        var customerEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
-        var orderEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
+        var customerEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit)!;
+        var orderEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit)!;
 
-        var relationshipBuilder = orderEntityBuilder.HasRelationship(customerEntityBuilder.Metadata, ConfigurationSource.Convention);
+        var relationshipBuilder = orderEntityBuilder.HasRelationship(customerEntityBuilder.Metadata, ConfigurationSource.Convention)!;
         Assert.False(relationshipBuilder.Metadata.IsRequiredDependent);
 
-        relationshipBuilder = relationshipBuilder.IsUnique(true, ConfigurationSource.Convention);
-        relationshipBuilder = relationshipBuilder.IsRequiredDependent(true, ConfigurationSource.Convention);
+        relationshipBuilder = relationshipBuilder.IsUnique(true, ConfigurationSource.Convention)!;
+        relationshipBuilder = relationshipBuilder.IsRequiredDependent(true, ConfigurationSource.Convention)!;
         Assert.True(relationshipBuilder.Metadata.IsRequiredDependent);
 
-        relationshipBuilder = relationshipBuilder.IsRequiredDependent(false, ConfigurationSource.DataAnnotation);
+        relationshipBuilder = relationshipBuilder.IsRequiredDependent(false, ConfigurationSource.DataAnnotation)!;
         Assert.False(relationshipBuilder.Metadata.IsRequiredDependent);
 
         Assert.Null(relationshipBuilder.IsRequiredDependent(true, ConfigurationSource.Convention));
@@ -558,12 +558,12 @@ public class InternalForeignKeyBuilderTest
     public void IsRequiredDependent_throws_when_ambiguous()
     {
         var modelBuilder = CreateInternalModelBuilder();
-        var customerEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
-        var orderEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
+        var customerEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit)!;
+        var orderEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit)!;
 
-        var relationshipBuilder = orderEntityBuilder.HasRelationship(customerEntityBuilder.Metadata, ConfigurationSource.Convention);
+        var relationshipBuilder = orderEntityBuilder.HasRelationship(customerEntityBuilder.Metadata, ConfigurationSource.Convention)!;
 
-        relationshipBuilder = relationshipBuilder.IsUnique(true, ConfigurationSource.Convention);
+        relationshipBuilder = relationshipBuilder.IsUnique(true, ConfigurationSource.Convention)!;
 
         Assert.Equal(
             CoreStrings.AmbiguousEndRequiredDependent(
@@ -577,17 +577,17 @@ public class InternalForeignKeyBuilderTest
     public void Can_only_override_lower_or_equal_source_Ownership()
     {
         var modelBuilder = CreateInternalModelBuilder();
-        var customerEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
-        var orderEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit, shouldBeOwned: true);
+        var customerEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit)!;
+        var orderEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit, shouldBeOwned: true)!;
 
         var relationshipBuilder = orderEntityBuilder.HasRelationship(
-            customerEntityBuilder.Metadata, null, nameof(Customer.Orders), ConfigurationSource.Convention);
+            customerEntityBuilder.Metadata, null, nameof(Customer.Orders), ConfigurationSource.Convention)!;
         Assert.False(relationshipBuilder.Metadata.IsOwnership);
 
-        relationshipBuilder = relationshipBuilder.IsOwnership(true, ConfigurationSource.Convention);
+        relationshipBuilder = relationshipBuilder.IsOwnership(true, ConfigurationSource.Convention)!;
         Assert.True(relationshipBuilder.Metadata.IsOwnership);
 
-        relationshipBuilder = relationshipBuilder.IsOwnership(false, ConfigurationSource.DataAnnotation);
+        relationshipBuilder = relationshipBuilder.IsOwnership(false, ConfigurationSource.DataAnnotation)!;
         Assert.False(relationshipBuilder.Metadata.IsOwnership);
 
         Assert.Null(relationshipBuilder.IsOwnership(true, ConfigurationSource.Convention));
@@ -598,8 +598,8 @@ public class InternalForeignKeyBuilderTest
     public void HasRelationship_throws_when_incompatible_navigations()
     {
         var modelBuilder = CreateInternalModelBuilder();
-        var customerEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
-        var orderEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
+        var customerEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit)!;
+        var orderEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit)!;
 
         Assert.Equal(
             CoreStrings.PrincipalEndIncompatibleNavigations(
@@ -616,24 +616,24 @@ public class InternalForeignKeyBuilderTest
     public void Can_only_invert_lower_or_equal_source()
     {
         var modelBuilder = CreateInternalModelBuilder();
-        var customerEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
-        var orderEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
+        var customerEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit)!;
+        var orderEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit)!;
 
         var relationshipBuilder = orderEntityBuilder
-            .HasRelationship(customerEntityBuilder.Metadata, ConfigurationSource.Convention);
+            .HasRelationship(customerEntityBuilder.Metadata, ConfigurationSource.Convention)!;
 
         Assert.Same(orderEntityBuilder.Metadata, relationshipBuilder.Metadata.DeclaringEntityType);
 
         relationshipBuilder = relationshipBuilder.HasEntityTypes(
             relationshipBuilder.Metadata.DeclaringEntityType,
             relationshipBuilder.Metadata.PrincipalEntityType,
-            ConfigurationSource.DataAnnotation);
+            ConfigurationSource.DataAnnotation)!;
         Assert.Same(customerEntityBuilder.Metadata, relationshipBuilder.Metadata.DeclaringEntityType);
 
         relationshipBuilder = relationshipBuilder.HasPrincipalKey(
                 orderEntityBuilder.Metadata.GetKeys().Single().Properties,
-                ConfigurationSource.Convention)
-            .HasForeignKey([Customer.IdProperty], ConfigurationSource.DataAnnotation);
+                ConfigurationSource.Convention)!
+            .HasForeignKey([Customer.IdProperty], ConfigurationSource.DataAnnotation)!;
 
         Assert.Null(
             relationshipBuilder.DependentEntityType(
@@ -674,7 +674,7 @@ public class InternalForeignKeyBuilderTest
         relationshipBuilder = relationshipBuilder.HasEntityTypes(
             relationshipBuilder.Metadata.DeclaringEntityType,
             relationshipBuilder.Metadata.PrincipalEntityType,
-            ConfigurationSource.DataAnnotation);
+            ConfigurationSource.DataAnnotation)!;
         Assert.Same(orderEntityBuilder.Metadata, relationshipBuilder.Metadata.DeclaringEntityType);
     }
 
@@ -682,17 +682,17 @@ public class InternalForeignKeyBuilderTest
     public void Can_invert_one_to_many()
     {
         var modelBuilder = CreateInternalModelBuilder();
-        var customerEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
-        var orderEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
+        var customerEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit)!;
+        var orderEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit)!;
 
         var relationshipBuilder = orderEntityBuilder
-            .HasRelationship(customerEntityBuilder.Metadata, ConfigurationSource.Convention)
-            .IsUnique(false, ConfigurationSource.DataAnnotation);
+            .HasRelationship(customerEntityBuilder.Metadata, ConfigurationSource.Convention)!
+            .IsUnique(false, ConfigurationSource.DataAnnotation)!;
 
         relationshipBuilder = relationshipBuilder.HasEntityTypes(
             relationshipBuilder.Metadata.DeclaringEntityType,
             relationshipBuilder.Metadata.PrincipalEntityType,
-            ConfigurationSource.Convention);
+            ConfigurationSource.Convention)!;
 
         Assert.Same(customerEntityBuilder.Metadata, relationshipBuilder.Metadata.DeclaringEntityType);
         Assert.Same(orderEntityBuilder.Metadata, relationshipBuilder.Metadata.PrincipalEntityType);
@@ -702,12 +702,12 @@ public class InternalForeignKeyBuilderTest
     public void IsConstrained_is_preserved_when_relationship_is_inverted()
     {
         var modelBuilder = CreateInternalModelBuilder();
-        var customerEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
-        var orderEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
+        var customerEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit)!;
+        var orderEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit)!;
 
         var relationshipBuilder = orderEntityBuilder
-            .HasRelationship(customerEntityBuilder.Metadata, ConfigurationSource.Convention)
-            .IsConstrained(false, ConfigurationSource.Explicit);
+            .HasRelationship(customerEntityBuilder.Metadata, ConfigurationSource.Convention)!
+            .IsConstrained(false, ConfigurationSource.Explicit)!;
 
         Assert.False(relationshipBuilder.Metadata.IsConstrained);
 
@@ -716,7 +716,7 @@ public class InternalForeignKeyBuilderTest
         relationshipBuilder = relationshipBuilder.HasEntityTypes(
             relationshipBuilder.Metadata.DeclaringEntityType,
             relationshipBuilder.Metadata.PrincipalEntityType,
-            ConfigurationSource.Convention);
+            ConfigurationSource.Convention)!;
 
         Assert.False(relationshipBuilder.Metadata.IsConstrained);
     }
@@ -725,12 +725,12 @@ public class InternalForeignKeyBuilderTest
     public void Inverting_to_keyless_throws()
     {
         var modelBuilder = CreateInternalModelBuilder();
-        var customerEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
-        var orderEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit)
-            .HasNoKey(ConfigurationSource.Explicit);
+        var customerEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit)!;
+        var orderEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit)!
+            .HasNoKey(ConfigurationSource.Explicit)!;
 
         var relationshipBuilder = orderEntityBuilder
-            .HasRelationship(customerEntityBuilder.Metadata, ConfigurationSource.Convention);
+            .HasRelationship(customerEntityBuilder.Metadata, ConfigurationSource.Convention)!;
 
         Assert.Same(orderEntityBuilder.Metadata, relationshipBuilder.Metadata.DeclaringEntityType);
 
@@ -748,116 +748,116 @@ public class InternalForeignKeyBuilderTest
     public void Can_lift_self_referencing_relationships()
     {
         var modelBuilder = CreateInternalModelBuilder();
-        var specialOrderEntityBuilder = modelBuilder.Entity(typeof(SpecialOrder), ConfigurationSource.Explicit);
-        var orderEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
+        var specialOrderEntityBuilder = modelBuilder.Entity(typeof(SpecialOrder), ConfigurationSource.Explicit)!;
+        var orderEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit)!;
         specialOrderEntityBuilder.HasBaseType(orderEntityBuilder.Metadata, ConfigurationSource.Explicit);
         var relationshipBuilder = specialOrderEntityBuilder
-            .HasRelationship(specialOrderEntityBuilder.Metadata, ConfigurationSource.Convention).HasNavigation(
+            .HasRelationship(specialOrderEntityBuilder.Metadata, ConfigurationSource.Convention)!.HasNavigation(
                 nameof(SpecialOrder.SpecialOrder),
                 pointsToPrincipal: false,
-                ConfigurationSource.Explicit);
+                ConfigurationSource.Explicit)!;
 
         relationshipBuilder = relationshipBuilder.PrincipalEntityType(
-            orderEntityBuilder.Metadata, ConfigurationSource.DataAnnotation);
+            orderEntityBuilder.Metadata, ConfigurationSource.DataAnnotation)!;
 
         Assert.Single(specialOrderEntityBuilder.Metadata.GetForeignKeys());
         Assert.Same(specialOrderEntityBuilder.Metadata, relationshipBuilder.Metadata.DeclaringEntityType);
         Assert.Same(orderEntityBuilder.Metadata, relationshipBuilder.Metadata.PrincipalEntityType);
         Assert.Null(relationshipBuilder.Metadata.DependentToPrincipal);
-        Assert.Equal(nameof(SpecialOrder.SpecialOrder), relationshipBuilder.Metadata.PrincipalToDependent.Name);
+        Assert.Equal(nameof(SpecialOrder.SpecialOrder), relationshipBuilder.Metadata.PrincipalToDependent!.Name);
     }
 
     [Fact]
     public void Can_add_navigations_to_higher_source_foreign_key()
     {
         var modelBuilder = CreateInternalModelBuilder();
-        var principalEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
+        var principalEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit)!;
         principalEntityBuilder.PrimaryKey([Customer.IdProperty, Customer.UniqueProperty], ConfigurationSource.Explicit);
-        var dependentEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
+        var dependentEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit)!;
         var foreignKeyBuilder = dependentEntityBuilder.HasRelationship(
-            typeof(Customer).FullName, [Order.CustomerIdProperty.Name, Order.CustomerUniqueProperty.Name],
-            ConfigurationSource.DataAnnotation);
+            typeof(Customer).FullName!, [Order.CustomerIdProperty.Name, Order.CustomerUniqueProperty.Name],
+            ConfigurationSource.DataAnnotation)!;
 
         var relationship = foreignKeyBuilder.HasNavigation(
             Order.CustomerProperty.Name,
             pointsToPrincipal: true,
-            ConfigurationSource.Convention);
+            ConfigurationSource.Convention)!;
         relationship = relationship.HasNavigation(
             Customer.OrdersProperty.Name,
             pointsToPrincipal: false,
-            ConfigurationSource.Convention);
+            ConfigurationSource.Convention)!;
 
-        Assert.Same(relationship.Metadata, dependentEntityBuilder.Metadata.FindNavigation(Order.CustomerProperty.Name).ForeignKey);
-        Assert.Same(relationship.Metadata, principalEntityBuilder.Metadata.FindNavigation(Customer.OrdersProperty.Name).ForeignKey);
+        Assert.Same(relationship.Metadata, dependentEntityBuilder.Metadata.FindNavigation(Order.CustomerProperty.Name)!.ForeignKey);
+        Assert.Same(relationship.Metadata, principalEntityBuilder.Metadata.FindNavigation(Customer.OrdersProperty.Name)!.ForeignKey);
     }
 
     [Fact]
     public void Can_only_override_existing_conflicting_navigations_explicitly()
     {
         var modelBuilder = CreateInternalModelBuilder();
-        var principalEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
+        var principalEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit)!;
         principalEntityBuilder.PrimaryKey([Customer.IdProperty, Customer.UniqueProperty], ConfigurationSource.Explicit);
-        var dependentEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
+        var dependentEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit)!;
         var existingForeignKey = dependentEntityBuilder.Metadata.AddForeignKey(
             [
-                dependentEntityBuilder.Property(Order.CustomerIdProperty, ConfigurationSource.Explicit).Metadata,
-                dependentEntityBuilder.Property(Order.CustomerUniqueProperty, ConfigurationSource.Explicit).Metadata
+                dependentEntityBuilder.Property(Order.CustomerIdProperty, ConfigurationSource.Explicit)!.Metadata,
+                dependentEntityBuilder.Property(Order.CustomerUniqueProperty, ConfigurationSource.Explicit)!.Metadata
             ],
-            principalEntityBuilder.Metadata.FindPrimaryKey(),
+            principalEntityBuilder.Metadata.FindPrimaryKey()!,
             principalEntityBuilder.Metadata,
             ConfigurationSource.Explicit,
-            ConfigurationSource.Explicit);
+            ConfigurationSource.Explicit)!;
         existingForeignKey.SetPrincipalToDependent(Customer.OrdersProperty, ConfigurationSource.Explicit);
         existingForeignKey.SetDependentToPrincipal(Order.CustomerProperty, ConfigurationSource.Explicit);
         Assert.Equal(ConfigurationSource.Explicit, existingForeignKey.GetDependentToPrincipalConfigurationSource());
         Assert.Equal(ConfigurationSource.Explicit, existingForeignKey.GetPrincipalToDependentConfigurationSource());
 
         var newForeignKeyBuilder = dependentEntityBuilder.HasRelationship(
-            typeof(Customer).FullName, [Order.IdProperty.Name, Order.CustomerUniqueProperty.Name],
-            ConfigurationSource.Convention);
+            typeof(Customer).FullName!, [Order.IdProperty.Name, Order.CustomerUniqueProperty.Name],
+            ConfigurationSource.Convention)!;
 
         newForeignKeyBuilder = newForeignKeyBuilder.HasNavigation(
             Order.CustomerProperty.Name,
             pointsToPrincipal: true,
-            ConfigurationSource.Convention);
+            ConfigurationSource.Convention)!;
         Assert.Same(existingForeignKey, newForeignKeyBuilder.Metadata);
 
         newForeignKeyBuilder = dependentEntityBuilder.HasRelationship(
-            typeof(Customer).FullName, [Order.CustomerIdProperty.Name, Order.CustomerUniqueProperty.Name],
-            ConfigurationSource.Convention);
+            typeof(Customer).FullName!, [Order.CustomerIdProperty.Name, Order.CustomerUniqueProperty.Name],
+            ConfigurationSource.Convention)!;
         newForeignKeyBuilder = newForeignKeyBuilder.HasNavigation(
             Customer.OrdersProperty.Name,
             pointsToPrincipal: false,
-            ConfigurationSource.Explicit);
+            ConfigurationSource.Explicit)!;
         Assert.Same(existingForeignKey, newForeignKeyBuilder.Metadata);
 
-        Assert.Equal(Customer.OrdersProperty.Name, newForeignKeyBuilder.Metadata.PrincipalToDependent.Name);
-        Assert.Equal(Order.CustomerProperty.Name, newForeignKeyBuilder.Metadata.DependentToPrincipal.Name);
+        Assert.Equal(Customer.OrdersProperty.Name, newForeignKeyBuilder.Metadata.PrincipalToDependent!.Name);
+        Assert.Equal(Order.CustomerProperty.Name, newForeignKeyBuilder.Metadata.DependentToPrincipal!.Name);
     }
 
     [Fact]
     public void Can_override_lower_or_equal_source_conflicting_navigation()
     {
         var modelBuilder = CreateInternalModelBuilder();
-        var principalEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
+        var principalEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit)!;
         principalEntityBuilder.PrimaryKey([Customer.IdProperty, Customer.UniqueProperty], ConfigurationSource.Explicit);
-        var dependentEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
+        var dependentEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit)!;
 
         var conflictingForeignKeyBuilder = dependentEntityBuilder.HasRelationship(
-            typeof(Customer).FullName, [Order.IdProperty.Name, Order.CustomerUniqueProperty.Name],
-            ConfigurationSource.DataAnnotation);
+            typeof(Customer).FullName!, [Order.IdProperty.Name, Order.CustomerUniqueProperty.Name],
+            ConfigurationSource.DataAnnotation)!;
         conflictingForeignKeyBuilder = conflictingForeignKeyBuilder.HasNavigation(
             Order.CustomerProperty.Name,
             pointsToPrincipal: true,
-            ConfigurationSource.DataAnnotation);
+            ConfigurationSource.DataAnnotation)!;
         conflictingForeignKeyBuilder = conflictingForeignKeyBuilder.HasNavigation(
             Customer.OrdersProperty.Name,
             pointsToPrincipal: false,
-            ConfigurationSource.DataAnnotation);
+            ConfigurationSource.DataAnnotation)!;
 
         var foreignKeyBuilder = dependentEntityBuilder.HasRelationship(
-            typeof(Customer).FullName, [Order.CustomerIdProperty.Name, Order.CustomerUniqueProperty.Name],
-            ConfigurationSource.Convention);
+            typeof(Customer).FullName!, [Order.CustomerIdProperty.Name, Order.CustomerUniqueProperty.Name],
+            ConfigurationSource.Convention)!;
 
         Assert.Same(
             conflictingForeignKeyBuilder,
@@ -874,27 +874,27 @@ public class InternalForeignKeyBuilderTest
 
         Assert.Same(
             conflictingForeignKeyBuilder.Metadata,
-            dependentEntityBuilder.Metadata.FindNavigation(Order.CustomerProperty.Name).ForeignKey);
+            dependentEntityBuilder.Metadata.FindNavigation(Order.CustomerProperty.Name)!.ForeignKey);
         Assert.Same(
             conflictingForeignKeyBuilder.Metadata,
-            principalEntityBuilder.Metadata.FindNavigation(Customer.OrdersProperty.Name).ForeignKey);
+            principalEntityBuilder.Metadata.FindNavigation(Customer.OrdersProperty.Name)!.ForeignKey);
 
         var newForeignKeyBuilder = dependentEntityBuilder.HasRelationship(
-            typeof(Customer).FullName, [Order.CustomerIdProperty.Name], ConfigurationSource.DataAnnotation);
+            typeof(Customer).FullName!, [Order.CustomerIdProperty.Name], ConfigurationSource.DataAnnotation)!;
         newForeignKeyBuilder = newForeignKeyBuilder.HasNavigation(
             Order.CustomerProperty.Name,
             pointsToPrincipal: true,
-            ConfigurationSource.DataAnnotation);
+            ConfigurationSource.DataAnnotation)!;
         newForeignKeyBuilder = newForeignKeyBuilder.HasNavigation(
             Customer.OrdersProperty.Name,
             pointsToPrincipal: false,
-            ConfigurationSource.DataAnnotation);
+            ConfigurationSource.DataAnnotation)!;
 
         Assert.Equal(Order.CustomerIdProperty.Name, newForeignKeyBuilder.Metadata.Properties.Single().Name);
         Assert.Same(
-            newForeignKeyBuilder.Metadata, dependentEntityBuilder.Metadata.FindNavigation(Order.CustomerProperty.Name).ForeignKey);
+            newForeignKeyBuilder.Metadata, dependentEntityBuilder.Metadata.FindNavigation(Order.CustomerProperty.Name)!.ForeignKey);
         Assert.Same(
-            newForeignKeyBuilder.Metadata, principalEntityBuilder.Metadata.FindNavigation(Customer.OrdersProperty.Name).ForeignKey);
+            newForeignKeyBuilder.Metadata, principalEntityBuilder.Metadata.FindNavigation(Customer.OrdersProperty.Name)!.ForeignKey);
         Assert.Same(newForeignKeyBuilder.Metadata, dependentEntityBuilder.Metadata.GetForeignKeys().Single());
     }
 
@@ -902,19 +902,19 @@ public class InternalForeignKeyBuilderTest
     public void Navigation_to_principal_uses_same_relationship_if_conflicting_navigation_configured_with_lower_source()
     {
         var modelBuilder = CreateInternalModelBuilder();
-        var customerEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
-        var orderEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
+        var customerEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit)!;
+        var orderEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit)!;
 
         var relationshipBuilder = customerEntityBuilder
-            .HasRelationship(orderEntityBuilder.Metadata, ConfigurationSource.Explicit).HasNavigation(
+            .HasRelationship(orderEntityBuilder.Metadata, ConfigurationSource.Explicit)!.HasNavigation(
                 nameof(Order.Customer),
                 pointsToPrincipal: false,
-                ConfigurationSource.Convention);
+                ConfigurationSource.Convention)!;
 
         Assert.NotNull(relationshipBuilder);
         Assert.Same(
             relationshipBuilder, orderEntityBuilder
-                .HasRelationship(customerEntityBuilder.Metadata, ConfigurationSource.DataAnnotation).HasNavigation(
+                .HasRelationship(customerEntityBuilder.Metadata, ConfigurationSource.DataAnnotation)!.HasNavigation(
                     nameof(Order.Customer),
                     pointsToPrincipal: true,
                     ConfigurationSource.DataAnnotation));
@@ -927,20 +927,20 @@ public class InternalForeignKeyBuilderTest
     public void Navigation_to_principal_does_not_change_uniqueness_for_relationship()
     {
         var modelBuilder = CreateInternalModelBuilder();
-        var principalEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
+        var principalEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit)!;
         principalEntityBuilder.PrimaryKey([Customer.IdProperty, Customer.UniqueProperty], ConfigurationSource.Explicit);
-        var dependentEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
+        var dependentEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit)!;
 
         var foreignKeyBuilder = dependentEntityBuilder.HasRelationship(
-            typeof(Customer).FullName, [Order.CustomerIdProperty.Name, Order.CustomerUniqueProperty.Name],
-            ConfigurationSource.Convention);
+            typeof(Customer).FullName!, [Order.CustomerIdProperty.Name, Order.CustomerUniqueProperty.Name],
+            ConfigurationSource.Convention)!;
         foreignKeyBuilder.IsUnique(false, ConfigurationSource.Convention);
         Assert.False(foreignKeyBuilder.Metadata.IsUnique);
 
         foreignKeyBuilder = foreignKeyBuilder.HasNavigation(
             nameof(Order.Customer),
             pointsToPrincipal: true,
-            ConfigurationSource.Convention);
+            ConfigurationSource.Convention)!;
         Assert.NotNull(foreignKeyBuilder.Metadata.DependentToPrincipal);
         Assert.False(foreignKeyBuilder.Metadata.IsUnique);
     }
@@ -949,19 +949,19 @@ public class InternalForeignKeyBuilderTest
     public void Navigation_to_dependent_uses_same_relationship_if_conflicting_navigation_configured_with_lower_source()
     {
         var modelBuilder = CreateInternalModelBuilder();
-        var customerEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
-        var orderEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
+        var customerEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit)!;
+        var orderEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit)!;
 
         var relationshipBuilder = orderEntityBuilder
-            .HasRelationship(customerEntityBuilder.Metadata, ConfigurationSource.DataAnnotation).HasNavigation(
+            .HasRelationship(customerEntityBuilder.Metadata, ConfigurationSource.DataAnnotation)!.HasNavigation(
                 nameof(Customer.Orders),
                 pointsToPrincipal: false,
-                ConfigurationSource.Convention);
+                ConfigurationSource.Convention)!;
 
         Assert.NotNull(relationshipBuilder);
         Assert.Same(
             relationshipBuilder, orderEntityBuilder
-                .HasRelationship(customerEntityBuilder.Metadata, ConfigurationSource.DataAnnotation).HasNavigation(
+                .HasRelationship(customerEntityBuilder.Metadata, ConfigurationSource.DataAnnotation)!.HasNavigation(
                     nameof(Customer.Orders),
                     pointsToPrincipal: false,
                     ConfigurationSource.DataAnnotation));
@@ -972,41 +972,41 @@ public class InternalForeignKeyBuilderTest
     public void Navigation_to_dependent_changes_uniqueness_for_relationship_of_lower_or_equal_source()
     {
         var modelBuilder = CreateInternalModelBuilder();
-        var principalEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
+        var principalEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit)!;
         principalEntityBuilder.PrimaryKey([Customer.IdProperty, Customer.UniqueProperty], ConfigurationSource.Explicit);
-        var dependentEntityBuilder = modelBuilder.Entity(typeof(SpecialOrder), ConfigurationSource.Explicit);
+        var dependentEntityBuilder = modelBuilder.Entity(typeof(SpecialOrder), ConfigurationSource.Explicit)!;
 
         var foreignKeyBuilder = dependentEntityBuilder.HasRelationship(
-            typeof(Customer).FullName, [Order.CustomerIdProperty.Name, Order.CustomerUniqueProperty.Name],
-            ConfigurationSource.Convention);
+            typeof(Customer).FullName!, [Order.CustomerIdProperty.Name, Order.CustomerUniqueProperty.Name],
+            ConfigurationSource.Convention)!;
         Assert.False(foreignKeyBuilder.Metadata.IsUnique);
 
         foreignKeyBuilder = foreignKeyBuilder.HasNavigation(
             nameof(Customer.NotCollectionOrders),
             pointsToPrincipal: false,
-            ConfigurationSource.DataAnnotation);
-        Assert.Equal(nameof(Customer.NotCollectionOrders), foreignKeyBuilder.Metadata.PrincipalToDependent.Name);
+            ConfigurationSource.DataAnnotation)!;
+        Assert.Equal(nameof(Customer.NotCollectionOrders), foreignKeyBuilder.Metadata.PrincipalToDependent!.Name);
         Assert.True(foreignKeyBuilder.Metadata.IsUnique);
 
         foreignKeyBuilder = foreignKeyBuilder.HasNavigation(
             nameof(Customer.AmbiguousOrder),
             pointsToPrincipal: false,
-            ConfigurationSource.DataAnnotation);
-        Assert.Equal(nameof(Customer.AmbiguousOrder), foreignKeyBuilder.Metadata.PrincipalToDependent.Name);
+            ConfigurationSource.DataAnnotation)!;
+        Assert.Equal(nameof(Customer.AmbiguousOrder), foreignKeyBuilder.Metadata.PrincipalToDependent!.Name);
         Assert.True(foreignKeyBuilder.Metadata.IsUnique);
 
         foreignKeyBuilder = foreignKeyBuilder.HasNavigation(
             nameof(Customer.Orders),
             pointsToPrincipal: false,
-            ConfigurationSource.DataAnnotation);
-        Assert.Equal(nameof(Customer.Orders), foreignKeyBuilder.Metadata.PrincipalToDependent.Name);
+            ConfigurationSource.DataAnnotation)!;
+        Assert.Equal(nameof(Customer.Orders), foreignKeyBuilder.Metadata.PrincipalToDependent!.Name);
         Assert.False(foreignKeyBuilder.Metadata.IsUnique);
 
         foreignKeyBuilder = foreignKeyBuilder.HasNavigation(
             nameof(Customer.AmbiguousOrder),
             pointsToPrincipal: false,
-            ConfigurationSource.DataAnnotation);
-        Assert.Equal(nameof(Customer.AmbiguousOrder), foreignKeyBuilder.Metadata.PrincipalToDependent.Name);
+            ConfigurationSource.DataAnnotation)!;
+        Assert.Equal(nameof(Customer.AmbiguousOrder), foreignKeyBuilder.Metadata.PrincipalToDependent!.Name);
         Assert.False(foreignKeyBuilder.Metadata.IsUnique);
     }
 
@@ -1014,16 +1014,16 @@ public class InternalForeignKeyBuilderTest
     public void Navigation_to_dependent_does_not_change_uniqueness_for_relationship_of_higher_source()
     {
         var modelBuilder = CreateInternalModelBuilder();
-        var principalEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
+        var principalEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit)!;
         principalEntityBuilder.PrimaryKey([Customer.IdProperty, Customer.UniqueProperty], ConfigurationSource.Explicit);
-        var dependentEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
+        var dependentEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit)!;
 
         var foreignKeyBuilder = dependentEntityBuilder.HasRelationship(
-            typeof(Customer).FullName, [Order.CustomerIdProperty.Name, Order.CustomerUniqueProperty.Name],
-            ConfigurationSource.Convention);
+            typeof(Customer).FullName!, [Order.CustomerIdProperty.Name, Order.CustomerUniqueProperty.Name],
+            ConfigurationSource.Convention)!;
         Assert.False(foreignKeyBuilder.Metadata.IsUnique);
 
-        foreignKeyBuilder = foreignKeyBuilder.IsUnique(false, ConfigurationSource.DataAnnotation);
+        foreignKeyBuilder = foreignKeyBuilder.IsUnique(false, ConfigurationSource.DataAnnotation)!;
         Assert.False(foreignKeyBuilder.Metadata.IsUnique);
 
         Assert.Null(
@@ -1036,20 +1036,20 @@ public class InternalForeignKeyBuilderTest
         foreignKeyBuilder = foreignKeyBuilder.HasNavigation(
             "Orders",
             pointsToPrincipal: false,
-            ConfigurationSource.Convention);
-        Assert.Equal("Orders", foreignKeyBuilder.Metadata.PrincipalToDependent.Name);
+            ConfigurationSource.Convention)!;
+        Assert.Equal("Orders", foreignKeyBuilder.Metadata.PrincipalToDependent!.Name);
     }
 
     [Fact]
     public void Can_set_IsConstrained_and_respects_configuration_source()
     {
         var modelBuilder = CreateInternalModelBuilder();
-        var principalEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
+        var principalEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit)!;
         principalEntityBuilder.PrimaryKey([Customer.IdProperty, Customer.UniqueProperty], ConfigurationSource.Convention);
-        var dependentEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
+        var dependentEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit)!;
 
         var relationshipBuilder = dependentEntityBuilder.HasRelationship(
-            principalEntityBuilder.Metadata, ConfigurationSource.Convention);
+            principalEntityBuilder.Metadata, ConfigurationSource.Convention)!;
 
         Assert.True(relationshipBuilder.Metadata.IsConstrained);
 
@@ -1066,20 +1066,20 @@ public class InternalForeignKeyBuilderTest
     public void Inverting_identifying_relationship_keeps_derived_dependent()
     {
         var modelBuilder = CreateInternalModelBuilder();
-        var customerEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
+        var customerEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit)!;
         customerEntityBuilder.PrimaryKey([Customer.IdProperty], ConfigurationSource.Explicit);
-        var orderEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
+        var orderEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit)!;
         orderEntityBuilder.PrimaryKey([Order.IdProperty], ConfigurationSource.Explicit);
-        var specialOrderEntityBuilder = modelBuilder.Entity(typeof(SpecialOrder), ConfigurationSource.Explicit);
+        var specialOrderEntityBuilder = modelBuilder.Entity(typeof(SpecialOrder), ConfigurationSource.Explicit)!;
         specialOrderEntityBuilder.HasBaseType(orderEntityBuilder.Metadata, ConfigurationSource.Explicit);
 
         // Identifying FK: principal = SpecialOrder (derived), dependent = Customer (non-derived),
         // where the FK property is the dependent's primary key.
         var relationshipBuilder = customerEntityBuilder
-            .HasRelationship(specialOrderEntityBuilder.Metadata, ConfigurationSource.Convention)
-            .HasForeignKey([Customer.IdProperty], ConfigurationSource.Explicit)
-            .HasPrincipalKey(specialOrderEntityBuilder.Metadata.FindPrimaryKey().Properties, ConfigurationSource.Explicit)
-            .IsUnique(true, ConfigurationSource.Explicit);
+            .HasRelationship(specialOrderEntityBuilder.Metadata, ConfigurationSource.Convention)!
+            .HasForeignKey([Customer.IdProperty], ConfigurationSource.Explicit)!
+            .HasPrincipalKey(specialOrderEntityBuilder.Metadata.FindPrimaryKey()!.Properties, ConfigurationSource.Explicit)!
+            .IsUnique(true, ConfigurationSource.Explicit)!;
 
         Assert.Same(specialOrderEntityBuilder.Metadata, relationshipBuilder.Metadata.PrincipalEntityType);
         Assert.Same(customerEntityBuilder.Metadata, relationshipBuilder.Metadata.DeclaringEntityType);
@@ -1098,12 +1098,12 @@ public class InternalForeignKeyBuilderTest
     public void Attach_uses_provided_principal_type_when_in_model()
     {
         var modelBuilder = CreateInternalModelBuilder();
-        var principalEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
+        var principalEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit)!;
         principalEntityBuilder.PrimaryKey([Customer.IdProperty], ConfigurationSource.Explicit);
-        var dependentEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
+        var dependentEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit)!;
 
         var fkBuilder = dependentEntityBuilder
-            .HasRelationship(principalEntityBuilder.Metadata, ConfigurationSource.Convention);
+            .HasRelationship(principalEntityBuilder.Metadata, ConfigurationSource.Convention)!;
 
         var snapshot = InternalEntityTypeBuilder.DetachRelationship(fkBuilder.Metadata);
 
@@ -1127,10 +1127,10 @@ public class InternalForeignKeyBuilderTest
         principalABuilder.PrimaryKey([Customer.IdProperty], ConfigurationSource.Explicit);
         var principalBBuilder = modelBuilder.SharedTypeEntity("PrincipalB", typeof(Customer), ConfigurationSource.Explicit)!;
 
-        var dependentEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
+        var dependentEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit)!;
 
         var fkBuilder = dependentEntityBuilder
-            .HasRelationship(principalABuilder.Metadata, ConfigurationSource.Convention);
+            .HasRelationship(principalABuilder.Metadata, ConfigurationSource.Convention)!;
 
         var snapshot = InternalEntityTypeBuilder.DetachRelationship(fkBuilder.Metadata);
 
@@ -1148,12 +1148,12 @@ public class InternalForeignKeyBuilderTest
     public void Attach_falls_back_to_model_lookup_when_provided_principal_is_not_in_model()
     {
         var modelBuilder = CreateInternalModelBuilder();
-        var principalEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
+        var principalEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit)!;
         principalEntityBuilder.PrimaryKey([Customer.IdProperty], ConfigurationSource.Explicit);
-        var dependentEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
+        var dependentEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit)!;
 
         var fkBuilder = dependentEntityBuilder
-            .HasRelationship(principalEntityBuilder.Metadata, ConfigurationSource.Convention);
+            .HasRelationship(principalEntityBuilder.Metadata, ConfigurationSource.Convention)!;
 
         var stalePrincipal = principalEntityBuilder.Metadata;
         var snapshot = InternalEntityTypeBuilder.DetachRelationship(fkBuilder.Metadata);
@@ -1178,18 +1178,18 @@ public class InternalForeignKeyBuilderTest
 
     private class Order
     {
-        public static readonly PropertyInfo IdProperty = typeof(Order).GetProperty("Id");
-        public static readonly PropertyInfo CustomerIdProperty = typeof(Order).GetProperty("CustomerId");
-        public static readonly PropertyInfo CustomerUniqueProperty = typeof(Order).GetProperty("CustomerUnique");
-        public static readonly PropertyInfo CustomerProperty = typeof(Order).GetProperty("Customer");
+        public static readonly PropertyInfo IdProperty = typeof(Order).GetProperty("Id")!;
+        public static readonly PropertyInfo CustomerIdProperty = typeof(Order).GetProperty("CustomerId")!;
+        public static readonly PropertyInfo CustomerUniqueProperty = typeof(Order).GetProperty("CustomerUnique")!;
+        public static readonly PropertyInfo CustomerProperty = typeof(Order).GetProperty("Customer")!;
 
         public int Id { get; set; }
         public int CustomerId { get; set; }
         public Guid? CustomerUnique { get; set; }
-        public Customer Customer { get; set; }
+        public Customer Customer { get; set; } = null!;
 
-        public Order OrderCustomer { get; set; }
-        public SpecialOrder SpecialOrder { get; set; }
+        public Order OrderCustomer { get; set; } = null!;
+        public SpecialOrder SpecialOrder { get; set; } = null!;
     }
 
     private class SpecialOrder : Order, IEnumerable<Order>
@@ -1202,23 +1202,23 @@ public class InternalForeignKeyBuilderTest
         IEnumerator IEnumerable.GetEnumerator()
             => GetEnumerator();
 
-        public string Specialty { get; set; }
+        public string Specialty { get; set; } = null!;
     }
 
     private class Customer
     {
-        public static readonly PropertyInfo IdProperty = typeof(Customer).GetProperty("Id");
-        public static readonly PropertyInfo UniqueProperty = typeof(Customer).GetProperty("Unique");
-        public static readonly PropertyInfo OrdersProperty = typeof(Customer).GetProperty("Orders");
+        public static readonly PropertyInfo IdProperty = typeof(Customer).GetProperty("Id")!;
+        public static readonly PropertyInfo UniqueProperty = typeof(Customer).GetProperty("Unique")!;
+        public static readonly PropertyInfo OrdersProperty = typeof(Customer).GetProperty("Orders")!;
 
         public int Id { get; set; }
         public Guid Unique { get; set; }
-        public string Name { get; set; }
-        public string Mane { get; set; }
-        public ICollection<Order> Orders { get; set; }
-        public SpecialOrder AmbiguousOrder { get; set; }
-        public IEnumerable<Order> EnumerableOrders { get; set; }
-        public ICollection<SpecialOrder> SpecialOrders { get; set; }
-        public Order NotCollectionOrders { get; set; }
+        public string Name { get; set; } = null!;
+        public string Mane { get; set; } = null!;
+        public ICollection<Order> Orders { get; set; } = null!;
+        public SpecialOrder AmbiguousOrder { get; set; } = null!;
+        public IEnumerable<Order> EnumerableOrders { get; set; } = null!;
+        public ICollection<SpecialOrder> SpecialOrders { get; set; } = null!;
+        public Order NotCollectionOrders { get; set; } = null!;
     }
 }

--- a/test/EFCore.Tests/Metadata/Internal/InternalIndexBuilderTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/InternalIndexBuilderTest.cs
@@ -44,17 +44,17 @@ public class InternalIndexBuilderTest
     private InternalIndexBuilder CreateInternalIndexBuilder()
     {
         var modelBuilder = new InternalModelBuilder(new Model());
-        var entityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
+        var entityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit)!;
 
-        return entityBuilder.HasIndex([Customer.IdProperty, Customer.NameProperty], ConfigurationSource.Explicit);
+        return entityBuilder.HasIndex([Customer.IdProperty, Customer.NameProperty], ConfigurationSource.Explicit)!;
     }
 
     private class Customer
     {
-        public static readonly PropertyInfo IdProperty = typeof(Customer).GetProperty("Id");
-        public static readonly PropertyInfo NameProperty = typeof(Customer).GetProperty("Name");
+        public static readonly PropertyInfo IdProperty = typeof(Customer).GetProperty("Id")!;
+        public static readonly PropertyInfo NameProperty = typeof(Customer).GetProperty("Name")!;
 
         public int Id { get; set; }
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
     }
 }

--- a/test/EFCore.Tests/Metadata/Internal/InternalModelBuilderTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/InternalModelBuilderTest.cs
@@ -22,7 +22,7 @@ public class InternalModelBuilderTest
         Assert.NotNull(entityBuilder);
         Assert.NotNull(model.FindEntityType(typeof(Customer)));
         Assert.Same(entityBuilder, modelBuilder.Entity(typeof(Customer).DisplayName(), ConfigurationSource.DataAnnotation));
-        Assert.NotNull(model.FindEntityType(typeof(Customer)).ClrType);
+        Assert.NotNull(model.FindEntityType(typeof(Customer))!.ClrType);
     }
 
     [Fact]
@@ -36,7 +36,7 @@ public class InternalModelBuilderTest
         Assert.NotNull(entityBuilder);
         Assert.NotNull(model.FindEntityType(typeof(Customer).DisplayName()));
         Assert.NotSame(entityBuilder, modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit));
-        Assert.NotNull(model.FindEntityType(typeof(Customer)).ClrType);
+        Assert.NotNull(model.FindEntityType(typeof(Customer))!.ClrType);
     }
 
     [Fact]
@@ -112,13 +112,13 @@ public class InternalModelBuilderTest
         var model = new Model();
         var modelBuilder = CreateModelBuilder(model);
 
-        Assert.NotNull(modelBuilder.Ignore(typeof(Customer).FullName, ConfigurationSource.Convention));
-        Assert.Null(modelBuilder.Entity(typeof(Customer).FullName, ConfigurationSource.Convention));
-        Assert.NotNull(modelBuilder.Entity(typeof(Customer).FullName, ConfigurationSource.DataAnnotation));
+        Assert.NotNull(modelBuilder.Ignore(typeof(Customer).FullName!, ConfigurationSource.Convention));
+        Assert.Null(modelBuilder.Entity(typeof(Customer).FullName!, ConfigurationSource.Convention));
+        Assert.NotNull(modelBuilder.Entity(typeof(Customer).FullName!, ConfigurationSource.DataAnnotation));
 
-        Assert.Null(modelBuilder.Ignore(typeof(Customer).FullName, ConfigurationSource.Convention));
+        Assert.Null(modelBuilder.Ignore(typeof(Customer).FullName!, ConfigurationSource.Convention));
 
-        Assert.NotNull(model.FindEntityType(typeof(Customer).FullName));
+        Assert.NotNull(model.FindEntityType(typeof(Customer).FullName!));
     }
 
     [Fact]
@@ -171,9 +171,9 @@ public class InternalModelBuilderTest
     {
         var modelBuilder = CreateModelBuilder();
         modelBuilder
-            .Entity(typeof(Customer), ConfigurationSource.Convention)
+            .Entity(typeof(Customer), ConfigurationSource.Convention)!
             .PrimaryKey([Customer.IdProperty], ConfigurationSource.Convention);
-        var orderEntityTypeBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
+        var orderEntityTypeBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit)!;
 
         Assert.NotNull(
             orderEntityTypeBuilder.HasRelationship(
@@ -190,9 +190,9 @@ public class InternalModelBuilderTest
     {
         var modelBuilder = CreateModelBuilder();
         var customerEntityTypeBuilder = modelBuilder
-            .Entity(typeof(Customer), ConfigurationSource.Explicit)
-            .PrimaryKey([Customer.IdProperty], ConfigurationSource.Convention);
-        var orderEntityTypeBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Convention);
+            .Entity(typeof(Customer), ConfigurationSource.Explicit)!
+            .PrimaryKey([Customer.IdProperty], ConfigurationSource.Convention)!;
+        var orderEntityTypeBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Convention)!;
 
         Assert.NotNull(
             orderEntityTypeBuilder
@@ -208,9 +208,9 @@ public class InternalModelBuilderTest
     public void Can_ignore_entity_type_with_base_and_derived_types()
     {
         var modelBuilder = CreateModelBuilder();
-        var baseEntityTypeBuilder = modelBuilder.Entity(typeof(Base), ConfigurationSource.Explicit);
-        var customerEntityTypeBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Convention);
-        var specialCustomerEntityTypeBuilder = modelBuilder.Entity(typeof(SpecialCustomer), ConfigurationSource.Explicit);
+        var baseEntityTypeBuilder = modelBuilder.Entity(typeof(Base), ConfigurationSource.Explicit)!;
+        var customerEntityTypeBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Convention)!;
+        var specialCustomerEntityTypeBuilder = modelBuilder.Entity(typeof(SpecialCustomer), ConfigurationSource.Explicit)!;
 
         Assert.NotNull(customerEntityTypeBuilder.HasBaseType(baseEntityTypeBuilder.Metadata, ConfigurationSource.Convention));
         Assert.NotNull(
@@ -227,9 +227,9 @@ public class InternalModelBuilderTest
     {
         var modelBuilder = CreateModelBuilder();
         modelBuilder
-            .Entity(typeof(Customer), ConfigurationSource.Convention)
+            .Entity(typeof(Customer), ConfigurationSource.Convention)!
             .PrimaryKey([Customer.IdProperty], ConfigurationSource.Convention);
-        var orderEntityTypeBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Convention);
+        var orderEntityTypeBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Convention)!;
 
         Assert.NotNull(
             orderEntityTypeBuilder.HasRelationship(typeof(Customer), [Order.CustomerIdProperty], ConfigurationSource.Explicit));
@@ -245,13 +245,13 @@ public class InternalModelBuilderTest
     {
         var modelBuilder = CreateModelBuilder();
         modelBuilder
-            .Entity(typeof(Customer), ConfigurationSource.Convention)
+            .Entity(typeof(Customer), ConfigurationSource.Convention)!
             .PrimaryKey([Customer.IdProperty], ConfigurationSource.Convention);
         modelBuilder
-            .Entity(typeof(Product), ConfigurationSource.Convention)
+            .Entity(typeof(Product), ConfigurationSource.Convention)!
             .PrimaryKey([Product.IdProperty], ConfigurationSource.Convention);
 
-        var orderEntityTypeBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Convention);
+        var orderEntityTypeBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Convention)!;
         orderEntityTypeBuilder.HasRelationship(typeof(Customer), [Order.CustomerIdProperty], ConfigurationSource.Convention);
         orderEntityTypeBuilder.HasRelationship(typeof(Product), [Order.ProductIdProperty], ConfigurationSource.Convention);
 
@@ -266,14 +266,14 @@ public class InternalModelBuilderTest
     {
         var modelBuilder = CreateModelBuilder();
         modelBuilder
-            .Entity(typeof(Customer), ConfigurationSource.Convention)
+            .Entity(typeof(Customer), ConfigurationSource.Convention)!
             .PrimaryKey([Customer.IdProperty], ConfigurationSource.Convention);
         modelBuilder
-            .Entity(typeof(Product), ConfigurationSource.Convention)
+            .Entity(typeof(Product), ConfigurationSource.Convention)!
             .PrimaryKey([Product.IdProperty], ConfigurationSource.Convention);
 
-        var orderEntityTypeBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
-        orderEntityTypeBuilder.HasRelationship(typeof(Product), [Order.ProductIdProperty], ConfigurationSource.Convention)
+        var orderEntityTypeBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit)!;
+        orderEntityTypeBuilder.HasRelationship(typeof(Product), [Order.ProductIdProperty], ConfigurationSource.Convention)!
             .HasNavigation(
                 "Product",
                 pointsToPrincipal: true,
@@ -291,15 +291,15 @@ public class InternalModelBuilderTest
     {
         var modelBuilder = CreateModelBuilder();
         modelBuilder
-            .Entity(typeof(Customer), ConfigurationSource.Convention)
+            .Entity(typeof(Customer), ConfigurationSource.Convention)!
             .PrimaryKey([Customer.IdProperty], ConfigurationSource.Convention);
         modelBuilder
-            .Entity(typeof(Product), ConfigurationSource.Explicit)
+            .Entity(typeof(Product), ConfigurationSource.Explicit)!
             .PrimaryKey([Product.IdProperty], ConfigurationSource.Convention);
 
-        var orderEntityTypeBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Convention);
+        var orderEntityTypeBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Convention)!;
         orderEntityTypeBuilder.HasRelationship(typeof(Product), [Order.ProductIdProperty], ConfigurationSource.Convention)
-            .HasNavigation(
+            !.HasNavigation(
                 "Order",
                 pointsToPrincipal: false,
                 ConfigurationSource.Convention);
@@ -317,9 +317,9 @@ public class InternalModelBuilderTest
         var model = new Model();
         var modelBuilder = CreateModelBuilder(model);
 
-        var entityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
+        var entityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit)!;
 
-        var ownedEntityTypeBuilder = modelBuilder.Entity(typeof(Details), ConfigurationSource.Convention);
+        var ownedEntityTypeBuilder = modelBuilder.Entity(typeof(Details), ConfigurationSource.Convention)!;
         Assert.NotNull(ownedEntityTypeBuilder);
 
         Assert.False(model.IsOwned(typeof(Details)));
@@ -350,7 +350,7 @@ public class InternalModelBuilderTest
 
         Assert.NotNull(
             modelBuilder.Entity(typeof(Product), ConfigurationSource.Explicit)
-                .HasOwnership(typeof(Details), nameof(Product.Details), ConfigurationSource.Explicit));
+                !.HasOwnership(typeof(Details), nameof(Product.Details), ConfigurationSource.Explicit));
 
         Assert.Null(modelBuilder.Ignore(typeof(Details), ConfigurationSource.Convention));
 
@@ -386,19 +386,19 @@ public class InternalModelBuilderTest
         var model = new Model();
         var modelBuilder = CreateModelBuilder(model);
 
-        var manyToManyLeft = modelBuilder.Entity(typeof(ManyToManyLeft), ConfigurationSource.Convention);
-        var manyToManyRight = modelBuilder.Entity(typeof(ManyToManyRight), ConfigurationSource.Convention);
-        var manyToManyLeftPK = manyToManyLeft.PrimaryKey([nameof(ManyToManyLeft.Id)], ConfigurationSource.Convention);
-        var manyToManyRightPK = manyToManyRight.PrimaryKey([nameof(ManyToManyRight.Id)], ConfigurationSource.Convention);
+        var manyToManyLeft = modelBuilder.Entity(typeof(ManyToManyLeft), ConfigurationSource.Convention)!;
+        var manyToManyRight = modelBuilder.Entity(typeof(ManyToManyRight), ConfigurationSource.Convention)!;
+        var manyToManyLeftPK = manyToManyLeft.PrimaryKey([nameof(ManyToManyLeft.Id)], ConfigurationSource.Convention)!;
+        var manyToManyRightPK = manyToManyRight.PrimaryKey([nameof(ManyToManyRight.Id)], ConfigurationSource.Convention)!;
 
         var skipNavOnLeft = manyToManyLeft.HasSkipNavigation(
-            new MemberIdentity(typeof(ManyToManyLeft).GetProperty(nameof(ManyToManyLeft.Rights))),
+            new MemberIdentity(typeof(ManyToManyLeft).GetProperty(nameof(ManyToManyLeft.Rights))!),
             manyToManyRight.Metadata,
-            ConfigurationSource.Convention);
+            ConfigurationSource.Convention)!;
         var skipNavOnRight = manyToManyRight.HasSkipNavigation(
-            new MemberIdentity(typeof(ManyToManyRight).GetProperty(nameof(ManyToManyRight.Lefts))),
+            new MemberIdentity(typeof(ManyToManyRight).GetProperty(nameof(ManyToManyRight.Lefts))!),
             manyToManyLeft.Metadata,
-            ConfigurationSource.Convention);
+            ConfigurationSource.Convention)!;
         skipNavOnLeft.HasInverse(skipNavOnRight.Metadata, ConfigurationSource.Convention);
 
         var joinEntityTypeBuilder =
@@ -406,14 +406,14 @@ public class InternalModelBuilderTest
                 "JoinEntity",
                 typeof(Dictionary<string, object>),
                 owned: false,
-                ConfigurationSource.Convention).Builder;
+                ConfigurationSource.Convention)!.Builder;
         var leftFK = joinEntityTypeBuilder
             .HasRelationship(
                 manyToManyLeft.Metadata.Name,
                 new List<string> { "ManyToManyLeft_Id" },
                 manyToManyLeftPK.Metadata,
                 ConfigurationSource.Convention)
-            .IsUnique(false, ConfigurationSource.Convention)
+            !.IsUnique(false, ConfigurationSource.Convention)!
             .Metadata;
         var rightFK = joinEntityTypeBuilder
             .HasRelationship(
@@ -421,7 +421,7 @@ public class InternalModelBuilderTest
                 new List<string> { "ManyToManyRight_Id" },
                 manyToManyRightPK.Metadata,
                 ConfigurationSource.Convention)
-            .IsUnique(false, ConfigurationSource.Convention)
+            !.IsUnique(false, ConfigurationSource.Convention)!
             .Metadata;
         skipNavOnLeft.HasForeignKey(leftFK, ConfigurationSource.Convention);
         skipNavOnRight.HasForeignKey(rightFK, ConfigurationSource.Convention);
@@ -451,35 +451,35 @@ public class InternalModelBuilderTest
         var model = new Model();
         var modelBuilder = CreateModelBuilder(model);
 
-        var manyToManyLeft = modelBuilder.Entity(typeof(ManyToManyLeft), ConfigurationSource.Convention);
-        var manyToManyRight = modelBuilder.Entity(typeof(ManyToManyRight), ConfigurationSource.Convention);
-        var manyToManyJoin = modelBuilder.Entity(typeof(ManyToManyJoin), ConfigurationSource.Convention);
-        var manyToManyLeftPK = manyToManyLeft.PrimaryKey([nameof(ManyToManyLeft.Id)], ConfigurationSource.Convention);
-        var manyToManyRightPK = manyToManyRight.PrimaryKey([nameof(ManyToManyRight.Id)], ConfigurationSource.Convention);
+        var manyToManyLeft = modelBuilder.Entity(typeof(ManyToManyLeft), ConfigurationSource.Convention)!;
+        var manyToManyRight = modelBuilder.Entity(typeof(ManyToManyRight), ConfigurationSource.Convention)!;
+        var manyToManyJoin = modelBuilder.Entity(typeof(ManyToManyJoin), ConfigurationSource.Convention)!;
+        var manyToManyLeftPK = manyToManyLeft.PrimaryKey([nameof(ManyToManyLeft.Id)], ConfigurationSource.Convention)!;
+        var manyToManyRightPK = manyToManyRight.PrimaryKey([nameof(ManyToManyRight.Id)], ConfigurationSource.Convention)!;
         manyToManyJoin.PrimaryKey(
             [nameof(ManyToManyJoin.LeftId), nameof(ManyToManyJoin.RightId)], ConfigurationSource.Convention);
 
         var skipNavOnLeft = manyToManyLeft.HasSkipNavigation(
-            new MemberIdentity(typeof(ManyToManyLeft).GetProperty(nameof(ManyToManyLeft.Rights))),
+            new MemberIdentity(typeof(ManyToManyLeft).GetProperty(nameof(ManyToManyLeft.Rights))!),
             manyToManyRight.Metadata,
-            ConfigurationSource.Convention);
+            ConfigurationSource.Convention)!;
         var skipNavOnRight = manyToManyRight.HasSkipNavigation(
-            new MemberIdentity(typeof(ManyToManyRight).GetProperty(nameof(ManyToManyRight.Lefts))),
+            new MemberIdentity(typeof(ManyToManyRight).GetProperty(nameof(ManyToManyRight.Lefts))!),
             manyToManyLeft.Metadata,
-            ConfigurationSource.Convention);
+            ConfigurationSource.Convention)!;
         skipNavOnLeft.HasInverse(skipNavOnRight.Metadata, ConfigurationSource.Convention);
 
         var leftFK = manyToManyJoin.HasRelationship(
             manyToManyLeft.Metadata.Name,
             [nameof(ManyToManyJoin.LeftId)],
             manyToManyLeftPK.Metadata,
-            ConfigurationSource.Convention);
+            ConfigurationSource.Convention)!;
         skipNavOnLeft.Metadata.SetForeignKey(leftFK.Metadata, ConfigurationSource.Convention);
         var rightFK = manyToManyJoin.HasRelationship(
             manyToManyRight.Metadata.Name,
             [nameof(ManyToManyJoin.RightId)],
             manyToManyRightPK.Metadata,
-            ConfigurationSource.Convention);
+            ConfigurationSource.Convention)!;
         skipNavOnRight.Metadata.SetForeignKey(rightFK.Metadata, ConfigurationSource.Convention);
         skipNavOnLeft.HasInverse(skipNavOnRight.Metadata, ConfigurationSource.Convention);
 
@@ -508,7 +508,7 @@ public class InternalModelBuilderTest
 
         Assert.NotNull(modelBuilder.SharedTypeEntity(sharedTypeName, typeof(Details), ConfigurationSource.Convention));
 
-        Assert.True(model.FindEntityType(sharedTypeName).HasSharedClrType);
+        Assert.True(model.FindEntityType(sharedTypeName)!.HasSharedClrType);
 
         Assert.Null(modelBuilder.SharedTypeEntity(sharedTypeName, typeof(Product), ConfigurationSource.Convention));
 
@@ -518,7 +518,7 @@ public class InternalModelBuilderTest
 
         Assert.NotNull(modelBuilder.SharedTypeEntity(sharedTypeName, typeof(Product), ConfigurationSource.Explicit));
 
-        Assert.Equal(typeof(Product), model.FindEntityType(sharedTypeName).ClrType);
+        Assert.Equal(typeof(Product), model.FindEntityType(sharedTypeName)!.ClrType);
 
         Assert.Equal(
             CoreStrings.ClashingMismatchedSharedType("SpecialDetails", nameof(Product)),
@@ -546,7 +546,7 @@ public class InternalModelBuilderTest
     private static ProviderConventionSetBuilderDependencies CreateDependencies()
         => InMemoryTestHelpers.Instance.CreateContextServices().GetRequiredService<ProviderConventionSetBuilderDependencies>();
 
-    protected virtual InternalModelBuilder CreateModelBuilder(Model model = null)
+    protected virtual InternalModelBuilder CreateModelBuilder(Model? model = null)
         => new(model ?? new Model());
 
     private class Base
@@ -556,53 +556,53 @@ public class InternalModelBuilderTest
 
     private class Customer : Base
     {
-        public static readonly PropertyInfo IdProperty = typeof(Customer).GetProperty("Id");
+        public static readonly PropertyInfo IdProperty = typeof(Customer).GetProperty("Id")!;
 
-        public string Name { get; set; }
-        public Details Details { get; set; }
+        public string Name { get; set; } = null!;
+        public Details Details { get; set; } = null!;
     }
 
     private class SpecialCustomer : Customer;
 
     private class Order
     {
-        public static readonly PropertyInfo IdProperty = typeof(Order).GetProperty("Id");
-        public static readonly PropertyInfo CustomerIdProperty = typeof(Order).GetProperty("CustomerId");
-        public static readonly PropertyInfo ProductIdProperty = typeof(Order).GetProperty("ProductId");
+        public static readonly PropertyInfo IdProperty = typeof(Order).GetProperty("Id")!;
+        public static readonly PropertyInfo CustomerIdProperty = typeof(Order).GetProperty("CustomerId")!;
+        public static readonly PropertyInfo ProductIdProperty = typeof(Order).GetProperty("ProductId")!;
 
         public int Id { get; set; }
         public int CustomerId { get; set; }
-        public Customer Customer { get; set; }
+        public Customer Customer { get; set; } = null!;
         public int ProductId { get; set; }
-        public Product Product { get; set; }
-        public Details Details { get; set; }
+        public Product Product { get; set; } = null!;
+        public Details Details { get; set; } = null!;
     }
 
     private class Product
     {
-        public static readonly PropertyInfo IdProperty = typeof(Product).GetProperty("Id");
+        public static readonly PropertyInfo IdProperty = typeof(Product).GetProperty("Id")!;
         public int Id { get; set; }
-        public Order Order { get; set; }
-        public Details Details { get; set; }
+        public Order Order { get; set; } = null!;
+        public Details Details { get; set; } = null!;
     }
 
     private class Details
     {
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
     }
 
     private class ManyToManyLeft
     {
         public int Id { get; set; }
-        public List<ManyToManyRight> Rights { get; set; }
-        public List<ManyToManyRight> OtherRights { get; set; }
+        public List<ManyToManyRight> Rights { get; set; } = null!;
+        public List<ManyToManyRight> OtherRights { get; set; } = null!;
     }
 
     private class ManyToManyRight
     {
         public int Id { get; set; }
-        public List<ManyToManyLeft> Lefts { get; set; }
-        public List<ManyToManyLeft> OtherLefts { get; set; }
+        public List<ManyToManyLeft> Lefts { get; set; } = null!;
+        public List<ManyToManyLeft> OtherLefts { get; set; } = null!;
     }
 
     private class ManyToManyJoin

--- a/test/EFCore.Tests/Metadata/Internal/InternalNavigationBuilderTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/InternalNavigationBuilderTest.cs
@@ -36,8 +36,8 @@ public class InternalNavigationBuilderTest
         Assert.Equal(Order.OtherDetailsField, metadata.FieldInfo);
         Assert.Equal(ConfigurationSource.DataAnnotation, metadata.GetFieldInfoConfigurationSource());
 
-        Assert.True(builder.CanSetField((string)null, ConfigurationSource.DataAnnotation));
-        Assert.NotNull(builder.HasField((string)null, ConfigurationSource.DataAnnotation));
+        Assert.True(builder.CanSetField((string?)null, ConfigurationSource.DataAnnotation));
+        Assert.NotNull(builder.HasField((string?)null, ConfigurationSource.DataAnnotation));
 
         Assert.Null(metadata.FieldInfo);
         Assert.Null(metadata.GetFieldInfoConfigurationSource());
@@ -72,8 +72,8 @@ public class InternalNavigationBuilderTest
         Assert.Equal("_otherDetails", metadata.FieldInfo?.Name);
         Assert.Equal(ConfigurationSource.DataAnnotation, metadata.GetFieldInfoConfigurationSource());
 
-        Assert.True(builder.CanSetField((string)null, ConfigurationSource.DataAnnotation));
-        Assert.NotNull(builder.HasField((string)null, ConfigurationSource.DataAnnotation));
+        Assert.True(builder.CanSetField((string?)null, ConfigurationSource.DataAnnotation));
+        Assert.NotNull(builder.HasField((string?)null, ConfigurationSource.DataAnnotation));
 
         Assert.Null(metadata.FieldInfo);
         Assert.Null(metadata.GetFieldInfoConfigurationSource());
@@ -206,7 +206,7 @@ public class InternalNavigationBuilderTest
         var builder = CreateInternalNavigationBuilder()
             .Metadata.ForeignKey.Builder.HasNavigation(
                 nameof(OrderDetails.Order), pointsToPrincipal: true, ConfigurationSource.Explicit)
-            .Metadata.DependentToPrincipal.Builder;
+            !.Metadata.DependentToPrincipal!.Builder;
         builder.IsRequired(true, ConfigurationSource.Explicit);
 
         Assert.True(builder.Metadata.ForeignKey.IsRequired);
@@ -219,9 +219,9 @@ public class InternalNavigationBuilderTest
             .Metadata.ForeignKey;
         foreignKey = foreignKey.Builder.HasNavigations(
                 nameof(OrderDetails.Order), nameof(Order.SingleDetails), ConfigurationSource.Explicit)
-            .Metadata;
+            !.Metadata;
 
-        foreignKey.PrincipalToDependent.Builder.IsRequired(true, ConfigurationSource.Explicit);
+        foreignKey.PrincipalToDependent!.Builder.IsRequired(true, ConfigurationSource.Explicit);
 
         Assert.True(foreignKey.IsRequiredDependent);
     }
@@ -233,9 +233,9 @@ public class InternalNavigationBuilderTest
             .Metadata.ForeignKey;
         foreignKey = foreignKey.Builder.HasNavigations(
                 nameof(OrderDetails.Order), nameof(Order.SingleDetails), ConfigurationSource.Explicit)
-            .Metadata;
+            !.Metadata;
 
-        foreignKey.PrincipalToDependent.Builder.IsRequired(true, ConfigurationSource.Explicit);
+        foreignKey.PrincipalToDependent!.Builder.IsRequired(true, ConfigurationSource.Explicit);
 
         Assert.True(foreignKey.IsRequiredDependent);
     }
@@ -244,13 +244,13 @@ public class InternalNavigationBuilderTest
     {
         var modelBuilder = (InternalModelBuilder)
             InMemoryTestHelpers.Instance.CreateConventionBuilder().GetInfrastructure();
-        var orderEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Convention);
-        var detailsEntityBuilder = modelBuilder.Entity(typeof(OrderDetails), ConfigurationSource.Convention);
+        var orderEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Convention)!;
+        var detailsEntityBuilder = modelBuilder.Entity(typeof(OrderDetails), ConfigurationSource.Convention)!;
         orderEntityBuilder
             .HasRelationship(
                 detailsEntityBuilder.Metadata, nameof(Order.Details), ConfigurationSource.DataAnnotation, targetIsPrincipal: false)
-            .IsUnique(false, ConfigurationSource.Convention);
-        var navigation = (Navigation)orderEntityBuilder.Navigation(nameof(Order.Details));
+            !.IsUnique(false, ConfigurationSource.Convention);
+        var navigation = (Navigation)orderEntityBuilder.Navigation(nameof(Order.Details))!;
 
         return new InternalNavigationBuilder(navigation, modelBuilder);
     }
@@ -258,22 +258,22 @@ public class InternalNavigationBuilderTest
     protected class Order
     {
         public static readonly FieldInfo DetailsField = typeof(Order)
-            .GetField(nameof(_details), BindingFlags.Instance | BindingFlags.NonPublic);
+            .GetField(nameof(_details), BindingFlags.Instance | BindingFlags.NonPublic)!;
 
         public static readonly FieldInfo OtherDetailsField = typeof(Order)
-            .GetField(nameof(_otherDetails), BindingFlags.Instance | BindingFlags.NonPublic);
+            .GetField(nameof(_otherDetails), BindingFlags.Instance | BindingFlags.NonPublic)!;
 
         public int OrderId { get; set; }
 
-        private ICollection<OrderDetails> _details;
+        private ICollection<OrderDetails> _details = null!;
         private readonly ICollection<OrderDetails> _otherDetails = new List<OrderDetails>();
-        public OrderDetails SingleDetails { get; set; }
+        public OrderDetails SingleDetails { get; set; } = null!;
         public ICollection<OrderDetails> Details { get => _details; set => _details = value; }
     }
 
     protected class OrderDetails
     {
         public int Id { get; set; }
-        public Order Order { get; set; }
+        public Order Order { get; set; } = null!;
     }
 }

--- a/test/EFCore.Tests/Metadata/Internal/InternalPropertyBuilderTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/InternalPropertyBuilderTest.cs
@@ -12,8 +12,8 @@ public class InternalPropertyBuilderTest
     {
         var model = new Model();
         var modelBuilder = new InternalModelBuilder(model);
-        var entityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
-        var builder = entityBuilder.Property(Customer.NameProperty.Name, ConfigurationSource.Convention);
+        var entityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit)!;
+        var builder = entityBuilder.Property(Customer.NameProperty.Name, ConfigurationSource.Convention)!;
         var property = builder.Metadata;
 
         Assert.Equal(typeof(string), property.ClrType);
@@ -128,10 +128,10 @@ public class InternalPropertyBuilderTest
         Assert.NotNull(builder.HasMaxLength(1, ConfigurationSource.DataAnnotation));
         Assert.NotNull(builder.HasMaxLength(2, ConfigurationSource.DataAnnotation));
 
-        Assert.Equal(2, metadata.GetMaxLength().Value);
+        Assert.Equal(2, metadata.GetMaxLength()!.Value);
 
         Assert.Null(builder.HasMaxLength(1, ConfigurationSource.Convention));
-        Assert.Equal(2, metadata.GetMaxLength().Value);
+        Assert.Equal(2, metadata.GetMaxLength()!.Value);
     }
 
     [Fact]
@@ -144,10 +144,10 @@ public class InternalPropertyBuilderTest
         Assert.NotNull(builder.HasMaxLength(1, ConfigurationSource.DataAnnotation));
         Assert.Null(builder.HasMaxLength(2, ConfigurationSource.DataAnnotation));
 
-        Assert.Equal(1, metadata.GetMaxLength().Value);
+        Assert.Equal(1, metadata.GetMaxLength()!.Value);
 
         Assert.NotNull(builder.HasMaxLength(2, ConfigurationSource.Explicit));
-        Assert.Equal(2, metadata.GetMaxLength().Value);
+        Assert.Equal(2, metadata.GetMaxLength()!.Value);
     }
 
     [Fact]
@@ -190,10 +190,10 @@ public class InternalPropertyBuilderTest
         Assert.NotNull(builder.HasPrecision(1, ConfigurationSource.DataAnnotation));
         Assert.NotNull(builder.HasPrecision(2, ConfigurationSource.DataAnnotation));
 
-        Assert.Equal(2, metadata.GetPrecision().Value);
+        Assert.Equal(2, metadata.GetPrecision()!.Value);
 
         Assert.Null(builder.HasPrecision(1, ConfigurationSource.Convention));
-        Assert.Equal(2, metadata.GetPrecision().Value);
+        Assert.Equal(2, metadata.GetPrecision()!.Value);
     }
 
     [Fact]
@@ -206,10 +206,10 @@ public class InternalPropertyBuilderTest
         Assert.NotNull(builder.HasPrecision(1, ConfigurationSource.DataAnnotation));
         Assert.Null(builder.HasPrecision(2, ConfigurationSource.DataAnnotation));
 
-        Assert.Equal(1, metadata.GetPrecision().Value);
+        Assert.Equal(1, metadata.GetPrecision()!.Value);
 
         Assert.NotNull(builder.HasPrecision(2, ConfigurationSource.Explicit));
-        Assert.Equal(2, metadata.GetPrecision().Value);
+        Assert.Equal(2, metadata.GetPrecision()!.Value);
     }
 
     [Fact]
@@ -221,10 +221,10 @@ public class InternalPropertyBuilderTest
         Assert.NotNull(builder.HasScale(1, ConfigurationSource.DataAnnotation));
         Assert.NotNull(builder.HasScale(2, ConfigurationSource.DataAnnotation));
 
-        Assert.Equal(2, metadata.GetScale().Value);
+        Assert.Equal(2, metadata.GetScale()!.Value);
 
         Assert.Null(builder.HasScale(1, ConfigurationSource.Convention));
-        Assert.Equal(2, metadata.GetScale().Value);
+        Assert.Equal(2, metadata.GetScale()!.Value);
     }
 
     [Fact]
@@ -237,10 +237,10 @@ public class InternalPropertyBuilderTest
         Assert.NotNull(builder.HasScale(1, ConfigurationSource.DataAnnotation));
         Assert.Null(builder.HasScale(2, ConfigurationSource.DataAnnotation));
 
-        Assert.Equal(1, metadata.GetScale().Value);
+        Assert.Equal(1, metadata.GetScale()!.Value);
 
         Assert.NotNull(builder.HasScale(2, ConfigurationSource.Explicit));
-        Assert.Equal(2, metadata.GetScale().Value);
+        Assert.Equal(2, metadata.GetScale()!.Value);
     }
 
     [Fact]
@@ -252,18 +252,18 @@ public class InternalPropertyBuilderTest
         Assert.NotNull(builder.HasValueGenerator((p, e) => new CustomValueGenerator1(), ConfigurationSource.DataAnnotation));
         Assert.NotNull(builder.HasValueGenerator((p, e) => new CustomValueGenerator2(), ConfigurationSource.DataAnnotation));
 
-        Assert.IsType<CustomValueGenerator2>(metadata.GetValueGeneratorFactory()(null, null));
+        Assert.IsType<CustomValueGenerator2>(metadata.GetValueGeneratorFactory()!(null!, null!));
         Assert.True(metadata.RequiresValueGenerator());
 
         Assert.Null(builder.HasValueGenerator((p, e) => new CustomValueGenerator1(), ConfigurationSource.Convention));
-        Assert.IsType<CustomValueGenerator2>(metadata.GetValueGeneratorFactory()(null, null));
+        Assert.IsType<CustomValueGenerator2>(metadata.GetValueGeneratorFactory()!(null!, null!));
         Assert.True(metadata.RequiresValueGenerator());
 
         Assert.Null(builder.HasValueGeneratorFactory(typeof(CustomValueGeneratorFactory), ConfigurationSource.Convention));
-        Assert.IsType<CustomValueGenerator2>(metadata.GetValueGeneratorFactory()(null, null));
+        Assert.IsType<CustomValueGenerator2>(metadata.GetValueGeneratorFactory()!(null!, null!));
 
         Assert.NotNull(builder.HasValueGeneratorFactory(typeof(CustomValueGeneratorFactory), ConfigurationSource.DataAnnotation));
-        Assert.IsType<CustomValueGenerator1>(metadata.GetValueGeneratorFactory()(null, null));
+        Assert.IsType<CustomValueGenerator1>(metadata.GetValueGeneratorFactory()!(null!, null!));
         Assert.True(metadata.RequiresValueGenerator());
 
         Assert.NotNull(builder.HasValueGeneratorFactory(null, ConfigurationSource.DataAnnotation));
@@ -286,11 +286,11 @@ public class InternalPropertyBuilderTest
         Assert.NotNull(builder.HasValueGenerator(factory, ConfigurationSource.DataAnnotation));
         Assert.Null(builder.HasValueGenerator((p, e) => new CustomValueGenerator2(), ConfigurationSource.DataAnnotation));
 
-        Assert.IsType<CustomValueGenerator1>(metadata.GetValueGeneratorFactory()(null, null));
+        Assert.IsType<CustomValueGenerator1>(metadata.GetValueGeneratorFactory()!(null!, null!));
         Assert.True(metadata.RequiresValueGenerator());
 
         Assert.NotNull(builder.HasValueGenerator((p, e) => new CustomValueGenerator2(), ConfigurationSource.Explicit));
-        Assert.IsType<CustomValueGenerator2>(metadata.GetValueGeneratorFactory()(null, null));
+        Assert.IsType<CustomValueGenerator2>(metadata.GetValueGeneratorFactory()!(null!, null!));
         Assert.True(metadata.RequiresValueGenerator());
     }
 
@@ -302,21 +302,21 @@ public class InternalPropertyBuilderTest
 
         Assert.NotNull(builder.HasValueGenerator((p, e) => new CustomValueGenerator1(), ConfigurationSource.DataAnnotation));
 
-        Assert.IsType<CustomValueGenerator1>(metadata.GetValueGeneratorFactory()(null, null));
+        Assert.IsType<CustomValueGenerator1>(metadata.GetValueGeneratorFactory()!(null!, null!));
         Assert.Equal(ValueGenerated.Never, metadata.ValueGenerated);
         Assert.True(metadata.RequiresValueGenerator());
 
         Assert.Null(
             builder.HasValueGenerator(
-                (Func<IReadOnlyProperty, ITypeBase, ValueGenerator>)null, ConfigurationSource.Convention));
+                (Func<IReadOnlyProperty, ITypeBase, ValueGenerator>?)null, ConfigurationSource.Convention));
 
-        Assert.IsType<CustomValueGenerator1>(metadata.GetValueGeneratorFactory()(null, null));
+        Assert.IsType<CustomValueGenerator1>(metadata.GetValueGeneratorFactory()!(null!, null!));
         Assert.Equal(ValueGenerated.Never, metadata.ValueGenerated);
         Assert.True(metadata.RequiresValueGenerator());
 
         Assert.NotNull(
             builder.HasValueGenerator(
-                (Func<IReadOnlyProperty, ITypeBase, ValueGenerator>)null, ConfigurationSource.Explicit));
+                (Func<IReadOnlyProperty, ITypeBase, ValueGenerator>?)null, ConfigurationSource.Explicit));
 
         Assert.Null(metadata.GetValueGeneratorFactory());
         Assert.Equal(ValueGenerated.Never, metadata.ValueGenerated);
@@ -332,11 +332,11 @@ public class InternalPropertyBuilderTest
         Assert.NotNull(builder.HasValueGenerator(typeof(CustomValueGenerator1), ConfigurationSource.DataAnnotation));
         Assert.NotNull(builder.HasValueGenerator(typeof(CustomValueGenerator2), ConfigurationSource.DataAnnotation));
 
-        Assert.IsType<CustomValueGenerator2>(metadata.GetValueGeneratorFactory()(null, null));
+        Assert.IsType<CustomValueGenerator2>(metadata.GetValueGeneratorFactory()!(null!, null!));
         Assert.True(metadata.RequiresValueGenerator());
 
         Assert.Null(builder.HasValueGenerator(typeof(CustomValueGenerator1), ConfigurationSource.Convention));
-        Assert.IsType<CustomValueGenerator2>(metadata.GetValueGeneratorFactory()(null, null));
+        Assert.IsType<CustomValueGenerator2>(metadata.GetValueGeneratorFactory()!(null!, null!));
         Assert.True(metadata.RequiresValueGenerator());
     }
 
@@ -348,17 +348,17 @@ public class InternalPropertyBuilderTest
 
         Assert.NotNull(builder.HasValueGenerator(typeof(CustomValueGenerator1), ConfigurationSource.DataAnnotation));
 
-        Assert.IsType<CustomValueGenerator1>(metadata.GetValueGeneratorFactory()(null, null));
+        Assert.IsType<CustomValueGenerator1>(metadata.GetValueGeneratorFactory()!(null!, null!));
         Assert.Equal(ValueGenerated.Never, metadata.ValueGenerated);
         Assert.True(metadata.RequiresValueGenerator());
 
-        Assert.Null(builder.HasValueGenerator((Type)null, ConfigurationSource.Convention));
+        Assert.Null(builder.HasValueGenerator((Type?)null, ConfigurationSource.Convention));
 
-        Assert.IsType<CustomValueGenerator1>(metadata.GetValueGeneratorFactory()(null, null));
+        Assert.IsType<CustomValueGenerator1>(metadata.GetValueGeneratorFactory()!(null!, null!));
         Assert.Equal(ValueGenerated.Never, metadata.ValueGenerated);
         Assert.True(metadata.RequiresValueGenerator());
 
-        Assert.NotNull(builder.HasValueGenerator((Type)null, ConfigurationSource.Explicit));
+        Assert.NotNull(builder.HasValueGenerator((Type?)null, ConfigurationSource.Explicit));
 
         Assert.Null(metadata.GetValueGeneratorFactory());
         Assert.Equal(ValueGenerated.Never, metadata.ValueGenerated);
@@ -437,7 +437,7 @@ public class InternalPropertyBuilderTest
         Assert.NotNull(builder.HasValueComparer(typeof(CustomValueComparer<string>), ConfigurationSource.DataAnnotation));
         Assert.IsType<CustomValueComparer<string>>(metadata.GetValueComparer());
 
-        Assert.NotNull(builder.HasValueComparer((ValueComparer)null, ConfigurationSource.DataAnnotation));
+        Assert.NotNull(builder.HasValueComparer((ValueComparer?)null, ConfigurationSource.DataAnnotation));
         Assert.Null(metadata.GetValueComparer());
         Assert.Null(metadata[CoreAnnotationNames.ValueComparer]);
         Assert.Null(metadata[CoreAnnotationNames.ValueComparerType]);
@@ -465,7 +465,7 @@ public class InternalPropertyBuilderTest
         Assert.NotNull(builder.HasProviderValueComparer(typeof(CustomValueComparer<string>), ConfigurationSource.DataAnnotation));
         Assert.IsType<CustomValueComparer<string>>(metadata.GetProviderValueComparer());
 
-        Assert.NotNull(builder.HasProviderValueComparer((ValueComparer)null, ConfigurationSource.DataAnnotation));
+        Assert.NotNull(builder.HasProviderValueComparer((ValueComparer?)null, ConfigurationSource.DataAnnotation));
         Assert.Null(metadata.GetProviderValueComparer());
         Assert.Null(metadata[CoreAnnotationNames.ProviderValueComparer]);
         Assert.Null(metadata[CoreAnnotationNames.ProviderValueComparerType]);
@@ -480,10 +480,10 @@ public class InternalPropertyBuilderTest
         Assert.NotNull(builder.IsUnicode(true, ConfigurationSource.DataAnnotation));
         Assert.NotNull(builder.IsUnicode(false, ConfigurationSource.DataAnnotation));
 
-        Assert.False(metadata.IsUnicode().Value);
+        Assert.False(metadata.IsUnicode()!.Value);
 
         Assert.Null(builder.IsUnicode(true, ConfigurationSource.Convention));
-        Assert.False(metadata.IsUnicode().Value);
+        Assert.False(metadata.IsUnicode()!.Value);
     }
 
     [Fact]
@@ -496,10 +496,10 @@ public class InternalPropertyBuilderTest
         Assert.NotNull(builder.IsUnicode(true, ConfigurationSource.DataAnnotation));
         Assert.Null(builder.IsUnicode(false, ConfigurationSource.DataAnnotation));
 
-        Assert.True(metadata.IsUnicode().Value);
+        Assert.True(metadata.IsUnicode()!.Value);
 
         Assert.NotNull(builder.IsUnicode(false, ConfigurationSource.Explicit));
-        Assert.False(metadata.IsUnicode().Value);
+        Assert.False(metadata.IsUnicode()!.Value);
     }
 
     [Fact]
@@ -539,8 +539,8 @@ public class InternalPropertyBuilderTest
     public void Cannot_set_required_to_false_if_nonnullable()
     {
         var modelBuilder = new InternalModelBuilder(new Model());
-        var entityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Convention);
-        var builder = entityBuilder.Property(typeof(int), nameof(Customer.Id), ConfigurationSource.Convention);
+        var entityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Convention)!;
+        var builder = entityBuilder.Property(typeof(int), nameof(Customer.Id), ConfigurationSource.Convention)!;
 
         Assert.Null(builder.IsRequired(false, ConfigurationSource.DataAnnotation));
 
@@ -619,8 +619,8 @@ public class InternalPropertyBuilderTest
     {
         var modelBuilder = (InternalModelBuilder)
             InMemoryTestHelpers.Instance.CreateConventionBuilder().GetInfrastructure();
-        var entityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Convention);
-        return entityBuilder.Property(Customer.NameProperty, ConfigurationSource.Convention);
+        var entityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Convention)!;
+        return entityBuilder.Property(Customer.NameProperty, ConfigurationSource.Convention)!;
     }
 
     private Property CreateProperty()
@@ -628,9 +628,9 @@ public class InternalPropertyBuilderTest
 
     private class Customer
     {
-        public static readonly PropertyInfo NameProperty = typeof(Customer).GetProperty("Name");
+        public static readonly PropertyInfo NameProperty = typeof(Customer).GetProperty("Name")!;
 
         public int Id { get; set; }
-        public string Name { get; set; }
+        public string? Name { get; set; }
     }
 }

--- a/test/EFCore.Tests/Metadata/Internal/InternalSkipNavigationBuilderTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/InternalSkipNavigationBuilderTest.cs
@@ -16,11 +16,11 @@ public class InternalSkipNavigationBuilderTest
         ((SkipNavigation)skipNavigation).SetConfigurationSource(ConfigurationSource.DataAnnotation);
 
         var productEntity = skipNavigation.TargetEntityType.Builder;
-        Assert.Null(productEntity.HasRelationship(skipNavigation.DeclaringEntityType, null, nameof(Order.Products)));
+        Assert.Null(productEntity.HasRelationship(skipNavigation.DeclaringEntityType, null!, nameof(Order.Products)));
 
         Assert.NotNull(
             productEntity.HasRelationship(
-                skipNavigation.DeclaringEntityType, null, nameof(Order.Products), fromDataAnnotation: true));
+                skipNavigation.DeclaringEntityType, null!, nameof(Order.Products), fromDataAnnotation: true));
 
         Assert.False(skipNavigation.IsInModel);
         Assert.Empty(skipNavigation.DeclaringEntityType.GetSkipNavigations());
@@ -55,8 +55,8 @@ public class InternalSkipNavigationBuilderTest
         Assert.Equal(Order.OtherProductsField, metadata.FieldInfo);
         Assert.Equal(ConfigurationSource.DataAnnotation, metadata.GetFieldInfoConfigurationSource());
 
-        Assert.True(builder.CanSetField((string)null, ConfigurationSource.DataAnnotation));
-        Assert.NotNull(builder.HasField((string)null, ConfigurationSource.DataAnnotation));
+        Assert.True(builder.CanSetField((string?)null, ConfigurationSource.DataAnnotation));
+        Assert.NotNull(builder.HasField((string?)null, ConfigurationSource.DataAnnotation));
 
         Assert.Null(metadata.FieldInfo);
         Assert.Null(metadata.GetFieldInfoConfigurationSource());
@@ -91,8 +91,8 @@ public class InternalSkipNavigationBuilderTest
         Assert.Equal("_otherProducts", metadata.FieldInfo?.Name);
         Assert.Equal(ConfigurationSource.DataAnnotation, metadata.GetFieldInfoConfigurationSource());
 
-        Assert.True(builder.CanSetField((string)null, ConfigurationSource.DataAnnotation));
-        Assert.NotNull(builder.HasField((string)null, ConfigurationSource.DataAnnotation));
+        Assert.True(builder.CanSetField((string?)null, ConfigurationSource.DataAnnotation));
+        Assert.NotNull(builder.HasField((string?)null, ConfigurationSource.DataAnnotation));
 
         Assert.Null(metadata.FieldInfo);
         Assert.Null(metadata.GetFieldInfoConfigurationSource());
@@ -147,16 +147,16 @@ public class InternalSkipNavigationBuilderTest
         Assert.NotNull(originalFK);
         Assert.Equal(ConfigurationSource.Convention, metadata.GetForeignKeyConfigurationSource());
 
-        var orderProductEntity = metadata.DeclaringEntityType.Model.Builder.Entity(typeof(OrderProduct));
+        var orderProductEntity = metadata.DeclaringEntityType.Model.Builder.Entity(typeof(OrderProduct))!;
         var fk = (ForeignKey)orderProductEntity
             .HasRelationship(metadata.DeclaringEntityType, nameof(OrderProduct.Order))
-            .IsUnique(false)
+            !.IsUnique(false)!
             .Metadata;
 
         Assert.NotSame(fk, metadata.ForeignKey);
         Assert.Same(originalFK, metadata.ForeignKey);
         Assert.Equal(ConfigurationSource.Convention, metadata.GetForeignKeyConfigurationSource());
-        Assert.NotNull(metadata.Inverse.ForeignKey);
+        Assert.NotNull(metadata.Inverse!.ForeignKey);
 
         Assert.True(builder.CanSetForeignKey(fk, ConfigurationSource.DataAnnotation));
         Assert.NotNull(builder.HasForeignKey(fk, ConfigurationSource.DataAnnotation));
@@ -191,7 +191,7 @@ public class InternalSkipNavigationBuilderTest
         var inverse = (SkipNavigation)metadata.TargetEntityType.Builder.HasSkipNavigation(
                 Product.OrdersProperty,
                 metadata.DeclaringEntityType)
-            .Metadata;
+            !.Metadata;
 
         Assert.NotNull(metadata.Inverse);
         Assert.Equal(ConfigurationSource.Convention, metadata.GetInverseConfigurationSource());
@@ -303,47 +303,47 @@ public class InternalSkipNavigationBuilderTest
         var modelBuilder = (InternalModelBuilder)
             InMemoryTestHelpers.Instance.CreateConventionBuilder().GetInfrastructure();
 
-        return modelBuilder.Entity(typeof(Order), ConfigurationSource.Convention)
+        return modelBuilder.Entity(typeof(Order), ConfigurationSource.Convention)!
             .HasSkipNavigation(
                 MemberIdentity.Create(Order.ProductsProperty),
-                modelBuilder.Entity(typeof(Product), ConfigurationSource.Convention).Metadata,
-                ConfigurationSource.Convention);
+            modelBuilder.Entity(typeof(Product), ConfigurationSource.Convention)!.Metadata,
+            ConfigurationSource.Convention)!;
     }
 
     protected class Order
     {
-        public static readonly PropertyInfo ProductsProperty = typeof(Order).GetProperty(nameof(Products));
+        public static readonly PropertyInfo ProductsProperty = typeof(Order).GetProperty(nameof(Products))!;
 
         public static readonly FieldInfo ProductsField = typeof(Order)
-            .GetField(nameof(_products), BindingFlags.Instance | BindingFlags.NonPublic);
+            .GetField(nameof(_products), BindingFlags.Instance | BindingFlags.NonPublic)!;
 
         public static readonly FieldInfo OtherProductsField = typeof(Order)
-            .GetField(nameof(_otherProducts), BindingFlags.Instance | BindingFlags.NonPublic);
+            .GetField(nameof(_otherProducts), BindingFlags.Instance | BindingFlags.NonPublic)!;
 
         public int OrderId { get; set; }
 
-        private ICollection<Product> _products;
+        private ICollection<Product> _products = null!;
         private readonly ICollection<Product> _otherProducts = new List<Product>();
         public ICollection<Product> Products { get => _products; set => _products = value; }
     }
 
     private class OrderProduct
     {
-        public static readonly PropertyInfo OrderIdProperty = typeof(OrderProduct).GetProperty(nameof(OrderId));
-        public static readonly PropertyInfo ProductIdProperty = typeof(OrderProduct).GetProperty(nameof(ProductId));
+        public static readonly PropertyInfo OrderIdProperty = typeof(OrderProduct).GetProperty(nameof(OrderId))!;
+        public static readonly PropertyInfo ProductIdProperty = typeof(OrderProduct).GetProperty(nameof(ProductId))!;
 
         public int OrderId { get; set; }
         public int ProductId { get; set; }
-        public virtual Order Order { get; set; }
-        public virtual Product Product { get; set; }
+        public virtual Order Order { get; set; } = null!;
+        public virtual Product Product { get; set; } = null!;
     }
 
     protected class Product
     {
-        public static readonly PropertyInfo OrdersProperty = typeof(Product).GetProperty(nameof(Orders));
+        public static readonly PropertyInfo OrdersProperty = typeof(Product).GetProperty(nameof(Orders))!;
 
         public int Id { get; set; }
 
-        public virtual ICollection<Order> Orders { get; set; }
+        public virtual ICollection<Order> Orders { get; set; } = null!;
     }
 }

--- a/test/EFCore.Tests/Metadata/Internal/KeyTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/KeyTest.cs
@@ -27,12 +27,12 @@ public class KeyTest
     [Fact]
     public void Can_create_key_from_properties()
     {
-        var entityType = ((IConventionModel)CreateModel()).AddEntityType(typeof(Customer));
-        var property1 = entityType.AddProperty(Customer.IdProperty);
-        var property2 = entityType.AddProperty(Customer.NameProperty);
+        var entityType = ((IConventionModel)CreateModel()).AddEntityType(typeof(Customer))!;
+        var property1 = entityType.AddProperty(Customer.IdProperty)!;
+        var property2 = entityType.AddProperty(Customer.NameProperty)!;
         property2.SetIsNullable(false);
 
-        var key = entityType.AddKey([property1, property2]);
+        var key = entityType.AddKey([property1, property2])!;
 
         Assert.True(new[] { property1, property2 }.SequenceEqual(key.Properties));
         Assert.Equal(ConfigurationSource.Convention, key.GetConfigurationSource());
@@ -57,17 +57,17 @@ public class KeyTest
 
     private class Customer
     {
-        public static readonly PropertyInfo IdProperty = typeof(Customer).GetProperty("Id");
-        public static readonly PropertyInfo NameProperty = typeof(Customer).GetProperty("Name");
+        public static readonly PropertyInfo IdProperty = typeof(Customer).GetProperty("Id")!;
+        public static readonly PropertyInfo NameProperty = typeof(Customer).GetProperty("Name")!;
 
         public int Id { get; set; }
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
     }
 
     private class Order
     {
-        public static readonly PropertyInfo NameProperty = typeof(Order).GetProperty("Name");
+        public static readonly PropertyInfo NameProperty = typeof(Order).GetProperty("Name")!;
 
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
     }
 }

--- a/test/EFCore.Tests/Metadata/Internal/ModelTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/ModelTest.cs
@@ -92,25 +92,25 @@ public class ModelTest
     public void Can_add_and_remove_entity_by_name()
     {
         var model = CreateModel();
-        Assert.Null(model.FindEntityType(typeof(Customer).FullName));
-        Assert.Null(model.RemoveEntityType(typeof(Customer).FullName));
+        Assert.Null(model.FindEntityType(typeof(Customer).FullName!));
+        Assert.Null(model.RemoveEntityType(typeof(Customer).FullName!));
 
-        var entityType = model.AddEntityType(typeof(Customer).FullName);
+        var entityType = model.AddEntityType(typeof(Customer).FullName!);
 
         Assert.Equal(typeof(Dictionary<string, object>), entityType.ClrType);
         Assert.Equal(typeof(Customer).FullName, entityType.Name);
-        Assert.NotNull(model.FindEntityType(typeof(Customer).FullName));
+        Assert.NotNull(model.FindEntityType(typeof(Customer).FullName!));
         Assert.Same(model, entityType.Model);
         Assert.True(((EntityType)entityType).IsInModel);
 
-        Assert.Same(entityType, model.FindEntityType(typeof(Customer).FullName));
+        Assert.Same(entityType, model.FindEntityType(typeof(Customer).FullName!));
 
         Assert.Equal([entityType], model.GetEntityTypes().ToArray());
 
         Assert.Same(entityType, model.RemoveEntityType(entityType.Name));
 
         Assert.Null(model.RemoveEntityType(entityType.Name));
-        Assert.Null(model.FindEntityType(typeof(Customer).FullName));
+        Assert.Null(model.FindEntityType(typeof(Customer).FullName!));
         Assert.False(((EntityType)entityType).IsInModel);
     }
 
@@ -201,7 +201,7 @@ public class ModelTest
     public void Adding_duplicate_entity_by_type_throws()
     {
         var model = CreateModel();
-        Assert.Null(model.RemoveEntityType(typeof(Customer).FullName));
+        Assert.Null(model.RemoveEntityType(typeof(Customer).FullName!));
 
         model.AddEntityType(typeof(Customer));
 
@@ -220,14 +220,14 @@ public class ModelTest
 
         Assert.Equal(
             CoreStrings.DuplicateEntityType(typeof(Customer).FullName + " (Dictionary<string, object>)"),
-            Assert.Throws<InvalidOperationException>(() => model.AddEntityType(typeof(Customer).FullName)).Message);
+            Assert.Throws<InvalidOperationException>(() => model.AddEntityType(typeof(Customer).FullName!)).Message);
     }
 
     [Fact]
     public void Adding_duplicate_shared_type_throws()
     {
         var model = (Model)CreateModel();
-        Assert.Null(model.RemoveEntityType(typeof(Customer).FullName));
+        Assert.Null(model.RemoveEntityType(typeof(Customer).FullName!));
 
         model.AddEntityType(typeof(Customer), owned: false, ConfigurationSource.Explicit);
 
@@ -252,10 +252,10 @@ public class ModelTest
     public void Can_get_entity_by_name()
     {
         var model = CreateModel();
-        var entityType = model.AddEntityType(typeof(Customer).FullName);
+        var entityType = model.AddEntityType(typeof(Customer).FullName!);
 
-        Assert.Same(entityType, model.FindEntityType(typeof(Customer).FullName));
-        Assert.Same(entityType, model.FindEntityType(typeof(Customer).FullName));
+        Assert.Same(entityType, model.FindEntityType(typeof(Customer).FullName!));
+        Assert.Same(entityType, model.FindEntityType(typeof(Customer).FullName!));
         Assert.Null(model.FindEntityType(typeof(string)));
     }
 
@@ -290,21 +290,21 @@ public class ModelTest
 
     private class Customer
     {
-        public static readonly PropertyInfo IdProperty = typeof(Customer).GetProperty(nameof(Id));
+        public static readonly PropertyInfo IdProperty = typeof(Customer).GetProperty(nameof(Id))!;
 
         public int Id { get; set; }
-        public string Name { get; set; }
-        public ICollection<Order> Orders { get; set; }
+        public string Name { get; set; } = null!;
+        public ICollection<Order> Orders { get; set; } = null!;
     }
 
     private class SpecialCustomer : Customer;
 
     private class Order
     {
-        public static readonly PropertyInfo CustomerIdProperty = typeof(Order).GetProperty("CustomerId");
+        public static readonly PropertyInfo CustomerIdProperty = typeof(Order).GetProperty("CustomerId")!;
 
         public int Id { get; set; }
         public int CustomerId { get; set; }
-        public Customer Customer { get; set; }
+        public Customer Customer { get; set; } = null!;
     }
 }

--- a/test/EFCore.Tests/Metadata/Internal/NavigationTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/NavigationTest.cs
@@ -10,7 +10,7 @@ public class NavigationTest
     {
         var foreignKey = CreateForeignKey();
 
-        var navigation = foreignKey.SetDependentToPrincipal(E.DeceptionProperty);
+        var navigation = foreignKey.SetDependentToPrincipal(E.DeceptionProperty)!;
 
         Assert.Same(foreignKey, navigation.ForeignKey);
         Assert.Equal(nameof(E.Deception), navigation.Name);
@@ -23,7 +23,7 @@ public class NavigationTest
         IMutableModel model = new Model();
         var entityType = model.AddEntityType(typeof(B));
         var idProperty = entityType.AddProperty("id", typeof(int));
-        var key = entityType.SetPrimaryKey(idProperty);
+        var key = entityType.SetPrimaryKey(idProperty)!;
         var keylessType = model.AddEntityType(typeof(A));
         keylessType.IsKeyless = true;
         var fkProperty = keylessType.AddProperty("p", typeof(int));
@@ -38,7 +38,7 @@ public class NavigationTest
         IMutableModel model = new Model();
         var entityType = model.AddEntityType(typeof(E));
         var idProperty = entityType.AddProperty("id", typeof(int));
-        var key = entityType.SetPrimaryKey(idProperty);
+        var key = entityType.SetPrimaryKey(idProperty)!;
         var fkProperty = entityType.AddProperty("p", typeof(int));
         return entityType.AddForeignKey(fkProperty, key, entityType);
     }
@@ -62,15 +62,15 @@ public class NavigationTest
         public int? P2 { get; set; }
         public int? P3 { get; set; }
 
-        public A A { get; set; }
-        public A AnotherA { get; set; }
-        public ICollection<A> ManyAs { get; set; }
+        public A A { get; set; } = null!;
+        public A AnotherA { get; set; } = null!;
+        public ICollection<A> ManyAs { get; set; } = null!;
     }
 
     private class E
     {
-        public static readonly PropertyInfo DeceptionProperty = typeof(E).GetProperty(nameof(Deception));
+        public static readonly PropertyInfo DeceptionProperty = typeof(E).GetProperty(nameof(Deception))!;
 
-        public E Deception { get; set; }
+        public E Deception { get; set; } = null!;
     }
 }

--- a/test/EFCore.Tests/Metadata/Internal/PropertyAccessorsFactoryTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/PropertyAccessorsFactoryTest.cs
@@ -25,10 +25,10 @@ public class PropertyAccessorsFactoryTest
         var entry = new InternalEntityEntry(stateManager, (IEntityType)entityTypeBuilder.Metadata, entity);
 
         var propertyAccessors = PropertyAccessorsFactory.Instance.Create((IProperty)propertyA);
-        Assert.Equal("ValueA", ((Func<IInternalEntry, string>)propertyAccessors.CurrentValueGetter)(entry));
-        Assert.Equal("ValueA", ((Func<IInternalEntry, string>)propertyAccessors.OriginalValueGetter)(entry));
-        Assert.Equal("ValueA", ((Func<IInternalEntry, string>)propertyAccessors.PreStoreGeneratedCurrentValueGetter)(entry));
-        Assert.Equal("ValueA", ((Func<IInternalEntry, string>)propertyAccessors.RelationshipSnapshotGetter)(entry));
+        Assert.Equal("ValueA", ((Func<IInternalEntry, string>)propertyAccessors.CurrentValueGetter!)(entry));
+        Assert.Equal("ValueA", ((Func<IInternalEntry, string>)propertyAccessors.OriginalValueGetter!)(entry));
+        Assert.Equal("ValueA", ((Func<IInternalEntry, string>)propertyAccessors.PreStoreGeneratedCurrentValueGetter!)(entry));
+        Assert.Equal("ValueA", ((Func<IInternalEntry, string>)propertyAccessors.RelationshipSnapshotGetter!)(entry));
     }
 
     [Fact]
@@ -48,10 +48,10 @@ public class PropertyAccessorsFactoryTest
         var entry = new InternalEntityEntry(stateManager, (IEntityType)entityTypeBuilder.Metadata, entity);
 
         var propertyAccessors = PropertyAccessorsFactory.Instance.Create((IProperty)propA);
-        Assert.Equal("ValueA", ((Func<IInternalEntry, string>)propertyAccessors.CurrentValueGetter)(entry));
-        Assert.Equal("ValueA", ((Func<IInternalEntry, string>)propertyAccessors.OriginalValueGetter)(entry));
-        Assert.Equal("ValueA", ((Func<IInternalEntry, string>)propertyAccessors.PreStoreGeneratedCurrentValueGetter)(entry));
-        Assert.Equal("ValueA", ((Func<IInternalEntry, string>)propertyAccessors.RelationshipSnapshotGetter)(entry));
+        Assert.Equal("ValueA", ((Func<IInternalEntry, string>)propertyAccessors.CurrentValueGetter!)(entry));
+        Assert.Equal("ValueA", ((Func<IInternalEntry, string>)propertyAccessors.OriginalValueGetter!)(entry));
+        Assert.Equal("ValueA", ((Func<IInternalEntry, string>)propertyAccessors.PreStoreGeneratedCurrentValueGetter!)(entry));
+        Assert.Equal("ValueA", ((Func<IInternalEntry, string>)propertyAccessors.RelationshipSnapshotGetter!)(entry));
     }
 
     private class IndexedClass

--- a/test/EFCore.Tests/Metadata/Internal/PropertyBaseTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/PropertyBaseTest.cs
@@ -1003,7 +1003,7 @@ public class PropertyBaseTest
     private static string NoGetterSkipColl<TEntity>()
         => CoreStrings.NoGetter(SkipCollection, typeof(TEntity).Name, nameof(PropertyAccessMode));
 
-    private static IMutableProperty CreateProperty<TEntity>(string fieldName, string propertyName = Property)
+    private static IMutableProperty CreateProperty<TEntity>(string? fieldName, string propertyName = Property)
         where TEntity : class
     {
         var model = CreateModelBuilder();
@@ -1021,7 +1021,7 @@ public class PropertyBaseTest
     }
 
     private static IMutableNavigation CreateReferenceNavigation<TEntity>(
-        string fieldName,
+        string? fieldName,
         string navigationName = Reference)
         where TEntity : class
     {
@@ -1033,14 +1033,14 @@ public class PropertyBaseTest
             .HasOne(typeof(TEntity), navigationName)
             .WithMany();
 
-        var navigation = relationship.Metadata.DependentToPrincipal;
+        var navigation = relationship.Metadata.DependentToPrincipal!;
         navigation.SetField(fieldName);
 
         return navigation;
     }
 
     private static IMutableNavigation CreateCollectionNavigation<TEntity>(
-        string fieldName,
+        string? fieldName,
         string navigationName = Collection)
         where TEntity : class
     {
@@ -1052,14 +1052,14 @@ public class PropertyBaseTest
             .HasMany(typeof(TEntity), navigationName)
             .WithOne();
 
-        var navigation = relationship.Metadata.PrincipalToDependent;
+        var navigation = relationship.Metadata.PrincipalToDependent!;
         navigation.SetField(fieldName);
 
         return navigation;
     }
 
     private static IMutableSkipNavigation CreateSkipCollectionNavigation<TEntity, TOtherEntity>(
-        string fieldName,
+        string? fieldName,
         string navigationName = SkipCollection)
         where TEntity : class
         where TOtherEntity : class
@@ -1072,7 +1072,7 @@ public class PropertyBaseTest
             .HasMany(typeof(TOtherEntity), navigationName)
             .WithMany();
 
-        var navigation = model.Entity<TEntity>().Navigation(navigationName);
+        var navigation = model.Entity<TEntity>().Navigation(navigationName)!;
         navigation.HasField(fieldName);
 
         return (IMutableSkipNavigation)navigation.Metadata;
@@ -1084,9 +1084,9 @@ public class PropertyBaseTest
     private void MemberInfoTest(
         IMutableProperty property,
         PropertyAccessMode? accessMode,
-        string forConstruction,
-        string forSet,
-        string forGet)
+        string? forConstruction,
+        string? forSet,
+        string? forGet)
     {
         property.SetPropertyAccessMode(accessMode);
 
@@ -1096,9 +1096,9 @@ public class PropertyBaseTest
     private void MemberInfoTest(
         IMutableNavigationBase navigation,
         PropertyAccessMode? accessMode,
-        string forConstruction,
-        string forSet,
-        string forGet)
+        string? forConstruction,
+        string? forSet,
+        string? forGet)
     {
         navigation.SetPropertyAccessMode(accessMode);
 
@@ -1108,11 +1108,11 @@ public class PropertyBaseTest
     private void MemberInfoTestCommon(
         IPropertyBase propertyBase,
         PropertyAccessMode? accessMode,
-        string forConstruction,
-        string forSet,
-        string forGet)
+        string? forConstruction,
+        string? forSet,
+        string? forGet)
     {
-        string failMessage = null;
+        string? failMessage = null;
         try
         {
             var memberInfo = propertyBase.GetMemberInfo(forMaterialization: true, forSet: true);
@@ -1212,7 +1212,7 @@ public class PropertyBaseTest
     [Fact]
     public virtual void Properties_can_have_field_cleared()
     {
-        var propertyInfo = typeof(FullProp).GetAnyProperty("Foo");
+        var propertyInfo = typeof(FullProp).GetAnyProperty("Foo")!;
 
         Properties_can_have_field_cleared_test(
             ((IMutableModel)new Model()).AddEntityType(typeof(FullProp)).AddProperty(propertyInfo), propertyInfo, "_foo");
@@ -1233,13 +1233,13 @@ public class PropertyBaseTest
     {
         var entityType = ((IMutableModel)new Model()).AddEntityType(typeof(FullProp));
         var property = entityType.AddProperty("Id", typeof(int));
-        var key = entityType.SetPrimaryKey(property);
+        var key = entityType.SetPrimaryKey(property)!;
         var foreignKey = entityType.AddForeignKey(property, key, entityType);
 
-        var propertyInfo = typeof(FullProp).GetAnyProperty("Reference");
+        var propertyInfo = typeof(FullProp).GetAnyProperty("Reference")!;
 
         Properties_can_have_field_cleared_test(
-            foreignKey.SetDependentToPrincipal(propertyInfo), propertyInfo, "_reference");
+            foreignKey.SetDependentToPrincipal(propertyInfo)!, propertyInfo, "_reference");
     }
 
     private void Properties_can_have_field_cleared_test(IMutablePropertyBase propertyBase, PropertyInfo propertyInfo, string fieldName)
@@ -1251,7 +1251,7 @@ public class PropertyBaseTest
         propertyBase.SetField(fieldName);
 
         Assert.Equal(fieldName, propertyBase.GetFieldName());
-        var fieldInfo = propertyBase.FieldInfo;
+        var fieldInfo = propertyBase.FieldInfo!;
         Assert.Equal(fieldName, fieldInfo.Name);
         Assert.Same(propertyInfo ?? (MemberInfo)fieldInfo, propertyBase.GetIdentifyingMemberInfo());
 
@@ -1290,9 +1290,9 @@ public class PropertyBaseTest
     {
         public int Id { get; set; }
         public int Foo { get; set; }
-        public AutoProp Reference { get; set; }
-        public IEnumerable<AutoProp> Collection { get; set; }
-        public IEnumerable<AutoPropOther> SkipCollection { get; set; }
+        public AutoProp Reference { get; set; } = null!;
+        public IEnumerable<AutoProp> Collection { get; set; } = null!;
+        public IEnumerable<AutoPropOther> SkipCollection { get; set; } = null!;
     }
 
     private class AutoPropOther
@@ -1303,9 +1303,9 @@ public class PropertyBaseTest
     private class FullProp
     {
         private int _foo;
-        private FullProp _reference;
-        private IEnumerable<FullProp> _collection;
-        private IEnumerable<FullPropOther> _skipCollection;
+        private FullProp _reference = null!;
+        private IEnumerable<FullProp> _collection = null!;
+        private IEnumerable<FullPropOther> _skipCollection = null!;
 
         public int Id { get; set; }
 
@@ -1342,9 +1342,9 @@ public class PropertyBaseTest
     private class ReadOnlyProp
     {
         private readonly int _foo;
-        private readonly ReadOnlyProp _reference;
-        private readonly IEnumerable<ReadOnlyProp> _collection;
-        private readonly IEnumerable<ReadOnlyPropOther> _skipCollection;
+        private readonly ReadOnlyProp _reference = null!;
+        private readonly IEnumerable<ReadOnlyProp> _collection = null!;
+        private readonly IEnumerable<ReadOnlyPropOther> _skipCollection = null!;
 
         public int Id { get; set; }
 
@@ -1402,9 +1402,9 @@ public class PropertyBaseTest
 
         public int Id { get; set; }
         public int Foo { get; }
-        public ReadOnlyAutoProp Reference { get; }
-        public IEnumerable<ReadOnlyAutoProp> Collection { get; }
-        public IEnumerable<ReadOnlyAutoPropOther> SkipCollection { get; }
+        public ReadOnlyAutoProp Reference { get; } = null!;
+        public IEnumerable<ReadOnlyAutoProp> Collection { get; } = null!;
+        public IEnumerable<ReadOnlyAutoPropOther> SkipCollection { get; } = null!;
     }
 
     private class ReadOnlyAutoPropOther
@@ -1415,9 +1415,9 @@ public class PropertyBaseTest
     private class ReadOnlyFieldProp
     {
         private readonly int _foo;
-        private readonly ReadOnlyFieldProp _reference;
-        private readonly IEnumerable<ReadOnlyFieldProp> _collection;
-        private readonly IEnumerable<ReadOnlyFieldPropOther> _skipCollection;
+        private readonly ReadOnlyFieldProp _reference = null!;
+        private readonly IEnumerable<ReadOnlyFieldProp> _collection = null!;
+        private readonly IEnumerable<ReadOnlyFieldPropOther> _skipCollection = null!;
 
         public ReadOnlyFieldProp()
         {
@@ -1458,9 +1458,9 @@ public class PropertyBaseTest
     private class WriteOnlyProp
     {
         private int _foo;
-        private WriteOnlyProp _reference;
-        private IEnumerable<WriteOnlyProp> _collection;
-        private IEnumerable<WriteOnlyPropOther> _skipCollection;
+        private WriteOnlyProp _reference = null!;
+        private IEnumerable<WriteOnlyProp> _collection = null!;
+        private IEnumerable<WriteOnlyPropOther> _skipCollection = null!;
 
         public int Id { get; set; }
 
@@ -1507,9 +1507,9 @@ public class PropertyBaseTest
     private class FullPropNoField
     {
         private int _notFound;
-        private FullPropNoField _notFoundRef;
-        private IEnumerable<FullPropNoField> _notFoundColl;
-        private IEnumerable<FullPropNoFieldOther> _notFoundSkipColl;
+        private FullPropNoField _notFoundRef = null!;
+        private IEnumerable<FullPropNoField> _notFoundColl = null!;
+        private IEnumerable<FullPropNoFieldOther> _notFoundSkipColl = null!;
 
         public int Id { get; set; }
 
@@ -1546,9 +1546,9 @@ public class PropertyBaseTest
     private class ReadOnlyPropNoField
     {
         private readonly int _notFound;
-        private readonly ReadOnlyPropNoField _notFoundRef;
-        private readonly IEnumerable<ReadOnlyPropNoField> _notFoundColl;
-        private readonly IEnumerable<ReadOnlyPropNoFieldOther> _notFoundSkipColl;
+        private readonly ReadOnlyPropNoField _notFoundRef = null!;
+        private readonly IEnumerable<ReadOnlyPropNoField> _notFoundColl = null!;
+        private readonly IEnumerable<ReadOnlyPropNoFieldOther> _notFoundSkipColl = null!;
 
         public ReadOnlyPropNoField()
         {
@@ -1589,9 +1589,9 @@ public class PropertyBaseTest
     private class WriteOnlyPropNoField
     {
         private int _notFound;
-        private WriteOnlyPropNoField _notFoundRef;
-        private IEnumerable<WriteOnlyPropNoField> _notFoundColl;
-        private IEnumerable<WriteOnlyPropNoFieldOther> _notFoundSkipColl;
+        private WriteOnlyPropNoField _notFoundRef = null!;
+        private IEnumerable<WriteOnlyPropNoField> _notFoundColl = null!;
+        private IEnumerable<WriteOnlyPropNoFieldOther> _notFoundSkipColl = null!;
 
         public int Id { get; set; }
 
@@ -1640,9 +1640,9 @@ public class PropertyBaseTest
     {
         public int Id { get; set; }
         protected int _foo;
-        protected PrivateSetterInBase _reference;
-        protected IEnumerable<PrivateSetterInBase> _collection;
-        protected IEnumerable<PrivateSetterBaseOther> _skipCollection;
+        protected PrivateSetterInBase _reference = null!;
+        protected IEnumerable<PrivateSetterInBase> _collection = null!;
+        protected IEnumerable<PrivateSetterBaseOther> _skipCollection = null!;
 
         public virtual int Foo
         {
@@ -1701,9 +1701,9 @@ public class PropertyBaseTest
     {
         public int Id { get; set; }
         protected int _foo;
-        protected PrivateGetterInBase _reference;
-        protected IEnumerable<PrivateGetterInBase> _collection;
-        protected IEnumerable<PrivateGetterBaseOther> _skipCollection;
+        protected PrivateGetterInBase _reference = null!;
+        protected IEnumerable<PrivateGetterInBase> _collection = null!;
+        protected IEnumerable<PrivateGetterBaseOther> _skipCollection = null!;
 
         public virtual int Foo
         {

--- a/test/EFCore.Tests/Metadata/Internal/PropertyListComparerTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/PropertyListComparerTest.cs
@@ -9,7 +9,7 @@ public class PropertyListComparerTest
     public void Distinguishes_properties_with_same_name_in_different_complex_types()
     {
         var model = new Model();
-        var entityType = model.AddEntityType(typeof(Customer), owned: false, ConfigurationSource.Explicit);
+        var entityType = model.AddEntityType(typeof(Customer), owned: false, ConfigurationSource.Explicit)!;
 
         var homeAddress = entityType.AddComplexProperty(
             nameof(Customer.HomeAddress), typeof(Address), typeof(Address), collection: false, ConfigurationSource.Explicit)!;
@@ -41,7 +41,7 @@ public class PropertyListComparerTest
     public void Allows_index_with_same_property_names_through_different_complex_paths()
     {
         var model = new Model();
-        var entityType = model.AddEntityType(typeof(Customer), owned: false, ConfigurationSource.Explicit);
+        var entityType = model.AddEntityType(typeof(Customer), owned: false, ConfigurationSource.Explicit)!;
 
         var homeAddress = entityType.AddComplexProperty(
             nameof(Customer.HomeAddress), typeof(Address), typeof(Address), collection: false, ConfigurationSource.Explicit)!;
@@ -65,7 +65,7 @@ public class PropertyListComparerTest
     public void Distinguishes_properties_with_same_name_through_nested_complex_paths()
     {
         var model = new Model();
-        var entityType = model.AddEntityType(typeof(Order), owned: false, ConfigurationSource.Explicit);
+        var entityType = model.AddEntityType(typeof(Order), owned: false, ConfigurationSource.Explicit)!;
 
         var oldDetails = entityType.AddComplexProperty(
             nameof(Order.OldDetails), typeof(Details), typeof(Details), collection: false, ConfigurationSource.Explicit)!;
@@ -96,7 +96,7 @@ public class PropertyListComparerTest
     public void PropertyNameComparer_orders_keys_with_same_name_in_different_complex_types_independently()
     {
         var model = new Model();
-        var entityType = model.AddEntityType(typeof(Customer), owned: false, ConfigurationSource.Explicit);
+        var entityType = model.AddEntityType(typeof(Customer), owned: false, ConfigurationSource.Explicit)!;
 
         var homeAddress = entityType.AddComplexProperty(
             nameof(Customer.HomeAddress), typeof(Address), typeof(Address), collection: false, ConfigurationSource.Explicit)!;

--- a/test/EFCore.Tests/Metadata/Internal/PropertyTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/PropertyTest.cs
@@ -82,23 +82,23 @@ public class PropertyTest
 
         Assert.Equal(
             CoreStrings.ModelReadOnly,
-            Assert.Throws<InvalidOperationException>(() => property.SetValueComparer((ValueComparer)null)).Message);
+            Assert.Throws<InvalidOperationException>(() => property.SetValueComparer((ValueComparer?)null)).Message);
 
         Assert.Equal(
             CoreStrings.ModelReadOnly,
-            Assert.Throws<InvalidOperationException>(() => property.SetValueComparer((Type)null)).Message);
+            Assert.Throws<InvalidOperationException>(() => property.SetValueComparer((Type?)null)).Message);
 
         Assert.Equal(
             CoreStrings.ModelReadOnly,
-            Assert.Throws<InvalidOperationException>(() => property.SetValueConverter((ValueConverter)null)).Message);
+            Assert.Throws<InvalidOperationException>(() => property.SetValueConverter((ValueConverter?)null)).Message);
 
         Assert.Equal(
             CoreStrings.ModelReadOnly,
-            Assert.Throws<InvalidOperationException>(() => property.SetValueConverter((Type)null)).Message);
+            Assert.Throws<InvalidOperationException>(() => property.SetValueConverter((Type?)null)).Message);
 
         Assert.Equal(
             CoreStrings.ModelReadOnly,
-            Assert.Throws<InvalidOperationException>(() => property.SetValueGeneratorFactory((Type)null)).Message);
+            Assert.Throws<InvalidOperationException>(() => property.SetValueGeneratorFactory((Type?)null)).Message);
     }
 
     [Fact]
@@ -298,13 +298,13 @@ public class PropertyTest
     private class NonDerivedValueGeneratorFactory
     {
         public ValueGenerator Create(IProperty property, ITypeBase typeBase)
-            => null;
+            => null!;
     }
 
     private abstract class AbstractValueGeneratorFactory : ValueGeneratorFactory
     {
         public override ValueGenerator Create(IProperty property, ITypeBase typeBase)
-            => null;
+            => null!;
     }
 
     private class StaticValueGeneratorFactory : ValueGeneratorFactory
@@ -314,7 +314,7 @@ public class PropertyTest
         }
 
         public override ValueGenerator Create(IProperty property, ITypeBase typeBase)
-            => null;
+            => null!;
     }
 
     private class PrivateValueGeneratorFactory : ValueGeneratorFactory
@@ -324,7 +324,7 @@ public class PropertyTest
         }
 
         public override ValueGenerator Create(IProperty property, ITypeBase typeBase)
-            => null;
+            => null!;
     }
 
 #pragma warning disable CS9113 // Parameter '_' is unread
@@ -332,7 +332,7 @@ public class PropertyTest
 #pragma warning restore CS9113
     {
         public override ValueGenerator Create(IProperty property, ITypeBase typeBase)
-            => null;
+            => null!;
     }
 
     [Fact]
@@ -387,7 +387,7 @@ public class PropertyTest
         }
     }
 
-    private class NonParameterlessValueConverter(ConverterMappingHints mappingHints = null) : StringToBoolConverter(mappingHints);
+    private class NonParameterlessValueConverter(ConverterMappingHints? mappingHints = null) : StringToBoolConverter(mappingHints);
 
     [Fact]
     public void Throws_when_ValueComparer_type_is_invalid()
@@ -529,7 +529,7 @@ public class PropertyTest
     {
         var model = CreateModel();
         var entityType = model.AddEntityType(typeof(Customer));
-        var memberInfo = typeof(Customer).GetProperty(nameof(Customer.Numbers));
+        var memberInfo = typeof(Customer).GetProperty(nameof(Customer.Numbers))!;
         var property = entityType.AddPrimitiveCollection(nameof(Customer.Numbers), typeof(IList<int>), memberInfo, typeof(int));
 
         Assert.Equal(typeof(int), property.GetElementType()!.ClrType);
@@ -555,7 +555,7 @@ public class PropertyTest
 
     private class SimpleJasonValueReaderWriter : JsonValueReaderWriter<string>
     {
-        public override string FromJsonTyped(ref Utf8JsonReaderManager manager, object existingObject = null)
+        public override string FromJsonTyped(ref Utf8JsonReaderManager manager, object? existingObject = null)
             => manager.CurrentReader.GetString()!;
 
         public override void ToJsonTyped(Utf8JsonWriter writer, string value)
@@ -571,7 +571,7 @@ public class PropertyTest
     {
         private static JasonValueReaderWriterWithPrivateInstance Instance { get; } = new();
 
-        public override string FromJsonTyped(ref Utf8JsonReaderManager manager, object existingObject = null)
+        public override string FromJsonTyped(ref Utf8JsonReaderManager manager, object? existingObject = null)
             => manager.CurrentReader.GetString()!;
 
         public override void ToJsonTyped(Utf8JsonWriter writer, string value)
@@ -587,7 +587,7 @@ public class PropertyTest
     {
         public static object Instance { get; } = new();
 
-        public override string FromJsonTyped(ref Utf8JsonReaderManager manager, object existingObject = null)
+        public override string FromJsonTyped(ref Utf8JsonReaderManager manager, object? existingObject = null)
             => manager.CurrentReader.GetString()!;
 
         public override void ToJsonTyped(Utf8JsonWriter writer, string value)
@@ -601,7 +601,7 @@ public class PropertyTest
     {
         public static SimpleJasonValueReaderWriterWithInstance Instance { get; } = new();
 
-        public override string FromJsonTyped(ref Utf8JsonReaderManager manager, object existingObject = null)
+        public override string FromJsonTyped(ref Utf8JsonReaderManager manager, object? existingObject = null)
             => manager.CurrentReader.GetString()!;
 
         public override void ToJsonTyped(Utf8JsonWriter writer, string value)
@@ -621,7 +621,7 @@ public class PropertyTest
         {
         }
 
-        public override string FromJsonTyped(ref Utf8JsonReaderManager manager, object existingObject = null)
+        public override string FromJsonTyped(ref Utf8JsonReaderManager manager, object? existingObject = null)
             => manager.CurrentReader.GetString()!;
 
         public override void ToJsonTyped(Utf8JsonWriter writer, string value)
@@ -637,11 +637,11 @@ public class PropertyTest
 
     private class NonGenericJsonValueReaderWriter : JsonValueReaderWriter
     {
-        public override object FromJson(ref Utf8JsonReaderManager manager, object existingObject = null)
+        public override object FromJson(ref Utf8JsonReaderManager manager, object? existingObject = null)
             => manager.CurrentReader.GetString()!;
 
-        public override void ToJson(Utf8JsonWriter writer, object value)
-            => writer.WriteStringValue((string)value);
+        public override void ToJson(Utf8JsonWriter writer, object? value)
+            => writer.WriteStringValue((string)value!);
 
         public override Type ValueType
             => typeof(string);
@@ -660,7 +660,7 @@ public class PropertyTest
         {
         }
 
-        public override string FromJsonTyped(ref Utf8JsonReaderManager manager, object existingObject = null)
+        public override string FromJsonTyped(ref Utf8JsonReaderManager manager, object? existingObject = null)
             => manager.CurrentReader.GetString()!;
 
         public override void ToJsonTyped(Utf8JsonWriter writer, string value)
@@ -674,7 +674,7 @@ public class PropertyTest
 
     private class NonParameterlessJsonValueReaderWriter(bool _) : JsonValueReaderWriter<string>
     {
-        public override string FromJsonTyped(ref Utf8JsonReaderManager manager, object existingObject = null)
+        public override string FromJsonTyped(ref Utf8JsonReaderManager manager, object? existingObject = null)
             => manager.CurrentReader.GetString()!;
 
         public override void ToJsonTyped(Utf8JsonWriter writer, string value)
@@ -691,7 +691,7 @@ public class PropertyTest
 
     private class Entity
     {
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
         public int? Id { get; set; }
     }
 
@@ -704,21 +704,21 @@ public class PropertyTest
     {
         public int AlternateId { get; set; }
         public Guid Unique { get; set; }
-        public string Name { get; set; }
-        public string Mane { get; set; }
-        public ICollection<Order> Orders { get; set; }
+        public string Name { get; set; } = null!;
+        public string Mane { get; set; } = null!;
+        public ICollection<Order> Orders { get; set; } = null!;
 
-        public IEnumerable<Order> EnumerableOrders { get; set; }
-        public Order NotCollectionOrders { get; set; }
-        public IList<int> Numbers { get; set; }
+        public IEnumerable<Order> EnumerableOrders { get; set; } = null!;
+        public Order NotCollectionOrders { get; set; } = null!;
+        public IList<int> Numbers { get; set; } = null!;
     }
 
     private class Order : BaseType
     {
         public int CustomerId { get; set; }
         public Guid CustomerUnique { get; set; }
-        public Customer Customer { get; set; }
+        public Customer Customer { get; set; } = null!;
 
-        public Order OrderCustomer { get; set; }
+        public Order OrderCustomer { get; set; } = null!;
     }
 }

--- a/test/EFCore.Tests/Metadata/Internal/SkipNavigationTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/SkipNavigationTest.cs
@@ -58,16 +58,16 @@ public class SkipNavigationTest
     public void Gets_expected_default_values()
     {
         var model = (IConventionModel)CreateModel();
-        var firstEntity = model.AddEntityType(typeof(Order));
-        var firstIdProperty = firstEntity.AddProperty(Order.IdProperty);
-        var firstKey = firstEntity.AddKey(firstIdProperty);
-        var secondEntity = model.AddEntityType(typeof(Product));
-        var joinEntityBuilder = model.AddEntityType(typeof(OrderProduct));
-        var orderIdProperty = joinEntityBuilder.AddProperty(OrderProduct.OrderIdProperty);
+        var firstEntity = model.AddEntityType(typeof(Order))!;
+        var firstIdProperty = firstEntity.AddProperty(Order.IdProperty)!;
+        var firstKey = firstEntity.AddKey(firstIdProperty)!;
+        var secondEntity = model.AddEntityType(typeof(Product))!;
+        var joinEntityBuilder = model.AddEntityType(typeof(OrderProduct))!;
+        var orderIdProperty = joinEntityBuilder.AddProperty(OrderProduct.OrderIdProperty)!;
         var firstFk = joinEntityBuilder
-            .AddForeignKey([orderIdProperty], firstKey, firstEntity);
+            .AddForeignKey([orderIdProperty], firstKey, firstEntity)!;
 
-        var navigation = firstEntity.AddSkipNavigation(nameof(Order.Products), null, null, secondEntity, true, false);
+        var navigation = firstEntity.AddSkipNavigation(nameof(Order.Products), null, null, secondEntity, true, false)!;
         navigation.SetForeignKey(firstFk);
 
         Assert.True(navigation.IsCollection);
@@ -86,7 +86,7 @@ public class SkipNavigationTest
 
         Assert.Same(navigation, firstEntity.FindDeclaredSkipNavigation(navigation.Name));
         Assert.Same(navigation, firstEntity.FindSkipNavigation(navigation.Name));
-        Assert.Same(navigation, firstEntity.FindSkipNavigation(navigation.GetIdentifyingMemberInfo()));
+        Assert.Same(navigation, firstEntity.FindSkipNavigation(navigation.GetIdentifyingMemberInfo()!));
         Assert.Same(navigation, firstEntity.GetDeclaredSkipNavigations().Single());
     }
 
@@ -94,16 +94,16 @@ public class SkipNavigationTest
     public void Can_set_foreign_key()
     {
         var model = (IConventionModel)CreateModel();
-        var firstEntity = model.AddEntityType(typeof(Order));
-        var firstIdProperty = firstEntity.AddProperty(Order.IdProperty);
-        var firstKey = firstEntity.AddKey(firstIdProperty);
-        var secondEntity = model.AddEntityType(typeof(Product));
-        var joinEntityBuilder = model.AddEntityType(typeof(OrderProduct));
-        var orderIdProperty = joinEntityBuilder.AddProperty(OrderProduct.OrderIdProperty);
+        var firstEntity = model.AddEntityType(typeof(Order))!;
+        var firstIdProperty = firstEntity.AddProperty(Order.IdProperty)!;
+        var firstKey = firstEntity.AddKey(firstIdProperty)!;
+        var secondEntity = model.AddEntityType(typeof(Product))!;
+        var joinEntityBuilder = model.AddEntityType(typeof(OrderProduct))!;
+        var orderIdProperty = joinEntityBuilder.AddProperty(OrderProduct.OrderIdProperty)!;
         var firstFk = joinEntityBuilder
-            .AddForeignKey([orderIdProperty], firstKey, firstEntity);
+            .AddForeignKey([orderIdProperty], firstKey, firstEntity)!;
 
-        var navigation = firstEntity.AddSkipNavigation(nameof(Order.Products), null, null, secondEntity, true, false);
+        var navigation = firstEntity.AddSkipNavigation(nameof(Order.Products), null, null, secondEntity, true, false)!;
 
         Assert.Null(navigation.ForeignKey);
         Assert.Null(navigation.GetForeignKeyConfigurationSource());
@@ -304,30 +304,30 @@ public class SkipNavigationTest
 
     private class Order
     {
-        public static readonly PropertyInfo IdProperty = typeof(Order).GetProperty(nameof(Id));
+        public static readonly PropertyInfo IdProperty = typeof(Order).GetProperty(nameof(Id))!;
 
         public int Id { get; set; }
 
-        public virtual ICollection<Product> Products { get; set; }
+        public virtual ICollection<Product> Products { get; set; } = null!;
     }
 
     private class OrderProduct
     {
-        public static readonly PropertyInfo OrderIdProperty = typeof(OrderProduct).GetProperty(nameof(OrderId));
-        public static readonly PropertyInfo ProductIdProperty = typeof(OrderProduct).GetProperty(nameof(ProductId));
+        public static readonly PropertyInfo OrderIdProperty = typeof(OrderProduct).GetProperty(nameof(OrderId))!;
+        public static readonly PropertyInfo ProductIdProperty = typeof(OrderProduct).GetProperty(nameof(ProductId))!;
 
         public int OrderId { get; set; }
         public int ProductId { get; set; }
-        public virtual Order Order { get; set; }
-        public virtual Product Product { get; set; }
+        public virtual Order Order { get; set; } = null!;
+        public virtual Product Product { get; set; } = null!;
     }
 
     private class Product
     {
-        public static readonly PropertyInfo IdProperty = typeof(Product).GetProperty(nameof(Id));
+        public static readonly PropertyInfo IdProperty = typeof(Product).GetProperty(nameof(Id))!;
 
         public int Id { get; set; }
 
-        public virtual ICollection<Order> Orders { get; set; }
+        public virtual ICollection<Order> Orders { get; set; } = null!;
     }
 }

--- a/test/EFCore.Tests/Query/EntityMaterializerSourceTest.cs
+++ b/test/EFCore.Tests/Query/EntityMaterializerSourceTest.cs
@@ -196,14 +196,14 @@ public class EntityMaterializerSourceTest
         public static readonly TestProxyFactory Instance = new();
 
         public object Create(IEntityType entityType)
-            => Activator.CreateInstance(entityType.ClrType);
+            => Activator.CreateInstance(entityType.ClrType)!;
     }
 
     [Fact]
     public void Can_create_materializer_for_entity_with_auto_properties()
     {
         using var context = new SomeEntityContext(b => b.Entity<SomeEntity>());
-        var entityType = context.Model.FindEntityType(typeof(SomeEntity));
+        var entityType = context.Model.FindEntityType(typeof(SomeEntity))!;
 
         var factory = GetMaterializer(
             new StructuralTypeMaterializerSource(new StructuralTypeMaterializerSourceDependencies([])), entityType);
@@ -235,7 +235,7 @@ public class EntityMaterializerSourceTest
             eb.Property(e => e.MaybeEnum).HasField("_maybeEnum");
         }));
 
-        var entityType = context.Model.FindEntityType(typeof(SomeEntityWithFields));
+        var entityType = context.Model.FindEntityType(typeof(SomeEntityWithFields))!;
 
         var factory = GetMaterializer(
             new StructuralTypeMaterializerSource(new StructuralTypeMaterializerSourceDependencies([])), entityType);
@@ -262,7 +262,7 @@ public class EntityMaterializerSourceTest
             eb.Ignore(e => e.MaybeEnum);
         }));
 
-        var entityType = context.Model.FindEntityType(typeof(SomeEntity));
+        var entityType = context.Model.FindEntityType(typeof(SomeEntity))!;
 
         var factory = GetMaterializer(
             new StructuralTypeMaterializerSource(new StructuralTypeMaterializerSourceDependencies([])), entityType);
@@ -292,7 +292,7 @@ public class EntityMaterializerSourceTest
             eb.Property<Guid>("GooShadow");
         }));
 
-        var entityType = context.Model.FindEntityType(typeof(SomeEntity));
+        var entityType = context.Model.FindEntityType(typeof(SomeEntity))!;
 
         var factory = GetMaterializer(
             new StructuralTypeMaterializerSource(new StructuralTypeMaterializerSourceDependencies([])), entityType);
@@ -616,11 +616,11 @@ public class EntityMaterializerSourceTest
         [NotMapped]
         public bool GooSetterCalled { get; set; }
 
-        public static readonly PropertyInfo IdProperty = typeof(SomeEntity).GetProperty("Id");
-        public static readonly PropertyInfo FooProperty = typeof(SomeEntity).GetProperty("Foo");
-        public static readonly PropertyInfo GooProperty = typeof(SomeEntity).GetProperty("Goo");
-        public static readonly PropertyInfo EnumProperty = typeof(SomeEntity).GetProperty("Enum");
-        public static readonly PropertyInfo MaybeEnumProperty = typeof(SomeEntity).GetProperty("MaybeEnum");
+        public static readonly PropertyInfo IdProperty = typeof(SomeEntity).GetProperty("Id")!;
+        public static readonly PropertyInfo FooProperty = typeof(SomeEntity).GetProperty("Foo")!;
+        public static readonly PropertyInfo GooProperty = typeof(SomeEntity).GetProperty("Goo")!;
+        public static readonly PropertyInfo EnumProperty = typeof(SomeEntity).GetProperty("Enum")!;
+        public static readonly PropertyInfo MaybeEnumProperty = typeof(SomeEntity).GetProperty("MaybeEnum")!;
 
         // ReSharper disable UnusedAutoPropertyAccessor.Local
         public int Id
@@ -633,7 +633,7 @@ public class EntityMaterializerSourceTest
             }
         }
 
-        public string Foo { get; set; }
+        public string? Foo { get; set; }
 
         public Guid? Goo
         {
@@ -653,15 +653,15 @@ public class EntityMaterializerSourceTest
 
     private class SomeEntityWithFields
     {
-        public static readonly PropertyInfo IdProperty = typeof(SomeEntityWithFields).GetProperty("Id");
-        public static readonly PropertyInfo FooProperty = typeof(SomeEntityWithFields).GetProperty("Foo");
-        public static readonly PropertyInfo GooProperty = typeof(SomeEntityWithFields).GetProperty("Goo");
-        public static readonly PropertyInfo EnumProperty = typeof(SomeEntityWithFields).GetProperty("Enum");
-        public static readonly PropertyInfo MaybeEnumProperty = typeof(SomeEntityWithFields).GetProperty("MaybeEnum");
+        public static readonly PropertyInfo IdProperty = typeof(SomeEntityWithFields).GetProperty("Id")!;
+        public static readonly PropertyInfo FooProperty = typeof(SomeEntityWithFields).GetProperty("Foo")!;
+        public static readonly PropertyInfo GooProperty = typeof(SomeEntityWithFields).GetProperty("Goo")!;
+        public static readonly PropertyInfo EnumProperty = typeof(SomeEntityWithFields).GetProperty("Enum")!;
+        public static readonly PropertyInfo MaybeEnumProperty = typeof(SomeEntityWithFields).GetProperty("MaybeEnum")!;
 
 #pragma warning disable 649, IDE0044 // Add readonly modifier
         private int _id;
-        private string _foo;
+        private string _foo = null!;
         private Guid? _goo;
         private SomeEnum _enum;
         private SomeEnum? _maybeEnum;
@@ -690,7 +690,7 @@ public class EntityMaterializerSourceTest
 
     private class EntityWithoutParameterlessConstructor(int value)
     {
-        public static readonly PropertyInfo IdProperty = typeof(EntityWithoutParameterlessConstructor).GetProperty("Id");
+        public static readonly PropertyInfo IdProperty = typeof(EntityWithoutParameterlessConstructor).GetProperty("Id")!;
 
         public int Id { get; set; }
 

--- a/test/EFCore.Tests/Query/ExpressionEqualityComparerTest.cs
+++ b/test/EFCore.Tests/Query/ExpressionEqualityComparerTest.cs
@@ -15,14 +15,14 @@ public class ExpressionEqualityComparerTest
     {
         var expressionComparer = ExpressionEqualityComparer.Instance;
 
-        var addMethod = typeof(List<string>).GetTypeInfo().GetDeclaredMethod("Add");
+        var addMethod = typeof(List<string>).GetTypeInfo().GetDeclaredMethod("Add")!;
 
         var bindingMessages = ListBind(
-            typeof(Node).GetProperty("Messages"),
+            typeof(Node).GetProperty("Messages")!,
             ElementInit(addMethod, Constant("Constant1")));
 
         var bindingDescriptions = ListBind(
-            typeof(Node).GetProperty("Descriptions"),
+            typeof(Node).GetProperty("Descriptions")!,
             ElementInit(addMethod, Constant("Constant2")));
 
         Expression e1 = MemberInit(
@@ -126,10 +126,10 @@ public class ExpressionEqualityComparerTest
     private class Node
     {
         [UsedImplicitly]
-        public List<string> Messages { set; get; }
+        public List<string> Messages { set; get; } = null!;
 
         [UsedImplicitly]
-        public List<string> Descriptions { set; get; }
+        public List<string> Descriptions { set; get; } = null!;
     }
 
     private class Indexable

--- a/test/EFCore.Tests/Query/Internal/NavigationExpandingExpressionVisitorTests.cs
+++ b/test/EFCore.Tests/Query/Internal/NavigationExpandingExpressionVisitorTests.cs
@@ -12,28 +12,28 @@ public class NavigationExpandingExpressionVisitorTests
     {
         public TInterceptor Aggregate<TInterceptor>()
             where TInterceptor : class, IInterceptor
-            => null;
+            => null!;
     }
 
     private class TestNavigationExpandingExpressionVisitor() : NavigationExpandingExpressionVisitor(
-        null,
+        null!,
         new QueryCompilationContext(
             new QueryCompilationContextDependencies(
-                model: null,
-                queryTranslationPreprocessorFactory: null,
-                queryableMethodTranslatingExpressionVisitorFactory: null,
-                queryTranslationPostprocessorFactory: null,
-                shapedQueryCompilingExpressionVisitorFactory: null,
-                liftableConstantFactory: null,
-                liftableConstantProcessor: null,
+                model: null!,
+                queryTranslationPreprocessorFactory: null!,
+                queryableMethodTranslatingExpressionVisitorFactory: null!,
+                queryTranslationPostprocessorFactory: null!,
+                shapedQueryCompilingExpressionVisitorFactory: null!,
+                liftableConstantFactory: null!,
+                liftableConstantProcessor: null!,
                 new ExecutionStrategyTest.TestExecutionStrategy(new MyDemoContext()),
                 new CurrentDbContext(new MyDemoContext()),
-                contextOptions: null,
-                logger: null,
+                contextOptions: null!,
+                logger: null!,
                 new TestInterceptors()
             ), async: false),
-        null,
-        null)
+        null!,
+        null!)
     {
         public Expression TestVisitExtension(Expression extensionExpression)
             => base.VisitExtension(extensionExpression);
@@ -75,7 +75,7 @@ public class NavigationExpandingExpressionVisitorTests
     public void Visits_extension_children()
     {
         var model = new Model();
-        var e = model.AddEntityType(typeof(A), false, ConfigurationSource.Explicit);
+        var e = model.AddEntityType(typeof(A), false, ConfigurationSource.Explicit)!;
         var visitor = new TestNavigationExpandingExpressionVisitor();
         var testExpression = new TestEntityQueryRootExpression(e);
 

--- a/test/EFCore.Tests/Query/QueryProviderTest.cs
+++ b/test/EFCore.Tests/Query/QueryProviderTest.cs
@@ -37,7 +37,7 @@ public class QueryProviderTest
         IQueryable q = context.TestEntities;
         var expr = Expression.Call(null, func.GetMethodInfo(), q.Expression);
         Assert.Equal(0, q.Provider.Execute<int>(expr));
-        Assert.Equal(0, (int)q.Provider.Execute(expr));
+        Assert.Equal(0, (int)q.Provider.Execute(expr)!);
     }
 
     #region Fixture
@@ -50,7 +50,7 @@ public class QueryProviderTest
     private class TestContext : DbContext
     {
         // ReSharper disable once UnusedAutoPropertyAccessor.Local
-        public DbSet<TestEntity> TestEntities { get; set; }
+        public DbSet<TestEntity> TestEntities { get; set; } = null!;
 
         protected internal override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
             => optionsBuilder

--- a/test/EFCore.Tests/ServiceProviderCacheTest.cs
+++ b/test/EFCore.Tests/ServiceProviderCacheTest.cs
@@ -98,12 +98,12 @@ public class ServiceProviderCacheTest
 
         var config1 = CreateOptions<CoreOptionsExtension>(loggerFactory);
         config1 = config1.WithExtension(
-            config1.FindExtension<CoreOptionsExtension>()
+            config1.FindExtension<CoreOptionsExtension>()!
                 .WithReplacedService(typeof(object), typeof(Random)));
 
         var config2 = CreateOptions<CoreOptionsExtension>(loggerFactory);
         config2 = config2.WithExtension(
-            config2.FindExtension<CoreOptionsExtension>()
+            config2.FindExtension<CoreOptionsExtension>()!
                 .WithReplacedService(typeof(object), typeof(Random)));
 
         var cache = new ServiceProviderCache();
@@ -124,12 +124,12 @@ public class ServiceProviderCacheTest
 
         var config1 = CreateOptions<CoreOptionsExtension>(loggerFactory);
         config1 = config1.WithExtension(
-            config1.FindExtension<CoreOptionsExtension>()
+            config1.FindExtension<CoreOptionsExtension>()!
                 .WithReplacedService(typeof(object), typeof(Random)));
 
         var config2 = CreateOptions<CoreOptionsExtension>(loggerFactory);
         config2 = config2.WithExtension(
-            config2.FindExtension<CoreOptionsExtension>()
+            config2.FindExtension<CoreOptionsExtension>()!
                 .WithReplacedService(typeof(object), typeof(string)));
 
         var cache = new ServiceProviderCache();
@@ -251,10 +251,10 @@ public class ServiceProviderCacheTest
 
     private class FakeDbContextOptionsExtension1(List<string> log) : IDbContextOptionsExtension
     {
-        private DbContextOptionsExtensionInfo _info;
+        private DbContextOptionsExtensionInfo? _info;
         private readonly List<string> _log = log;
 
-        public string Something { get; set; }
+        public string Something { get; set; } = null!;
 
         public DbContextOptionsExtensionInfo Info
             => _info ??= new ExtensionInfo(this);
@@ -292,7 +292,7 @@ public class ServiceProviderCacheTest
 
     private class FakeDbContextOptionsExtension2(List<string> log) : IDbContextOptionsExtension
     {
-        private DbContextOptionsExtensionInfo _info;
+        private DbContextOptionsExtensionInfo? _info;
         private readonly List<string> _log = log;
 
         public DbContextOptionsExtensionInfo Info
@@ -338,8 +338,8 @@ public class ServiceProviderCacheTest
         var provider1 = cache.GetOrAdd(options, providerRequired: false);
         cache.Clear();
 
-        var field = typeof(ServiceProviderCache).GetField("_configurations", BindingFlags.NonPublic | BindingFlags.Instance);
-        var dict = (IDictionary)field.GetValue(cache);
+        var field = typeof(ServiceProviderCache).GetField("_configurations", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var dict = (IDictionary)field.GetValue(cache)!;
 
         Assert.Equal(0, dict.Count);
 

--- a/test/EFCore.Tests/SharedTypeDbSetTest.cs
+++ b/test/EFCore.Tests/SharedTypeDbSetTest.cs
@@ -693,20 +693,20 @@ public class SharedTypeDbSetTest
     private class Category
     {
         public int Id { get; set; }
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
     }
 
     private class Product
     {
         public int Id { get; set; }
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
         public decimal Price { get; set; }
     }
 
     private class TheGu
     {
         public Guid Id { get; set; }
-        public string ShirtColor { get; set; }
+        public string ShirtColor { get; set; } = null!;
     }
 
     private class EarlyLearningCenter : DbContext

--- a/test/EFCore.Tests/Storage/ExecutionStrategyTest.cs
+++ b/test/EFCore.Tests/Storage/ExecutionStrategyTest.cs
@@ -586,7 +586,7 @@ public class ExecutionStrategyTest : IDisposable
 
                         Assert.True(false);
                         return Task.FromResult(0);
-                    }))).InnerException.InnerException);
+                    }))).InnerException!.InnerException);
 
         Assert.Equal(3, executionCount);
     }
@@ -655,14 +655,14 @@ public class ExecutionStrategyTest : IDisposable
 
     public class TestExecutionStrategy : ExecutionStrategy
     {
-        private readonly Func<Exception, bool> _shouldRetryOn;
-        private readonly Func<Exception, TimeSpan?> _getNextDelay;
+        private readonly Func<Exception, bool>? _shouldRetryOn;
+        private readonly Func<Exception, TimeSpan?>? _getNextDelay;
 
         public TestExecutionStrategy(
             DbContext context,
             int? retryCount = null,
-            Func<Exception, bool> shouldRetryOn = null,
-            Func<Exception, TimeSpan?> getNextDelay = null)
+            Func<Exception, bool>? shouldRetryOn = null,
+            Func<Exception, TimeSpan?>? getNextDelay = null)
             : base(
                 context,
                 retryCount ?? DefaultMaxRetryCount,
@@ -674,7 +674,7 @@ public class ExecutionStrategyTest : IDisposable
 
         protected TestExecutionStrategy()
             : base(
-                (ExecutionStrategyDependencies)null,
+                (ExecutionStrategyDependencies)null!,
                 DefaultMaxRetryCount,
                 DefaultMaxDelay)
         {

--- a/test/EFCore.Tests/Storage/ValueConversion/BoolToStringConverterTest.cs
+++ b/test/EFCore.Tests/Storage/ValueConversion/BoolToStringConverterTest.cs
@@ -30,7 +30,7 @@ public class BoolToStringConverterTest
         Assert.True(converter("T"));
         Assert.False(converter("Yes"));
         Assert.False(converter(""));
-        Assert.False(converter(null));
+        Assert.False(converter(null!));
     }
 
     private static readonly BoolToStringConverter _boolToYn
@@ -56,7 +56,7 @@ public class BoolToStringConverterTest
         Assert.True(converter("yes"));
         Assert.False(converter("True"));
         Assert.False(converter(""));
-        Assert.False(converter(null));
+        Assert.False(converter(null!));
     }
 
     [Fact]
@@ -76,6 +76,6 @@ public class BoolToStringConverterTest
         Assert.False(converter(""));
         Assert.True(converter(" "));
         Assert.False(converter("\t"));
-        Assert.False(converter(null));
+        Assert.False(converter(null!));
     }
 }

--- a/test/EFCore.Tests/Storage/ValueConversion/CharToStringConverterTest.cs
+++ b/test/EFCore.Tests/Storage/ValueConversion/CharToStringConverterTest.cs
@@ -38,7 +38,7 @@ public class CharToStringConverterTest
         Assert.Equal('F', converter("Funkadelic"));
         Assert.Equal('\0', converter(""));
 
-        Assert.Throws<NullReferenceException>(() => converter(null));
+        Assert.Throws<NullReferenceException>(() => converter(null!));
     }
 
     [Fact]

--- a/test/EFCore.Tests/Storage/ValueConversion/DateOnlyConvertersTest.cs
+++ b/test/EFCore.Tests/Storage/ValueConversion/DateOnlyConvertersTest.cs
@@ -24,7 +24,7 @@ public class DateOnlyConvertersTest
         Assert.Equal(new DateOnly(1973, 9, 3), converter("1973-09-03"));
         Assert.Equal(new DateOnly(), converter("0001-01-01"));
 
-        Assert.Throws<ArgumentNullException>(() => converter(null));
+        Assert.Throws<ArgumentNullException>(() => converter(null!));
         Assert.Throws<FormatException>(() => converter("Not a DateOnly"));
     }
 

--- a/test/EFCore.Tests/Storage/ValueConversion/DateTimeConvertersTest.cs
+++ b/test/EFCore.Tests/Storage/ValueConversion/DateTimeConvertersTest.cs
@@ -220,7 +220,7 @@ public class DateTimeConvertersTest
         Assert.NotEqual(DateTimeKind.Utc, converter("1973-09-03 00:10:15").Kind);
         Assert.Equal(new DateTime(), converter("0001-01-01 00:00:00"));
 
-        Assert.Throws<ArgumentNullException>(() => converter(null));
+        Assert.Throws<ArgumentNullException>(() => converter(null!));
         Assert.Throws<FormatException>(() => converter("Not a DateTime"));
     }
 

--- a/test/EFCore.Tests/Storage/ValueConversion/DateTimeOffsetConvertersTest.cs
+++ b/test/EFCore.Tests/Storage/ValueConversion/DateTimeOffsetConvertersTest.cs
@@ -34,7 +34,7 @@ public class DateTimeOffsetConvertersTest
             new DateTimeOffset(),
             converter("0001-01-01 00:00:00+00:00"));
 
-        Assert.Throws<ArgumentNullException>(() => converter(null));
+        Assert.Throws<ArgumentNullException>(() => converter(null!));
         Assert.Throws<FormatException>(() => converter("Not a DateTimeOffset"));
     }
 
@@ -101,7 +101,7 @@ public class DateTimeOffsetConvertersTest
             converter([0, 0, 0, 0, 0, 0, 0, 0, 0, 0]));
 
         Assert.Equal(new DateTimeOffset(), converter([]));
-        Assert.Throws<NullReferenceException>(() => converter(null));
+        Assert.Throws<NullReferenceException>(() => converter(null!));
         Assert.Throws<IndexOutOfRangeException>(() => converter([1, 2]));
     }
 

--- a/test/EFCore.Tests/Storage/ValueConversion/EnumToStringConverterTest.cs
+++ b/test/EFCore.Tests/Storage/ValueConversion/EnumToStringConverterTest.cs
@@ -51,7 +51,7 @@ public class EnumToStringConverterTest
         Assert.Equal(default, converter("0"));
         Assert.Equal(default, converter(""));
 
-        Assert.Throws<ArgumentNullException>(() => converter(null));
+        Assert.Throws<ArgumentNullException>(() => converter(null!));
 
         Assert.Equal(
             CoreStrings.CannotConvertEnumValue("Jon", "Beatles"),

--- a/test/EFCore.Tests/Storage/ValueConversion/GuidToBytesConverterTest.cs
+++ b/test/EFCore.Tests/Storage/ValueConversion/GuidToBytesConverterTest.cs
@@ -66,7 +66,7 @@ public class GuidToBytesConverterTest
 
         Assert.Throws<ArgumentException>(() => converter([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]));
 
-        Assert.Throws<ArgumentNullException>(() => converter(null));
+        Assert.Throws<ArgumentNullException>(() => converter(null!));
     }
 
     [Fact]

--- a/test/EFCore.Tests/Storage/ValueConversion/GuidToStringConverterTest.cs
+++ b/test/EFCore.Tests/Storage/ValueConversion/GuidToStringConverterTest.cs
@@ -35,7 +35,7 @@ public class GuidToStringConverterTest
             converter("00000000-0000-0000-0000-000000000000"));
 
         Assert.Throws<FormatException>(() => converter("Not a GUID"));
-        Assert.Throws<ArgumentNullException>(() => converter(null));
+        Assert.Throws<ArgumentNullException>(() => converter(null!));
     }
 
     [Fact]

--- a/test/EFCore.Tests/Storage/ValueConversion/NumberToBytesConverterTest.cs
+++ b/test/EFCore.Tests/Storage/ValueConversion/NumberToBytesConverterTest.cs
@@ -21,7 +21,7 @@ public class NumberToBytesConverterTest
         var converter = _byteToBytesConverter.ConvertFromProviderExpression.Compile();
 
         Assert.Equal(7, converter([7]));
-        Assert.Equal(0, converter(null));
+        Assert.Equal(0, converter(null!));
     }
 
     [Fact]
@@ -45,7 +45,7 @@ public class NumberToBytesConverterTest
         var converter = _nullableByteToBytesConverter.ConvertFromProviderExpression.Compile();
 
         Assert.Equal((byte?)7, converter([7]));
-        Assert.Null(converter(null));
+        Assert.Null(converter(null!));
     }
 
     [Fact]
@@ -70,7 +70,7 @@ public class NumberToBytesConverterTest
 
         Assert.Equal(7777, converter([30, 97]));
         Assert.Equal(-7777, converter([225, 159]));
-        Assert.Equal(0, converter(null));
+        Assert.Equal(0, converter(null!));
     }
 
     private static readonly NumberToBytesConverter<int> _intToBytesConverter = new();
@@ -91,7 +91,7 @@ public class NumberToBytesConverterTest
 
         Assert.Equal(77777777, converter([4, 162, 203, 113]));
         Assert.Equal(-77777777, converter([251, 93, 52, 143]));
-        Assert.Equal(0, converter(null));
+        Assert.Equal(0, converter(null!));
     }
 
     private static readonly NumberToBytesConverter<int?> _nullableIntToBytesConverter = new();
@@ -113,7 +113,7 @@ public class NumberToBytesConverterTest
 
         Assert.Equal(77777777, converter([4, 162, 203, 113]));
         Assert.Equal(-77777777, converter([251, 93, 52, 143]));
-        Assert.Null(converter(null));
+        Assert.Null(converter(null!));
     }
 
     private static readonly NumberToBytesConverter<long> _longToBytesConverter = new();
@@ -134,7 +134,7 @@ public class NumberToBytesConverterTest
 
         Assert.Equal(777777777777, converter([0, 0, 0, 181, 23, 43, 12, 113]));
         Assert.Equal(-777777777777, converter([255, 255, 255, 74, 232, 212, 243, 143]));
-        Assert.Equal(0, converter(null));
+        Assert.Equal(0, converter(null!));
     }
 
     private static readonly NumberToBytesConverter<sbyte> _sbyteToBytesConverter = new();
@@ -155,7 +155,7 @@ public class NumberToBytesConverterTest
 
         Assert.Equal(7, converter([7]));
         Assert.Equal(-7, converter([249]));
-        Assert.Equal(0, converter(null));
+        Assert.Equal(0, converter(null!));
     }
 
     private static readonly NumberToBytesConverter<sbyte?> _nullableSbyteToBytesConverter = new();
@@ -177,7 +177,7 @@ public class NumberToBytesConverterTest
 
         Assert.Equal((sbyte?)7, converter([7]));
         Assert.Equal((sbyte?)-7, converter([249]));
-        Assert.Null(converter(null));
+        Assert.Null(converter(null!));
     }
 
     private static readonly NumberToBytesConverter<ushort> _ushortToBytesConverter = new();
@@ -196,7 +196,7 @@ public class NumberToBytesConverterTest
         var converter = _ushortToBytesConverter.ConvertFromProviderExpression.Compile();
 
         Assert.Equal(7777, converter([30, 97]));
-        Assert.Equal(0, converter(null));
+        Assert.Equal(0, converter(null!));
     }
 
     [Fact]
@@ -219,7 +219,7 @@ public class NumberToBytesConverterTest
         var converter = _uintToBytesConverter.ConvertFromProviderExpression.Compile();
 
         Assert.Equal((uint)77777777, converter([4, 162, 203, 113]));
-        Assert.Equal((uint)0, converter(null));
+        Assert.Equal((uint)0, converter(null!));
     }
 
     private static readonly NumberToBytesConverter<uint?> _nullableUintToBytesConverter = new();
@@ -239,7 +239,7 @@ public class NumberToBytesConverterTest
         var converter = _nullableUintToBytesConverter.ConvertFromProviderExpression.Compile();
 
         Assert.Equal((uint?)77777777, converter([4, 162, 203, 113]));
-        Assert.Null(converter(null));
+        Assert.Null(converter(null!));
     }
 
     [Fact]
@@ -262,7 +262,7 @@ public class NumberToBytesConverterTest
         var converter = _ulongToBytesConverter.ConvertFromProviderExpression.Compile();
 
         Assert.Equal((ulong)777777777777, converter([0, 0, 0, 181, 23, 43, 12, 113]));
-        Assert.Equal((ulong)0, converter(null));
+        Assert.Equal((ulong)0, converter(null!));
     }
 
     [Fact]
@@ -285,7 +285,7 @@ public class NumberToBytesConverterTest
         var converter = _charToBytesConverter.ConvertFromProviderExpression.Compile();
 
         Assert.Equal('A', converter([0, 65]));
-        Assert.Equal(0, converter(null));
+        Assert.Equal(0, converter(null!));
     }
 
     [Fact]
@@ -419,7 +419,7 @@ public class NumberToBytesConverterTest
         Assert.Equal(
             (decimal?)-0.00000000000000000001,
             converter([0x80, 0x14, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01]));
-        Assert.Null(converter(null));
+        Assert.Null(converter(null!));
     }
 
     private static readonly NumberToBytesConverter<float> _floatToBytesConverter = new();
@@ -440,7 +440,7 @@ public class NumberToBytesConverterTest
 
         Assert.Equal((float)777.77, converter([68, 66, 113, 72]));
         Assert.Equal((float)-777.77, converter([196, 66, 113, 72]));
-        Assert.Equal(0, converter(null));
+        Assert.Equal(0, converter(null!));
     }
 
     private static readonly NumberToBytesConverter<double> _doubleToBytesConverter = new();
@@ -461,7 +461,7 @@ public class NumberToBytesConverterTest
 
         Assert.Equal(7777777.77777, converter([65, 93, 171, 124, 113, 198, 251, 210]));
         Assert.Equal(-7777777.77777, converter([193, 93, 171, 124, 113, 198, 251, 210]));
-        Assert.Equal(0, converter(null));
+        Assert.Equal(0, converter(null!));
     }
 
     [Fact]

--- a/test/EFCore.Tests/Storage/ValueConversion/NumberToStringConverterTest.cs
+++ b/test/EFCore.Tests/Storage/ValueConversion/NumberToStringConverterTest.cs
@@ -42,7 +42,7 @@ public class NumberToStringConverterTest
 
         Assert.Throws<OverflowException>(() => converter("-1"));
         Assert.Throws<FormatException>(() => converter("Not a number"));
-        Assert.Throws<ArgumentNullException>(() => converter(null));
+        Assert.Throws<ArgumentNullException>(() => converter(null!));
     }
 
     [Fact]
@@ -101,7 +101,7 @@ public class NumberToStringConverterTest
         Assert.Throws<OverflowException>(() => converter("-9223372036854775809"));
         Assert.Throws<OverflowException>(() => converter("9223372036854775808"));
         Assert.Throws<FormatException>(() => converter("Not a number"));
-        Assert.Throws<ArgumentNullException>(() => converter(null));
+        Assert.Throws<ArgumentNullException>(() => converter(null!));
     }
 
     [Fact]
@@ -157,7 +157,7 @@ public class NumberToStringConverterTest
         Assert.Throws<OverflowException>(() => converter("-1"));
         Assert.Throws<OverflowException>(() => converter("4294967296"));
         Assert.Throws<FormatException>(() => converter("Not a number"));
-        Assert.Throws<ArgumentNullException>(() => converter(null));
+        Assert.Throws<ArgumentNullException>(() => converter(null!));
     }
 
     [Fact]
@@ -217,7 +217,7 @@ public class NumberToStringConverterTest
         Assert.Throws<OverflowException>(() => converter("-2147483649"));
         Assert.Throws<OverflowException>(() => converter("2147483648"));
         Assert.Throws<FormatException>(() => converter("Not a number"));
-        Assert.Throws<ArgumentNullException>(() => converter(null));
+        Assert.Throws<ArgumentNullException>(() => converter(null!));
     }
 
     [Fact]
@@ -272,7 +272,7 @@ public class NumberToStringConverterTest
         Assert.Throws<OverflowException>(() => converter("-1"));
         Assert.Throws<OverflowException>(() => converter("65536"));
         Assert.Throws<FormatException>(() => converter("Not a number"));
-        Assert.Throws<ArgumentNullException>(() => converter(null));
+        Assert.Throws<ArgumentNullException>(() => converter(null!));
     }
 
     [Fact]
@@ -332,7 +332,7 @@ public class NumberToStringConverterTest
         Assert.Throws<OverflowException>(() => converter("-32769"));
         Assert.Throws<OverflowException>(() => converter("32768"));
         Assert.Throws<FormatException>(() => converter("Not a number"));
-        Assert.Throws<ArgumentNullException>(() => converter(null));
+        Assert.Throws<ArgumentNullException>(() => converter(null!));
     }
 
     [Fact]
@@ -387,7 +387,7 @@ public class NumberToStringConverterTest
 
         Assert.Throws<OverflowException>(() => converter("-1"));
         Assert.Throws<OverflowException>(() => converter("256"));
-        Assert.Throws<ArgumentNullException>(() => converter(null));
+        Assert.Throws<ArgumentNullException>(() => converter(null!));
     }
 
     [Fact]
@@ -446,7 +446,7 @@ public class NumberToStringConverterTest
         Assert.Throws<OverflowException>(() => converter("-129"));
         Assert.Throws<OverflowException>(() => converter("128"));
         Assert.Throws<FormatException>(() => converter("Not a number"));
-        Assert.Throws<ArgumentNullException>(() => converter(null));
+        Assert.Throws<ArgumentNullException>(() => converter(null!));
     }
 
     [Fact]
@@ -496,7 +496,7 @@ public class NumberToStringConverterTest
         Assert.Throws<OverflowException>(() => converter("-79228162514264337593543950336"));
         Assert.Throws<OverflowException>(() => converter("79228162514264337593543950336"));
         Assert.Throws<FormatException>(() => converter("Not a number"));
-        Assert.Throws<ArgumentNullException>(() => converter(null));
+        Assert.Throws<ArgumentNullException>(() => converter(null!));
     }
 
     [Fact]
@@ -560,7 +560,7 @@ public class NumberToStringConverterTest
         Assert.Equal(double.PositiveInfinity, converter("1.7976931348623157E+309"));
         Assert.Equal(double.NegativeInfinity, converter("-1.7976931348623157E+309"));
         Assert.Throws<FormatException>(() => converter("Not a number"));
-        Assert.Throws<ArgumentNullException>(() => converter(null));
+        Assert.Throws<ArgumentNullException>(() => converter(null!));
     }
 
     [Fact]
@@ -624,7 +624,7 @@ public class NumberToStringConverterTest
         Assert.Equal(float.PositiveInfinity, converter("3.40282347E+39"));
         Assert.Equal(float.NegativeInfinity, converter("-3.40282347E+39"));
         Assert.Throws<FormatException>(() => converter("Not a number"));
-        Assert.Throws<ArgumentNullException>(() => converter(null));
+        Assert.Throws<ArgumentNullException>(() => converter(null!));
     }
 
     [Fact]
@@ -700,7 +700,7 @@ public class NumberToStringConverterTest
         Assert.Throws<OverflowException>(() => converter("-129"));
         Assert.Throws<OverflowException>(() => converter("128"));
         Assert.Throws<FormatException>(() => converter("Not a number"));
-        Assert.Null(converter(null));
+        Assert.Null(converter(null!));
     }
 
     [Fact]

--- a/test/EFCore.Tests/Storage/ValueConversion/StringToBoolConverterTest.cs
+++ b/test/EFCore.Tests/Storage/ValueConversion/StringToBoolConverterTest.cs
@@ -16,7 +16,7 @@ public class StringToBoolConverterTest
         Assert.True(converter("True"));
         Assert.False(converter("false"));
         Assert.True(converter("true"));
-        Assert.False(converter(null));
+        Assert.False(converter(null!));
     }
 
     [Fact]
@@ -33,10 +33,10 @@ public class StringToBoolConverterTest
     {
         var converter = _stringToBool.ConvertToProvider;
 
-        Assert.False((bool)converter("False"));
-        Assert.True((bool)converter("True"));
-        Assert.False((bool)converter("false"));
-        Assert.True((bool)converter("true"));
+        Assert.False((bool)converter("False")!);
+        Assert.True((bool)converter("True")!);
+        Assert.False((bool)converter("false")!);
+        Assert.True((bool)converter("true")!);
         Assert.Null(converter(null));
     }
 

--- a/test/EFCore.Tests/Storage/ValueConversion/StringToCharConverterTest.cs
+++ b/test/EFCore.Tests/Storage/ValueConversion/StringToCharConverterTest.cs
@@ -17,7 +17,7 @@ public class StringToCharConverterTest
         Assert.Equal('F', converter("Funkadelic"));
         Assert.Equal('\0', converter(""));
 
-        Assert.Throws<NullReferenceException>(() => converter(null));
+        Assert.Throws<NullReferenceException>(() => converter(null!));
     }
 
     [Fact]

--- a/test/EFCore.Tests/Storage/ValueConversion/StringToDateTimeConverterTest.cs
+++ b/test/EFCore.Tests/Storage/ValueConversion/StringToDateTimeConverterTest.cs
@@ -19,7 +19,7 @@ public class StringToDateTimeConverterTest
         Assert.Equal(new DateTime(), converter("0001-01-01 00:00:00"));
 
         Assert.Throws<FormatException>(() => converter("Not a DateTime"));
-        Assert.Throws<ArgumentNullException>(() => converter(null));
+        Assert.Throws<ArgumentNullException>(() => converter(null!));
     }
 
     [Fact]

--- a/test/EFCore.Tests/Storage/ValueConversion/StringToDateTimeOffsetConverterTest.cs
+++ b/test/EFCore.Tests/Storage/ValueConversion/StringToDateTimeOffsetConverterTest.cs
@@ -20,7 +20,7 @@ public class StringToDateTimeOffsetConverterTest
             new DateTimeOffset(), converter("0001-01-01 00:00:00+00:00"));
 
         Assert.Throws<FormatException>(() => converter("Not a DateTime"));
-        Assert.Throws<ArgumentNullException>(() => converter(null));
+        Assert.Throws<ArgumentNullException>(() => converter(null!));
     }
 
     [Fact]

--- a/test/EFCore.Tests/Storage/ValueConversion/StringToEnumConverterTest.cs
+++ b/test/EFCore.Tests/Storage/ValueConversion/StringToEnumConverterTest.cs
@@ -24,7 +24,7 @@ public class StringToEnumConverterTest
         Assert.Equal(default, converter("0"));
         Assert.Equal(default, converter(""));
 
-        Assert.Throws<ArgumentNullException>(() => converter(null));
+        Assert.Throws<ArgumentNullException>(() => converter(null!));
 
         Assert.Equal(
             CoreStrings.CannotConvertEnumValue("Jon", "Beatles"),

--- a/test/EFCore.Tests/Storage/ValueConversion/StringToGuidConverterTest.cs
+++ b/test/EFCore.Tests/Storage/ValueConversion/StringToGuidConverterTest.cs
@@ -20,7 +20,7 @@ public class StringToGuidConverterTest
             Guid.Empty,
             converter("00000000-0000-0000-0000-000000000000"));
 
-        Assert.Throws<ArgumentNullException>(() => converter(null));
+        Assert.Throws<ArgumentNullException>(() => converter(null!));
         Assert.Throws<FormatException>(() => converter("Not a GUID"));
     }
 

--- a/test/EFCore.Tests/Storage/ValueConversion/StringToNumberConverterTest.cs
+++ b/test/EFCore.Tests/Storage/ValueConversion/StringToNumberConverterTest.cs
@@ -20,7 +20,7 @@ public class StringToNumberConverterTest
 
         Assert.Throws<OverflowException>(() => converter("-1"));
         Assert.Throws<FormatException>(() => converter("Not a number"));
-        Assert.Throws<ArgumentNullException>(() => converter(null));
+        Assert.Throws<ArgumentNullException>(() => converter(null!));
     }
 
     [Fact]
@@ -75,7 +75,7 @@ public class StringToNumberConverterTest
         Assert.Throws<OverflowException>(() => converter("-9223372036854775809"));
         Assert.Throws<OverflowException>(() => converter("9223372036854775808"));
         Assert.Throws<FormatException>(() => converter("Not a number"));
-        Assert.Throws<ArgumentNullException>(() => converter(null));
+        Assert.Throws<ArgumentNullException>(() => converter(null!));
     }
 
     [Fact]
@@ -135,7 +135,7 @@ public class StringToNumberConverterTest
         Assert.Throws<OverflowException>(() => converter("-1"));
         Assert.Throws<OverflowException>(() => converter("4294967296"));
         Assert.Throws<FormatException>(() => converter("Not a number"));
-        Assert.Throws<ArgumentNullException>(() => converter(null));
+        Assert.Throws<ArgumentNullException>(() => converter(null!));
     }
 
     [Fact]
@@ -191,7 +191,7 @@ public class StringToNumberConverterTest
         Assert.Throws<OverflowException>(() => converter("-2147483649"));
         Assert.Throws<OverflowException>(() => converter("2147483648"));
         Assert.Throws<FormatException>(() => converter("Not a number"));
-        Assert.Throws<ArgumentNullException>(() => converter(null));
+        Assert.Throws<ArgumentNullException>(() => converter(null!));
     }
 
     [Fact]
@@ -250,7 +250,7 @@ public class StringToNumberConverterTest
         Assert.Throws<OverflowException>(() => converter("-1"));
         Assert.Throws<OverflowException>(() => converter("65536"));
         Assert.Throws<FormatException>(() => converter("Not a number"));
-        Assert.Throws<ArgumentNullException>(() => converter(null));
+        Assert.Throws<ArgumentNullException>(() => converter(null!));
     }
 
     [Fact]
@@ -306,7 +306,7 @@ public class StringToNumberConverterTest
         Assert.Throws<OverflowException>(() => converter("-32769"));
         Assert.Throws<OverflowException>(() => converter("32768"));
         Assert.Throws<FormatException>(() => converter("Not a number"));
-        Assert.Throws<ArgumentNullException>(() => converter(null));
+        Assert.Throws<ArgumentNullException>(() => converter(null!));
     }
 
     [Fact]
@@ -365,7 +365,7 @@ public class StringToNumberConverterTest
 
         Assert.Throws<OverflowException>(() => converter("-1"));
         Assert.Throws<OverflowException>(() => converter("256"));
-        Assert.Throws<ArgumentNullException>(() => converter(null));
+        Assert.Throws<ArgumentNullException>(() => converter(null!));
     }
 
     [Fact]
@@ -420,7 +420,7 @@ public class StringToNumberConverterTest
         Assert.Throws<OverflowException>(() => converter("-129"));
         Assert.Throws<OverflowException>(() => converter("128"));
         Assert.Throws<FormatException>(() => converter("Not a number"));
-        Assert.Throws<ArgumentNullException>(() => converter(null));
+        Assert.Throws<ArgumentNullException>(() => converter(null!));
     }
 
     [Fact]
@@ -483,7 +483,7 @@ public class StringToNumberConverterTest
         Assert.Throws<OverflowException>(() => converter("-79228162514264337593543950336"));
         Assert.Throws<OverflowException>(() => converter("79228162514264337593543950336"));
         Assert.Throws<FormatException>(() => converter("Not a number"));
-        Assert.Throws<ArgumentNullException>(() => converter(null));
+        Assert.Throws<ArgumentNullException>(() => converter(null!));
     }
 
     [Fact]
@@ -516,7 +516,7 @@ public class StringToNumberConverterTest
         Assert.Equal(double.PositiveInfinity, converter("1.7976931348623157E+309"));
         Assert.Equal(double.NegativeInfinity, converter("-1.7976931348623157E+309"));
         Assert.Throws<FormatException>(() => converter("Not a number"));
-        Assert.Throws<ArgumentNullException>(() => converter(null));
+        Assert.Throws<ArgumentNullException>(() => converter(null!));
     }
 
     [Fact]
@@ -549,7 +549,7 @@ public class StringToNumberConverterTest
         Assert.Equal(float.PositiveInfinity, converter("3.40282347E+39"));
         Assert.Equal(float.NegativeInfinity, converter("-3.40282347E+39"));
         Assert.Throws<FormatException>(() => converter("Not a number"));
-        Assert.Throws<ArgumentNullException>(() => converter(null));
+        Assert.Throws<ArgumentNullException>(() => converter(null!));
     }
 
     [Fact]
@@ -581,7 +581,7 @@ public class StringToNumberConverterTest
         Assert.Throws<OverflowException>(() => converter("-129"));
         Assert.Throws<OverflowException>(() => converter("128"));
         Assert.Throws<FormatException>(() => converter("Not a number"));
-        Assert.Null(converter(null));
+        Assert.Null(converter(null!));
     }
 
     [Fact]

--- a/test/EFCore.Tests/Storage/ValueConversion/StringToTimeSpanConverterTest.cs
+++ b/test/EFCore.Tests/Storage/ValueConversion/StringToTimeSpanConverterTest.cs
@@ -18,7 +18,7 @@ public class StringToTimeSpanConverterTest
 
         Assert.Equal(new TimeSpan(), converter("00:00:00"));
 
-        Assert.Throws<ArgumentNullException>(() => converter(null));
+        Assert.Throws<ArgumentNullException>(() => converter(null!));
         Assert.Throws<FormatException>(() => converter("Not a TimeSpan"));
     }
 

--- a/test/EFCore.Tests/Storage/ValueConversion/TimeOnlyConvertersTest.cs
+++ b/test/EFCore.Tests/Storage/ValueConversion/TimeOnlyConvertersTest.cs
@@ -30,7 +30,7 @@ public class TimeOnlyConvertersTest
         Assert.Equal(new TimeOnly(7, 30, 15, 333, 444).Add(new TimeSpan(5)), converter("07:30:15.3334445"));
         Assert.Equal(new TimeOnly(), converter("00:00:00"));
 
-        Assert.Throws<ArgumentNullException>(() => converter(null));
+        Assert.Throws<ArgumentNullException>(() => converter(null!));
         Assert.Throws<FormatException>(() => converter("Not a TimeOnly"));
     }
 

--- a/test/EFCore.Tests/Storage/ValueConversion/TimeSpanConvertersTest.cs
+++ b/test/EFCore.Tests/Storage/ValueConversion/TimeSpanConvertersTest.cs
@@ -32,7 +32,7 @@ public class TimeSpanConvertersTest
 
         Assert.Equal(new TimeSpan(), converter("00:00:00"));
 
-        Assert.Throws<ArgumentNullException>(() => converter(null));
+        Assert.Throws<ArgumentNullException>(() => converter(null!));
         Assert.Throws<FormatException>(() => converter("Not a timespan"));
     }
 

--- a/test/EFCore.Tests/Storage/ValueConversion/ValueConverterSelectorTest.cs
+++ b/test/EFCore.Tests/Storage/ValueConversion/ValueConverterSelectorTest.cs
@@ -629,7 +629,7 @@ public class ValueConverterSelectorTest
 
     private static void AssertConverters(
         IList<ValueConverterInfo> converterInfos,
-        params (Type InfoType, ConverterMappingHints Hints)[] converterTypes)
+        params (Type InfoType, ConverterMappingHints? Hints)[] converterTypes)
     {
         Assert.Equal(converterTypes.Length, converterInfos.Count);
 
@@ -642,7 +642,7 @@ public class ValueConverterSelectorTest
         }
     }
 
-    private static void AssertHints(ConverterMappingHints expected, ConverterMappingHints actual)
+    private static void AssertHints(ConverterMappingHints? expected, ConverterMappingHints? actual)
     {
         Assert.Equal(actual?.IsUnicode, expected?.IsUnicode);
         Assert.Equal(actual?.Precision, expected?.Precision);

--- a/test/EFCore.Tests/Storage/ValueConversion/ValueConverterTest.cs
+++ b/test/EFCore.Tests/Storage/ValueConversion/ValueConverterTest.cs
@@ -27,6 +27,7 @@ public class ValueConverterTest
         using (var context = new InMemoryConvertersContext())
         {
             var person = context.Set<Person>().Find(async ? 1L : 2L);
+            Assert.NotNull(person);
 
             Assert.Equal(DateTimeKind.Utc, person.ConvertedGoingIn.Kind);
             Assert.Equal(new DateTime(2015, 1, 10, 8, 8, 8, DateTimeKind.Utc), person.ConvertedGoingIn);
@@ -223,7 +224,7 @@ public class ValueConverterTest
             {
                 var converter = (ValueConverter)Activator.CreateInstance(
                     typeof(CastingConverter<,>).MakeGenericType(fromType, toType),
-                    [null]);
+                    [null])!;
 
                 var resultToProvider = Expression.Lambda<Func<object>>(
                         Expression.Convert(
@@ -367,7 +368,7 @@ public class ValueConverterTest
 
     private class BytesComparer : IComparer<byte[]>
     {
-        public int Compare(byte[] x, byte[] y)
+        public int Compare(byte[]? x, byte[]? y)
             => StructuralComparisons.StructuralComparer.Compare(x, y);
     }
 }

--- a/test/EFCore.Tests/TestUtilities/FakeStateManager.cs
+++ b/test/EFCore.Tests/TestUtilities/FakeStateManager.cs
@@ -8,7 +8,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities;
 
 public class FakeStateManager : IStateManager
 {
-    public IEnumerable<InternalEntityEntry> InternalEntries { get; set; }
+    public IEnumerable<InternalEntityEntry>? InternalEntries { get; set; }
     public bool SaveChangesCalled { get; set; }
     public bool SaveChangesAsyncCalled { get; set; }
 
@@ -23,15 +23,15 @@ public class FakeStateManager : IStateManager
     {
     }
 
-    public (EventHandler<EntityTrackingEventArgs> Tracking, EventHandler<EntityTrackedEventArgs> Tracked,
-        EventHandler<EntityStateChangingEventArgs> StateChanging, EventHandler<EntityStateChangedEventArgs> StateChanged) CaptureEvents()
+    public (EventHandler<EntityTrackingEventArgs>? Tracking, EventHandler<EntityTrackedEventArgs>? Tracked,
+        EventHandler<EntityStateChangingEventArgs>? StateChanging, EventHandler<EntityStateChangedEventArgs>? StateChanged) CaptureEvents()
         => (null, null, null, null);
 
     public void SetEvents(
-        EventHandler<EntityTrackingEventArgs> tracking,
-        EventHandler<EntityTrackedEventArgs> tracked,
-        EventHandler<EntityStateChangingEventArgs> stateChanging,
-        EventHandler<EntityStateChangedEventArgs> stateChanged)
+        EventHandler<EntityTrackingEventArgs>? tracking,
+        EventHandler<EntityTrackedEventArgs>? tracked,
+        EventHandler<EntityStateChangingEventArgs>? stateChanging,
+        EventHandler<EntityStateChangedEventArgs>? stateChanged)
     {
     }
 
@@ -74,7 +74,7 @@ public class FakeStateManager : IStateManager
     public int Count
         => throw new NotImplementedException();
 
-    public IDiagnosticsLogger<DbLoggerCategory.Update> UpdateLogger { get; }
+    public IDiagnosticsLogger<DbLoggerCategory.Update> UpdateLogger { get; } = null!;
 
     public void Clear(bool resetting)
         => throw new NotImplementedException();
@@ -118,20 +118,20 @@ public class FakeStateManager : IStateManager
     public virtual void AcceptAllChanges()
         => throw new NotImplementedException();
 
-    public StateManagerDependencies Dependencies { get; }
+    public StateManagerDependencies Dependencies { get; } = null!;
     public CascadeTiming DeleteOrphansTiming { get; set; }
     public CascadeTiming CascadeDeleteTiming { get; set; }
 
     public InternalEntityEntry GetOrCreateEntry(object entity)
         => throw new NotImplementedException();
 
-    public InternalEntityEntry GetOrCreateEntry(object entity, IEntityType entityType)
+    public InternalEntityEntry GetOrCreateEntry(object entity, IEntityType? entityType)
         => throw new NotImplementedException();
 
-    public InternalEntityEntry CreateEntry(IDictionary<string, object> values, IEntityType entityType)
+    public InternalEntityEntry CreateEntry(IDictionary<string, object?> values, IEntityType entityType)
         => throw new NotImplementedException();
 
-    public InternalEntityEntry CreateEntry(IReadOnlyDictionary<IProperty, object> values, IEntityType entityType)
+    public InternalEntityEntry CreateEntry(IReadOnlyDictionary<IProperty, object?> values, IEntityType entityType)
         => throw new NotImplementedException();
 
     public InternalEntityEntry StartTrackingFromQuery(
@@ -140,7 +140,7 @@ public class FakeStateManager : IStateManager
         in ISnapshot snapshot)
         => throw new NotImplementedException();
 
-    public InternalEntityEntry TryGetEntry(IKey key, IReadOnlyList<object> keyValues)
+    public InternalEntityEntry? TryGetEntry(IKey key, IReadOnlyList<object?> keyValues)
         => throw new NotImplementedException();
 
     public InternalEntityEntry TryGetEntryTyped<TKey>(IKey key, TKey keyValue)
@@ -167,7 +167,7 @@ public class FakeStateManager : IStateManager
     public IValueGenerationManager ValueGenerationManager
         => throw new NotImplementedException();
 
-    public IStructuralTypeMaterializerSource EntityMaterializerSource { get; }
+    public IStructuralTypeMaterializerSource EntityMaterializerSource { get; } = null!;
 
     public InternalEntityEntry StartTracking(InternalEntityEntry entry)
         => throw new NotImplementedException();
@@ -190,8 +190,8 @@ public class FakeStateManager : IStateManager
 
     public bool ResolveToExistingEntry(
         InternalEntityEntry newEntry,
-        INavigationBase navigation,
-        InternalEntityEntry referencedFromEntry)
+        INavigationBase? navigation,
+        InternalEntityEntry? referencedFromEntry)
         => throw new NotImplementedException();
 
     public IEnumerable<Tuple<INavigationBase, InternalEntityEntry>> GetRecordedReferrers(object referencedEntity, bool clear)
@@ -225,35 +225,35 @@ public class FakeStateManager : IStateManager
     public IModel Model
         => throw new NotImplementedException();
 
-    public event EventHandler<EntityTrackingEventArgs> Tracking;
+    public event EventHandler<EntityTrackingEventArgs>? Tracking;
 
     public void OnTracking(InternalEntityEntry internalEntityEntry, EntityState state, bool fromQuery)
-        => Tracking?.Invoke(null, null);
+        => Tracking?.Invoke(null, null!);
 
-    public event EventHandler<EntityTrackedEventArgs> Tracked;
+    public event EventHandler<EntityTrackedEventArgs>? Tracked;
 
     public void OnTracked(InternalEntityEntry internalEntityEntry, bool fromQuery)
-        => Tracked?.Invoke(null, null);
+        => Tracked?.Invoke(null, null!);
 
-    public event EventHandler<EntityStateChangingEventArgs> StateChanging;
+    public event EventHandler<EntityStateChangingEventArgs>? StateChanging;
 
     public void OnStateChanging(InternalEntityEntry internalEntityEntry, EntityState newState)
-        => StateChanging?.Invoke(null, null);
+        => StateChanging?.Invoke(null, null!);
 
-    public event EventHandler<EntityStateChangedEventArgs> StateChanged;
+    public event EventHandler<EntityStateChangedEventArgs>? StateChanged;
 
     public void OnStateChanged(InternalEntityEntry internalEntityEntry, EntityState oldState)
-        => StateChanged?.Invoke(null, null);
+        => StateChanged?.Invoke(null, null!);
 
     public bool SensitiveLoggingEnabled { get; }
 
     public void CascadeChanges(bool force)
         => throw new NotImplementedException();
 
-    public void CascadeDelete(InternalEntityEntry entry, bool force, IEnumerable<IForeignKey> foreignKeys = null)
+    public void CascadeDelete(InternalEntityEntry entry, bool force, IEnumerable<IForeignKey>? foreignKeys = null)
         => throw new NotImplementedException();
 
-    public InternalEntityEntry TryGetEntry(IKey key, object[] keyValues, bool throwOnNullKey, out bool hasNullKey)
+    public InternalEntityEntry? TryGetEntry(IKey key, object?[] keyValues, bool throwOnNullKey, out bool hasNullKey)
         => throw new NotImplementedException();
 
     public InternalComplexEntry StartTracking(InternalComplexEntry entry)

--- a/test/EFCore.Tests/TestUtilities/TestInMemoryTransactionManager.cs
+++ b/test/EFCore.Tests/TestUtilities/TestInMemoryTransactionManager.cs
@@ -9,13 +9,13 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities;
 public class TestInMemoryTransactionManager(
     IDiagnosticsLogger<DbLoggerCategory.Database.Transaction> logger) : InMemoryTransactionManager(logger)
 {
-    private IDbContextTransaction _currentTransaction;
-    private Transaction _enlistedTransaction;
+    private IDbContextTransaction? _currentTransaction;
+    private Transaction? _enlistedTransaction;
 
-    public override IDbContextTransaction CurrentTransaction
+    public override IDbContextTransaction? CurrentTransaction
         => _currentTransaction;
 
-    public override Transaction EnlistedTransaction
+    public override Transaction? EnlistedTransaction
         => _enlistedTransaction;
 
     public override IDbContextTransaction BeginTransaction()
@@ -25,18 +25,18 @@ public class TestInMemoryTransactionManager(
         => Task.FromResult(_currentTransaction = new TestInMemoryTransaction(this));
 
     public override void CommitTransaction()
-        => CurrentTransaction.Commit();
+        => CurrentTransaction!.Commit();
 
     public override Task CommitTransactionAsync(CancellationToken cancellationToken = default)
-        => CurrentTransaction.CommitAsync(cancellationToken);
+        => CurrentTransaction!.CommitAsync(cancellationToken);
 
     public override void RollbackTransaction()
-        => CurrentTransaction.Rollback();
+        => CurrentTransaction!.Rollback();
 
     public override Task RollbackTransactionAsync(CancellationToken cancellationToken = default)
-        => CurrentTransaction.RollbackAsync(cancellationToken);
+        => CurrentTransaction!.RollbackAsync(cancellationToken);
 
-    public override void EnlistTransaction(Transaction transaction)
+    public override void EnlistTransaction(Transaction? transaction)
         => _enlistedTransaction = transaction;
 
     private class TestInMemoryTransaction(TestInMemoryTransactionManager transactionManager) : IDbContextTransaction

--- a/test/EFCore.Tests/Utilities/CheckTest.cs
+++ b/test/EFCore.Tests/Utilities/CheckTest.cs
@@ -8,7 +8,7 @@ namespace Microsoft.EntityFrameworkCore.Utilities;
 public class CheckTest
 {
     [Theory, InlineData(null)]
-    public void Not_null_throws_when_arg_is_null(string arg1)
+    public void Not_null_throws_when_arg_is_null(string? arg1)
         => Assert.Equal(nameof(arg1), Assert.Throws<ArgumentNullException>(() => Check.NotNull(arg1)).ParamName);
 
     [Theory, InlineData(""), InlineData(" ")]
@@ -16,7 +16,7 @@ public class CheckTest
         => Assert.Equal(nameof(arg1), Assert.Throws<ArgumentException>(() => Check.NotEmpty(arg1)).ParamName);
 
     [Theory, InlineData(null)]
-    public void Generic_Not_empty_throws_when_arg_is_null(string[] arg1)
+    public void Generic_Not_empty_throws_when_arg_is_null(string[]? arg1)
         => Assert.Equal(nameof(arg1), Assert.Throws<ArgumentNullException>(() => Check.NotEmpty(arg1)).ParamName);
 
     [Theory, InlineData([new string[0]])]
@@ -27,11 +27,11 @@ public class CheckTest
     public void Not_but_not_empty_throws_when_arg_is_empty(string arg1)
         => Assert.Equal(nameof(arg1), Assert.Throws<ArgumentException>(() => Check.NullButNotEmpty(arg1)).ParamName);
 
-    [Theory, InlineData([new string[] { null }])]
+    [Theory, InlineData([new string[] { null! }])]
     public void Has_no_nulls_throws_when_arg_has_nulls(string[] arg1)
         => Assert.Equal(nameof(arg1), Assert.Throws<ArgumentException>(() => Check.HasNoNulls(arg1)).ParamName);
 
-    [Theory, InlineData([new string[] { null }]), InlineData([new[] { "" }]),
+    [Theory, InlineData([new string[] { null! }]), InlineData([new[] { "" }]),
      InlineData([new[] { " " }])]
     public void Has_no_empty_elements_throws_when_arg_has_empty_elements(string[] arg1)
         => Assert.Equal(nameof(arg1), Assert.Throws<ArgumentException>(() => Check.HasNoEmptyElements(arg1)).ParamName);

--- a/test/EFCore.Tests/Utilities/MultigraphTest.cs
+++ b/test/EFCore.Tests/Utilities/MultigraphTest.cs
@@ -28,7 +28,7 @@ public class MultigraphTest
 
     private class A
     {
-        public static readonly PropertyInfo PProperty = typeof(A).GetProperty("P");
+        public static readonly PropertyInfo PProperty = typeof(A).GetProperty("P")!;
 
         public int P { get; set; }
         public int P2 { get; set; }
@@ -36,7 +36,7 @@ public class MultigraphTest
 
     private class B
     {
-        public static readonly PropertyInfo PProperty = typeof(B).GetProperty("P");
+        public static readonly PropertyInfo PProperty = typeof(B).GetProperty("P")!;
 
         public int P { get; set; }
         public int P2 { get; set; }
@@ -44,7 +44,7 @@ public class MultigraphTest
 
     private class C
     {
-        public static readonly PropertyInfo PProperty = typeof(C).GetProperty("P");
+        public static readonly PropertyInfo PProperty = typeof(C).GetProperty("P")!;
 
         public int P { get; set; }
         public int P2 { get; set; }
@@ -52,7 +52,7 @@ public class MultigraphTest
 
     private class D
     {
-        public static readonly PropertyInfo PProperty = typeof(D).GetProperty("P");
+        public static readonly PropertyInfo PProperty = typeof(D).GetProperty("P")!;
 
         public int P { get; set; }
         public int P2 { get; set; }
@@ -60,7 +60,7 @@ public class MultigraphTest
 
     private class E
     {
-        public static readonly PropertyInfo PProperty = typeof(E).GetProperty("P");
+        public static readonly PropertyInfo PProperty = typeof(E).GetProperty("P")!;
 
         public int P { get; set; }
         public int P2 { get; set; }
@@ -365,7 +365,7 @@ public class MultigraphTest
         // 3 -> {1}
         graph.AddEdge(vertexThree, vertexOne, edgeThree);
 
-        Dictionary<Vertex, Tuple<Vertex, Vertex, IEnumerable<Edge>>> cycleData = null;
+        Dictionary<Vertex, Tuple<Vertex, Vertex, IEnumerable<Edge>>> cycleData = null!;
 
         string formatter(IEnumerable<Tuple<Vertex, Vertex, IEnumerable<Edge>>> data)
         {
@@ -460,7 +460,7 @@ public class MultigraphTest
         // 3 -> {1}
         graph.AddEdge(vertexThree, vertexOne, edgeThree);
 
-        Dictionary<Vertex, Tuple<Vertex, Vertex, IEnumerable<Edge>>> cycleData = null;
+        Dictionary<Vertex, Tuple<Vertex, Vertex, IEnumerable<Edge>>> cycleData = null!;
 
         string formatter(IEnumerable<Tuple<Vertex, Vertex, IEnumerable<Edge>>> data)
         {
@@ -511,7 +511,7 @@ public class MultigraphTest
         // 3 -> {4}
         graph.AddEdge(vertexThree, vertexFour, edgeFour);
 
-        Dictionary<Vertex, Tuple<Vertex, Vertex, IEnumerable<Edge>>> cycleData = null;
+        Dictionary<Vertex, Tuple<Vertex, Vertex, IEnumerable<Edge>>> cycleData = null!;
 
         string formatter(IEnumerable<Tuple<Vertex, Vertex, IEnumerable<Edge>>> data)
         {
@@ -547,8 +547,8 @@ public class MultigraphTest
         entityTypeC.SetPrimaryKey(entityTypeC.AddProperty("Id", typeof(int)));
 
         // B -> A -> C
-        entityTypeC.AddForeignKey(entityTypeC.AddProperty(C.PProperty), entityTypeA.FindPrimaryKey(), entityTypeA);
-        entityTypeA.AddForeignKey(entityTypeA.AddProperty(A.PProperty), entityTypeB.FindPrimaryKey(), entityTypeB);
+        entityTypeC.AddForeignKey(entityTypeC.AddProperty(C.PProperty), entityTypeA.FindPrimaryKey()!, entityTypeA);
+        entityTypeA.AddForeignKey(entityTypeA.AddProperty(A.PProperty), entityTypeB.FindPrimaryKey()!, entityTypeB);
 
         var graph = new EntityTypeGraph();
         graph.Populate(entityTypeA, entityTypeB, entityTypeC);
@@ -573,8 +573,8 @@ public class MultigraphTest
         entityTypeC.SetPrimaryKey(entityTypeC.AddProperty("Id", typeof(int)));
 
         // C -> B -> A
-        entityTypeA.AddForeignKey(entityTypeA.AddProperty(A.PProperty), entityTypeB.FindPrimaryKey(), entityTypeB);
-        entityTypeB.AddForeignKey(entityTypeB.AddProperty(B.PProperty), entityTypeC.FindPrimaryKey(), entityTypeC);
+        entityTypeA.AddForeignKey(entityTypeA.AddProperty(A.PProperty), entityTypeB.FindPrimaryKey()!, entityTypeB);
+        entityTypeB.AddForeignKey(entityTypeB.AddProperty(B.PProperty), entityTypeC.FindPrimaryKey()!, entityTypeC);
 
         var graph = new EntityTypeGraph();
         graph.Populate(entityTypeA, entityTypeB, entityTypeC);
@@ -599,8 +599,8 @@ public class MultigraphTest
         entityTypeC.SetPrimaryKey(entityTypeC.AddProperty("Id", typeof(int)));
 
         // B -> A -> C
-        entityTypeC.AddForeignKey(entityTypeC.AddProperty(C.PProperty), entityTypeA.FindPrimaryKey(), entityTypeA);
-        entityTypeA.AddForeignKey(entityTypeA.AddProperty(A.PProperty), entityTypeB.FindPrimaryKey(), entityTypeB);
+        entityTypeC.AddForeignKey(entityTypeC.AddProperty(C.PProperty), entityTypeA.FindPrimaryKey()!, entityTypeA);
+        entityTypeA.AddForeignKey(entityTypeA.AddProperty(A.PProperty), entityTypeB.FindPrimaryKey()!, entityTypeB);
 
         var graph = new EntityTypeGraph();
         graph.Populate(entityTypeA, entityTypeB, entityTypeC);
@@ -641,9 +641,9 @@ public class MultigraphTest
         entityTypeC.SetPrimaryKey(entityTypeC.AddProperty("Id", typeof(int)));
 
         // A -> B, A -> C, C -> B
-        entityTypeB.AddForeignKey(entityTypeB.AddProperty(B.PProperty), entityTypeA.FindPrimaryKey(), entityTypeA);
-        entityTypeC.AddForeignKey(entityTypeC.AddProperty(C.PProperty), entityTypeA.FindPrimaryKey(), entityTypeA);
-        entityTypeB.AddForeignKey(entityTypeB.AddProperty("P2", typeof(int)), entityTypeC.FindPrimaryKey(), entityTypeC);
+        entityTypeB.AddForeignKey(entityTypeB.AddProperty(B.PProperty), entityTypeA.FindPrimaryKey()!, entityTypeA);
+        entityTypeC.AddForeignKey(entityTypeC.AddProperty(C.PProperty), entityTypeA.FindPrimaryKey()!, entityTypeA);
+        entityTypeB.AddForeignKey(entityTypeB.AddProperty("P2", typeof(int)), entityTypeC.FindPrimaryKey()!, entityTypeC);
 
         var graph = new EntityTypeGraph();
         graph.Populate(entityTypeA, entityTypeB, entityTypeC);
@@ -686,7 +686,7 @@ public class MultigraphTest
         entityTypeA.SetPrimaryKey(property);
 
         // A -> A
-        entityTypeA.AddForeignKey(entityTypeA.AddProperty(A.PProperty), entityTypeA.FindPrimaryKey(), entityTypeA);
+        entityTypeA.AddForeignKey(entityTypeA.AddProperty(A.PProperty), entityTypeA.FindPrimaryKey()!, entityTypeA);
 
         var graph = new EntityTypeGraph();
         graph.Populate(entityTypeA);
@@ -711,8 +711,8 @@ public class MultigraphTest
         entityTypeC.SetPrimaryKey(entityTypeC.AddProperty("Id", typeof(int)));
 
         // C, A -> B -> A
-        entityTypeA.AddForeignKey(entityTypeA.AddProperty(A.PProperty), entityTypeB.FindPrimaryKey(), entityTypeB);
-        entityTypeB.AddForeignKey(entityTypeB.AddProperty(B.PProperty), entityTypeA.FindPrimaryKey(), entityTypeA);
+        entityTypeA.AddForeignKey(entityTypeA.AddProperty(A.PProperty), entityTypeB.FindPrimaryKey()!, entityTypeB);
+        entityTypeB.AddForeignKey(entityTypeB.AddProperty(B.PProperty), entityTypeA.FindPrimaryKey()!, entityTypeA);
 
         var graph = new EntityTypeGraph();
         graph.Populate(entityTypeC, entityTypeA, entityTypeB);
@@ -738,9 +738,9 @@ public class MultigraphTest
         entityTypeC.SetPrimaryKey(entityTypeC.AddProperty("Id", typeof(int)));
 
         // A -> C -> B -> A
-        entityTypeA.AddForeignKey(entityTypeA.AddProperty(A.PProperty), entityTypeB.FindPrimaryKey(), entityTypeB);
-        entityTypeB.AddForeignKey(entityTypeB.AddProperty(B.PProperty), entityTypeC.FindPrimaryKey(), entityTypeC);
-        entityTypeC.AddForeignKey(entityTypeC.AddProperty(C.PProperty), entityTypeA.FindPrimaryKey(), entityTypeA);
+        entityTypeA.AddForeignKey(entityTypeA.AddProperty(A.PProperty), entityTypeB.FindPrimaryKey()!, entityTypeB);
+        entityTypeB.AddForeignKey(entityTypeB.AddProperty(B.PProperty), entityTypeC.FindPrimaryKey()!, entityTypeC);
+        entityTypeC.AddForeignKey(entityTypeC.AddProperty(C.PProperty), entityTypeA.FindPrimaryKey()!, entityTypeA);
 
         var graph = new EntityTypeGraph();
         graph.Populate(entityTypeA, entityTypeB, entityTypeC);
@@ -781,14 +781,14 @@ public class MultigraphTest
         entityTypeE.SetPrimaryKey(entityTypeE.AddProperty("Id", typeof(int)));
 
         // A -> C -> B -> A
-        entityTypeA.AddForeignKey(entityTypeA.AddProperty(A.PProperty), entityTypeB.FindPrimaryKey(), entityTypeB);
-        entityTypeB.AddForeignKey(entityTypeB.AddProperty(B.PProperty), entityTypeC.FindPrimaryKey(), entityTypeC);
-        entityTypeC.AddForeignKey(entityTypeC.AddProperty(C.PProperty), entityTypeA.FindPrimaryKey(), entityTypeA);
+        entityTypeA.AddForeignKey(entityTypeA.AddProperty(A.PProperty), entityTypeB.FindPrimaryKey()!, entityTypeB);
+        entityTypeB.AddForeignKey(entityTypeB.AddProperty(B.PProperty), entityTypeC.FindPrimaryKey()!, entityTypeC);
+        entityTypeC.AddForeignKey(entityTypeC.AddProperty(C.PProperty), entityTypeA.FindPrimaryKey()!, entityTypeA);
 
         // A -> E -> D -> A
-        entityTypeA.AddForeignKey(entityTypeA.AddProperty("P2", typeof(int)), entityTypeD.FindPrimaryKey(), entityTypeD);
-        entityTypeD.AddForeignKey(entityTypeD.AddProperty("P2", typeof(int)), entityTypeE.FindPrimaryKey(), entityTypeE);
-        entityTypeE.AddForeignKey(entityTypeE.AddProperty("P2", typeof(int)), entityTypeA.FindPrimaryKey(), entityTypeA);
+        entityTypeA.AddForeignKey(entityTypeA.AddProperty("P2", typeof(int)), entityTypeD.FindPrimaryKey()!, entityTypeD);
+        entityTypeD.AddForeignKey(entityTypeD.AddProperty("P2", typeof(int)), entityTypeE.FindPrimaryKey()!, entityTypeE);
+        entityTypeE.AddForeignKey(entityTypeE.AddProperty("P2", typeof(int)), entityTypeA.FindPrimaryKey()!, entityTypeA);
 
         var graph = new EntityTypeGraph();
         graph.Populate(entityTypeA, entityTypeB, entityTypeC, entityTypeD, entityTypeE);
@@ -823,9 +823,9 @@ public class MultigraphTest
         entityTypeC.SetPrimaryKey(entityTypeC.AddProperty("Id", typeof(int)));
 
         // C -> B -> C -> A
-        entityTypeB.AddForeignKey(entityTypeB.AddProperty(B.PProperty), entityTypeC.FindPrimaryKey(), entityTypeC);
-        entityTypeC.AddForeignKey(entityTypeC.AddProperty(C.PProperty), entityTypeB.FindPrimaryKey(), entityTypeB);
-        entityTypeA.AddForeignKey(entityTypeA.AddProperty(A.PProperty), entityTypeC.FindPrimaryKey(), entityTypeC);
+        entityTypeB.AddForeignKey(entityTypeB.AddProperty(B.PProperty), entityTypeC.FindPrimaryKey()!, entityTypeC);
+        entityTypeC.AddForeignKey(entityTypeC.AddProperty(C.PProperty), entityTypeB.FindPrimaryKey()!, entityTypeB);
+        entityTypeA.AddForeignKey(entityTypeA.AddProperty(A.PProperty), entityTypeC.FindPrimaryKey()!, entityTypeC);
 
         var graph = new EntityTypeGraph();
         graph.Populate(entityTypeA, entityTypeB, entityTypeC);

--- a/test/EFCore.Tests/ValueGeneration/BinaryValueGeneratorTest.cs
+++ b/test/EFCore.Tests/ValueGeneration/BinaryValueGeneratorTest.cs
@@ -13,7 +13,7 @@ public class BinaryValueGeneratorTest
         var values = new HashSet<Guid>();
         for (var i = 0; i < 100; i++)
         {
-            var generatedValue = generator.Next(null);
+            var generatedValue = generator.Next(null!);
 
             values.Add(new Guid(generatedValue));
         }

--- a/test/EFCore.Tests/ValueGeneration/GuidValueGeneratorTest.cs
+++ b/test/EFCore.Tests/ValueGeneration/GuidValueGeneratorTest.cs
@@ -13,7 +13,7 @@ public class GuidValueGeneratorTest
         var values = new HashSet<Guid>();
         for (var i = 0; i < 100; i++)
         {
-            var generatedValue = sequentialGuidIdentityGenerator.Next(null);
+            var generatedValue = sequentialGuidIdentityGenerator.Next(null!);
 
             values.Add(generatedValue);
         }

--- a/test/EFCore.Tests/ValueGeneration/SequentialGuidValueGeneratorTest.cs
+++ b/test/EFCore.Tests/ValueGeneration/SequentialGuidValueGeneratorTest.cs
@@ -13,7 +13,7 @@ public class SequentialGuidValueGeneratorTest
         var values = new HashSet<Guid>();
         for (var i = 0; i < 100; i++)
         {
-            var generatedValue = sequentialGuidIdentityGenerator.Next(null);
+            var generatedValue = sequentialGuidIdentityGenerator.Next(null!);
 
             values.Add(generatedValue);
         }

--- a/test/EFCore.Tests/ValueGeneration/StringValueGeneratorTest.cs
+++ b/test/EFCore.Tests/ValueGeneration/StringValueGeneratorTest.cs
@@ -13,7 +13,7 @@ public class StringValueGeneratorTest
         var values = new HashSet<Guid>();
         for (var i = 0; i < 100; i++)
         {
-            var generatedValue = generator.Next(null);
+            var generatedValue = generator.Next(null!);
 
             values.Add(Guid.Parse(generatedValue));
         }

--- a/test/EFCore.Tests/ValueGeneration/TemporaryNumberValueGeneratorFactoryTest.cs
+++ b/test/EFCore.Tests/ValueGeneration/TemporaryNumberValueGeneratorFactoryTest.cs
@@ -18,34 +18,34 @@ public class TemporaryNumberValueGeneratorFactoryTest
     [Fact]
     public void Can_create_factories_for_all_integer_types()
     {
-        var entityType = _model.FindEntityType(typeof(AnEntity));
+        var entityType = _model.FindEntityType(typeof(AnEntity))!;
 
-        Assert.Equal(int.MinValue + 1001, CreateAndUseFactory(entityType.FindProperty("Id")));
-        Assert.Equal(long.MinValue + 1001, CreateAndUseFactory(entityType.FindProperty("Long")));
-        Assert.Equal((short)(short.MinValue + 101), CreateAndUseFactory(entityType.FindProperty("Short")));
-        Assert.Equal((byte)255, CreateAndUseFactory(entityType.FindProperty("Byte")));
-        Assert.Equal(int.MinValue + 1001, CreateAndUseFactory(entityType.FindProperty("NullableInt")));
-        Assert.Equal(long.MinValue + 1001, CreateAndUseFactory(entityType.FindProperty("NullableLong")));
-        Assert.Equal((short)(short.MinValue + 101), CreateAndUseFactory(entityType.FindProperty("NullableShort")));
-        Assert.Equal((byte)255, CreateAndUseFactory(entityType.FindProperty("NullableByte")));
-        Assert.Equal(unchecked((uint)(int.MinValue + 1001)), CreateAndUseFactory(entityType.FindProperty("UInt")));
-        Assert.Equal(unchecked((ulong)(long.MinValue + 1001)), CreateAndUseFactory(entityType.FindProperty("ULong")));
-        Assert.Equal(unchecked((ushort)(short.MinValue + 101)), CreateAndUseFactory(entityType.FindProperty("UShort")));
-        Assert.Equal((sbyte)-127, CreateAndUseFactory(entityType.FindProperty("SByte")));
-        Assert.Equal(unchecked((uint)(int.MinValue + 1001)), CreateAndUseFactory(entityType.FindProperty("NullableUInt")));
-        Assert.Equal(unchecked((ulong)(long.MinValue + 1001)), CreateAndUseFactory(entityType.FindProperty("NullableULong")));
-        Assert.Equal(unchecked((ushort)(short.MinValue + 101)), CreateAndUseFactory(entityType.FindProperty("NullableUShort")));
-        Assert.Equal((sbyte)-127, CreateAndUseFactory(entityType.FindProperty("NullableSByte")));
+        Assert.Equal(int.MinValue + 1001, CreateAndUseFactory(entityType.FindProperty("Id")!));
+        Assert.Equal(long.MinValue + 1001, CreateAndUseFactory(entityType.FindProperty("Long")!));
+        Assert.Equal((short)(short.MinValue + 101), CreateAndUseFactory(entityType.FindProperty("Short")!));
+        Assert.Equal((byte)255, CreateAndUseFactory(entityType.FindProperty("Byte")!));
+        Assert.Equal(int.MinValue + 1001, CreateAndUseFactory(entityType.FindProperty("NullableInt")!));
+        Assert.Equal(long.MinValue + 1001, CreateAndUseFactory(entityType.FindProperty("NullableLong")!));
+        Assert.Equal((short)(short.MinValue + 101), CreateAndUseFactory(entityType.FindProperty("NullableShort")!));
+        Assert.Equal((byte)255, CreateAndUseFactory(entityType.FindProperty("NullableByte")!));
+        Assert.Equal(unchecked((uint)(int.MinValue + 1001)), CreateAndUseFactory(entityType.FindProperty("UInt")!));
+        Assert.Equal(unchecked((ulong)(long.MinValue + 1001)), CreateAndUseFactory(entityType.FindProperty("ULong")!));
+        Assert.Equal(unchecked((ushort)(short.MinValue + 101)), CreateAndUseFactory(entityType.FindProperty("UShort")!));
+        Assert.Equal((sbyte)-127, CreateAndUseFactory(entityType.FindProperty("SByte")!));
+        Assert.Equal(unchecked((uint)(int.MinValue + 1001)), CreateAndUseFactory(entityType.FindProperty("NullableUInt")!));
+        Assert.Equal(unchecked((ulong)(long.MinValue + 1001)), CreateAndUseFactory(entityType.FindProperty("NullableULong")!));
+        Assert.Equal(unchecked((ushort)(short.MinValue + 101)), CreateAndUseFactory(entityType.FindProperty("NullableUShort")!));
+        Assert.Equal((sbyte)-127, CreateAndUseFactory(entityType.FindProperty("NullableSByte")!));
     }
 
     private static object CreateAndUseFactory(IProperty property)
-        => new TemporaryNumberValueGeneratorFactory().Create(property, property.DeclaringType).Next(null);
+        => new TemporaryNumberValueGeneratorFactory().Create(property, property.DeclaringType).Next(null!)!;
 
     [Fact]
     public void Throws_for_non_integer_property()
     {
-        var entityType = _model.FindEntityType(typeof(AnEntity));
-        var property = entityType.FindProperty("BadCheese");
+        var entityType = _model.FindEntityType(typeof(AnEntity))!;
+        var property = entityType.FindProperty("BadCheese")!;
 
         Assert.Equal(
             CoreStrings.InvalidValueGeneratorFactoryProperty(nameof(TemporaryNumberValueGeneratorFactory), "BadCheese", "AnEntity"),
@@ -70,6 +70,6 @@ public class TemporaryNumberValueGeneratorFactoryTest
         public ulong? NullableULong { get; set; }
         public ushort? NullableUShort { get; set; }
         public sbyte? NullableSByte { get; set; }
-        public string BadCheese { get; set; }
+        public string BadCheese { get; set; } = null!;
     }
 }

--- a/test/EFCore.Tests/ValueGeneration/TemporaryNumberValueGeneratorTest.cs
+++ b/test/EFCore.Tests/ValueGeneration/TemporaryNumberValueGeneratorTest.cs
@@ -12,9 +12,9 @@ public class TemporaryNumberValueGeneratorTest
     {
         var generator = new TemporaryIntValueGenerator();
 
-        Assert.Equal(int.MinValue + 1001, generator.Next(null));
-        Assert.Equal(int.MinValue + 1002, generator.Next(null));
-        Assert.Equal(int.MinValue + 1003, generator.Next(null));
+        Assert.Equal(int.MinValue + 1001, generator.Next(null!));
+        Assert.Equal(int.MinValue + 1002, generator.Next(null!));
+        Assert.Equal(int.MinValue + 1003, generator.Next(null!));
     }
 
     [Fact]
@@ -22,9 +22,9 @@ public class TemporaryNumberValueGeneratorTest
     {
         var generator = new TemporaryLongValueGenerator();
 
-        Assert.Equal(long.MinValue + 1001, generator.Next(null));
-        Assert.Equal(long.MinValue + 1002, generator.Next(null));
-        Assert.Equal(long.MinValue + 1003, generator.Next(null));
+        Assert.Equal(long.MinValue + 1001, generator.Next(null!));
+        Assert.Equal(long.MinValue + 1002, generator.Next(null!));
+        Assert.Equal(long.MinValue + 1003, generator.Next(null!));
     }
 
     [Fact]
@@ -32,9 +32,9 @@ public class TemporaryNumberValueGeneratorTest
     {
         var generator = new TemporaryShortValueGenerator();
 
-        Assert.Equal(short.MinValue + 101, generator.Next(null));
-        Assert.Equal(short.MinValue + 102, generator.Next(null));
-        Assert.Equal(short.MinValue + 103, generator.Next(null));
+        Assert.Equal(short.MinValue + 101, generator.Next(null!));
+        Assert.Equal(short.MinValue + 102, generator.Next(null!));
+        Assert.Equal(short.MinValue + 103, generator.Next(null!));
     }
 
     [Fact]
@@ -42,9 +42,9 @@ public class TemporaryNumberValueGeneratorTest
     {
         var generator = new TemporaryByteValueGenerator();
 
-        Assert.Equal(255, generator.Next(null));
-        Assert.Equal(254, generator.Next(null));
-        Assert.Equal(253, generator.Next(null));
+        Assert.Equal(255, generator.Next(null!));
+        Assert.Equal(254, generator.Next(null!));
+        Assert.Equal(253, generator.Next(null!));
     }
 
     [Fact]
@@ -52,9 +52,9 @@ public class TemporaryNumberValueGeneratorTest
     {
         var generator = new TemporaryUIntValueGenerator();
 
-        Assert.Equal(unchecked((uint)int.MinValue + 1001), generator.Next(null));
-        Assert.Equal(unchecked((uint)int.MinValue + 1002), generator.Next(null));
-        Assert.Equal(unchecked((uint)int.MinValue + 1003), generator.Next(null));
+        Assert.Equal(unchecked((uint)int.MinValue + 1001), generator.Next(null!));
+        Assert.Equal(unchecked((uint)int.MinValue + 1002), generator.Next(null!));
+        Assert.Equal(unchecked((uint)int.MinValue + 1003), generator.Next(null!));
     }
 
     [Fact]
@@ -62,9 +62,9 @@ public class TemporaryNumberValueGeneratorTest
     {
         var generator = new TemporaryULongValueGenerator();
 
-        Assert.Equal(unchecked((ulong)long.MinValue + 1001), generator.Next(null));
-        Assert.Equal(unchecked((ulong)long.MinValue + 1002), generator.Next(null));
-        Assert.Equal(unchecked((ulong)long.MinValue + 1003), generator.Next(null));
+        Assert.Equal(unchecked((ulong)long.MinValue + 1001), generator.Next(null!));
+        Assert.Equal(unchecked((ulong)long.MinValue + 1002), generator.Next(null!));
+        Assert.Equal(unchecked((ulong)long.MinValue + 1003), generator.Next(null!));
     }
 
     [Fact]
@@ -72,9 +72,9 @@ public class TemporaryNumberValueGeneratorTest
     {
         var generator = new TemporaryUShortValueGenerator();
 
-        Assert.Equal(unchecked((ushort)short.MinValue + 101), generator.Next(null));
-        Assert.Equal(unchecked((ushort)short.MinValue + 102), generator.Next(null));
-        Assert.Equal(unchecked((ushort)short.MinValue + 103), generator.Next(null));
+        Assert.Equal(unchecked((ushort)short.MinValue + 101), generator.Next(null!));
+        Assert.Equal(unchecked((ushort)short.MinValue + 102), generator.Next(null!));
+        Assert.Equal(unchecked((ushort)short.MinValue + 103), generator.Next(null!));
     }
 
     [Fact]
@@ -82,9 +82,9 @@ public class TemporaryNumberValueGeneratorTest
     {
         var generator = new TemporarySByteValueGenerator();
 
-        Assert.Equal(-127, generator.Next(null));
-        Assert.Equal(-126, generator.Next(null));
-        Assert.Equal(-125, generator.Next(null));
+        Assert.Equal(-127, generator.Next(null!));
+        Assert.Equal(-126, generator.Next(null!));
+        Assert.Equal(-125, generator.Next(null!));
     }
 
     [Fact]
@@ -92,9 +92,9 @@ public class TemporaryNumberValueGeneratorTest
     {
         var generator = new TemporaryCharValueGenerator();
 
-        Assert.Equal(char.MaxValue - 101, generator.Next(null));
-        Assert.Equal(char.MaxValue - 102, generator.Next(null));
-        Assert.Equal(char.MaxValue - 103, generator.Next(null));
+        Assert.Equal(char.MaxValue - 101, generator.Next(null!));
+        Assert.Equal(char.MaxValue - 102, generator.Next(null!));
+        Assert.Equal(char.MaxValue - 103, generator.Next(null!));
     }
 
     [Fact]
@@ -102,8 +102,8 @@ public class TemporaryNumberValueGeneratorTest
     {
         var generator = new TemporaryDecimalValueGenerator();
 
-        Assert.Equal(-2147482647m, generator.Next(null));
-        Assert.Equal(-2147482646m, generator.Next(null));
+        Assert.Equal(-2147482647m, generator.Next(null!));
+        Assert.Equal(-2147482646m, generator.Next(null!));
     }
 
     [Fact]
@@ -111,8 +111,8 @@ public class TemporaryNumberValueGeneratorTest
     {
         var generator = new TemporaryFloatValueGenerator();
 
-        Assert.Equal(-2147482647.0f, generator.Next(null));
-        Assert.Equal(-2147482646.0f, generator.Next(null));
+        Assert.Equal(-2147482647.0f, generator.Next(null!));
+        Assert.Equal(-2147482646.0f, generator.Next(null!));
     }
 
     [Fact]
@@ -120,8 +120,8 @@ public class TemporaryNumberValueGeneratorTest
     {
         var generator = new TemporaryDoubleValueGenerator();
 
-        Assert.Equal(-2147482647.0, generator.Next(null));
-        Assert.Equal(-2147482646.0, generator.Next(null));
+        Assert.Equal(-2147482647.0, generator.Next(null!));
+        Assert.Equal(-2147482646.0, generator.Next(null!));
     }
 
     [Fact]

--- a/test/EFCore.Tests/ValueGeneration/ValueGeneratorCacheTest.cs
+++ b/test/EFCore.Tests/ValueGeneration/ValueGeneratorCacheTest.cs
@@ -9,9 +9,9 @@ public class ValueGeneratorCacheTest
     public void Uses_single_generator_per_property()
     {
         var model = CreateModel();
-        var entityType = model.FindEntityType("Led");
-        var property1 = entityType.FindProperty("Zeppelin");
-        var property2 = entityType.FindProperty("Stairway");
+        var entityType = model.FindEntityType("Led")!;
+        var property1 = entityType.FindProperty("Zeppelin")!;
+        var property2 = entityType.FindProperty("Stairway")!;
         var cache = InMemoryTestHelpers.Instance.CreateContextServices(model)
             .GetRequiredService<IValueGeneratorCache>();
 

--- a/test/EFCore.Tests/ValueGeneration/ValueGeneratorSelectorTest.cs
+++ b/test/EFCore.Tests/ValueGeneration/ValueGeneratorSelectorTest.cs
@@ -82,7 +82,7 @@ public class ValueGeneratorSelectorTest
     {
         var builder = InMemoryTestHelpers.Instance.CreateConventionBuilder();
         builder.Entity<AnEntity>().Property(e => e.Custom).HasValueGenerator<CustomValueGenerator>();
-        var entityType = builder.Model.FindEntityType(typeof(AnEntity));
+        var entityType = builder.Model.FindEntityType(typeof(AnEntity))!;
 
         foreach (var property in entityType.GetProperties())
         {
@@ -111,10 +111,10 @@ public class ValueGeneratorSelectorTest
         public ulong? NullableULong { get; set; }
         public ushort? NullableUShort { get; set; }
         public sbyte? NullableSByte { get; set; }
-        public string String { get; set; }
+        public string String { get; set; } = null!;
         public Guid Guid { get; set; }
         public Guid? NullableGuid { get; set; }
-        public byte[] Binary { get; set; }
+        public byte[] Binary { get; set; } = null!;
         public float Float { get; set; }
         public float? NullableFloat { get; set; }
         public double Double { get; set; }
@@ -145,6 +145,6 @@ public class ValueGeneratorSelectorTest
 
         selector.TrySelect(property, property.DeclaringType, out var generator);
 
-        return generator!.Next(null!);
+        return generator!.Next(null!)!;
     }
 }


### PR DESCRIPTION
Part 1 of 5 for #24427.

## Summary

- Removes nullable opt-outs from benchmark and core test projects.
- Annotates benchmark models, shared core test infrastructure, core unit tests, InMemory unit tests, and proxy tests.
- Preserves existing assertion behavior while making optional CLR members explicit.

## Stack

1. **#38788** (this PR)
2. #38789
3. #38790
4. #38791
5. #38792

Each PR is based on the preceding stack branch and builds independently.

## Validation

- Full `EFCore.slnx` build at this tip: 0 warnings, 0 errors.
- The final stack tip matches the fully validated snapshot used for all unit and functional test runs.

<!--
Please check whether the PR fulfills these requirements
-->

- [ ] I've read the guidelines for [contributing](https://github.com/dotnet/efcore/blob/main/.github/CONTRIBUTING.md) and seen the [walkthrough](https://youtu.be/9OMxy1s?t=1869)
- [ ] I've posted a comment on an issue with a detailed description of how I am planning to contribute and got approval from a member of the team
- [x] The code builds and tests pass locally (also verified by our automated build checks)
- [x] Commit messages follow the required format
- [x] Tests for the changes have been added or existing coverage validates the migration
- [x] Code follows the same patterns and style as existing code in this repo