### PR TITLE
Enable nullability in shared specification tests

### DIFF
--- a/test/EFCore.AspNet.InMemory.FunctionalTests/AppServiceProviderFactoryTest.cs
+++ b/test/EFCore.AspNet.InMemory.FunctionalTests/AppServiceProviderFactoryTest.cs
@@ -69,10 +69,10 @@ public class AppServiceProviderFactoryTest
         Assert.NotNull(services.GetRequiredService<TestService>());
     }
 
-    private static void InjectHostIntoDiagnostics(object[] args)
+    private static void InjectHostIntoDiagnostics(object?[] args)
     {
         Assert.Single(args);
-        Assert.Equal((string[])args[0], new[] { "arg1", "--applicationName", "MockAssembly" });
+        Assert.Equal((string[])args[0]!, new[] { "arg1", "--applicationName", "MockAssembly" });
 
         using var diagnosticListener = new DiagnosticListener("Microsoft.Extensions.Hosting");
 
@@ -129,7 +129,7 @@ public class AppServiceProviderFactoryTest
     }
 }
 
-public class TestAppServiceProviderFactory(Assembly startupAssembly, IOperationReporter reporter = null)
+public class TestAppServiceProviderFactory(Assembly startupAssembly, IOperationReporter? reporter = null)
     : AppServiceProviderFactory(startupAssembly, reporter ?? new TestOperationReporter());
 
 public class TestWebHost(IServiceProvider services)

--- a/test/EFCore.AspNet.InMemory.FunctionalTests/AspNetIdentityCustomTypesDefaultInMemoryTest.cs
+++ b/test/EFCore.AspNet.InMemory.FunctionalTests/AspNetIdentityCustomTypesDefaultInMemoryTest.cs
@@ -17,9 +17,9 @@ public class AspNetIdentityCustomTypesDefaultInMemoryTest(
 
     protected override async Task ExecuteWithStrategyInTransactionAsync(
         Func<CustomTypesIdentityContext, Task> testOperation,
-        Func<CustomTypesIdentityContext, Task> nestedTestOperation1 = null,
-        Func<CustomTypesIdentityContext, Task> nestedTestOperation2 = null,
-        Func<CustomTypesIdentityContext, Task> nestedTestOperation3 = null)
+        Func<CustomTypesIdentityContext, Task>? nestedTestOperation1 = null,
+        Func<CustomTypesIdentityContext, Task>? nestedTestOperation2 = null,
+        Func<CustomTypesIdentityContext, Task>? nestedTestOperation3 = null)
     {
         await base.ExecuteWithStrategyInTransactionAsync(
             testOperation, nestedTestOperation1, nestedTestOperation2, nestedTestOperation3);

--- a/test/EFCore.AspNet.InMemory.FunctionalTests/AspNetIdentityCustomTypesIntKeyInMemoryTest.cs
+++ b/test/EFCore.AspNet.InMemory.FunctionalTests/AspNetIdentityCustomTypesIntKeyInMemoryTest.cs
@@ -17,9 +17,9 @@ public class AspNetIdentityCustomTypesIntKeyInMemoryTest(
 
     protected override async Task ExecuteWithStrategyInTransactionAsync(
         Func<CustomTypesIdentityContextInt, Task> testOperation,
-        Func<CustomTypesIdentityContextInt, Task> nestedTestOperation1 = null,
-        Func<CustomTypesIdentityContextInt, Task> nestedTestOperation2 = null,
-        Func<CustomTypesIdentityContextInt, Task> nestedTestOperation3 = null)
+        Func<CustomTypesIdentityContextInt, Task>? nestedTestOperation1 = null,
+        Func<CustomTypesIdentityContextInt, Task>? nestedTestOperation2 = null,
+        Func<CustomTypesIdentityContextInt, Task>? nestedTestOperation3 = null)
     {
         await base.ExecuteWithStrategyInTransactionAsync(
             testOperation, nestedTestOperation1, nestedTestOperation2, nestedTestOperation3);

--- a/test/EFCore.AspNet.InMemory.FunctionalTests/AspNetIdentityDefaultInMemoryTest.cs
+++ b/test/EFCore.AspNet.InMemory.FunctionalTests/AspNetIdentityDefaultInMemoryTest.cs
@@ -17,9 +17,9 @@ public class AspNetIdentityDefaultInMemoryTest(AspNetIdentityDefaultInMemoryTest
 
     protected override async Task ExecuteWithStrategyInTransactionAsync(
         Func<IdentityDbContext, Task> testOperation,
-        Func<IdentityDbContext, Task> nestedTestOperation1 = null,
-        Func<IdentityDbContext, Task> nestedTestOperation2 = null,
-        Func<IdentityDbContext, Task> nestedTestOperation3 = null)
+        Func<IdentityDbContext, Task>? nestedTestOperation1 = null,
+        Func<IdentityDbContext, Task>? nestedTestOperation2 = null,
+        Func<IdentityDbContext, Task>? nestedTestOperation3 = null)
     {
         await base.ExecuteWithStrategyInTransactionAsync(
             testOperation, nestedTestOperation1, nestedTestOperation2, nestedTestOperation3);

--- a/test/EFCore.AspNet.InMemory.FunctionalTests/AspNetIdentityIntKeyInMemoryTest.cs
+++ b/test/EFCore.AspNet.InMemory.FunctionalTests/AspNetIdentityIntKeyInMemoryTest.cs
@@ -18,9 +18,9 @@ public class AspNetIdentityIntKeyInMemoryTest(AspNetIdentityIntKeyInMemoryTest.A
 
     protected override async Task ExecuteWithStrategyInTransactionAsync(
         Func<IdentityDbContext<IdentityUser<int>, IdentityRole<int>, int>, Task> testOperation,
-        Func<IdentityDbContext<IdentityUser<int>, IdentityRole<int>, int>, Task> nestedTestOperation1 = null,
-        Func<IdentityDbContext<IdentityUser<int>, IdentityRole<int>, int>, Task> nestedTestOperation2 = null,
-        Func<IdentityDbContext<IdentityUser<int>, IdentityRole<int>, int>, Task> nestedTestOperation3 = null)
+        Func<IdentityDbContext<IdentityUser<int>, IdentityRole<int>, int>, Task>? nestedTestOperation1 = null,
+        Func<IdentityDbContext<IdentityUser<int>, IdentityRole<int>, int>, Task>? nestedTestOperation2 = null,
+        Func<IdentityDbContext<IdentityUser<int>, IdentityRole<int>, int>, Task>? nestedTestOperation3 = null)
     {
         await base.ExecuteWithStrategyInTransactionAsync(
             testOperation, nestedTestOperation1, nestedTestOperation2, nestedTestOperation3);

--- a/test/EFCore.AspNet.InMemory.FunctionalTests/EFCore.AspNet.InMemory.FunctionalTests.csproj
+++ b/test/EFCore.AspNet.InMemory.FunctionalTests/EFCore.AspNet.InMemory.FunctionalTests.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
     <AssemblyName>Microsoft.EntityFrameworkCore.AspNet.InMemory.FunctionalTests</AssemblyName>
     <RootNamespace>Microsoft.EntityFrameworkCore</RootNamespace>
-    <Nullable>disable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
     <DefineConstants Condition="$([MSBuild]::IsOSPlatform('OSX'))">$(DefineConstants);EXCLUDE_ON_MAC</DefineConstants>
   </PropertyGroup>

--- a/test/EFCore.AspNet.Specification.Tests/AspNetIdentityCustomTypesDefaultTestBase.cs
+++ b/test/EFCore.AspNet.Specification.Tests/AspNetIdentityCustomTypesDefaultTestBase.cs
@@ -367,14 +367,14 @@ public class CustomUserString : IdentityUser<string>
     public CustomUserString()
         => Id = Guid.NewGuid().ToString();
 
-    public string CustomTag { get; set; }
+    public string? CustomTag { get; set; }
 
-    public virtual ICollection<CustomRoleString> Roles { get; set; }
+    public virtual ICollection<CustomRoleString> Roles { get; set; } = null!;
 
-    public virtual ICollection<CustomUserClaimString> Claims { get; set; }
-    public virtual ICollection<CustomUserLoginString> Logins { get; set; }
-    public virtual ICollection<CustomUserTokenString> Tokens { get; set; }
-    public virtual ICollection<CustomUserRoleString> UserRoles { get; set; }
+    public virtual ICollection<CustomUserClaimString> Claims { get; set; } = null!;
+    public virtual ICollection<CustomUserLoginString> Logins { get; set; } = null!;
+    public virtual ICollection<CustomUserTokenString> Tokens { get; set; } = null!;
+    public virtual ICollection<CustomUserRoleString> UserRoles { get; set; } = null!;
 }
 
 public class CustomRoleString : IdentityRole<string>
@@ -382,34 +382,34 @@ public class CustomRoleString : IdentityRole<string>
     public CustomRoleString()
         => Id = Guid.NewGuid().ToString();
 
-    public virtual ICollection<CustomUserString> Users { get; set; }
+    public virtual ICollection<CustomUserString> Users { get; set; } = null!;
 
-    public virtual ICollection<CustomUserRoleString> UserRoles { get; set; }
-    public virtual ICollection<CustomRoleClaimString> RoleClaims { get; set; }
+    public virtual ICollection<CustomUserRoleString> UserRoles { get; set; } = null!;
+    public virtual ICollection<CustomRoleClaimString> RoleClaims { get; set; } = null!;
 }
 
 public class CustomUserRoleString : IdentityUserRole<string>
 {
-    public virtual CustomUserString User { get; set; }
-    public virtual CustomRoleString Role { get; set; }
+    public virtual CustomUserString User { get; set; } = null!;
+    public virtual CustomRoleString Role { get; set; } = null!;
 }
 
 public class CustomUserClaimString : IdentityUserClaim<string>
 {
-    public virtual CustomUserString User { get; set; }
+    public virtual CustomUserString User { get; set; } = null!;
 }
 
 public class CustomUserLoginString : IdentityUserLogin<string>
 {
-    public virtual CustomUserString User { get; set; }
+    public virtual CustomUserString User { get; set; } = null!;
 }
 
 public class CustomRoleClaimString : IdentityRoleClaim<string>
 {
-    public virtual CustomRoleString Role { get; set; }
+    public virtual CustomRoleString Role { get; set; } = null!;
 }
 
 public class CustomUserTokenString : IdentityUserToken<string>
 {
-    public virtual CustomUserString User { get; set; }
+    public virtual CustomUserString User { get; set; } = null!;
 }

--- a/test/EFCore.AspNet.Specification.Tests/AspNetIdentityCustomTypesIntKeyTestBase.cs
+++ b/test/EFCore.AspNet.Specification.Tests/AspNetIdentityCustomTypesIntKeyTestBase.cs
@@ -192,11 +192,11 @@ public class CustomTypesIdentityContextInt(DbContextOptions options)
 
 public class CustomUserInt : IdentityUser<int>
 {
-    public string CustomTag { get; set; }
-    public virtual ICollection<CustomUserClaimInt> Claims { get; set; }
-    public virtual ICollection<CustomUserLoginInt> Logins { get; set; }
-    public virtual ICollection<CustomUserTokenInt> Tokens { get; set; }
-    public virtual ICollection<CustomUserRoleInt> UserRoles { get; set; }
+    public string? CustomTag { get; set; }
+    public virtual ICollection<CustomUserClaimInt> Claims { get; set; } = null!;
+    public virtual ICollection<CustomUserLoginInt> Logins { get; set; } = null!;
+    public virtual ICollection<CustomUserTokenInt> Tokens { get; set; } = null!;
+    public virtual ICollection<CustomUserRoleInt> UserRoles { get; set; } = null!;
 }
 
 public class CustomRoleInt : IdentityRole<int>;

--- a/test/EFCore.AspNet.Specification.Tests/AspNetIdentityTestBase.cs
+++ b/test/EFCore.AspNet.Specification.Tests/AspNetIdentityTestBase.cs
@@ -48,7 +48,7 @@ public abstract class
                 using var userStore =
                     new UserStore<TUser, TRole, TContext, TKey, TUserClaim, TUserRole, TUserLogin, TUserToken, TRoleClaim>(context);
 
-                Assert.Equal(user.Id, (await userStore.FindByNameAsync("wendy")).Id);
+                Assert.Equal(user.Id, (await userStore.FindByNameAsync("wendy"))!.Id);
             });
     }
 
@@ -64,7 +64,7 @@ public abstract class
                 using var userStore =
                     new UserStore<TUser, TRole, TContext, TKey, TUserClaim, TUserRole, TUserLogin, TUserToken, TRoleClaim>(context);
 
-                Assert.Equal(user.Id, (await userStore.FindByEmailAsync("wendy@example.com")).Id);
+                Assert.Equal(user.Id, (await userStore.FindByEmailAsync("wendy@example.com"))!.Id);
             });
     }
 
@@ -213,7 +213,7 @@ public abstract class
             {
                 using var userStore = new UserOnlyStore<TUser, TContext, TKey, TUserClaim, TUserLogin, TUserToken>(context);
 
-                Assert.Equal(user.Id, (await userStore.FindByNameAsync("wendy")).Id);
+                Assert.Equal(user.Id, (await userStore.FindByNameAsync("wendy"))!.Id);
             });
     }
 
@@ -228,7 +228,7 @@ public abstract class
             {
                 using var userStore = new UserOnlyStore<TUser, TContext, TKey, TUserClaim, TUserLogin, TUserToken>(context);
 
-                Assert.Equal(user.Id, (await userStore.FindByEmailAsync("wendy@example.com")).Id);
+                Assert.Equal(user.Id, (await userStore.FindByEmailAsync("wendy@example.com"))!.Id);
             });
     }
 
@@ -414,9 +414,9 @@ public abstract class
 
     protected virtual Task ExecuteWithStrategyInTransactionAsync(
         Func<TContext, Task> testOperation,
-        Func<TContext, Task> nestedTestOperation1 = null,
-        Func<TContext, Task> nestedTestOperation2 = null,
-        Func<TContext, Task> nestedTestOperation3 = null)
+        Func<TContext, Task>? nestedTestOperation1 = null,
+        Func<TContext, Task>? nestedTestOperation2 = null,
+        Func<TContext, Task>? nestedTestOperation3 = null)
         => TestHelpers.ExecuteWithStrategyInTransactionAsync(
             CreateContext, UseTransaction,
             testOperation, nestedTestOperation1, nestedTestOperation2, nestedTestOperation3);

--- a/test/EFCore.AspNet.Specification.Tests/EFCore.AspNet.Specification.Tests.csproj
+++ b/test/EFCore.AspNet.Specification.Tests/EFCore.AspNet.Specification.Tests.csproj
@@ -5,7 +5,6 @@
     <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
     <AssemblyName>Microsoft.EntityFrameworkCore.AspNet.Specification.Tests</AssemblyName>
     <RootNamespace>Microsoft.EntityFrameworkCore</RootNamespace>
-    <Nullable>disable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IsPackable>true</IsPackable>
     <!-- This project contains base tests to be used by providers, but is not itself a test project with

--- a/test/EFCore.AspNet.Specification.Tests/TestUtilities/EntityTypeMapping.cs
+++ b/test/EFCore.AspNet.Specification.Tests/TestUtilities/EntityTypeMapping.cs
@@ -12,7 +12,7 @@ public class EntityTypeMapping
     public EntityTypeMapping(IEntityType entityType)
     {
         Name = entityType.Name;
-        TableName = entityType.GetTableName();
+        TableName = entityType.GetTableName()!;
         PrimaryKey = entityType.FindPrimaryKey()!.ToDebugString(MetadataDebugStringOptions.SingleLineDefault);
 
         Properties.AddRange(
@@ -32,9 +32,9 @@ public class EntityTypeMapping
             entityType.GetSkipNavigations().Select(n => n.ToDebugString(MetadataDebugStringOptions.SingleLineDefault)));
     }
 
-    public string Name { get; set; }
-    public string TableName { get; set; }
-    public string PrimaryKey { get; set; }
+    public string Name { get; set; } = null!;
+    public string TableName { get; set; } = null!;
+    public string PrimaryKey { get; set; } = null!;
     public List<string> Properties { get; } = [];
     public List<string> Indexes { get; set; } = [];
     public List<string> FKs { get; } = [];

--- a/test/EFCore.AspNet.Specification.Tests/TestUtilities/FakeLogger.cs
+++ b/test/EFCore.AspNet.Specification.Tests/TestUtilities/FakeLogger.cs
@@ -9,14 +9,15 @@ public class FakeLogger<T> : ILogger<T>
         LogLevel logLevel,
         EventId eventId,
         TState state,
-        Exception exception,
-        Func<TState, Exception, string> formatter)
+        Exception? exception,
+        Func<TState, Exception?, string> formatter)
     {
     }
 
     public bool IsEnabled(LogLevel logLevel)
         => true;
 
-    public IDisposable BeginScope<TState>(TState state)
+    public IDisposable? BeginScope<TState>(TState state)
+        where TState : notnull
         => throw new NotImplementedException();
 }

--- a/test/EFCore.InMemory.FunctionalTests/BadDataJsonDeserializationInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/BadDataJsonDeserializationInMemoryTest.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore;
 
 public class BadDataJsonDeserializationInMemoryTest : BadDataJsonDeserializationTestBase

--- a/test/EFCore.InMemory.FunctionalTests/ComplexTypesTrackingInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/ComplexTypesTrackingInMemoryTest.cs
@@ -8,9 +8,9 @@ public class ComplexTypesTrackingInMemoryTest(ComplexTypesTrackingInMemoryTest.I
 {
     protected override async Task ExecuteWithStrategyInTransactionAsync(
         Func<DbContext, Task> testOperation,
-        Func<DbContext, Task> nestedTestOperation1 = null,
-        Func<DbContext, Task> nestedTestOperation2 = null,
-        Func<DbContext, Task> nestedTestOperation3 = null)
+        Func<DbContext, Task>? nestedTestOperation1 = null,
+        Func<DbContext, Task>? nestedTestOperation2 = null,
+        Func<DbContext, Task>? nestedTestOperation3 = null)
     {
         try
         {

--- a/test/EFCore.InMemory.FunctionalTests/CompositeKeyEndToEndTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/CompositeKeyEndToEndTest.cs
@@ -174,13 +174,13 @@ public class CompositeKeyEndToEndTest
         private readonly IServiceProvider _serviceProvider = serviceProvider;
 
         // ReSharper disable once UnusedAutoPropertyAccessor.Local
-        public DbSet<Pegasus> Pegasuses { get; set; }
+        public DbSet<Pegasus> Pegasuses { get; set; } = null!;
 
         // ReSharper disable once UnusedAutoPropertyAccessor.Local
-        public DbSet<Unicorn> Unicorns { get; set; }
+        public DbSet<Unicorn> Unicorns { get; set; } = null!;
 
         // ReSharper disable once UnusedAutoPropertyAccessor.Local
-        public DbSet<EarthPony> EarthPonies { get; set; }
+        public DbSet<EarthPony> EarthPonies { get; set; } = null!;
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
             => optionsBuilder.UseInMemoryDatabase(nameof(BronieContext)).UseInternalServiceProvider(_serviceProvider);
@@ -216,22 +216,22 @@ public class CompositeKeyEndToEndTest
     {
         public long Id1 { get; set; }
         public long Id2 { get; set; }
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
     }
 
     [PrimaryKey(nameof(Id1), nameof(Id2), nameof(Id3))]
     private class Unicorn
     {
         public int Id1 { get; set; }
-        public string Id2 { get; set; }
+        public string Id2 { get; set; } = null!;
         public Guid Id3 { get; set; }
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
     }
 
     private class EarthPony
     {
         public int Id1 { get; set; }
         public int Id2 { get; set; }
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
     }
 }

--- a/test/EFCore.InMemory.FunctionalTests/ConfigPatternsInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/ConfigPatternsInMemoryTest.cs
@@ -19,7 +19,7 @@ public class ConfigPatternsInMemoryTest
         {
             var blog = context.Blogs.SingleOrDefault();
 
-            Assert.NotEqual(0, blog.Id);
+            Assert.NotEqual(0, blog!.Id);
             Assert.Equal("The Waffle Cart", blog.Name);
 
             context.Blogs.RemoveRange(context.Blogs);
@@ -32,7 +32,7 @@ public class ConfigPatternsInMemoryTest
     private class ImplicitServicesAndConfigBlogContext : DbContext
     {
         // ReSharper disable once UnusedAutoPropertyAccessor.Local
-        public DbSet<Blog> Blogs { get; set; }
+        public DbSet<Blog> Blogs { get; set; } = null!;
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
             => optionsBuilder
@@ -56,7 +56,7 @@ public class ConfigPatternsInMemoryTest
         {
             var blog = context.Blogs.SingleOrDefault();
 
-            Assert.NotEqual(0, blog.Id);
+            Assert.NotEqual(0, blog!.Id);
             Assert.Equal("The Waffle Cart", blog.Name);
 
             context.Blogs.RemoveRange(context.Blogs);
@@ -69,7 +69,7 @@ public class ConfigPatternsInMemoryTest
     private class ImplicitServicesExplicitConfigBlogContext(DbContextOptions options) : DbContext(options)
     {
         // ReSharper disable once UnusedAutoPropertyAccessor.Local
-        public DbSet<Blog> Blogs { get; set; }
+        public DbSet<Blog> Blogs { get; set; } = null!;
     }
 
     [Fact]
@@ -90,7 +90,7 @@ public class ConfigPatternsInMemoryTest
         {
             var blog = context.Blogs.SingleOrDefault();
 
-            Assert.NotEqual(0, blog.Id);
+            Assert.NotEqual(0, blog!.Id);
             Assert.Equal("The Waffle Cart", blog.Name);
 
             context.Blogs.RemoveRange(context.Blogs);
@@ -105,7 +105,7 @@ public class ConfigPatternsInMemoryTest
         private readonly IServiceProvider _serviceProvider = serviceProvider;
 
         // ReSharper disable once UnusedAutoPropertyAccessor.Local
-        public DbSet<Blog> Blogs { get; set; }
+        public DbSet<Blog> Blogs { get; set; } = null!;
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
             => optionsBuilder
@@ -133,7 +133,7 @@ public class ConfigPatternsInMemoryTest
         {
             var blog = context.Blogs.SingleOrDefault();
 
-            Assert.NotEqual(0, blog.Id);
+            Assert.NotEqual(0, blog!.Id);
             Assert.Equal("The Waffle Cart", blog.Name);
 
             context.Blogs.RemoveRange(context.Blogs);
@@ -146,7 +146,7 @@ public class ConfigPatternsInMemoryTest
     private class ExplicitServicesAndConfigBlogContext(DbContextOptions options) : DbContext(options)
     {
         // ReSharper disable once UnusedAutoPropertyAccessor.Local
-        public DbSet<Blog> Blogs { get; set; }
+        public DbSet<Blog> Blogs { get; set; } = null!;
     }
 
     [Fact]
@@ -164,7 +164,7 @@ public class ConfigPatternsInMemoryTest
     private class NoServicesAndNoConfigBlogContext : DbContext
     {
         // ReSharper disable once UnusedAutoPropertyAccessor.Local
-        public DbSet<Blog> Blogs { get; set; }
+        public DbSet<Blog> Blogs { get; set; } = null!;
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
             => optionsBuilder.EnableServiceProviderCaching(false);
@@ -193,7 +193,7 @@ public class ConfigPatternsInMemoryTest
         private readonly IServiceProvider _serviceProvider = serviceProvider;
 
         // ReSharper disable once UnusedAutoPropertyAccessor.Local
-        public DbSet<Blog> Blogs { get; set; }
+        public DbSet<Blog> Blogs { get; set; } = null!;
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
             => optionsBuilder
@@ -233,7 +233,7 @@ public class ConfigPatternsInMemoryTest
 
             var blog = _context.Blogs.SingleOrDefault();
 
-            Assert.NotEqual(0, blog.Id);
+            Assert.NotEqual(0, blog!.Id);
             Assert.Equal("The Waffle Cart", blog.Name);
         }
     }
@@ -254,7 +254,7 @@ public class ConfigPatternsInMemoryTest
                 .UseInternalServiceProvider(_serviceProvider);
 
         // ReSharper disable once UnusedAutoPropertyAccessor.Local
-        public DbSet<Blog> Blogs { get; set; }
+        public DbSet<Blog> Blogs { get; set; } = null!;
     }
 
     [Fact]
@@ -292,7 +292,7 @@ public class ConfigPatternsInMemoryTest
 
             var blog = _context.Blogs.SingleOrDefault();
 
-            Assert.NotEqual(0, blog.Id);
+            Assert.NotEqual(0, blog!.Id);
             Assert.Equal("The Waffle Cart", blog.Name);
         }
     }
@@ -304,7 +304,7 @@ public class ConfigPatternsInMemoryTest
             => Assert.NotNull(options);
 
         // ReSharper disable once UnusedAutoPropertyAccessor.Local
-        public DbSet<Blog> Blogs { get; set; }
+        public DbSet<Blog> Blogs { get; set; } = null!;
     }
 
     [Fact]
@@ -345,7 +345,7 @@ public class ConfigPatternsInMemoryTest
 
             var blog = _context.Blogs.SingleOrDefault();
 
-            Assert.NotEqual(0, blog.Id);
+            Assert.NotEqual(0, blog!.Id);
             Assert.Equal("The Waffle Cart", blog.Name);
 
             _context.Remove(blog);
@@ -360,7 +360,7 @@ public class ConfigPatternsInMemoryTest
             => Assert.NotNull(options);
 
         // ReSharper disable once UnusedAutoPropertyAccessor.Local
-        public DbSet<Blog> Blogs { get; set; }
+        public DbSet<Blog> Blogs { get; set; } = null!;
     }
 
     [Fact]
@@ -408,7 +408,7 @@ public class ConfigPatternsInMemoryTest
 
             var blog = _context.Blogs.SingleOrDefault();
 
-            Assert.NotEqual(0, blog.Id);
+            Assert.NotEqual(0, blog!.Id);
             Assert.Equal("The Waffle Cart", blog.Name);
         }
     }
@@ -435,7 +435,7 @@ public class ConfigPatternsInMemoryTest
 
             var account = _context.Accounts.SingleOrDefault();
 
-            Assert.Equal(1, account.Id);
+            Assert.Equal(1, account!.Id);
             Assert.Equal("Eeky Bear", account.Name);
         }
     }
@@ -447,7 +447,7 @@ public class ConfigPatternsInMemoryTest
             => Assert.NotNull(options);
 
         // ReSharper disable once UnusedAutoPropertyAccessor.Local
-        public DbSet<Blog> Blogs { get; set; }
+        public DbSet<Blog> Blogs { get; set; } = null!;
     }
 
     private class InjectDifferentConfigurationsAccountContext : DbContext
@@ -457,18 +457,18 @@ public class ConfigPatternsInMemoryTest
             => Assert.NotNull(options);
 
         // ReSharper disable once UnusedAutoPropertyAccessor.Local
-        public DbSet<Account> Accounts { get; set; }
+        public DbSet<Account> Accounts { get; set; } = null!;
     }
 
     private class Account
     {
         public int Id { get; set; }
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
     }
 
     private class Blog
     {
         public int Id { get; set; }
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
     }
 }

--- a/test/EFCore.InMemory.FunctionalTests/CustomValueGeneratorTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/CustomValueGeneratorTest.cs
@@ -150,8 +150,8 @@ public class CustomValueGeneratorTest
     {
         public Guid Id { get; set; }
         public Guid SpecialId { get; set; }
-        public string SpecialString { get; set; }
-        public string Name { get; set; }
+        public string SpecialString { get; set; } = null!;
+        public string Name { get; set; } = null!;
     }
 
     private readonly string[] _names =
@@ -245,6 +245,6 @@ public class CustomValueGeneratorTest
                 : property.ClrType == typeof(string)
                 && property.DeclaringType.ClrType == typeof(SomeEntity)
                     ? new SomeEntityStringValueGenerator()
-                    : null;
+                    : null!;
     }
 }

--- a/test/EFCore.InMemory.FunctionalTests/DataAnnotationInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/DataAnnotationInMemoryTest.cs
@@ -15,14 +15,14 @@ public class DataAnnotationInMemoryTest(DataAnnotationInMemoryTest.DataAnnotatio
     public override Task ConcurrencyCheckAttribute_throws_if_value_in_database_changed()
     {
         using var context = CreateContext();
-        Assert.True(context.Model.FindEntityType(typeof(One)).FindProperty("RowVersion").IsConcurrencyToken);
+        Assert.True(context.Model.FindEntityType(typeof(One))!.FindProperty("RowVersion")!.IsConcurrencyToken);
         return Task.CompletedTask;
     }
 
     public override Task MaxLengthAttribute_throws_while_inserting_value_longer_than_max_length()
     {
         using var context = CreateContext();
-        Assert.Equal(10, context.Model.FindEntityType(typeof(One)).FindProperty("MaxLengthProperty").GetMaxLength());
+        Assert.Equal(10, context.Model.FindEntityType(typeof(One))!.FindProperty("MaxLengthProperty")!.GetMaxLength());
         return Task.CompletedTask;
     }
 
@@ -30,28 +30,28 @@ public class DataAnnotationInMemoryTest(DataAnnotationInMemoryTest.DataAnnotatio
     {
         using var context = CreateContext();
         Assert.True(
-            context.Model.FindEntityType(typeof(BookDetails)).FindNavigation(nameof(BookDetails.AnotherBook)).ForeignKey.IsRequired);
+            context.Model.FindEntityType(typeof(BookDetails))!.FindNavigation(nameof(BookDetails.AnotherBook))!.ForeignKey.IsRequired);
         return Task.CompletedTask;
     }
 
     public override Task RequiredAttribute_for_property_throws_while_inserting_null_value()
     {
         using var context = CreateContext();
-        Assert.False(context.Model.FindEntityType(typeof(One)).FindProperty("RequiredColumn").IsNullable);
+        Assert.False(context.Model.FindEntityType(typeof(One))!.FindProperty("RequiredColumn")!.IsNullable);
         return Task.CompletedTask;
     }
 
     public override Task StringLengthAttribute_throws_while_inserting_value_longer_than_max_length()
     {
         using var context = CreateContext();
-        Assert.Equal(16, context.Model.FindEntityType(typeof(Two)).FindProperty("Data").GetMaxLength());
+        Assert.Equal(16, context.Model.FindEntityType(typeof(Two))!.FindProperty("Data")!.GetMaxLength());
         return Task.CompletedTask;
     }
 
     public override Task TimestampAttribute_throws_if_value_in_database_changed()
     {
         using var context = CreateContext();
-        Assert.True(context.Model.FindEntityType(typeof(Two)).FindProperty("Timestamp").IsConcurrencyToken);
+        Assert.True(context.Model.FindEntityType(typeof(Two))!.FindProperty("Timestamp")!.IsConcurrencyToken);
         return Task.CompletedTask;
     }
 

--- a/test/EFCore.InMemory.FunctionalTests/DatabaseErrorLogStateTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/DatabaseErrorLogStateTest.cs
@@ -111,7 +111,7 @@ public class DatabaseErrorLogStateTest
     {
         private readonly IServiceProvider _serviceProvider = serviceProvider;
 
-        public DbSet<Blog> Blogs { get; set; }
+        public DbSet<Blog> Blogs { get; set; } = null!;
 
         public class Blog
         {
@@ -128,8 +128,8 @@ public class DatabaseErrorLogStateTest
                 }
             }
 
-            public string Url { get; set; }
-            public string Name { get; set; }
+            public string Url { get; set; } = null!;
+            public string? Name { get; set; }
         }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
@@ -158,21 +158,22 @@ public class DatabaseErrorLogStateTest
 
         public class TestLogger : ILogger
         {
-            public IDisposable BeginScope<TState>(TState state)
+            public IDisposable? BeginScope<TState>(TState state)
+                where TState : notnull
                 => NullScope.Instance;
 
             public void Log<TState>(
                 LogLevel logLevel,
                 EventId eventId,
                 TState state,
-                Exception exception,
-                Func<TState, Exception, string> formatter)
+                Exception? exception,
+                Func<TState, Exception?, string> formatter)
             {
                 if (eventId.Id == CoreEventId.SaveChangesFailed.Id
                     || eventId.Id == CoreEventId.QueryIterationFailed.Id)
                 {
-                    LastDatabaseErrorState = (IReadOnlyList<KeyValuePair<string, object>>)state;
-                    LastDatabaseErrorException = exception;
+                    LastDatabaseErrorState = (IReadOnlyList<KeyValuePair<string, object>>)(object)state!;
+                    LastDatabaseErrorException = exception!;
                     LastDatabaseErrorFormatter = (s, e) => formatter((TState)s, e);
                 }
             }
@@ -180,9 +181,9 @@ public class DatabaseErrorLogStateTest
             public bool IsEnabled(LogLevel logLevel)
                 => true;
 
-            public IReadOnlyList<KeyValuePair<string, object>> LastDatabaseErrorState { get; private set; }
-            public Exception LastDatabaseErrorException { get; private set; }
-            public Func<object, Exception, string> LastDatabaseErrorFormatter { get; private set; }
+            public IReadOnlyList<KeyValuePair<string, object>> LastDatabaseErrorState { get; private set; } = null!;
+            public Exception LastDatabaseErrorException { get; private set; } = null!;
+            public Func<object, Exception, string> LastDatabaseErrorFormatter { get; private set; } = null!;
 
             private class NullScope : IDisposable
             {

--- a/test/EFCore.InMemory.FunctionalTests/DatabaseInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/DatabaseInMemoryTest.cs
@@ -90,7 +90,7 @@ public class DatabaseInMemoryTest
         }
 
         public int Id { get; set; }
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
     }
 
     protected virtual void OnModelCreating(ModelBuilder modelBuilder)
@@ -118,7 +118,7 @@ public class DatabaseInMemoryTest
     private class SimpleContext : DbContext
     {
         // ReSharper disable once UnusedAutoPropertyAccessor.Local
-        public DbSet<Artist> Artists { get; set; }
+        public DbSet<Artist> Artists { get; set; } = null!;
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
             => optionsBuilder
@@ -132,8 +132,8 @@ public class DatabaseInMemoryTest
 
         public class ArtistBase<TKey>
         {
-            public TKey ArtistId { get; set; }
-            public string Name { get; set; }
+            public TKey ArtistId { get; set; } = default!;
+            public string Name { get; set; } = null!;
         }
     }
 }

--- a/test/EFCore.InMemory.FunctionalTests/EFCore.InMemory.FunctionalTests.csproj
+++ b/test/EFCore.InMemory.FunctionalTests/EFCore.InMemory.FunctionalTests.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
     <AssemblyName>Microsoft.EntityFrameworkCore.InMemory.FunctionalTests</AssemblyName>
     <RootNamespace>Microsoft.EntityFrameworkCore</RootNamespace>
-    <Nullable>disable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <!-- Avoid referencing EFCore.Relational -->

--- a/test/EFCore.InMemory.FunctionalTests/GlobalDatabaseTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/GlobalDatabaseTest.cs
@@ -50,7 +50,7 @@ public class GlobalDatabaseTest
 
         using var scope = serviceProvider.CreateScope();
         {
-            var context = scope.ServiceProvider.GetService<BooFooContext>();
+            var context = scope.ServiceProvider.GetService<BooFooContext>()!;
             Assert.NotEmpty(context.Foos.ToList());
         }
     }
@@ -136,7 +136,7 @@ public class GlobalDatabaseTest
 
         using var scope = serviceProvider.CreateScope();
         {
-            var context = scope.ServiceProvider.GetService<BooFooContext>();
+            var context = scope.ServiceProvider.GetService<BooFooContext>()!;
             Assert.Equal(1, context.Boos.Count());
         }
     }
@@ -210,26 +210,26 @@ public class GlobalDatabaseTest
             });
         }
 
-        public DbSet<Foo> Foos { get; set; }
-        public DbSet<Boo> Boos { get; set; }
+        public DbSet<Foo> Foos { get; set; } = null!;
+        public DbSet<Boo> Boos { get; set; } = null!;
     }
 
     private class Foo
     {
         public int Id { get; set; }
-        public Goo Goo1 { get; set; }
-        public Goo Goo2 { get; set; }
+        public Goo? Goo1 { get; set; }
+        public Goo? Goo2 { get; set; }
     }
 
     private class Boo
     {
         public int Id { get; set; }
-        public Goo Goo1 { get; set; }
-        public Goo Goo2 { get; set; }
+        public Goo? Goo1 { get; set; }
+        public Goo? Goo2 { get; set; }
     }
 
     private class Goo
     {
-        public string Goop { get; set; }
+        public string? Goop { get; set; }
     }
 }

--- a/test/EFCore.InMemory.FunctionalTests/GraphUpdates/GraphUpdatesInMemoryTestBase.cs
+++ b/test/EFCore.InMemory.FunctionalTests/GraphUpdates/GraphUpdatesInMemoryTestBase.cs
@@ -156,9 +156,9 @@ public abstract class GraphUpdatesInMemoryTestBase<TFixture>(TFixture fixture) :
 
     protected override async Task ExecuteWithStrategyInTransactionAsync(
         Func<DbContext, Task> testOperation,
-        Func<DbContext, Task> nestedTestOperation1 = null,
-        Func<DbContext, Task> nestedTestOperation2 = null,
-        Func<DbContext, Task> nestedTestOperation3 = null)
+        Func<DbContext, Task>? nestedTestOperation1 = null,
+        Func<DbContext, Task>? nestedTestOperation2 = null,
+        Func<DbContext, Task>? nestedTestOperation3 = null)
     {
         await base.ExecuteWithStrategyInTransactionAsync(
             testOperation, nestedTestOperation1, nestedTestOperation2, nestedTestOperation3);

--- a/test/EFCore.InMemory.FunctionalTests/GraphUpdates/ProxyGraphUpdatesInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/GraphUpdates/ProxyGraphUpdatesInMemoryTest.cs
@@ -167,9 +167,9 @@ public class ProxyGraphUpdatesInMemoryTest
 
         protected override async Task ExecuteWithStrategyInTransactionAsync(
             Func<DbContext, Task> testOperation,
-            Func<DbContext, Task> nestedTestOperation1 = null,
-            Func<DbContext, Task> nestedTestOperation2 = null,
-            Func<DbContext, Task> nestedTestOperation3 = null)
+            Func<DbContext, Task>? nestedTestOperation1 = null,
+            Func<DbContext, Task>? nestedTestOperation2 = null,
+            Func<DbContext, Task>? nestedTestOperation3 = null)
         {
             // InMemory has no real transactions, so the shared store is mutated directly by each test and must be
             // reseeded afterwards.

--- a/test/EFCore.InMemory.FunctionalTests/GuidValueGeneratorEndToEndTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/GuidValueGeneratorEndToEndTest.cs
@@ -50,12 +50,12 @@ public class GuidValueGeneratorEndToEndTest
                 .UseInternalServiceProvider(_serviceProvider);
 
         // ReSharper disable once UnusedAutoPropertyAccessor.Local
-        public DbSet<Pegasus> Pegasuses { get; set; }
+        public DbSet<Pegasus> Pegasuses { get; set; } = null!;
     }
 
     private class Pegasus
     {
         public Guid Id { get; set; }
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
     }
 }

--- a/test/EFCore.InMemory.FunctionalTests/InMemoryFixture.cs
+++ b/test/EFCore.InMemory.FunctionalTests/InMemoryFixture.cs
@@ -22,7 +22,7 @@ public class InMemoryFixture
     public static ServiceProvider BuildServiceProvider(ILoggerFactory loggerFactory)
         => BuildServiceProvider(new ServiceCollection().AddSingleton(loggerFactory));
 
-    public static ServiceProvider BuildServiceProvider(IServiceCollection providerServices = null)
+    public static ServiceProvider BuildServiceProvider(IServiceCollection? providerServices = null)
         => InMemoryTestStoreFactory.Instance.AddProviderServices(
                 providerServices
                 ?? new ServiceCollection())

--- a/test/EFCore.InMemory.FunctionalTests/IntegerGeneratorEndToEndInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/IntegerGeneratorEndToEndInMemoryTest.cs
@@ -119,12 +119,12 @@ public class IntegerGeneratorEndToEndInMemoryTest
                 .UseInternalServiceProvider(_serviceProvider);
 
         // ReSharper disable once UnusedAutoPropertyAccessor.Local
-        public DbSet<Pegasus> Pegasuses { get; set; }
+        public DbSet<Pegasus> Pegasuses { get; set; } = null!;
     }
 
     private class Pegasus
     {
         public int Id { get; set; }
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
     }
 }

--- a/test/EFCore.InMemory.FunctionalTests/IntegerValueGeneratorTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/IntegerValueGeneratorTest.cs
@@ -354,12 +354,12 @@ public class IntegerValueGeneratorTest
 
     private class PetsContext(
         string databaseName,
-        InMemoryDatabaseRoot root = null,
-        IServiceProvider internalServiceProvider = null) : DbContext
+        InMemoryDatabaseRoot? root = null,
+        IServiceProvider? internalServiceProvider = null) : DbContext
     {
         private readonly string _databaseName = databaseName;
-        private readonly InMemoryDatabaseRoot _root = root;
-        private readonly IServiceProvider _internalServiceProvider = internalServiceProvider;
+        private readonly InMemoryDatabaseRoot? _root = root;
+        private readonly IServiceProvider? _internalServiceProvider = internalServiceProvider;
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         {
@@ -382,19 +382,19 @@ public class IntegerValueGeneratorTest
         }
 
         // ReSharper disable once UnusedAutoPropertyAccessor.Local
-        public DbSet<Toast> CookedBreads { get; set; }
-        public DbSet<Olive> Olives { get; set; }
+        public DbSet<Toast> CookedBreads { get; set; } = null!;
+        public DbSet<Olive> Olives { get; set; } = null!;
 
         // ReSharper disable once UnusedAutoPropertyAccessor.Local
-        public DbSet<Mac> Macs { get; set; }
-        public DbSet<Smokey> Smokeys { get; set; }
-        public DbSet<Alice> Alices { get; set; }
+        public DbSet<Mac> Macs { get; set; } = null!;
+        public DbSet<Smokey> Smokeys { get; set; } = null!;
+        public DbSet<Alice> Alices { get; set; } = null!;
     }
 
     private class PetsContextWithData(
         string databaseName,
-        InMemoryDatabaseRoot root = null,
-        IServiceProvider internalServiceProvider = null) : PetsContext(databaseName, root, internalServiceProvider)
+        InMemoryDatabaseRoot? root = null,
+        IServiceProvider? internalServiceProvider = null) : PetsContext(databaseName, root, internalServiceProvider)
     {
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {

--- a/test/EFCore.InMemory.FunctionalTests/JsonTypesInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/JsonTypesInMemoryTest.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore;
 
 public class JsonTypesInMemoryTest(NonSharedFixture fixture) : JsonTypesTestBase(fixture)

--- a/test/EFCore.InMemory.FunctionalTests/LazyLoadProxyInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/LazyLoadProxyInMemoryTest.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore;
 
 public class LazyLoadProxyInMemoryTest(LazyLoadProxyInMemoryTest.LoadInMemoryFixture fixture)

--- a/test/EFCore.InMemory.FunctionalTests/LoggingInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/LoggingInMemoryTest.cs
@@ -21,7 +21,7 @@ public class LoggingInMemoryTest : LoggingTestBase
 
     protected override string ProviderVersion
         => typeof(InMemoryOptionsExtension).Assembly
-            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()!.InformationalVersion;
 
     protected override string DefaultOptions
         => "StoreName=LoggingInMemoryTest NullabilityChecksEnabled ";

--- a/test/EFCore.InMemory.FunctionalTests/ManyToManyTrackingInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/ManyToManyTrackingInMemoryTest.cs
@@ -10,9 +10,9 @@ public class ManyToManyTrackingInMemoryTest(ManyToManyTrackingInMemoryTest.ManyT
 {
     protected override async Task ExecuteWithStrategyInTransactionAsync(
         Func<ManyToManyContext, Task> testOperation,
-        Func<ManyToManyContext, Task> nestedTestOperation1 = null,
-        Func<ManyToManyContext, Task> nestedTestOperation2 = null,
-        Func<ManyToManyContext, Task> nestedTestOperation3 = null)
+        Func<ManyToManyContext, Task>? nestedTestOperation1 = null,
+        Func<ManyToManyContext, Task>? nestedTestOperation2 = null,
+        Func<ManyToManyContext, Task>? nestedTestOperation3 = null)
     {
         await base.ExecuteWithStrategyInTransactionAsync(
             testOperation, nestedTestOperation1, nestedTestOperation2, nestedTestOperation3);

--- a/test/EFCore.InMemory.FunctionalTests/MaterializationInterceptionInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/MaterializationInterceptionInMemoryTest.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore;
 
 public class MaterializationInterceptionInMemoryTest(NonSharedFixture fixture) :

--- a/test/EFCore.InMemory.FunctionalTests/ModelBuilding/InMemoryModelBuilderAssemblyScanTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/ModelBuilding/InMemoryModelBuilderAssemblyScanTest.cs
@@ -21,11 +21,11 @@ public class InMemoryModelBuilderAssemblyScanTest : ModelBuilderTest
 
         var entityType = builder.Model.FindEntityType(typeof(ScannerCustomer));
         // ScannerCustomerEntityConfiguration called
-        Assert.Equal(200, entityType.FindProperty(nameof(ScannerCustomer.FirstName)).GetMaxLength());
+        Assert.Equal(200, entityType!.FindProperty(nameof(ScannerCustomer.FirstName))!.GetMaxLength());
         // ScannerCustomerEntityConfiguration2 called
-        Assert.Equal(1000, entityType.FindProperty(nameof(ScannerCustomer.LastName)).GetMaxLength());
+        Assert.Equal(1000, entityType.FindProperty(nameof(ScannerCustomer.LastName))!.GetMaxLength());
         // AbstractCustomerEntityConfiguration not called
-        Assert.Null(entityType.FindProperty(nameof(ScannerCustomer.MiddleName)).GetMaxLength());
+        Assert.Null(entityType.FindProperty(nameof(ScannerCustomer.MiddleName))!.GetMaxLength());
         // AbstractCustomerEntityConfigurationImpl called
         Assert.Single(entityType.GetIndexes());
 
@@ -85,11 +85,11 @@ public class InMemoryModelBuilderAssemblyScanTest : ModelBuilderTest
 
         var entityType = builder.Model.FindEntityType(typeof(ScannerCustomer));
         // ScannerCustomerEntityConfiguration called
-        Assert.Equal(200, entityType.FindProperty(nameof(ScannerCustomer.FirstName)).GetMaxLength());
+        Assert.Equal(200, entityType!.FindProperty(nameof(ScannerCustomer.FirstName))!.GetMaxLength());
         // ScannerCustomerEntityConfiguration2 not called
-        Assert.Null(entityType.FindProperty(nameof(ScannerCustomer.LastName)).GetMaxLength());
+        Assert.Null(entityType.FindProperty(nameof(ScannerCustomer.LastName))!.GetMaxLength());
         // AbstractCustomerEntityConfiguration not called
-        Assert.Null(entityType.FindProperty(nameof(ScannerCustomer.MiddleName)).GetMaxLength());
+        Assert.Null(entityType.FindProperty(nameof(ScannerCustomer.MiddleName))!.GetMaxLength());
         // AbstractCustomerEntityConfigurationImpl not called
         Assert.Empty(entityType.GetIndexes());
 
@@ -110,7 +110,7 @@ public class InMemoryModelBuilderAssemblyScanTest : ModelBuilderTest
         Assert.Null(entityType);
 
         var expectedMessage = CoreResources.LogNoEntityTypeConfigurationsWarning(
-            new TestLogger<TestLoggingDefinitions>()).GenerateMessage(_mockEntityTypeAssembly.FullName);
+            new TestLogger<TestLoggingDefinitions>()).GenerateMessage(_mockEntityTypeAssembly.FullName!);
 
         Assert.Equal(expectedMessage, loggerFactory.Log[0].Message);
     }
@@ -126,7 +126,7 @@ public class InMemoryModelBuilderAssemblyScanTest : ModelBuilderTest
         Assert.Equal(1, loggerFactory.Log.Count);
 
         var expectedMessage = CoreResources.LogNoEntityTypeConfigurationsWarning(
-            new TestLogger<TestLoggingDefinitions>()).GenerateMessage(typeof(Random).Assembly.FullName);
+            new TestLogger<TestLoggingDefinitions>()).GenerateMessage(typeof(Random).Assembly.FullName!);
 
         Assert.Equal(expectedMessage, loggerFactory.Log[0].Message);
     }
@@ -163,20 +163,20 @@ public class InMemoryModelBuilderAssemblyScanTest : ModelBuilderTest
     protected class ScannerCustomer
     {
         public int Id { get; set; }
-        public string FirstName { get; set; }
-        public string LastName { get; set; }
-        public string MiddleName { get; set; }
-        public string Address { get; set; }
+        public string FirstName { get; set; } = null!;
+        public string LastName { get; set; } = null!;
+        public string MiddleName { get; set; } = null!;
+        public string Address { get; set; } = null!;
         public int IndexedField { get; set; }
     }
 
     protected class ScannerCustomer2
     {
         public int Id { get; set; }
-        public string FirstName { get; set; }
-        public string LastName { get; set; }
-        public string MiddleName { get; set; }
-        public string Address { get; set; }
+        public string FirstName { get; set; } = null!;
+        public string LastName { get; set; } = null!;
+        public string MiddleName { get; set; } = null!;
+        public string Address { get; set; } = null!;
         public int IndexedField { get; set; }
     }
 

--- a/test/EFCore.InMemory.FunctionalTests/ModelBuilding/InMemoryModelBuilderGenericRelationshipStringTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/ModelBuilding/InMemoryModelBuilderGenericRelationshipStringTest.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore.ModelBuilding;
 
 public class InMemoryModelBuilderGenericRelationshipStringTest : InMemoryModelBuilderGenericTest

--- a/test/EFCore.InMemory.FunctionalTests/ModelBuilding/InMemoryModelBuilderGenericRelationshipTypeTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/ModelBuilding/InMemoryModelBuilderGenericRelationshipTypeTest.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore.ModelBuilding;
 
 public class InMemoryModelBuilderGenericRelationshipTypeTest : InMemoryModelBuilderGenericTest

--- a/test/EFCore.InMemory.FunctionalTests/ModelBuilding/InMemoryModelBuilderGenericTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/ModelBuilding/InMemoryModelBuilderGenericTest.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;

--- a/test/EFCore.InMemory.FunctionalTests/ModelBuilding/InMemoryModelBuilderNonGenericStringTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/ModelBuilding/InMemoryModelBuilderNonGenericStringTest.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using Xunit.Sdk;
 
 // ReSharper disable AssignNullToNotNullAttribute

--- a/test/EFCore.InMemory.FunctionalTests/ModelBuilding/InMemoryModelBuilderNonGenericTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/ModelBuilding/InMemoryModelBuilderNonGenericTest.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 // ReSharper disable InconsistentNaming
 namespace Microsoft.EntityFrameworkCore.ModelBuilding;
 

--- a/test/EFCore.InMemory.FunctionalTests/ModelBuilding/InMemoryModelBuilderNonGenericUnqualifiedStringTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/ModelBuilding/InMemoryModelBuilderNonGenericUnqualifiedStringTest.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore.ModelBuilding;
 
 public class InMemoryModelBuilderNonGenericUnqualifiedStringTest : InMemoryModelBuilderNonGenericTest

--- a/test/EFCore.InMemory.FunctionalTests/ModelBuilding/InMemoryModelBuilderTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/ModelBuilding/InMemoryModelBuilderTest.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 // ReSharper disable InconsistentNaming
 namespace Microsoft.EntityFrameworkCore.ModelBuilding;
 

--- a/test/EFCore.InMemory.FunctionalTests/ModelBuilding/PropertyBagEntityTypeTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/ModelBuilding/PropertyBagEntityTypeTest.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore.ModelBuilding;
 
 public class PropertyBagEntityTypeTest

--- a/test/EFCore.InMemory.FunctionalTests/ModelSourceTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/ModelSourceTest.cs
@@ -35,7 +35,7 @@ public class ModelSourceTest
     {
         private readonly IServiceProvider _serviceProvider = serviceProvider;
 
-        public DbSet<Peak> Peaks { get; set; }
+        public DbSet<Peak> Peaks { get; set; } = null!;
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
             => modelBuilder.Entity<Base>().HasAnnotation("AllYourBaseAreBelongTo", "Us!");

--- a/test/EFCore.InMemory.FunctionalTests/NamedDatabaseTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/NamedDatabaseTest.cs
@@ -189,18 +189,18 @@ public class NamedDatabaseTest
         }
     }
 
-    private class PusheenContext(string databaseName, IServiceProvider serviceProvider = null) : DbContext
+    private class PusheenContext(string? databaseName, IServiceProvider? serviceProvider = null) : DbContext
     {
-        private readonly string _databaseName = databaseName;
-        private readonly IServiceProvider _serviceProvider = serviceProvider;
+        private readonly string? _databaseName = databaseName;
+        private readonly IServiceProvider? _serviceProvider = serviceProvider;
 
-        public PusheenContext(IServiceProvider serviceProvider = null)
+        public PusheenContext(IServiceProvider? serviceProvider = null)
             : this(null, serviceProvider)
         {
         }
 
         // ReSharper disable once UnusedAutoPropertyAccessor.Local
-        public DbSet<Pusheen> Pusheens { get; set; }
+        public DbSet<Pusheen> Pusheens { get; set; } = null!;
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         {
@@ -222,6 +222,6 @@ public class NamedDatabaseTest
     private class Pusheen
     {
         public int Id { get; set; }
-        public string Activity { get; set; }
+        public string Activity { get; set; } = null!;
     }
 }

--- a/test/EFCore.InMemory.FunctionalTests/NullabilityCheckInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/NullabilityCheckInMemoryTest.cs
@@ -175,14 +175,14 @@ public class NullabilityCheckInMemoryTest(InMemoryFixture fixture) : IClassFixtu
         public int Id { get; set; }
 
         [Required]
-        public string RequiredProperty { get; set; }
+        public string? RequiredProperty { get; set; }
     }
 
     private class SomeEntity
     {
         public int Id { get; set; }
 
-        public string Property { get; set; }
+        public string? Property { get; set; }
     }
 
     private class AnotherEntityWithRequiredAttribute
@@ -190,9 +190,9 @@ public class NullabilityCheckInMemoryTest(InMemoryFixture fixture) : IClassFixtu
         public int Id { get; set; }
 
         [Required]
-        public string RequiredProperty { get; set; }
+        public string? RequiredProperty { get; set; }
 
-        public string Property { get; set; }
+        public string? Property { get; set; }
     }
 
     private class AnotherEntityWithCompositeKeys
@@ -201,6 +201,6 @@ public class NullabilityCheckInMemoryTest(InMemoryFixture fixture) : IClassFixtu
 
         public int SecondId { get; set; }
 
-        public string Property { get; set; }
+        public string? Property { get; set; }
     }
 }

--- a/test/EFCore.InMemory.FunctionalTests/Query/AdHocQueryFiltersQueryInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/AdHocQueryFiltersQueryInMemoryTest.cs
@@ -44,9 +44,9 @@ public class AdHocQueryFiltersQueryInMemoryTest(NonSharedFixture fixture) : AdHo
 
     protected class Context19708(DbContextOptions options) : DbContext(options)
     {
-        public DbSet<Customer19708> Customers { get; set; }
-        public DbSet<CustomerMembership19708> CustomerMemberships { get; set; }
-        public DbSet<CustomerFilter19708> CustomerFilters { get; set; }
+        public DbSet<Customer19708> Customers { get; set; } = null!;
+        public DbSet<CustomerMembership19708> CustomerMemberships { get; set; } = null!;
+        public DbSet<CustomerFilter19708> CustomerFilters { get; set; } = null!;
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
@@ -99,16 +99,16 @@ public class AdHocQueryFiltersQueryInMemoryTest(NonSharedFixture fixture) : AdHo
         public class Customer19708
         {
             public int Id { get; set; }
-            public string Name { get; set; }
+            public string Name { get; set; } = null!;
         }
 
         public class CustomerMembership19708
         {
             public int Id { get; set; }
-            public string Name { get; set; }
+            public string Name { get; set; } = null!;
 
             public int CustomerId { get; set; }
-            public Customer19708 Customer { get; set; }
+            public Customer19708 Customer { get; set; } = null!;
         }
 
         public class CustomerFilter19708
@@ -120,9 +120,9 @@ public class AdHocQueryFiltersQueryInMemoryTest(NonSharedFixture fixture) : AdHo
         public class CustomerView19708
         {
             public int Id { get; set; }
-            public string Name { get; set; }
+            public string Name { get; set; } = null!;
             public int? CustomerMembershipId { get; set; }
-            public string CustomerMembershipName { get; set; }
+            public string CustomerMembershipName { get; set; } = null!;
         }
     }
 

--- a/test/EFCore.InMemory.FunctionalTests/Query/GearsOfWarQueryInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/GearsOfWarQueryInMemoryTest.cs
@@ -148,8 +148,8 @@ public class GearsOfWarQueryInMemoryTest(GearsOfWarQueryInMemoryFixture fixture)
     public virtual Task Select_ToString_on_non_nullable_property_of_an_optional_entity(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<CogTag>().Select(x => new { x.Id, SquadIdString = x.Gear.SquadId.ToString() }),
-            ss => ss.Set<CogTag>().Select(x => new { x.Id, SquadIdString = x.Gear == null ? null : x.Gear.SquadId.ToString() }),
+            ss => ss.Set<CogTag>().Select(x => new { x.Id, SquadIdString = x.Gear!.SquadId.ToString() }),
+            ss => ss.Set<CogTag>().Select(x => new { x.Id, SquadIdString = x.Gear == null ? null! : x.Gear.SquadId.ToString() }),
             elementSorter: e => e.Id,
             elementAsserter: (e, a) =>
             {

--- a/test/EFCore.InMemory.FunctionalTests/Query/NorthwindWhereQueryInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/NorthwindWhereQueryInMemoryTest.cs
@@ -14,7 +14,7 @@ public class NorthwindWhereQueryInMemoryTest(NorthwindQueryInMemoryFixture<NoopM
 
         Assert.Equal(InMemoryStrings.NoQueryStrings, queryString);
 
-        return null;
+        return null!;
     }
 
     public override Task ElementAt_over_custom_projection_compared_to_not_null(bool async)

--- a/test/EFCore.InMemory.FunctionalTests/Query/OwnedEntityQueryInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/OwnedEntityQueryInMemoryTest.cs
@@ -40,7 +40,6 @@ public class OwnedEntityQueryInMemoryTest(NonSharedFixture fixture) : OwnedEntit
         }
     }
 
-#nullable enable
     protected class Bar
     {
         public long Id { get; set; }
@@ -58,7 +57,6 @@ public class OwnedEntityQueryInMemoryTest(NonSharedFixture fixture) : OwnedEntit
         public long Id { get; set; }
         public virtual Bar? Bar { get; set; }
     }
-#nullable disable
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual async Task Owned_references_on_same_level_expanded_at_different_times_around_take(bool async)

--- a/test/EFCore.InMemory.FunctionalTests/Query/QueryBugsInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/QueryBugsInMemoryTest.cs
@@ -119,10 +119,10 @@ public class QueryBugsInMemoryTest : IClassFixture<InMemoryFixture>
         }
 
         // ReSharper disable once UnusedAutoPropertyAccessor.Local
-        public DbSet<VehicleInspection> VehicleInspections { get; set; }
+        public DbSet<VehicleInspection> VehicleInspections { get; set; } = null!;
 
         // ReSharper disable once UnusedAutoPropertyAccessor.Local
-        public DbSet<Motor> Motors { get; set; }
+        public DbSet<Motor> Motors { get; set; } = null!;
     }
 
     private class VehicleInspection
@@ -135,7 +135,7 @@ public class QueryBugsInMemoryTest : IClassFixture<InMemoryFixture>
     {
         public long Id { get; set; }
         public long VehicleInspectionId { get; set; }
-        public VehicleInspection Inspection { get; set; }
+        public VehicleInspection Inspection { get; set; } = null!;
     }
 
     #endregion
@@ -195,20 +195,20 @@ public class QueryBugsInMemoryTest : IClassFixture<InMemoryFixture>
         public int Id { get; set; }
 
         public int QuestionId { get; set; }
-        public Question3595 Question { get; set; }
+        public Question3595 Question { get; set; } = null!;
 
         public int ExamId { get; set; }
-        public Exam3595 Exam { get; set; }
+        public Exam3595 Exam { get; set; } = null!;
     }
 
     private class Context3595 : DbContext
     {
         // ReSharper disable once UnusedAutoPropertyAccessor.Local
-        public DbSet<Exam3595> Exams { get; set; }
-        public DbSet<Question3595> Questions { get; set; }
+        public DbSet<Exam3595> Exams { get; set; } = null!;
+        public DbSet<Question3595> Questions { get; set; } = null!;
 
         // ReSharper disable once UnusedAutoPropertyAccessor.Local
-        public DbSet<ExamQuestion3595> ExamQuestions { get; set; }
+        public DbSet<ExamQuestion3595> ExamQuestions { get; set; } = null!;
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
             => optionsBuilder
@@ -420,10 +420,10 @@ public class QueryBugsInMemoryTest : IClassFixture<InMemoryFixture>
     private class MyContext3101 : DbContext
     {
         // ReSharper disable once UnusedAutoPropertyAccessor.Local
-        public DbSet<Entity3101> Entities { get; set; }
+        public DbSet<Entity3101> Entities { get; set; } = null!;
 
         // ReSharper disable once UnusedAutoPropertyAccessor.Local
-        public DbSet<Child3101> Children { get; set; }
+        public DbSet<Child3101> Children { get; set; } = null!;
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
             => optionsBuilder
@@ -440,7 +440,7 @@ public class QueryBugsInMemoryTest : IClassFixture<InMemoryFixture>
 
         public int? RootEntityId { get; set; }
 
-        public Entity3101 RootEntity { get; set; }
+        public Entity3101? RootEntity { get; set; }
 
         public ICollection<Child3101> Children { get; set; } = [];
     }
@@ -448,7 +448,7 @@ public class QueryBugsInMemoryTest : IClassFixture<InMemoryFixture>
     private class Child3101
     {
         public int Id { get; set; }
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
     }
 
     #endregion
@@ -592,12 +592,12 @@ public class QueryBugsInMemoryTest : IClassFixture<InMemoryFixture>
 
     private class MyContext5456 : DbContext
     {
-        public DbSet<Blog5456> Blogs { get; set; }
+        public DbSet<Blog5456> Blogs { get; set; } = null!;
 
         // ReSharper disable once UnusedAutoPropertyAccessor.Local
-        public DbSet<Post5456> Posts { get; set; }
-        public DbSet<Comment5456> Comments { get; set; }
-        public DbSet<Author5456> Authors { get; set; }
+        public DbSet<Post5456> Posts { get; set; } = null!;
+        public DbSet<Comment5456> Comments { get; set; } = null!;
+        public DbSet<Author5456> Authors { get; set; } = null!;
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
             => optionsBuilder
@@ -611,27 +611,27 @@ public class QueryBugsInMemoryTest : IClassFixture<InMemoryFixture>
     private class Blog5456
     {
         public int Id { get; set; }
-        public List<Post5456> Posts { get; set; }
-        public Author5456 Author { get; set; }
+        public List<Post5456> Posts { get; set; } = null!;
+        public Author5456 Author { get; set; } = null!;
     }
 
     private class Author5456
     {
         public int Id { get; set; }
-        public List<Blog5456> Blogs { get; set; }
+        public List<Blog5456> Blogs { get; set; } = null!;
     }
 
     private class Post5456
     {
         public int Id { get; set; }
-        public Blog5456 Blog { get; set; }
-        public List<Comment5456> Comments { get; set; }
+        public Blog5456 Blog { get; set; } = null!;
+        public List<Comment5456> Comments { get; set; } = null!;
     }
 
     private class Comment5456
     {
         public int Id { get; set; }
-        public Post5456 Blog { get; set; }
+        public Post5456 Blog { get; set; } = null!;
     }
 
     #endregion
@@ -653,7 +653,7 @@ public class QueryBugsInMemoryTest : IClassFixture<InMemoryFixture>
     private class MyContext8282 : DbContext
     {
         // ReSharper disable once UnusedAutoPropertyAccessor.Local
-        public DbSet<Entity8282> Entity { get; set; }
+        public DbSet<Entity8282> Entity { get; set; } = null!;
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
             => optionsBuilder
@@ -713,12 +713,12 @@ public class QueryBugsInMemoryTest : IClassFixture<InMemoryFixture>
     private class OtherEntity21803
     {
         public int Id { get; private set; }
-        public AppEntity21803 AppEntity { get; set; }
+        public AppEntity21803 AppEntity { get; set; } = null!;
     }
 
     private class MyContext21803 : DbContext
     {
-        public DbSet<AppEntity21803> Entities { get; set; }
+        public DbSet<AppEntity21803> Entities { get; set; } = null!;
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
             => optionsBuilder
@@ -769,8 +769,8 @@ public class QueryBugsInMemoryTest : IClassFixture<InMemoryFixture>
     private class Owner20729
     {
         public int Id { get; set; }
-        public Owned120729 Owned1 { get; set; }
-        public Owned220729 Owned2 { get; set; }
+        public Owned120729? Owned1 { get; set; }
+        public Owned220729? Owned2 { get; set; }
     }
 
     [Owned]
@@ -784,7 +784,7 @@ public class QueryBugsInMemoryTest : IClassFixture<InMemoryFixture>
     private class Owned220729
     {
         // ReSharper disable once UnusedAutoPropertyAccessor.Local
-        public Other20729 Other { get; set; }
+        public Other20729? Other { get; set; }
     }
 
     private class Other20729
@@ -796,7 +796,7 @@ public class QueryBugsInMemoryTest : IClassFixture<InMemoryFixture>
     private class MyContext20729 : DbContext
     {
         // ReSharper disable once UnusedAutoPropertyAccessor.Local
-        public DbSet<Owner20729> Owners { get; set; }
+        public DbSet<Owner20729> Owners { get; set; } = null!;
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
             => optionsBuilder
@@ -832,14 +832,14 @@ public class QueryBugsInMemoryTest : IClassFixture<InMemoryFixture>
     [Owned]
     private class OwnedClass23285
     {
-        public string A { get; set; }
-        public string B { get; set; }
+        public string? A { get; set; }
+        public string? B { get; set; }
     }
 
     private class Root23285
     {
         public int Id { get; set; }
-        public OwnedClass23285 OwnedProp { get; set; }
+        public OwnedClass23285? OwnedProp { get; set; }
     }
 
     private class ChildA23285 : Root23285
@@ -855,7 +855,7 @@ public class QueryBugsInMemoryTest : IClassFixture<InMemoryFixture>
     private class MyContext23285 : DbContext
     {
         // ReSharper disable once UnusedAutoPropertyAccessor.Local
-        public DbSet<Root23285> Table { get; set; }
+        public DbSet<Root23285> Table { get; set; } = null!;
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
             => optionsBuilder
@@ -904,8 +904,8 @@ public class QueryBugsInMemoryTest : IClassFixture<InMemoryFixture>
     [Owned]
     private class OwnedClass23687
     {
-        public string A { get; set; }
-        public string B { get; set; }
+        public string A { get; set; } = null!;
+        public string B { get; set; } = null!;
     }
 
     [PrimaryKey(nameof(Id1), nameof(Id2))]
@@ -913,13 +913,13 @@ public class QueryBugsInMemoryTest : IClassFixture<InMemoryFixture>
     {
         public int Id1 { get; set; }
         public int Id2 { get; set; }
-        public OwnedClass23687 OwnedProp { get; set; }
+        public OwnedClass23687 OwnedProp { get; set; } = null!;
     }
 
     private class MyContext23687 : DbContext
     {
         // ReSharper disable once UnusedAutoPropertyAccessor.Local
-        public DbSet<Root23687> Table { get; set; }
+        public DbSet<Root23687> Table { get; set; } = null!;
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
             => optionsBuilder
@@ -1012,10 +1012,10 @@ public class QueryBugsInMemoryTest : IClassFixture<InMemoryFixture>
     private class MyContext23593 : DbContext
     {
         // ReSharper disable once UnusedAutoPropertyAccessor.Local
-        public DbSet<StatusMap23593> StatusMaps { get; set; }
+        public DbSet<StatusMap23593> StatusMaps { get; set; } = null!;
 
         // ReSharper disable once UnusedAutoPropertyAccessor.Local
-        public DbSet<StatusMapEvent23593> StatusMapEvents { get; set; }
+        public DbSet<StatusMapEvent23593> StatusMapEvents { get; set; } = null!;
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
             => optionsBuilder
@@ -1034,7 +1034,7 @@ public class QueryBugsInMemoryTest : IClassFixture<InMemoryFixture>
         {
             using var context = new MyContext23926();
 
-            var query = context.History.Select(e => e.User.Name).ToList();
+            var query = context.History.Select(e => e.User!.Name).ToList();
 
             Assert.Equal(query, new[] { "UserA", "DerivedUserB", null });
         }
@@ -1053,14 +1053,14 @@ public class QueryBugsInMemoryTest : IClassFixture<InMemoryFixture>
     {
         public int Id { get; set; }
         public int? UserId { get; set; }
-        public User23926 User { get; set; }
+        public User23926? User { get; set; }
     }
 
     private class User23926
     {
         public int Id { get; set; }
         public UserTypes23926 Type { get; set; }
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
     }
 
     private enum UserTypes23926
@@ -1071,13 +1071,13 @@ public class QueryBugsInMemoryTest : IClassFixture<InMemoryFixture>
 
     private class DerivedUser23926 : User23926
     {
-        public string Value { get; set; }
+        public string? Value { get; set; }
     }
 
     private class MyContext23926 : DbContext
     {
         // ReSharper disable once UnusedAutoPropertyAccessor.Local
-        public DbSet<History23926> History { get; set; }
+        public DbSet<History23926> History { get; set; } = null!;
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
             => optionsBuilder
@@ -1111,7 +1111,7 @@ public class QueryBugsInMemoryTest : IClassFixture<InMemoryFixture>
                     D = x.Child.Owned.Second
                 }).FirstOrDefault();
 
-            Assert.Equal("test", result.Value);
+            Assert.Equal("test", result!.Value);
             Assert.Equal(2, result.A);
             Assert.Equal(4, result.B);
             Assert.Equal(1, result.C);
@@ -1148,16 +1148,16 @@ public class QueryBugsInMemoryTest : IClassFixture<InMemoryFixture>
     private class RootEntity18435
     {
         public int Id { get; set; }
-        public string Value { get; set; }
-        public TestOwned18435 Owned { get; set; }
-        public ChildEntity18435 Child { get; set; }
+        public string Value { get; set; } = null!;
+        public TestOwned18435 Owned { get; set; } = null!;
+        public ChildEntity18435 Child { get; set; } = null!;
     }
 
     private class ChildEntity18435
     {
         public int Id { get; set; }
-        public string Value { get; set; }
-        public TestOwned18435 Owned { get; set; }
+        public string? Value { get; set; }
+        public TestOwned18435 Owned { get; set; } = null!;
     }
 
     [Owned]
@@ -1165,13 +1165,13 @@ public class QueryBugsInMemoryTest : IClassFixture<InMemoryFixture>
     {
         public int First { get; set; }
         public int Second { get; set; }
-        public string AnotherValueType { get; set; }
+        public string AnotherValueType { get; set; } = null!;
     }
 
     private class MyContext18435 : DbContext
     {
         // ReSharper disable once UnusedAutoPropertyAccessor.Local
-        public DbSet<RootEntity18435> TestEntities { get; set; }
+        public DbSet<RootEntity18435> TestEntities { get; set; } = null!;
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
             => optionsBuilder
@@ -1219,7 +1219,7 @@ public class QueryBugsInMemoryTest : IClassFixture<InMemoryFixture>
     private class MyContext19425 : DbContext
     {
         // ReSharper disable once UnusedAutoPropertyAccessor.Local
-        public DbSet<FooTable19425> FooTable { get; set; }
+        public DbSet<FooTable19425> FooTable { get; set; } = null!;
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
             => optionsBuilder
@@ -1240,7 +1240,7 @@ public class QueryBugsInMemoryTest : IClassFixture<InMemoryFixture>
 
             var query = context.Entities.OrderByDescending(e => e.Id).FirstOrDefault(p => p.Type.Date.Year == 2020);
 
-            Assert.Equal(2, query.Id);
+            Assert.Equal(2, query!.Id);
         }
     }
 
@@ -1256,7 +1256,7 @@ public class QueryBugsInMemoryTest : IClassFixture<InMemoryFixture>
     {
         public int Id { get; set; }
 
-        public MyType19667 Type { get; set; }
+        public MyType19667 Type { get; set; } = null!;
     }
 
     [Owned]
@@ -1268,7 +1268,7 @@ public class QueryBugsInMemoryTest : IClassFixture<InMemoryFixture>
     private class MyContext19667 : DbContext
     {
         // ReSharper disable once UnusedAutoPropertyAccessor.Local
-        public DbSet<MyEntity19667> Entities { get; set; }
+        public DbSet<MyEntity19667> Entities { get; set; } = null!;
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
             => optionsBuilder
@@ -1297,7 +1297,7 @@ public class QueryBugsInMemoryTest : IClassFixture<InMemoryFixture>
                                r.B.BValue,
                            }).FirstOrDefault();
 
-            Assert.Equal(result1.BValue, result2.BValue);
+            Assert.Equal(result1!.BValue, result2!.BValue);
         }
     }
 
@@ -1318,31 +1318,31 @@ public class QueryBugsInMemoryTest : IClassFixture<InMemoryFixture>
     {
         public int Id { get; set; }
 
-        public ASubClass20359 Sub { get; set; }
+        public ASubClass20359 Sub { get; set; } = null!;
     }
 
     private class ASubClass20359
     {
-        public string AValue { get; set; }
+        public string AValue { get; set; } = null!;
     }
 
     private class B20359
     {
-        public string BValue { get; set; }
+        public string BValue { get; set; } = null!;
     }
 
     private class Root20359
     {
         public int Id { get; set; }
 
-        public A20359 A { get; set; }
-        public B20359 B { get; set; }
+        public A20359 A { get; set; } = null!;
+        public B20359 B { get; set; } = null!;
     }
 
     private class MyContext20359 : DbContext
     {
         // ReSharper disable once UnusedAutoPropertyAccessor.Local
-        public DbSet<Root20359> Root { get; set; }
+        public DbSet<Root20359> Root { get; set; } = null!;
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
             => optionsBuilder
@@ -1417,8 +1417,8 @@ public class QueryBugsInMemoryTest : IClassFixture<InMemoryFixture>
         [Key]
         public int Key { get; set; }
 
-        public string Forename { get; set; }
-        public string Surname { get; set; }
+        public string Forename { get; set; } = null!;
+        public string Surname { get; set; } = null!;
     }
 
     private class Customer23360
@@ -1426,20 +1426,20 @@ public class QueryBugsInMemoryTest : IClassFixture<InMemoryFixture>
         [Key]
         public int Key { get; set; }
 
-        public string GivenName { get; set; }
-        public string FamilyName { get; set; }
+        public string GivenName { get; set; } = null!;
+        public string FamilyName { get; set; } = null!;
     }
 
     private class CommonSelectType23360
     {
-        public string FirstName { get; set; }
-        public string LastName { get; set; }
+        public string FirstName { get; set; } = null!;
+        public string LastName { get; set; } = null!;
     }
 
     private class MyContext23360 : DbContext
     {
-        public virtual DbSet<User23360> User { get; set; }
-        public virtual DbSet<Customer23360> Customer { get; set; }
+        public virtual DbSet<User23360> User { get; set; } = null!;
+        public virtual DbSet<Customer23360> Customer { get; set; } = null!;
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
             => optionsBuilder
@@ -1474,7 +1474,7 @@ public class QueryBugsInMemoryTest : IClassFixture<InMemoryFixture>
                 })
                 .FirstOrDefault();
 
-            Assert.Equal("TestText", myA.PropertyB.PropertyCList.First().SomeText);
+            Assert.Equal("TestText", myA!.PropertyB!.PropertyCList.First().SomeText);
         }
     }
 
@@ -1490,7 +1490,7 @@ public class QueryBugsInMemoryTest : IClassFixture<InMemoryFixture>
     {
         public int Id { get; set; }
 
-        public BDto18394 PropertyB { get; set; }
+        public BDto18394? PropertyB { get; set; }
 
         public int PropertyBId { get; set; }
     }
@@ -1499,7 +1499,7 @@ public class QueryBugsInMemoryTest : IClassFixture<InMemoryFixture>
     {
         public int Id { get; set; }
 
-        public List<CDto18394> PropertyCList { get; set; }
+        public List<CDto18394> PropertyCList { get; set; } = null!;
     }
 
     private class CDto18394
@@ -1508,14 +1508,14 @@ public class QueryBugsInMemoryTest : IClassFixture<InMemoryFixture>
 
         public int CId { get; set; }
 
-        public string SomeText { get; set; }
+        public string SomeText { get; set; } = null!;
     }
 
     private class A18394
     {
         public int Id { get; set; }
 
-        public B18394 PropertyB { get; set; }
+        public B18394? PropertyB { get; set; }
 
         public int PropertyBId { get; set; }
     }
@@ -1524,7 +1524,7 @@ public class QueryBugsInMemoryTest : IClassFixture<InMemoryFixture>
     {
         public int Id { get; set; }
 
-        public List<C18394> PropertyCList { get; set; }
+        public List<C18394> PropertyCList { get; set; } = null!;
     }
 
     private class C18394
@@ -1533,17 +1533,17 @@ public class QueryBugsInMemoryTest : IClassFixture<InMemoryFixture>
 
         public int BId { get; set; }
 
-        public string SomeText { get; set; }
+        public string SomeText { get; set; } = null!;
 
-        public B18394 B { get; set; }
+        public B18394 B { get; set; } = null!;
     }
 
     private class MyContext18394 : DbContext
     {
         // ReSharper disable once UnusedAutoPropertyAccessor.Local
-        public DbSet<A18394> As { get; set; }
-        public DbSet<B18394> Bs { get; set; }
-        public DbSet<C18394> Cs { get; set; }
+        public DbSet<A18394> As { get; set; } = null!;
+        public DbSet<B18394> Bs { get; set; } = null!;
+        public DbSet<C18394> Cs { get; set; } = null!;
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
             => optionsBuilder
@@ -1590,15 +1590,15 @@ public class QueryBugsInMemoryTest : IClassFixture<InMemoryFixture>
     private class Outer23934
     {
         public Guid Id { get; set; }
-        public OwnedClass23934 OwnedProp { get; set; }
+        public OwnedClass23934 OwnedProp { get; set; } = null!;
         public Guid InnerId { get; set; }
-        public Inner23934 Inner { get; set; }
+        public Inner23934 Inner { get; set; } = null!;
     }
 
     private class Inner23934
     {
         public Guid Id { get; set; }
-        public OwnedClass23934 OwnedProp { get; set; }
+        public OwnedClass23934 OwnedProp { get; set; } = null!;
     }
 
     [Owned]
@@ -1610,10 +1610,10 @@ public class QueryBugsInMemoryTest : IClassFixture<InMemoryFixture>
     private class MyContext23934 : DbContext
     {
         // ReSharper disable once UnusedAutoPropertyAccessor.Local
-        public DbSet<Outer23934> Outers { get; set; }
+        public DbSet<Outer23934> Outers { get; set; } = null!;
 
         // ReSharper disable once UnusedAutoPropertyAccessor.Local
-        public DbSet<Inner23934> Inners { get; set; }
+        public DbSet<Inner23934> Inners { get; set; } = null!;
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
             => optionsBuilder

--- a/test/EFCore.InMemory.FunctionalTests/Query/WarningsTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/WarningsTest.cs
@@ -238,7 +238,7 @@ public class WarningsTest
         private readonly EventId? _toThrow = toThrow;
         private readonly (EventId Id, LogLevel Level)? _toChangeLevel = toChangeLevel;
 
-        public DbSet<WarningAsErrorEntity> WarningAsErrorEntities { get; set; }
+        public DbSet<WarningAsErrorEntity> WarningAsErrorEntities { get; set; } = null!;
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
             => modelBuilder
@@ -272,7 +272,7 @@ public class WarningsTest
 
     private class WarningAsErrorEntity
     {
-        private readonly Action<object, string> _loader;
+        private readonly Action<object, string> _loader = null!;
 
         public WarningAsErrorEntity()
         {
@@ -285,9 +285,9 @@ public class WarningsTest
         {
             get => _loader.Load(this, ref field);
             set;
-        }
+        } = null!;
 
-        public string Id { get; set; }
+        public string Id { get; set; } = null!;
     }
 
     private class IncludedEntity

--- a/test/EFCore.InMemory.FunctionalTests/Scaffolding/CompiledModelInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Scaffolding/CompiledModelInMemoryTest.cs
@@ -3,8 +3,6 @@
 
 // ReSharper disable InconsistentNaming
 
-#nullable enable
-
 using System.Runtime.CompilerServices;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore.Design.Internal;

--- a/test/EFCore.InMemory.FunctionalTests/ShadowStateUpdateTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/ShadowStateUpdateTest.cs
@@ -37,13 +37,13 @@ public class ShadowStateUpdateTest(InMemoryFixture fixture) : IClassFixture<InMe
             Assert.Equal(42, customerFromStore.Id);
             Assert.Equal(
                 "Daenerys",
-                (string)context.Entry(customerFromStore).Property("Name").CurrentValue);
+                (string)context.Entry(customerFromStore).Property("Name").CurrentValue!);
         }
 
         using (var context = new DbContext(optionsBuilder.Options))
         {
             var customerEntry = context.Entry(customer).GetInfrastructure();
-            customerEntry[customerEntry.EntityType.FindProperty("Name")] = "Daenerys Targaryen";
+            customerEntry[customerEntry.EntityType.FindProperty("Name")!] = "Daenerys Targaryen";
 
             context.Update(customer);
 
@@ -57,7 +57,7 @@ public class ShadowStateUpdateTest(InMemoryFixture fixture) : IClassFixture<InMe
             Assert.Equal(42, customerFromStore.Id);
             Assert.Equal(
                 "Daenerys Targaryen",
-                (string)context.Entry(customerFromStore).Property("Name").CurrentValue);
+                (string)context.Entry(customerFromStore).Property("Name").CurrentValue!);
         }
 
         using (var context = new DbContext(optionsBuilder.Options))

--- a/test/EFCore.InMemory.FunctionalTests/StoreGeneratedInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/StoreGeneratedInMemoryTest.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System.ComponentModel.DataAnnotations.Schema;
 
 namespace Microsoft.EntityFrameworkCore;

--- a/test/EFCore.InMemory.FunctionalTests/TestUtilities/InMemoryTestStore.cs
+++ b/test/EFCore.InMemory.FunctionalTests/TestUtilities/InMemoryTestStore.cs
@@ -5,33 +5,33 @@ using Microsoft.EntityFrameworkCore.InMemory.Storage.Internal;
 
 namespace Microsoft.EntityFrameworkCore.TestUtilities;
 
-public class InMemoryTestStore(string name = null, bool shared = true) : TestStore(name, shared)
+public class InMemoryTestStore(string? name = null, bool shared = true) : TestStore(name!, shared)
 {
     public static InMemoryTestStore GetOrCreate(string name)
         => new(name);
 
     public static Task<InMemoryTestStore> GetOrCreateInitializedAsync(string name)
-        => new InMemoryTestStore(name).InitializeInMemoryAsync(null, (Func<DbContext>)null, null);
+        => new InMemoryTestStore(name).InitializeInMemoryAsync(null, (Func<DbContext>?)null, null);
 
     public static InMemoryTestStore Create(string name)
         => new(name, shared: false);
 
     public static Task<InMemoryTestStore> CreateInitializedAsync(string name)
-        => new InMemoryTestStore(name, shared: false).InitializeInMemoryAsync(null, (Func<DbContext>)null, null);
+        => new InMemoryTestStore(name, shared: false).InitializeInMemoryAsync(null, (Func<DbContext>?)null, null);
 
     public async Task<InMemoryTestStore> InitializeInMemoryAsync(
-        IServiceProvider serviceProvider,
-        Func<DbContext> createContext,
-        Func<DbContext, Task> seed)
+        IServiceProvider? serviceProvider,
+        Func<DbContext>? createContext,
+        Func<DbContext, Task>? seed)
         => (InMemoryTestStore)await InitializeAsync(serviceProvider, createContext, seed);
 
     public async Task<InMemoryTestStore> InitializeInMemoryAsync(
-        IServiceProvider serviceProvider,
+        IServiceProvider? serviceProvider,
         Func<InMemoryTestStore, DbContext> createContext,
-        Func<DbContext, Task> seed)
+        Func<DbContext, Task>? seed)
         => (InMemoryTestStore)await InitializeAsync(serviceProvider, () => createContext(this), seed);
 
-    protected override TestStoreIndex GetTestStoreIndex(IServiceProvider serviceProvider)
+    protected override TestStoreIndex GetTestStoreIndex(IServiceProvider? serviceProvider)
         => serviceProvider == null
             ? base.GetTestStoreIndex(null)
             : serviceProvider.GetService<TestStoreIndex>() ?? base.GetTestStoreIndex(serviceProvider);

--- a/test/EFCore.InMemory.FunctionalTests/UnconstrainedForeignKeyFixupTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/UnconstrainedForeignKeyFixupTest.cs
@@ -84,7 +84,7 @@ public class UnconstrainedForeignKeyFixupTest
         // The FK is non-nullable, so severing the required relationship produces a conceptual null.
         // The default (Cascade) delete behavior resolves it by deleting the dependent — identical to a
         // constrained required relationship (Decision 2: fixup behaves the same regardless of IsConstrained).
-        dependent.Principal = null;
+        dependent.Principal = null!;
         context.ChangeTracker.DetectChanges();
 
         Assert.Equal(EntityState.Deleted, context.Entry(dependent).State);
@@ -122,7 +122,7 @@ public class UnconstrainedForeignKeyFixupTest
     {
         public int Id { get; set; }
         public int? PrincipalId { get; set; }
-        public Principal Principal { get; set; }
+        public Principal? Principal { get; set; }
     }
 
     private class RequiredTestContext(DbContextOptions options) : DbContext(options)
@@ -143,6 +143,6 @@ public class UnconstrainedForeignKeyFixupTest
     {
         public int Id { get; set; }
         public int PrincipalId { get; set; }
-        public RequiredPrincipal Principal { get; set; }
+        public RequiredPrincipal Principal { get; set; } = null!;
     }
 }

--- a/test/EFCore.InMemory.FunctionalTests/UpdatesInMemoryTestBase.cs
+++ b/test/EFCore.InMemory.FunctionalTests/UpdatesInMemoryTestBase.cs
@@ -14,8 +14,8 @@ public abstract class UpdatesInMemoryTestBase<TFixture>(TFixture fixture) : Upda
 
     protected override async Task ExecuteWithStrategyInTransactionAsync(
         Func<UpdatesContext, Task> testOperation,
-        Func<UpdatesContext, Task> nestedTestOperation1 = null,
-        Func<UpdatesContext, Task> nestedTestOperation2 = null)
+        Func<UpdatesContext, Task>? nestedTestOperation1 = null,
+        Func<UpdatesContext, Task>? nestedTestOperation2 = null)
     {
         try
         {

--- a/test/EFCore.InMemory.FunctionalTests/ValueConvertersEndToEndInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/ValueConvertersEndToEndInMemoryTest.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore;
 
 public class ValueConvertersEndToEndInMemoryTest(ValueConvertersEndToEndInMemoryTest.ValueConvertersEndToEndInMemoryFixture fixture)

--- a/test/EFCore.Specification.Tests/ApiConsistencyTestBase.cs
+++ b/test/EFCore.Specification.Tests/ApiConsistencyTestBase.cs
@@ -8,8 +8,6 @@ using System.Runtime.CompilerServices;
 // ReSharper disable InconsistentNaming
 namespace Microsoft.EntityFrameworkCore;
 
-#nullable disable
-
 public abstract class ApiConsistencyTestBase<TFixture>(TFixture fixture) : IClassFixture<TFixture>
     where TFixture : ApiConsistencyTestBase<TFixture>.ApiConsistencyFixtureBase, new()
 {
@@ -35,16 +33,16 @@ public abstract class ApiConsistencyTestBase<TFixture>(TFixture fixture) : IClas
     [Fact]
     public void Exceptions_are_valid()
     {
-        Assert.DoesNotContain(null, Fixture.AsyncMethodExceptions);
-        Assert.DoesNotContain(null, Fixture.MetadataMethodExceptions);
-        Assert.DoesNotContain(null, Fixture.UnmatchedMetadataMethods);
-        Assert.DoesNotContain(null, Fixture.VirtualMethodExceptions);
-        Assert.DoesNotContain(null, Fixture.NotAnnotatedMethods);
-        Assert.DoesNotContain(null, Fixture.NonCancellableAsyncMethods);
+        Assert.DoesNotContain(null!, Fixture.AsyncMethodExceptions);
+        Assert.DoesNotContain(null!, Fixture.MetadataMethodExceptions);
+        Assert.DoesNotContain(null!, Fixture.UnmatchedMetadataMethods);
+        Assert.DoesNotContain(null!, Fixture.VirtualMethodExceptions);
+        Assert.DoesNotContain(null!, Fixture.NotAnnotatedMethods);
+        Assert.DoesNotContain(null!, Fixture.NonCancellableAsyncMethods);
 
         foreach (var unmatched in Fixture.UnmatchedMirrorMethods)
         {
-            Assert.DoesNotContain(null, unmatched.Value);
+            Assert.DoesNotContain(null!, unmatched.Value);
         }
     }
 
@@ -77,7 +75,7 @@ public abstract class ApiConsistencyTestBase<TFixture>(TFixture fixture) : IClas
 
             if (type.IsGenericType
                 && type.BaseType != typeof(object)
-                && !type.BaseType.IsGenericType)
+                && !type.BaseType!.IsGenericType)
             {
                 foreach (var method in type.BaseType.GetMethods(PublicInstance))
                 {
@@ -222,7 +220,7 @@ public abstract class ApiConsistencyTestBase<TFixture>(TFixture fixture) : IClas
                     && !(Fixture.UnmatchedMirrorMethods.TryGetValue(tuple.Value, out var unmatchedMirrorMethods)
                         && unmatchedMirrorMethods.Contains(method)))
                 {
-                    MethodInfo matchingMethod = null;
+                    MethodInfo matchingMethod = null!;
                     foreach (var targetMethod in tuple.Value.GetMethods(PublicInstance | BindingFlags.DeclaredOnly))
                     {
                         if (targetMethod.Name == method.Name
@@ -272,10 +270,10 @@ public abstract class ApiConsistencyTestBase<TFixture>(TFixture fixture) : IClas
             "\r\n-- Errors: --\r\n" + string.Join(Environment.NewLine, errors));
     }
 
-    private static readonly string MetadataNamespace = typeof(IReadOnlyModel).Namespace;
-    private static readonly string MetadataBuilderNamespace = typeof(IConventionModelBuilder).Namespace;
+    private static readonly string MetadataNamespace = typeof(IReadOnlyModel).Namespace!;
+    private static readonly string MetadataBuilderNamespace = typeof(IConventionModelBuilder).Namespace!;
 
-    protected virtual string ValidateMetadata(KeyValuePair<Type, (Type, Type, Type, Type)> types)
+    protected virtual string? ValidateMetadata(KeyValuePair<Type, (Type, Type, Type?, Type?)> types)
     {
         var readOnlyType = types.Key;
         var (mutableType, conventionType, conventionBuilderType, runtimeType) = types.Value;
@@ -310,7 +308,7 @@ public abstract class ApiConsistencyTestBase<TFixture>(TFixture fixture) : IClas
 
             if (!typeof(IAnnotatable).IsAssignableFrom(runtimeType))
             {
-                return $"{runtimeType.Name} should derive from IAnnotatable";
+                return $"{runtimeType!.Name} should derive from IAnnotatable";
             }
 
             if (conventionBuilderType != null
@@ -390,7 +388,7 @@ public abstract class ApiConsistencyTestBase<TFixture>(TFixture fixture) : IClas
             "\r\n-- Mismatches: --\r\n" + string.Join(Environment.NewLine, errors));
     }
 
-    protected virtual string MatchMutable((MethodInfo Readonly, MethodInfo Mutable) methodTuple)
+    protected virtual string? MatchMutable((MethodInfo Readonly, MethodInfo Mutable) methodTuple)
     {
         var (readonlyMethod, mutableMethod) = methodTuple;
 
@@ -399,12 +397,12 @@ public abstract class ApiConsistencyTestBase<TFixture>(TFixture fixture) : IClas
             if (mutableMethod == null)
             {
                 return "No IMutable equivalent of "
-                    + $"{readonlyMethod.DeclaringType.Name}.{readonlyMethod.Name}({Format(readonlyMethod.GetParameters())})";
+                    + $"{readonlyMethod.DeclaringType!.Name}.{readonlyMethod.Name}({Format(readonlyMethod.GetParameters())})";
             }
 
             if (mutableMethod.ReturnType != expectedReturnTypes.Mutable)
             {
-                return $"{mutableMethod.DeclaringType.Name}.{mutableMethod.Name}({Format(mutableMethod.GetParameters())})"
+                return $"{mutableMethod.DeclaringType!.Name}.{mutableMethod.Name}({Format(mutableMethod.GetParameters())})"
                     + $" expected to have {expectedReturnTypes.Mutable.ShortDisplayName()} return type";
             }
         }
@@ -417,12 +415,12 @@ public abstract class ApiConsistencyTestBase<TFixture>(TFixture fixture) : IClas
                 if (mutableMethod == null)
                 {
                     return "No IMutable equivalent of "
-                        + $"{readonlyMethod.DeclaringType.Name}.{readonlyMethod.Name}({Format(readonlyMethod.GetParameters())})";
+                        + $"{readonlyMethod.DeclaringType!.Name}.{readonlyMethod.Name}({Format(readonlyMethod.GetParameters())})";
                 }
 
                 if (mutableMethod.ReturnType.TryGetSequenceType() != expectedReturnTypes.Mutable)
                 {
-                    return $"{mutableMethod.DeclaringType.Name}.{mutableMethod.Name}({Format(mutableMethod.GetParameters())})"
+                    return $"{mutableMethod.DeclaringType!.Name}.{mutableMethod.Name}({Format(mutableMethod.GetParameters())})"
                         + $" expected to have a return type that derives from IEnumerable<{expectedReturnTypes.Mutable}>.";
                 }
             }
@@ -462,7 +460,7 @@ public abstract class ApiConsistencyTestBase<TFixture>(TFixture fixture) : IClas
         }
     }
 
-    protected virtual string MatchConvention((MethodInfo Mutable, MethodInfo Convention) methodTuple)
+    protected virtual string? MatchConvention((MethodInfo Mutable, MethodInfo Convention) methodTuple)
     {
         var (mutableMethod, conventionMethod) = methodTuple;
 
@@ -471,7 +469,7 @@ public abstract class ApiConsistencyTestBase<TFixture>(TFixture fixture) : IClas
             if (conventionMethod == null)
             {
                 return "No IConvention equivalent of "
-                    + $"{mutableMethod.DeclaringType.Name}.{mutableMethod.Name}({Format(mutableMethod.GetParameters())})";
+                    + $"{mutableMethod.DeclaringType!.Name}.{mutableMethod.Name}({Format(mutableMethod.GetParameters())})";
             }
         }
         else if (Fixture.MutableMetadataTypes.TryGetValue(mutableMethod.ReturnType, out var expectedReturnType))
@@ -479,12 +477,12 @@ public abstract class ApiConsistencyTestBase<TFixture>(TFixture fixture) : IClas
             if (conventionMethod == null)
             {
                 return "No IConvention equivalent of "
-                    + $"{mutableMethod.DeclaringType.Name}.{mutableMethod.Name}({Format(mutableMethod.GetParameters())})";
+                    + $"{mutableMethod.DeclaringType!.Name}.{mutableMethod.Name}({Format(mutableMethod.GetParameters())})";
             }
 
             if (conventionMethod.ReturnType != expectedReturnType)
             {
-                return $"{conventionMethod.DeclaringType.Name}.{conventionMethod.Name}({Format(conventionMethod.GetParameters())})"
+                return $"{conventionMethod.DeclaringType!.Name}.{conventionMethod.Name}({Format(conventionMethod.GetParameters())})"
                     + $" expected to have {expectedReturnType.ShortDisplayName()} return type";
             }
         }
@@ -497,12 +495,12 @@ public abstract class ApiConsistencyTestBase<TFixture>(TFixture fixture) : IClas
                 if (conventionMethod == null)
                 {
                     return "No IConvention equivalent of "
-                        + $"{mutableMethod.DeclaringType.Name}.{mutableMethod.Name}({Format(mutableMethod.GetParameters())})";
+                        + $"{mutableMethod.DeclaringType!.Name}.{mutableMethod.Name}({Format(mutableMethod.GetParameters())})";
                 }
 
                 if (conventionMethod.ReturnType.TryGetSequenceType() != expectedReturnType)
                 {
-                    return $"{conventionMethod.DeclaringType.Name}.{conventionMethod.Name}({Format(conventionMethod.GetParameters())})"
+                    return $"{conventionMethod.DeclaringType!.Name}.{conventionMethod.Name}({Format(conventionMethod.GetParameters())})"
                         + $" expected to have a return type that derives from IEnumerable<{expectedReturnType.Name}>.";
                 }
             }
@@ -524,7 +522,7 @@ public abstract class ApiConsistencyTestBase<TFixture>(TFixture fixture) : IClas
             "\r\n-- Errors: --\r\n" + string.Join(Environment.NewLine, errors));
     }
 
-    protected virtual string ValidateConventionMethods(IReadOnlyList<MethodInfo> methods)
+    protected virtual string? ValidateConventionMethods(IReadOnlyList<MethodInfo> methods)
     {
         if (methods.Count == 0)
         {
@@ -546,12 +544,12 @@ public abstract class ApiConsistencyTestBase<TFixture>(TFixture fixture) : IClas
                 var expectedName = "Get" + methodTuple.Key[3..] + "ConfigurationSource";
                 if (!methodLookup.TryGetValue(expectedName, out var getAspectConfigurationSource))
                 {
-                    return $"{type.Name} expected to have a {expectedName}() method";
+                    return $"{type!.Name} expected to have a {expectedName}() method";
                 }
 
                 if (getAspectConfigurationSource.ReturnType != typeof(ConfigurationSource?))
                 {
-                    return $"{type.Name}.{getAspectConfigurationSource.Name}({Format(getAspectConfigurationSource.GetParameters())})"
+                    return $"{type!.Name}.{getAspectConfigurationSource.Name}({Format(getAspectConfigurationSource.GetParameters())})"
                         + " expected to have ConfigurationSource? return type";
                 }
             }
@@ -573,7 +571,7 @@ public abstract class ApiConsistencyTestBase<TFixture>(TFixture fixture) : IClas
             "\r\n-- Errors: --\r\n" + string.Join(Environment.NewLine, errors));
     }
 
-    protected virtual string ValidateConventionBuilderMethods(IReadOnlyList<MethodInfo> methods)
+    protected virtual string? ValidateConventionBuilderMethods(IReadOnlyList<MethodInfo> methods)
     {
         if (methods == null
             || methods.Count == 0)
@@ -589,7 +587,7 @@ public abstract class ApiConsistencyTestBase<TFixture>(TFixture fixture) : IClas
             methodLookup[Fixture.MetadataMethodNameTransformers.TryGetValue(method, out var name) ? name : method.Name] = method;
         }
 
-        foreach (var interfaceType in builderType.GetDeclaredInterfaces())
+        foreach (var interfaceType in builderType!.GetDeclaredInterfaces())
         {
             foreach (var method in interfaceType.GetMethods())
             {
@@ -627,7 +625,7 @@ public abstract class ApiConsistencyTestBase<TFixture>(TFixture fixture) : IClas
                     || methodName.StartsWith("To", StringComparison.Ordinal)
                     || methodName.StartsWith("With", StringComparison.Ordinal))
                 {
-                    return $"{declaringType.Name} expected to have a {expectedName} method";
+                    return $"{declaringType!.Name} expected to have a {expectedName} method";
                 }
 
                 var otherExpectedName = "Can" + methodName;
@@ -642,13 +640,13 @@ public abstract class ApiConsistencyTestBase<TFixture>(TFixture fixture) : IClas
 
                 if (!methodLookup.TryGetValue(otherExpectedName, out canSetMethod))
                 {
-                    return $"{declaringType.Name} expected to have a {expectedName} or {otherExpectedName} method";
+                    return $"{declaringType!.Name} expected to have a {expectedName} or {otherExpectedName} method";
                 }
             }
 
             if (canSetMethod.ReturnType != typeof(bool))
             {
-                return $"{declaringType.Name}.{canSetMethod.Name}({Format(canSetMethod.GetParameters())})"
+                return $"{declaringType!.Name}.{canSetMethod.Name}({Format(canSetMethod.GetParameters())})"
                     + $" expected to have return type of 'bool'";
             }
 
@@ -657,7 +655,7 @@ public abstract class ApiConsistencyTestBase<TFixture>(TFixture fixture) : IClas
             if (parameters.Length > parameterIndex
                 && parameters[parameterIndex].ParameterType != canSetMethod.GetParameters()[parameterIndex].ParameterType)
             {
-                return $"{declaringType.Name}.{canSetMethod.Name}({Format(canSetMethod.GetParameters())})"
+                return $"{declaringType!.Name}.{canSetMethod.Name}({Format(canSetMethod.GetParameters())})"
                     + $" expected to have the first parameter of type {parameters[parameterIndex].ParameterType.ShortDisplayName()}";
             }
         }
@@ -670,7 +668,7 @@ public abstract class ApiConsistencyTestBase<TFixture>(TFixture fixture) : IClas
     {
         var errors =
             Fixture.MetadataTypes.Select(t =>
-                    ValidateConventionBuilderMethodReturns(t.Value.ConventionBuilder, t.Value.Convention))
+                    ValidateConventionBuilderMethodReturns(t.Value.ConventionBuilder!, t.Value.Convention))
                 .Where(e => e != null)
                 .ToList();
 
@@ -680,7 +678,7 @@ public abstract class ApiConsistencyTestBase<TFixture>(TFixture fixture) : IClas
             + string.Join(Environment.NewLine, errors));
     }
 
-    protected virtual string ValidateConventionBuilderMethodReturns(Type builderType, Type conventionType)
+    protected virtual string? ValidateConventionBuilderMethodReturns(Type builderType, Type conventionType)
     {
         if (builderType == null)
         {
@@ -833,7 +831,7 @@ public abstract class ApiConsistencyTestBase<TFixture>(TFixture fixture) : IClas
             "\r\n-- Mismatches: --\r\n" + string.Join(Environment.NewLine, errors));
     }
 
-    protected virtual string MatchRuntime((MethodInfo ReadOnly, MethodInfo Runtime) methodTuple)
+    protected virtual string? MatchRuntime((MethodInfo ReadOnly, MethodInfo Runtime) methodTuple)
     {
         var (readOnlyMethod, runtimeMethod) = methodTuple;
 
@@ -842,7 +840,7 @@ public abstract class ApiConsistencyTestBase<TFixture>(TFixture fixture) : IClas
             if (runtimeMethod == null)
             {
                 return "No IRuntime equivalent of "
-                    + $"{readOnlyMethod.DeclaringType.Name}.{readOnlyMethod.Name}({Format(readOnlyMethod.GetParameters())})";
+                    + $"{readOnlyMethod.DeclaringType!.Name}.{readOnlyMethod.Name}({Format(readOnlyMethod.GetParameters())})";
             }
         }
         else if (Fixture.MutableMetadataTypes.TryGetValue(readOnlyMethod.ReturnType, out var expectedReturnType))
@@ -850,12 +848,12 @@ public abstract class ApiConsistencyTestBase<TFixture>(TFixture fixture) : IClas
             if (runtimeMethod == null)
             {
                 return "No IRuntime equivalent of "
-                    + $"{readOnlyMethod.DeclaringType.Name}.{readOnlyMethod.Name}({Format(readOnlyMethod.GetParameters())})";
+                    + $"{readOnlyMethod.DeclaringType!.Name}.{readOnlyMethod.Name}({Format(readOnlyMethod.GetParameters())})";
             }
 
             if (runtimeMethod.ReturnType != expectedReturnType)
             {
-                return $"{runtimeMethod.DeclaringType.Name}.{runtimeMethod.Name}({Format(runtimeMethod.GetParameters())})"
+                return $"{runtimeMethod.DeclaringType!.Name}.{runtimeMethod.Name}({Format(runtimeMethod.GetParameters())})"
                     + $" expected to have {expectedReturnType.ShortDisplayName()} return type";
             }
         }
@@ -868,12 +866,12 @@ public abstract class ApiConsistencyTestBase<TFixture>(TFixture fixture) : IClas
                 if (runtimeMethod == null)
                 {
                     return "No IRuntime equivalent of "
-                        + $"{readOnlyMethod.DeclaringType.Name}.{readOnlyMethod.Name}({Format(readOnlyMethod.GetParameters())})";
+                        + $"{readOnlyMethod.DeclaringType!.Name}.{readOnlyMethod.Name}({Format(readOnlyMethod.GetParameters())})";
                 }
 
                 if (runtimeMethod.ReturnType.TryGetSequenceType() != expectedReturnType)
                 {
-                    return $"{runtimeMethod.DeclaringType.Name}.{runtimeMethod.Name}({Format(runtimeMethod.GetParameters())})"
+                    return $"{runtimeMethod.DeclaringType!.Name}.{runtimeMethod.Name}({Format(runtimeMethod.GetParameters())})"
                         + $" expected to have a return type that derives from IEnumerable<{expectedReturnType.Name}>.";
                 }
             }
@@ -896,7 +894,7 @@ public abstract class ApiConsistencyTestBase<TFixture>(TFixture fixture) : IClas
             "\r\n-- Errors: --\r\n" + string.Join(Environment.NewLine, errors));
     }
 
-    protected string ValidateMethodName(MethodInfo method)
+    protected string? ValidateMethodName(MethodInfo method)
     {
         var name = method.Name;
         if (name.StartsWith("get_", StringComparison.Ordinal))
@@ -905,7 +903,7 @@ public abstract class ApiConsistencyTestBase<TFixture>(TFixture fixture) : IClas
             if (name.StartsWith("Get", StringComparison.Ordinal)
                 && !Fixture.MetadataMethodExceptions.Contains(method))
             {
-                return $"{method.DeclaringType.ShortDisplayName()}.{name}({Format(method.GetParameters())}) expected to not have "
+                return $"{method.DeclaringType!.ShortDisplayName()}.{name}({Format(method.GetParameters())}) expected to not have "
                     + "Get prefix";
             }
         }
@@ -927,7 +925,7 @@ public abstract class ApiConsistencyTestBase<TFixture>(TFixture fixture) : IClas
             "\r\n-- Errors: --\r\n" + string.Join(Environment.NewLine, errors));
     }
 
-    protected virtual string ValidateMutableMethod(MethodInfo mutableMethod)
+    protected virtual string? ValidateMutableMethod(MethodInfo mutableMethod)
     {
         var message = ValidateMethodName(mutableMethod);
         if (message != null)
@@ -953,12 +951,12 @@ public abstract class ApiConsistencyTestBase<TFixture>(TFixture fixture) : IClas
             {
                 if (mutableMethod.ReturnType != typeof(void))
                 {
-                    return $"{mutableMethod.DeclaringType.Name}.{name}({Format(parameters)}) expected to have a void return type";
+                    return $"{mutableMethod.DeclaringType!.Name}.{name}({Format(parameters)}) expected to have a void return type";
                 }
             }
             else
             {
-                return $"{mutableMethod.DeclaringType.Name}.{name}({Format(parameters)}) expected to have an IMutable or "
+                return $"{mutableMethod.DeclaringType!.Name}.{name}({Format(parameters)}) expected to have an IMutable or "
                     + $"{firstParameter.ParameterType.ShortDisplayName()} return type";
             }
         }
@@ -971,7 +969,7 @@ public abstract class ApiConsistencyTestBase<TFixture>(TFixture fixture) : IClas
     {
         var errors =
             Fixture.MetadataMethods
-                .SelectMany(m => m.Convention.Select(mi => ValidateConventionMethod(mi, m.Convention[0].DeclaringType)))
+                .SelectMany(m => m.Convention.Select(mi => ValidateConventionMethod(mi, m.Convention[0].DeclaringType!)))
                 .Where(e => e != null)
                 .ToList();
 
@@ -980,7 +978,7 @@ public abstract class ApiConsistencyTestBase<TFixture>(TFixture fixture) : IClas
             "\r\n-- Errors: --\r\n" + string.Join(Environment.NewLine, errors));
     }
 
-    protected virtual string ValidateConventionMethod(MethodInfo conventionMethod, Type type)
+    protected virtual string? ValidateConventionMethod(MethodInfo conventionMethod, Type type)
     {
         var message = ValidateMethodName(conventionMethod);
         if (message != null)
@@ -1006,7 +1004,7 @@ public abstract class ApiConsistencyTestBase<TFixture>(TFixture fixture) : IClas
             && !Fixture.ConventionMetadataTypes.ContainsKey(conventionMethod.ReturnType))
         {
             return
-                $"{conventionMethod.DeclaringType.ShortDisplayName()}.{name}({Format(parameters)}) expected to have an IConvention or "
+                $"{conventionMethod.DeclaringType!.ShortDisplayName()}.{name}({Format(parameters)}) expected to have an IConvention or "
                 + $"{firstParameter.ParameterType.ShortDisplayName()} return type";
         }
 
@@ -1023,7 +1021,7 @@ public abstract class ApiConsistencyTestBase<TFixture>(TFixture fixture) : IClas
                 || !Equals(lastParameter.DefaultValue, false))
             {
                 return
-                    $"{conventionMethod.DeclaringType.ShortDisplayName()}.{name}({Format(parameters)}) expected to have a 'bool fromDataAnnotation = false' parameter";
+                    $"{conventionMethod.DeclaringType!.ShortDisplayName()}.{name}({Format(parameters)}) expected to have a 'bool fromDataAnnotation = false' parameter";
             }
         }
 
@@ -1039,7 +1037,7 @@ public abstract class ApiConsistencyTestBase<TFixture>(TFixture fixture) : IClas
 
         var badServiceTypes
             = (from sd in serviceCollection
-               where sd.ServiceType.Namespace.StartsWith("Microsoft.Entity", StringComparison.Ordinal)
+               where sd.ServiceType.Namespace!.StartsWith("Microsoft.Entity", StringComparison.Ordinal)
                    && sd.ServiceType != typeof(IDiagnosticsLogger<>)
                    && sd.ServiceType != typeof(LoggingDefinitions)
                let it = TryGetImplementationType(sd)
@@ -1072,7 +1070,7 @@ public abstract class ApiConsistencyTestBase<TFixture>(TFixture fixture) : IClas
     private static Type TryGetImplementationType(ServiceDescriptor descriptor)
         => descriptor.ImplementationType
             ?? descriptor.ImplementationInstance?.GetType()
-            ?? descriptor.ImplementationFactory?.GetType().GenericTypeArguments[1];
+            ?? descriptor.ImplementationFactory?.GetType().GenericTypeArguments[1]!;
 
     [Fact]
     public virtual void Private_classes_should_be_sealed()
@@ -1082,7 +1080,7 @@ public abstract class ApiConsistencyTestBase<TFixture>(TFixture fixture) : IClas
                where type.IsNestedPrivate
                    && !type.IsSealed
                    && !type.IsAbstract
-                   && !type.DeclaringType.GetNestedTypes(BindingFlags.NonPublic).Any(t => t.BaseType == type)
+                   && !type.DeclaringType!.GetNestedTypes(BindingFlags.NonPublic).Any(t => t.BaseType == type)
                select type.FullName)
             .ToList();
 
@@ -1147,7 +1145,7 @@ public abstract class ApiConsistencyTestBase<TFixture>(TFixture fixture) : IClas
                            && methodWithoutToken.DeclaringType == methodWithToken.DeclaringType)
                    && !Fixture.AsyncMethodExceptions.Contains(methodWithoutToken)
                // ReSharper disable once PossibleNullReferenceException
-               select methodWithoutToken.DeclaringType.Name + "." + methodWithoutToken.Name)
+               select methodWithoutToken.DeclaringType!.Name + "." + methodWithoutToken.Name)
             .ToList();
 
         Assert.False(
@@ -1159,7 +1157,7 @@ public abstract class ApiConsistencyTestBase<TFixture>(TFixture fixture) : IClas
                 .Where(method => !method.Name.EndsWith("Async", StringComparison.Ordinal)
                     && method.DeclaringType != null
                     && !Fixture.AsyncMethodExceptions.Contains(method))
-                .Select(method => method.DeclaringType.Name + "." + method.Name)
+                .Select(method => method.DeclaringType!.Name + "." + method.Name)
                 .ToList();
 
         Assert.False(
@@ -1174,12 +1172,12 @@ public abstract class ApiConsistencyTestBase<TFixture>(TFixture fixture) : IClas
 
         var parameters = (
                 from type in GetAllTypes(TargetAssembly.GetExportedTypes())
-                where !type.Namespace.Contains("Internal", StringComparison.Ordinal)
+                where !type.Namespace!.Contains("Internal", StringComparison.Ordinal)
                 from method in type.GetTypeInfo().DeclaredMethods
                 where !method.IsPrivate
                 from parameter in method.GetParameters()
                 where parameter.ParameterType.UnwrapNullableType() == typeof(bool)
-                    && prefixes.Any(p => parameter.Name.StartsWith(p, StringComparison.Ordinal))
+                    && prefixes.Any(p => parameter.Name!.StartsWith(p, StringComparison.Ordinal))
                 select $"{type.FullName}.{method.Name}[{parameter.Name}]")
             .ToList();
 
@@ -1218,16 +1216,22 @@ public abstract class ApiConsistencyTestBase<TFixture>(TFixture fixture) : IClas
         private readonly MethodInfo _targetMethod = targetMethod;
         private readonly ApiConsistencyTestBase<TFixture> _tests = tests;
 
-        public bool Equals(Type sourceParameterType, Type targetParameterType)
+        public bool Equals(Type? sourceParameterType, Type? targetParameterType)
         {
             if (sourceParameterType == targetParameterType)
             {
                 return true;
             }
 
+            if (sourceParameterType is null
+                || targetParameterType is null)
+            {
+                return false;
+            }
+
             var sourceType = _sourceMethod.DeclaringType;
             var targetType = _targetMethod.DeclaringType;
-            if (_targetMethod.DeclaringType.IsGenericType
+            if (_targetMethod.DeclaringType!.IsGenericType
                 && sourceParameterType
                 == _tests.GetEquivalentGenericType(
                     sourceParameterType, _targetMethod.DeclaringType.GetGenericArguments(),
@@ -1236,8 +1240,8 @@ public abstract class ApiConsistencyTestBase<TFixture>(TFixture fixture) : IClas
                 return true;
             }
 
-            if (sourceType.IsGenericType
-                && targetType.IsGenericType
+            if (sourceType!.IsGenericType
+                && targetType!.IsGenericType
                 && sourceParameterType.IsGenericType
                 && sourceParameterType.GetGenericTypeDefinition() == typeof(Expression<>)
                 && targetParameterType.IsGenericType
@@ -1312,14 +1316,14 @@ public abstract class ApiConsistencyTestBase<TFixture>(TFixture fixture) : IClas
         public virtual HashSet<PropertyInfo> ComputedDependencyProperties { get; } =
         [
             typeof(ProviderConventionSetBuilderDependencies).GetProperty(
-                nameof(ProviderConventionSetBuilderDependencies.ContextType)),
-            typeof(QueryCompilationContextDependencies).GetProperty(nameof(QueryCompilationContextDependencies.ContextType)),
+                nameof(ProviderConventionSetBuilderDependencies.ContextType))!,
+            typeof(QueryCompilationContextDependencies).GetProperty(nameof(QueryCompilationContextDependencies.ContextType))!,
             typeof(QueryCompilationContextDependencies).GetProperty(
-                nameof(QueryCompilationContextDependencies.QueryTrackingBehavior)),
-            typeof(QueryContextDependencies).GetProperty(nameof(QueryContextDependencies.StateManager))
+                nameof(QueryCompilationContextDependencies.QueryTrackingBehavior))!,
+            typeof(QueryContextDependencies).GetProperty(nameof(QueryContextDependencies.StateManager))!
         ];
 
-        public Dictionary<Type, (Type Mutable, Type Convention, Type ConventionBuilder, Type Runtime)> MetadataTypes { get; }
+        public Dictionary<Type, (Type Mutable, Type Convention, Type? ConventionBuilder, Type? Runtime)> MetadataTypes { get; }
             = new()
             {
                 {
@@ -1473,7 +1477,7 @@ public abstract class ApiConsistencyTestBase<TFixture>(TFixture fixture) : IClas
             foreach (var (Mutable, Convention, ConventionBuilder, Runtime) in MetadataTypes.Values)
             {
                 MutableMetadataTypes[Mutable] = Convention;
-                ConventionMetadataTypes[Convention] = ConventionBuilder;
+                ConventionMetadataTypes[Convention] = ConventionBuilder!;
             }
 
             foreach (var extensionTypePair in MetadataExtensionTypes)

--- a/test/EFCore.Specification.Tests/BuiltInDataTypesTestBase.cs
+++ b/test/EFCore.Specification.Tests/BuiltInDataTypesTestBase.cs
@@ -7,8 +7,6 @@ using System.ComponentModel.DataAnnotations.Schema;
 // ReSharper disable InconsistentNaming
 namespace Microsoft.EntityFrameworkCore;
 
-#nullable disable
-
 public abstract class BuiltInDataTypesTestBase<TFixture>(TFixture fixture) : IClassFixture<TFixture>
     where TFixture : BuiltInDataTypesTestBase<TFixture>.BuiltInDataTypesFixtureBase, new()
 {
@@ -369,12 +367,12 @@ public abstract class BuiltInDataTypesTestBase<TFixture>(TFixture fixture) : ICl
             else if (type == typeof(DateTime))
             {
                 Assert.True(
-                    Equal((DateTime)(object)expected, (DateTime)(object)actual), $"Expected:\t{expected:O}\r\nActual:\t{actual:O}");
+                    Equal((DateTime)(object)expected!, (DateTime)(object)actual!), $"Expected:\t{expected:O}\r\nActual:\t{actual:O}");
             }
             else if (type == typeof(DateTimeOffset))
             {
                 Assert.True(
-                    Equal((DateTimeOffset)(object)expected, (DateTimeOffset)(object)actual),
+                    Equal((DateTimeOffset)(object)expected!, (DateTimeOffset)(object)actual!),
                     $"Expected:\t{expected:O}\r\nActual:\t{actual:O}");
             }
             else
@@ -413,12 +411,12 @@ public abstract class BuiltInDataTypesTestBase<TFixture>(TFixture fixture) : ICl
     private bool Equal(DateTimeOffset left, DateTimeOffset right)
         => left.EqualsExact(right);
 
-    private static Type UnwrapNullableType(Type type)
+    private static Type? UnwrapNullableType(Type? type)
         => type == null ? null : Nullable.GetUnderlyingType(type) ?? type;
 
     public static Type UnwrapNullableEnumType(Type type)
     {
-        var underlyingNonNullableType = UnwrapNullableType(type);
+        var underlyingNonNullableType = UnwrapNullableType(type)!;
         return !underlyingNonNullableType.IsEnum ? underlyingNonNullableType : Enum.GetUnderlyingType(underlyingNonNullableType);
     }
 
@@ -482,7 +480,7 @@ public abstract class BuiltInDataTypesTestBase<TFixture>(TFixture fixture) : ICl
         {
             var dt = (await context.Set<ObjectBackedDataTypes>().Where(ndt => ndt.Id == 101).ToListAsync()).Single();
 
-            var entityType = context.Model.FindEntityType(typeof(ObjectBackedDataTypes));
+            var entityType = context.Model.FindEntityType(typeof(ObjectBackedDataTypes))!;
             AssertEqualIfMapped(entityType, "TestString", () => dt.String);
             AssertEqualIfMapped(entityType, [10, 9, 8, 7, 6], () => dt.Bytes);
             AssertEqualIfMapped(entityType, (short)-1234, () => dt.Int16);
@@ -521,10 +519,10 @@ public abstract class BuiltInDataTypesTestBase<TFixture>(TFixture fixture) : ICl
     {
         using var context = CreateContext();
         var query = from animal in context.Set<Animal>()
-                    select new { animal.Id, animal.IdentificationMethods.FirstOrDefault().Method };
+                    select new { animal.Id, animal.IdentificationMethods.FirstOrDefault()!.Method };
 
         var result = await query.SingleOrDefaultAsync();
-        Assert.Equal(IdentificationMethod.EarTag, result.Method);
+        Assert.Equal(IdentificationMethod.EarTag, result!.Method);
     }
 
     [Fact]
@@ -952,53 +950,53 @@ public abstract class BuiltInDataTypesTestBase<TFixture>(TFixture fixture) : ICl
     protected class MaxLengthDataTypes
     {
         public int Id { get; set; }
-        public string String3 { get; set; }
-        public byte[] ByteArray5 { get; set; }
-        public string String9000 { get; set; }
-        public string StringUnbounded { get; set; }
-        public byte[] ByteArray9000 { get; set; }
+        public string String3 { get; set; } = null!;
+        public byte[] ByteArray5 { get; set; } = null!;
+        public string String9000 { get; set; } = null!;
+        public string StringUnbounded { get; set; } = null!;
+        public byte[] ByteArray9000 { get; set; } = null!;
     }
 
     protected class UnicodeDataTypes
     {
         public int Id { get; set; }
-        public string StringDefault { get; set; }
-        public string StringAnsi { get; set; }
-        public string StringAnsi3 { get; set; }
-        public string StringAnsi9000 { get; set; }
-        public string StringUnicode { get; set; }
+        public string StringDefault { get; set; } = null!;
+        public string StringAnsi { get; set; } = null!;
+        public string StringAnsi3 { get; set; } = null!;
+        public string StringAnsi9000 { get; set; } = null!;
+        public string StringUnicode { get; set; } = null!;
     }
 
     protected class BinaryKeyDataType
     {
-        public byte[] Id { get; set; }
+        public byte[] Id { get; set; } = null!;
 
-        public string Ex { get; set; }
+        public string Ex { get; set; } = null!;
 
-        public ICollection<BinaryForeignKeyDataType> Dependents { get; set; }
+        public ICollection<BinaryForeignKeyDataType> Dependents { get; set; } = null!;
     }
 
     protected class BinaryForeignKeyDataType
     {
         public int Id { get; set; }
-        public byte[] BinaryKeyDataTypeId { get; set; }
+        public byte[]? BinaryKeyDataTypeId { get; set; }
 
-        public BinaryKeyDataType Principal { get; set; }
+        public BinaryKeyDataType? Principal { get; set; }
     }
 
     protected class StringKeyDataType
     {
-        public string Id { get; set; }
+        public string Id { get; set; } = null!;
 
-        public ICollection<StringForeignKeyDataType> Dependents { get; set; }
+        public ICollection<StringForeignKeyDataType> Dependents { get; set; } = null!;
     }
 
     protected class StringForeignKeyDataType
     {
         public int Id { get; set; }
-        public string StringKeyDataTypeId { get; set; }
+        public string? StringKeyDataTypeId { get; set; }
 
-        public StringKeyDataType Principal { get; set; }
+        public StringKeyDataType? Principal { get; set; }
     }
 
     protected class BuiltInNullableDataTypesBase
@@ -1032,34 +1030,34 @@ public abstract class BuiltInDataTypesTestBase<TFixture>(TFixture fixture) : ICl
 
     protected class ObjectBackedDataTypes
     {
-        private object _string;
-        private object _bytes;
-        private object _int16;
-        private object _int32;
-        private object _int64;
-        private object _double;
-        private object _decimal;
-        private object _dateTime;
-        private object _dateTimeOffset;
-        private object _timeSpan;
-        private object _dateOnly;
-        private object _timeOnly;
-        private object _single;
-        private object _boolean;
-        private object _byte;
-        private object _unsignedInt16;
-        private object _unsignedInt32;
-        private object _unsignedInt64;
-        private object _character;
-        private object _signedByte;
-        private object _enum64;
-        private object _enum32;
-        private object _enum16;
-        private object _enum8;
-        private object _enumU64;
-        private object _enumU32;
-        private object _enumU16;
-        private object _enumS8;
+        private object _string = null!;
+        private object? _bytes;
+        private object _int16 = null!;
+        private object _int32 = null!;
+        private object _int64 = null!;
+        private object _double = null!;
+        private object _decimal = null!;
+        private object _dateTime = null!;
+        private object _dateTimeOffset = null!;
+        private object _timeSpan = null!;
+        private object _dateOnly = null!;
+        private object _timeOnly = null!;
+        private object _single = null!;
+        private object _boolean = null!;
+        private object _byte = null!;
+        private object _unsignedInt16 = null!;
+        private object _unsignedInt32 = null!;
+        private object _unsignedInt64 = null!;
+        private object _character = null!;
+        private object _signedByte = null!;
+        private object _enum64 = null!;
+        private object _enum32 = null!;
+        private object _enum16 = null!;
+        private object _enum8 = null!;
+        private object _enumU64 = null!;
+        private object _enumU32 = null!;
+        private object _enumU16 = null!;
+        private object _enumS8 = null!;
 
         [DatabaseGenerated(DatabaseGeneratedOption.None)]
         public int Id { get; set; }
@@ -1072,9 +1070,9 @@ public abstract class BuiltInDataTypesTestBase<TFixture>(TFixture fixture) : ICl
             set => _string = value;
         }
 
-        public byte[] Bytes
+        public byte[]? Bytes
         {
-            get => (byte[])_bytes;
+            get => (byte[]?)_bytes;
             set => _bytes = value;
         }
 
@@ -1238,8 +1236,8 @@ public abstract class BuiltInDataTypesTestBase<TFixture>(TFixture fixture) : ICl
     protected class Animal
     {
         public int Id { get; set; }
-        public ICollection<AnimalIdentification> IdentificationMethods { get; set; }
-        public AnimalDetails Details { get; set; }
+        public ICollection<AnimalIdentification> IdentificationMethods { get; set; } = null!;
+        public AnimalDetails Details { get; set; } = null!;
     }
 
     protected class AnimalDetails
@@ -1275,6 +1273,6 @@ public abstract class BuiltInDataTypesTestBase<TFixture>(TFixture fixture) : ICl
     {
         public int Id { get; set; }
 
-        public string Value { get; set; }
+        public string Value { get; set; } = null!;
     }
 }

--- a/test/EFCore.Specification.Tests/BulkUpdates/BulkUpdatesTestBase.cs
+++ b/test/EFCore.Specification.Tests/BulkUpdates/BulkUpdatesTestBase.cs
@@ -3,8 +3,6 @@
 
 namespace Microsoft.EntityFrameworkCore.BulkUpdates;
 
-#nullable disable
-
 public abstract class BulkUpdatesTestBase<TFixture> : IClassFixture<TFixture>
     where TFixture : class, IQueryFixtureBase, new()
 {
@@ -39,7 +37,7 @@ public abstract class BulkUpdatesTestBase<TFixture> : IClassFixture<TFixture>
         Expression<Func<TResult, TEntity>> entitySelector,
         Action<UpdateSettersBuilder<TResult>> setPropertyCalls,
         int rowsAffectedCount,
-        Action<IReadOnlyList<TEntity>, IReadOnlyList<TEntity>> asserter = null)
+        Action<IReadOnlyList<TEntity>, IReadOnlyList<TEntity>>? asserter = null)
         where TResult : class
         => AssertUpdate(async: true, query, entitySelector, setPropertyCalls, rowsAffectedCount, asserter);
 
@@ -49,7 +47,7 @@ public abstract class BulkUpdatesTestBase<TFixture> : IClassFixture<TFixture>
         Expression<Func<TResult, TEntity>> entitySelector,
         Action<UpdateSettersBuilder<TResult>> setPropertyCalls,
         int rowsAffectedCount,
-        Action<IReadOnlyList<TEntity>, IReadOnlyList<TEntity>> asserter = null)
+        Action<IReadOnlyList<TEntity>, IReadOnlyList<TEntity>>? asserter = null)
         where TResult : class
-        => BulkUpdatesAsserter.AssertUpdate(async, query, entitySelector, setPropertyCalls, rowsAffectedCount, asserter);
+        => BulkUpdatesAsserter.AssertUpdate(async, query, entitySelector, setPropertyCalls, rowsAffectedCount, asserter!);
 }

--- a/test/EFCore.Specification.Tests/BulkUpdates/Inheritance/FiltersInheritanceBulkUpdatesTestBase.cs
+++ b/test/EFCore.Specification.Tests/BulkUpdates/Inheritance/FiltersInheritanceBulkUpdatesTestBase.cs
@@ -5,8 +5,6 @@ using Microsoft.EntityFrameworkCore.TestModels.InheritanceModel;
 
 namespace Microsoft.EntityFrameworkCore.BulkUpdates.Inheritance;
 
-#nullable disable
-
 public abstract class FiltersInheritanceBulkUpdatesTestBase<TFixture>(TFixture fixture) : BulkUpdatesTestBase<TFixture>(fixture)
     where TFixture : InheritanceBulkUpdatesFixtureBase, new()
 {

--- a/test/EFCore.Specification.Tests/BulkUpdates/Inheritance/InheritanceBulkUpdatesFixtureBase.cs
+++ b/test/EFCore.Specification.Tests/BulkUpdates/Inheritance/InheritanceBulkUpdatesFixtureBase.cs
@@ -5,8 +5,6 @@ using Microsoft.EntityFrameworkCore.Query.Inheritance;
 
 namespace Microsoft.EntityFrameworkCore.BulkUpdates.Inheritance;
 
-#nullable disable
-
 public abstract class InheritanceBulkUpdatesFixtureBase : InheritanceQueryFixtureBase
 {
     public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)

--- a/test/EFCore.Specification.Tests/BulkUpdates/Inheritance/InheritanceBulkUpdatesTestBase.cs
+++ b/test/EFCore.Specification.Tests/BulkUpdates/Inheritance/InheritanceBulkUpdatesTestBase.cs
@@ -5,8 +5,6 @@ using Microsoft.EntityFrameworkCore.TestModels.InheritanceModel;
 
 namespace Microsoft.EntityFrameworkCore.BulkUpdates.Inheritance;
 
-#nullable disable
-
 public abstract class InheritanceBulkUpdatesTestBase<TFixture>(TFixture fixture) : BulkUpdatesTestBase<TFixture>(fixture)
     where TFixture : InheritanceBulkUpdatesFixtureBase, new()
 {

--- a/test/EFCore.Specification.Tests/BulkUpdates/NonSharedModelBulkUpdatesTestBase.cs
+++ b/test/EFCore.Specification.Tests/BulkUpdates/NonSharedModelBulkUpdatesTestBase.cs
@@ -3,8 +3,6 @@
 
 namespace Microsoft.EntityFrameworkCore.BulkUpdates;
 
-#nullable disable
-
 public abstract class NonSharedModelBulkUpdatesTestBase(NonSharedFixture fixture)
     : NonSharedModelTestBase(fixture), IClassFixture<NonSharedFixture>
 {
@@ -68,28 +66,28 @@ public abstract class NonSharedModelBulkUpdatesTestBase(NonSharedFixture fixture
     public class Owner
     {
         public int Id { get; set; }
-        public string Title { get; set; }
+        public string? Title { get; set; }
 
-        public OwnedReference OwnedReference { get; set; }
-        public List<OwnedCollection> OwnedCollections { get; set; }
+        public OwnedReference? OwnedReference { get; set; }
+        public List<OwnedCollection> OwnedCollections { get; set; } = null!;
     }
 
     public class OwnedReference
     {
         public int Number { get; set; }
-        public string Value { get; set; }
+        public string? Value { get; set; }
     }
 
     public class OwnedCollection
     {
-        public string Value { get; set; }
+        public string? Value { get; set; }
     }
 
     public class OtherReference
     {
         public int Id { get; set; }
         public int Number { get; set; }
-        public string Title { get; set; }
+        public string? Title { get; set; }
     }
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -145,8 +143,8 @@ public abstract class NonSharedModelBulkUpdatesTestBase(NonSharedFixture fixture
             contextFactory.CreateDbContext,
             ss => ss.Set<Owner>(),
             s => s
-                .SetProperty(o => o.Title, o => o.OwnedReference.Number.ToString())
-                .SetProperty(o => o.OwnedReference.Number, o => o.Title.Length),
+                .SetProperty(o => o.Title, o => o.OwnedReference!.Number.ToString())
+                .SetProperty(o => o.OwnedReference!.Number, o => o.Title!.Length),
             rowsAffectedCount: 0);
     }
 
@@ -166,9 +164,9 @@ public abstract class NonSharedModelBulkUpdatesTestBase(NonSharedFixture fixture
     public class Context30572_Principal
     {
         public int Id { get; set; }
-        public string Title { get; set; }
+        public string? Title { get; set; }
 
-        public Context30572_Dependent Dependent { get; set; }
+        public Context30572_Dependent? Dependent { get; set; }
     }
 
     public class Context30572_Dependent
@@ -260,7 +258,7 @@ public abstract class NonSharedModelBulkUpdatesTestBase(NonSharedFixture fixture
     public class Blog
     {
         public int Id { get; set; }
-        public string Title { get; set; }
+        public string? Title { get; set; }
         public int Rating { get; set; }
         public DateTime CreationTimestamp { get; set; }
 
@@ -270,7 +268,7 @@ public abstract class NonSharedModelBulkUpdatesTestBase(NonSharedFixture fixture
     public class Post
     {
         public int Id { get; set; }
-        public virtual Blog Blog { get; set; }
+        public virtual Blog? Blog { get; set; }
     }
 
     #region HelperMethods

--- a/test/EFCore.Specification.Tests/BulkUpdates/NorthwindBulkUpdatesFixture.cs
+++ b/test/EFCore.Specification.Tests/BulkUpdates/NorthwindBulkUpdatesFixture.cs
@@ -3,8 +3,6 @@
 
 namespace Microsoft.EntityFrameworkCore.BulkUpdates;
 
-#nullable disable
-
 public abstract class NorthwindBulkUpdatesFixture<TModelCustomizer> : NorthwindQueryFixtureBase<TModelCustomizer>
     where TModelCustomizer : ITestModelCustomizer, new()
 {

--- a/test/EFCore.Specification.Tests/BulkUpdates/NorthwindBulkUpdatesTestBase.cs
+++ b/test/EFCore.Specification.Tests/BulkUpdates/NorthwindBulkUpdatesTestBase.cs
@@ -5,8 +5,6 @@ using Microsoft.EntityFrameworkCore.TestModels.Northwind;
 
 namespace Microsoft.EntityFrameworkCore.BulkUpdates;
 
-#nullable disable
-
 public abstract class NorthwindBulkUpdatesTestBase<TFixture>(TFixture fixture) : BulkUpdatesTestBase<TFixture>(fixture)
     where TFixture : NorthwindBulkUpdatesFixture<NoopModelCustomizer>, new()
 {
@@ -56,11 +54,11 @@ public abstract class NorthwindBulkUpdatesTestBase<TFixture>(TFixture fixture) :
         => AssertUpdate(
             async,
             ss => ss.Set<Order>()
-                .Where(o => o.CustomerID.StartsWith("F"))
+                .Where(o => o.CustomerID!.StartsWith("F"))
                 .Select(e => new { e, e.Customer }),
             e => e.Customer,
             s => s
-                .SetProperty(c => c.Customer.ContactName, "Name")
+                .SetProperty(c => c.Customer!.ContactName, "Name")
                 .SetProperty(c => c.e.OrderDate, new DateTime(2020, 1, 1)),
             rowsAffectedCount: 0);
 
@@ -229,14 +227,14 @@ public abstract class NorthwindBulkUpdatesTestBase<TFixture>(TFixture fixture) :
     public virtual Task Delete_Where_using_navigation(bool async)
         => AssertDelete(
             async,
-            ss => ss.Set<OrderDetail>().Where(od => od.Order.OrderDate.Value.Year == 2000),
+            ss => ss.Set<OrderDetail>().Where(od => od.Order.OrderDate!.Value.Year == 2000),
             rowsAffectedCount: 0);
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Delete_Where_using_navigation_2(bool async)
         => AssertDelete(
             async,
-            ss => ss.Set<OrderDetail>().Where(od => od.Order.Customer.CustomerID.StartsWith("F")),
+            ss => ss.Set<OrderDetail>().Where(od => od.Order.Customer!.CustomerID.StartsWith("F")),
             rowsAffectedCount: 164);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -276,7 +274,7 @@ public abstract class NorthwindBulkUpdatesTestBase<TFixture>(TFixture fixture) :
         => AssertDelete(
             async,
             ss => from od in ss.Set<OrderDetail>()
-                  where od.Order.Customer.City.StartsWith("Se")
+                  where od.Order.Customer!.City!.StartsWith("Se")
                   select od,
             rowsAffectedCount: 66);
 
@@ -368,7 +366,7 @@ public abstract class NorthwindBulkUpdatesTestBase<TFixture>(TFixture fixture) :
             async,
             ss => ss.Set<Customer>().TagWith("MyUpdate"),
             e => e,
-            s => s.SetProperty(c => c.ContactName, (string)null),
+            s => s.SetProperty(c => c.ContactName, (string)null!),
             rowsAffectedCount: 91,
             (b, a) => Assert.All(a, c => Assert.Null(c.ContactName)));
 
@@ -476,12 +474,12 @@ public abstract class NorthwindBulkUpdatesTestBase<TFixture>(TFixture fixture) :
 
     private class Container
     {
-        public Containee Containee { get; set; }
+        public Containee Containee { get; set; } = null!;
     }
 
     private class Containee
     {
-        public string Property { get; set; }
+        public string Property { get; set; } = null!;
     }
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -629,7 +627,7 @@ public abstract class NorthwindBulkUpdatesTestBase<TFixture>(TFixture fixture) :
     public virtual Task Update_Where_using_navigation_set_null(bool async)
         => AssertUpdate(
             async,
-            ss => ss.Set<Order>().Where(o => o.Customer.City == "Seattle"),
+            ss => ss.Set<Order>().Where(o => o.Customer!.City == "Seattle"),
             e => e,
             s => s.SetProperty(c => c.OrderDate, (DateTime?)null),
             rowsAffectedCount: 14,
@@ -639,7 +637,7 @@ public abstract class NorthwindBulkUpdatesTestBase<TFixture>(TFixture fixture) :
     public virtual Task Update_Where_using_navigation_2_set_constant(bool async)
         => AssertUpdate(
             async,
-            ss => ss.Set<OrderDetail>().Where(od => od.Order.Customer.City == "Seattle"),
+            ss => ss.Set<OrderDetail>().Where(od => od.Order.Customer!.City == "Seattle"),
             e => e,
             s => s.SetProperty(c => c.Quantity, 1),
             rowsAffectedCount: 40,
@@ -704,7 +702,7 @@ public abstract class NorthwindBulkUpdatesTestBase<TFixture>(TFixture fixture) :
             async,
             ss => ss.Set<Customer>().Where(c => c.CustomerID.StartsWith("F")),
             e => e,
-            s => s.SetProperty(c => c.ContactName, (string)null),
+            s => s.SetProperty(c => c.ContactName, (string)null!),
             rowsAffectedCount: 8,
             (b, a) => Assert.All(a, c => Assert.Null(c.ContactName)));
 
@@ -824,7 +822,7 @@ public abstract class NorthwindBulkUpdatesTestBase<TFixture>(TFixture fixture) :
                     c => c.CustomerID,
                     (o, c) => new { Order = o, Customers = c }),
             e => e.Order,
-            s => s.SetProperty(t => t.Order.OrderDate, new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc)),
+            s => s.SetProperty(t => t.Order!.OrderDate, new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc)),
             rowsAffectedCount: 2,
             // The RIGHT JOIN returns all F-prefixed customers; those without a matching order (OrderID < 10300) yield a null outer
             // Order, which is left untouched. Only the matched (non-null) orders are updated.
@@ -855,7 +853,7 @@ public abstract class NorthwindBulkUpdatesTestBase<TFixture>(TFixture fixture) :
         => AssertUpdate(
             async,
             ss => from c in ss.Set<Customer>().Where(c => c.CustomerID.StartsWith("F"))
-                  from o in ss.Set<Order>().Where(o => o.OrderID < 10300 && o.OrderDate.Value.Year < c.ContactName.Length)
+                  from o in ss.Set<Order>().Where(o => o.OrderID < 10300 && o.OrderDate!.Value.Year < c.ContactName!.Length)
                   select new { c, o },
             e => e.c,
             s => s.SetProperty(c => c.c.ContactName, "Updated"),
@@ -867,7 +865,7 @@ public abstract class NorthwindBulkUpdatesTestBase<TFixture>(TFixture fixture) :
         => AssertUpdate(
             async,
             ss => from c in ss.Set<Customer>().Where(c => c.CustomerID.StartsWith("F"))
-                  from o in ss.Set<Order>().Where(o => o.OrderID < 10300 && o.OrderDate.Value.Year < c.ContactName.Length).DefaultIfEmpty()
+                  from o in ss.Set<Order>().Where(o => o.OrderID < 10300 && o.OrderDate!.Value.Year < c.ContactName!.Length).DefaultIfEmpty()
                   select new { c, o },
             e => e.c,
             s => s.SetProperty(c => c.c.ContactName, "Updated"),
@@ -879,7 +877,7 @@ public abstract class NorthwindBulkUpdatesTestBase<TFixture>(TFixture fixture) :
         => AssertUpdate(
             async,
             ss => from c in ss.Set<Customer>().Where(c => c.CustomerID.StartsWith("F"))
-                  from c2 in ss.Set<Customer>().Where(c => c.City.StartsWith("S"))
+                  from c2 in ss.Set<Customer>().Where(c => c.City!.StartsWith("S"))
                   join o in ss.Set<Order>().Where(o => o.OrderID < 10300)
                       on c.CustomerID equals o.CustomerID into grouping
                   from o in grouping.DefaultIfEmpty()
@@ -899,8 +897,8 @@ public abstract class NorthwindBulkUpdatesTestBase<TFixture>(TFixture fixture) :
         => AssertUpdate(
             async,
             ss => from c in ss.Set<Customer>().Where(c => c.CustomerID.StartsWith("F"))
-                  from c2 in ss.Set<Customer>().Where(c => c.City.StartsWith("S"))
-                  from o in ss.Set<Order>().Where(o => o.OrderID < 10300 && o.OrderDate.Value.Year < c.ContactName.Length)
+                  from c2 in ss.Set<Customer>().Where(c => c.City!.StartsWith("S"))
+                  from o in ss.Set<Order>().Where(o => o.OrderID < 10300 && o.OrderDate!.Value.Year < c.ContactName!.Length)
                   select new { c, o },
             e => e.c,
             s => s.SetProperty(c => c.c.ContactName, "Updated"),
@@ -912,8 +910,8 @@ public abstract class NorthwindBulkUpdatesTestBase<TFixture>(TFixture fixture) :
         => AssertUpdate(
             async,
             ss => from c in ss.Set<Customer>().Where(c => c.CustomerID.StartsWith("F"))
-                  from c2 in ss.Set<Customer>().Where(c => c.City.StartsWith("S"))
-                  from o in ss.Set<Order>().Where(o => o.OrderID < 10300 && o.OrderDate.Value.Year < c.ContactName.Length).DefaultIfEmpty()
+                  from c2 in ss.Set<Customer>().Where(c => c.City!.StartsWith("S"))
+                  from o in ss.Set<Order>().Where(o => o.OrderID < 10300 && o.OrderDate!.Value.Year < c.ContactName!.Length).DefaultIfEmpty()
                   select new
                   {
                       c,
@@ -930,7 +928,7 @@ public abstract class NorthwindBulkUpdatesTestBase<TFixture>(TFixture fixture) :
         => AssertUpdate(
             async,
             ss => ss.Set<Customer>().Where(c => c.CustomerID.StartsWith("F"))
-                .SelectMany(c => c.Orders.Where(o => o.OrderDate.Value.Year == 1997)),
+                .SelectMany(c => c.Orders.Where(o => o.OrderDate!.Value.Year == 1997)),
             e => e,
             s => s.SetProperty(c => c.OrderDate, (DateTime?)null),
             rowsAffectedCount: 35,
@@ -943,7 +941,7 @@ public abstract class NorthwindBulkUpdatesTestBase<TFixture>(TFixture fixture) :
             ss => from c in ss.Set<Customer>().Where(c => c.CustomerID.StartsWith("F"))
                   select new { c, LastOrder = c.Orders.OrderByDescending(o => o.OrderDate).FirstOrDefault() },
             e => e.c,
-            s => s.SetProperty(c => c.c.City, c => c.LastOrder.OrderDate.Value.Year.ToString()),
+            s => s.SetProperty(c => c.c.City, c => c.LastOrder.OrderDate!.Value.Year.ToString()),
             rowsAffectedCount: 8,
             (b, a) => Assert.All(a, c => Assert.NotNull(c.City)));
 
@@ -964,7 +962,7 @@ public abstract class NorthwindBulkUpdatesTestBase<TFixture>(TFixture fixture) :
         => AssertUpdate(
             async,
             ss => from c in ss.Set<Customer>().Where(c => c.CustomerID.StartsWith("F"))
-                  select new { c, LastOrderDate = c.Orders.OrderByDescending(o => o.OrderDate).FirstOrDefault().OrderDate.Value.Year },
+                  select new { c, LastOrderDate = c.Orders.OrderByDescending(o => o.OrderDate).FirstOrDefault()!.OrderDate!.Value.Year },
             e => e.c,
             s => s.SetProperty(c => c.c.City, c => c.LastOrderDate.ToString()),
             rowsAffectedCount: 8,

--- a/test/EFCore.Specification.Tests/ComplianceTestBase.cs
+++ b/test/EFCore.Specification.Tests/ComplianceTestBase.cs
@@ -5,8 +5,6 @@
 
 namespace Microsoft.EntityFrameworkCore;
 
-#nullable disable
-
 public abstract class ComplianceTestBase
 {
     protected abstract Assembly TargetAssembly { get; }
@@ -67,13 +65,13 @@ public abstract class ComplianceTestBase
 
     private static IEnumerable<Type> GetBaseTypes(Type type)
     {
-        type = type.BaseType;
+        type = type.BaseType!;
 
         while (type != null)
         {
             yield return type;
 
-            type = type.BaseType;
+            type = type.BaseType!;
         }
     }
 }

--- a/test/EFCore.Specification.Tests/CompositeKeyEndToEndTestBase.cs
+++ b/test/EFCore.Specification.Tests/CompositeKeyEndToEndTestBase.cs
@@ -6,8 +6,6 @@ using System.Globalization;
 // ReSharper disable InconsistentNaming
 namespace Microsoft.EntityFrameworkCore;
 
-#nullable disable
-
 public abstract class CompositeKeyEndToEndTestBase<TFixture>(TFixture fixture) : IClassFixture<TFixture>
     where TFixture : CompositeKeyEndToEndTestBase<TFixture>.CompositeKeyEndToEndFixtureBase
 {
@@ -198,10 +196,10 @@ public abstract class CompositeKeyEndToEndTestBase<TFixture>(TFixture fixture) :
     protected class BronieContext(DbContextOptions options) : PoolableDbContext(options)
     {
         // ReSharper disable UnusedAutoPropertyAccessor.Local
-        public DbSet<Pegasus> Pegasuses { get; set; }
-        public DbSet<Unicorn> Unicorns { get; set; }
+        public DbSet<Pegasus> Pegasuses { get; set; } = null!;
+        public DbSet<Unicorn> Unicorns { get; set; } = null!;
 
-        public DbSet<EarthPony> EarthPonies { get; set; }
+        public DbSet<EarthPony> EarthPonies { get; set; } = null!;
         // ReSharper restore UnusedAutoPropertyAccessor.Local
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
@@ -237,28 +235,28 @@ public abstract class CompositeKeyEndToEndTestBase<TFixture>(TFixture fixture) :
 
     protected abstract class Flyer
     {
-        public string Discriminator { get; set; }
+        public string Discriminator { get; set; } = null!;
         public long Id1 { get; set; }
         public long Id2 { get; set; }
     }
 
     protected class Pegasus : Flyer
     {
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
     }
 
     protected class Unicorn
     {
         public int Id1 { get; set; }
-        public string Id2 { get; set; }
+        public string Id2 { get; set; } = null!;
         public Guid Id3 { get; set; }
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
     }
 
     protected class EarthPony
     {
         public int Id1 { get; set; }
         public int Id2 { get; set; }
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
     }
 }

--- a/test/EFCore.Specification.Tests/ConcurrencyDetectorDisabledTestBase.cs
+++ b/test/EFCore.Specification.Tests/ConcurrencyDetectorDisabledTestBase.cs
@@ -6,8 +6,6 @@
 
 namespace Microsoft.EntityFrameworkCore;
 
-#nullable disable
-
 public abstract class ConcurrencyDetectorDisabledTestBase<TFixture>(TFixture fixture) : ConcurrencyDetectorTestBase<TFixture>(fixture)
     where TFixture : ConcurrencyDetectorTestBase<TFixture>.ConcurrencyDetectorFixtureBase, new()
 {
@@ -32,7 +30,7 @@ public abstract class ConcurrencyDetectorDisabledTestBase<TFixture>(TFixture fix
         using var context = CreateContext();
 
         var concurrencyDetector = context.GetService<IConcurrencyDetector>();
-        IDisposable disposer = null;
+        IDisposable disposer = null!;
 
         await Task.Run(() => disposer = concurrencyDetector.EnterCriticalSection());
 

--- a/test/EFCore.Specification.Tests/ConcurrencyDetectorEnabledTestBase.cs
+++ b/test/EFCore.Specification.Tests/ConcurrencyDetectorEnabledTestBase.cs
@@ -6,8 +6,6 @@
 
 namespace Microsoft.EntityFrameworkCore;
 
-#nullable disable
-
 public abstract class ConcurrencyDetectorEnabledTestBase<TFixture>(TFixture fixture) : ConcurrencyDetectorTestBase<TFixture>(fixture)
     where TFixture : ConcurrencyDetectorTestBase<TFixture>.ConcurrencyDetectorFixtureBase, new()
 {
@@ -30,7 +28,7 @@ public abstract class ConcurrencyDetectorEnabledTestBase<TFixture>(TFixture fixt
         using var context = CreateContext();
 
         var concurrencyDetector = context.GetService<IConcurrencyDetector>();
-        IDisposable disposer = null;
+        IDisposable disposer = null!;
 
         await Task.Run(() => disposer = concurrencyDetector.EnterCriticalSection());
 

--- a/test/EFCore.Specification.Tests/ConcurrencyDetectorTestBase.cs
+++ b/test/EFCore.Specification.Tests/ConcurrencyDetectorTestBase.cs
@@ -9,8 +9,6 @@
 // ReSharper disable MethodHasAsyncOverload
 namespace Microsoft.EntityFrameworkCore;
 
-#nullable disable
-
 public abstract class ConcurrencyDetectorTestBase<TFixture>(TFixture fixture) : IClassFixture<TFixture>
     where TFixture : ConcurrencyDetectorTestBase<TFixture>.ConcurrencyDetectorFixtureBase, new()
 {
@@ -18,7 +16,7 @@ public abstract class ConcurrencyDetectorTestBase<TFixture>(TFixture fixture) : 
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Find(bool async)
-        => ConcurrencyDetectorTest(async c => async ? await c.Products.FindAsync(1) : c.Products.Find(1));
+        => ConcurrencyDetectorTest(async c => async ? (await c.Products.FindAsync(1))! : c.Products.Find(1)!);
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Count(bool async)
@@ -59,7 +57,7 @@ public abstract class ConcurrencyDetectorTestBase<TFixture>(TFixture fixture) : 
 
     public class ConcurrencyDetectorDbContext(DbContextOptions<ConcurrencyDetectorDbContext> options) : DbContext(options)
     {
-        public DbSet<Product> Products { get; set; }
+        public DbSet<Product> Products { get; set; } = null!;
 
         public static Task SeedAsync(ConcurrencyDetectorDbContext context)
         {
@@ -71,7 +69,7 @@ public abstract class ConcurrencyDetectorTestBase<TFixture>(TFixture fixture) : 
     public class Product
     {
         public int Id { get; set; }
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
     }
 
     public abstract class ConcurrencyDetectorFixtureBase : SharedStoreFixtureBase<ConcurrencyDetectorDbContext>

--- a/test/EFCore.Specification.Tests/ConferencePlannerTestBase.cs
+++ b/test/EFCore.Specification.Tests/ConferencePlannerTestBase.cs
@@ -11,8 +11,6 @@ using Track = Microsoft.EntityFrameworkCore.TestModels.ConferencePlanner.Track;
 
 namespace Microsoft.EntityFrameworkCore;
 
-#nullable disable
-
 public abstract partial class ConferencePlannerTestBase<TFixture> : IClassFixture<TFixture>
     where TFixture : ConferencePlannerTestBase<TFixture>.ConferencePlannerFixtureBase, new()
 {
@@ -30,14 +28,14 @@ public abstract partial class ConferencePlannerTestBase<TFixture> : IClassFixtur
 
             var attendee = await controller.Get("RainbowDash");
 
-            Assert.Equal("Rainbow", attendee.FirstName);
+            Assert.Equal("Rainbow", attendee!.FirstName);
             Assert.Equal("Dash", attendee.LastName);
             Assert.Equal("RainbowDash", attendee.UserName);
             Assert.Equal("sonicrainboom@sample.com", attendee.EmailAddress);
 
             var sessions = attendee.Sessions;
 
-            Assert.Equal(21, sessions.Count);
+            Assert.Equal(21, sessions!.Count);
             Assert.All(sessions, s => Assert.NotEmpty(s.Title));
         });
 
@@ -51,7 +49,7 @@ public abstract partial class ConferencePlannerTestBase<TFixture> : IClassFixtur
 
             Assert.Equal(21, sessions.Count);
             Assert.All(sessions, s => Assert.NotEmpty(s.Abstract));
-            Assert.All(sessions, s => Assert.NotEmpty(s.Speakers));
+            Assert.All(sessions, s => Assert.NotEmpty(s.Speakers!));
             Assert.All(sessions, s => Assert.NotNull(s.Track));
         });
 
@@ -70,7 +68,7 @@ public abstract partial class ConferencePlannerTestBase<TFixture> : IClassFixtur
                     UserName = "Discord!"
                 });
 
-            Assert.NotEqual(default, result.Id);
+            Assert.NotEqual(default, result!.Id);
             Assert.Equal("discord@sample.com", result.EmailAddress);
             Assert.Equal("", result.FirstName);
             Assert.Equal("Discord", result.LastName);
@@ -115,7 +113,7 @@ public abstract partial class ConferencePlannerTestBase<TFixture> : IClassFixtur
 
             var result = (AttendeeResponse)await controller.AddSession("Pinks", session.Id);
 
-            Assert.Equal(22, result.Sessions.Count);
+            Assert.Equal(22, result.Sessions!.Count);
             Assert.Contains(session.Id, result.Sessions.Select(s => s.Id));
 
             Assert.Equal(pinky.Id, result.Id);
@@ -222,7 +220,7 @@ public abstract partial class ConferencePlannerTestBase<TFixture> : IClassFixtur
     {
         private readonly ApplicationDbContext _db = db;
 
-        public async Task<AttendeeResponse> Get(string username)
+        public async Task<AttendeeResponse?> Get(string username)
         {
             var attendee = await _db.Attendees
                 .Include(a => a.SessionsAttendees)
@@ -241,7 +239,7 @@ public abstract partial class ConferencePlannerTestBase<TFixture> : IClassFixtur
                 .Select(m => m.MapSessionResponse())
                 .ToListAsync();
 
-        public async Task<AttendeeResponse> Post(Attendee input)
+        public async Task<AttendeeResponse?> Post(Attendee input)
         {
             var existingAttendee = await _db.Attendees
                 .Where(a => a.UserName == input.UserName)
@@ -312,7 +310,7 @@ public abstract partial class ConferencePlannerTestBase<TFixture> : IClassFixtur
             }
 
             var sessionAttendee = attendee.SessionsAttendees.FirstOrDefault(sa => sa.SessionId == sessionId);
-            attendee.SessionsAttendees.Remove(sessionAttendee);
+            attendee.SessionsAttendees.Remove(sessionAttendee!);
 
             await _db.SaveChangesAsync();
 
@@ -341,11 +339,11 @@ public abstract partial class ConferencePlannerTestBase<TFixture> : IClassFixtur
             Assert.Equal(totalCount - sessionCount, speakers.Count);
 
             Assert.All(sessions, s => Assert.NotEqual(default, s.Id));
-            Assert.All(sessions, s => Assert.NotEmpty(s.Speakers));
+            Assert.All(sessions, s => Assert.NotEmpty(s.Speakers!));
             Assert.All(sessions, s => Assert.NotNull(s.Track));
 
             Assert.All(speakers, s => Assert.NotEqual(default, s.Id));
-            Assert.All(speakers, s => Assert.NotEmpty(s.Sessions));
+            Assert.All(speakers, s => Assert.NotEmpty(s.Sessions!));
         });
 
     protected class SearchController(ApplicationDbContext db)
@@ -360,7 +358,7 @@ public abstract partial class ConferencePlannerTestBase<TFixture> : IClassFixtur
                 .Include(s => s.SessionSpeakers)
                 .ThenInclude(ss => ss.Speaker)
                 .Where(s =>
-                    s.Title.Contains(query) || s.Track.Name.Contains(query)
+                    s.Title.Contains(query) || s.Track.Name!.Contains(query)
                 )
                 .ToListAsync();
 
@@ -368,7 +366,7 @@ public abstract partial class ConferencePlannerTestBase<TFixture> : IClassFixtur
                 .Include(s => s.SessionSpeakers)
                 .ThenInclude(ss => ss.Session)
                 .Where(s =>
-                    s.Name.Contains(query) || s.Bio.Contains(query) || s.WebSite.Contains(query)
+                    s.Name.Contains(query) || s.Bio!.Contains(query) || s.WebSite!.Contains(query)
                 )
                 .ToListAsync();
 
@@ -393,7 +391,7 @@ public abstract partial class ConferencePlannerTestBase<TFixture> : IClassFixtur
             Assert.Equal(57, results.Count);
 
             Assert.All(results, s => Assert.NotEqual(default, s.Id));
-            Assert.All(results, s => Assert.NotEmpty(s.Speakers));
+            Assert.All(results, s => Assert.NotEmpty(s.Speakers!));
             Assert.All(results, s => Assert.NotNull(s.Track));
         });
 
@@ -407,8 +405,8 @@ public abstract partial class ConferencePlannerTestBase<TFixture> : IClassFixtur
 
             var result = await controller.Get(session.Id);
 
-            Assert.Equal(session.Id, result.Id);
-            Assert.NotEmpty(result.Speakers);
+            Assert.Equal(session.Id, result!.Id);
+            Assert.NotEmpty(result.Speakers!);
             Assert.NotNull(result.Track);
         });
 
@@ -498,7 +496,7 @@ public abstract partial class ConferencePlannerTestBase<TFixture> : IClassFixtur
 
             var result = await controller.Delete(session.Id);
 
-            Assert.Equal(session.Id, result.Id);
+            Assert.Equal(session.Id, result!.Id);
             Assert.Null(result.Speakers);
             Assert.NotNull(result.Track);
 
@@ -528,7 +526,7 @@ public abstract partial class ConferencePlannerTestBase<TFixture> : IClassFixtur
                 .Select(m => m.MapSessionResponse())
                 .ToListAsync();
 
-        public async Task<SessionResponse> Get(int id)
+        public async Task<SessionResponse?> Get(int id)
         {
             var session = await _db.Sessions.AsNoTracking()
                 .Include(s => s.Track)
@@ -577,7 +575,7 @@ public abstract partial class ConferencePlannerTestBase<TFixture> : IClassFixtur
             return "Success";
         }
 
-        public async Task<SessionResponse> Delete(int id)
+        public async Task<SessionResponse?> Delete(int id)
         {
             var session = await _db.Sessions.FindAsync(id);
 
@@ -604,7 +602,7 @@ public abstract partial class ConferencePlannerTestBase<TFixture> : IClassFixtur
             Assert.Equal(70, results.Count);
 
             Assert.All(results, s => Assert.NotEqual(default, s.Id));
-            Assert.All(results, s => Assert.NotEmpty(s.Sessions));
+            Assert.All(results, s => Assert.NotEmpty(s.Sessions!));
         });
 
     [Fact]
@@ -617,8 +615,8 @@ public abstract partial class ConferencePlannerTestBase<TFixture> : IClassFixtur
 
             var result = await controller.GetSpeaker(speaker.Id);
 
-            Assert.Equal(speaker.Id, result.Id);
-            Assert.NotEmpty(result.Sessions);
+            Assert.Equal(speaker.Id, result!.Id);
+            Assert.NotEmpty(result.Sessions!);
         });
 
     [Fact]
@@ -643,7 +641,7 @@ public abstract partial class ConferencePlannerTestBase<TFixture> : IClassFixtur
                 .Select(s => s.MapSpeakerResponse())
                 .ToListAsync();
 
-        public async Task<SpeakerResponse> GetSpeaker(int id)
+        public async Task<SpeakerResponse?> GetSpeaker(int id)
         {
             var speaker = await _db.Speakers.AsNoTracking()
                 .Include(s => s.SessionSpeakers)
@@ -661,9 +659,9 @@ public abstract partial class ConferencePlannerTestBase<TFixture> : IClassFixtur
 
     protected virtual Task ExecuteWithStrategyInTransactionAsync(
         Func<ApplicationDbContext, Task> testOperation,
-        Func<ApplicationDbContext, Task> nestedTestOperation1 = null,
-        Func<ApplicationDbContext, Task> nestedTestOperation2 = null,
-        Func<ApplicationDbContext, Task> nestedTestOperation3 = null)
+        Func<ApplicationDbContext, Task>? nestedTestOperation1 = null,
+        Func<ApplicationDbContext, Task>? nestedTestOperation2 = null,
+        Func<ApplicationDbContext, Task>? nestedTestOperation3 = null)
         => TestHelpers.ExecuteWithStrategyInTransactionAsync(
             CreateContext,
             UseTransaction,
@@ -748,25 +746,25 @@ public abstract partial class ConferencePlannerTestBase<TFixture> : IClassFixtur
             var root = document.RootElement;
             foreach (var dayJson in root.EnumerateArray())
             {
-                foreach (var roomJson in dayJson.GetProperty("rooms").EnumerateArray())
+                foreach (var roomJson in dayJson.GetProperty("rooms")!.EnumerateArray())
                 {
-                    var roomId = roomJson.GetProperty("id").GetInt32();
+                    var roomId = roomJson.GetProperty("id")!.GetInt32();
                     if (!tracks.TryGetValue(roomId, out var track))
                     {
-                        track = new Track { Name = roomJson.GetProperty("name").GetString(), Sessions = [] };
+                        track = new Track { Name = roomJson.GetProperty("name")!.GetString(), Sessions = [] };
 
                         tracks[roomId] = track;
                     }
 
-                    foreach (var sessionJson in roomJson.GetProperty("sessions").EnumerateArray())
+                    foreach (var sessionJson in roomJson.GetProperty("sessions")!.EnumerateArray())
                     {
                         var sessionSpeakers = new List<Speaker>();
-                        foreach (var speakerJson in sessionJson.GetProperty("speakers").EnumerateArray())
+                        foreach (var speakerJson in sessionJson.GetProperty("speakers")!.EnumerateArray())
                         {
-                            var speakerId = speakerJson.GetProperty("id").GetGuid();
+                            var speakerId = speakerJson.GetProperty("id")!.GetGuid();
                             if (!speakers.TryGetValue(speakerId, out var speaker))
                             {
-                                speaker = new Speaker { Name = speakerJson.GetProperty("name").GetString() };
+                                speaker = new Speaker { Name = speakerJson.GetProperty("name")!.GetString()! };
 
                                 speakers[speakerId] = speaker;
                             }
@@ -776,17 +774,17 @@ public abstract partial class ConferencePlannerTestBase<TFixture> : IClassFixtur
 
                         var session = new TestModels.ConferencePlanner.Session
                         {
-                            Title = sessionJson.GetProperty("title").GetString(),
-                            Abstract = sessionJson.GetProperty("description").GetString(),
-                            StartTime = sessionJson.GetProperty("startsAt").GetDateTime(),
-                            EndTime = sessionJson.GetProperty("endsAt").GetDateTime()
+                            Title = sessionJson.GetProperty("title")!.GetString()!,
+                            Abstract = sessionJson.GetProperty("description")!.GetString()!,
+                            StartTime = sessionJson.GetProperty("startsAt")!.GetDateTime(),
+                            EndTime = sessionJson.GetProperty("endsAt")!.GetDateTime()
                         };
 
                         session.SessionSpeakers =
                             sessionSpeakers.Select(s => new SessionSpeaker { Session = session, Speaker = s }).ToList();
 
                         var trackName = track.Name;
-                        var attendees = trackName.Contains("1") ? attendees1
+                        var attendees = trackName!.Contains("1") ? attendees1
                             : trackName.Contains("2") ? attendees2
                             : trackName.Contains("3") ? attendees3
                             : attendees1.Concat(attendees2).Concat(attendees3).ToList();

--- a/test/EFCore.Specification.Tests/CustomConvertersTestBase.cs
+++ b/test/EFCore.Specification.Tests/CustomConvertersTestBase.cs
@@ -5,8 +5,6 @@
 
 namespace Microsoft.EntityFrameworkCore;
 
-#nullable disable
-
 public abstract class CustomConvertersTestBase<TFixture>(TFixture fixture) : BuiltInDataTypesTestBase<TFixture>(fixture)
     where TFixture : BuiltInDataTypesTestBase<TFixture>.BuiltInDataTypesFixtureBase, new()
 {
@@ -41,13 +39,13 @@ public abstract class CustomConvertersTestBase<TFixture>(TFixture fixture) : Bui
             Assert.Equal(4, drivers.Count);
 
             Assert.Equal("Kimi", drivers[0].Name);
-            Assert.Equal(222222222, drivers[0].SSN.Value.Number);
+            Assert.Equal(222222222, drivers[0].SSN!.Value.Number);
 
             Assert.Equal("Lewis", drivers[1].Name);
             Assert.False(drivers[1].SSN.HasValue);
 
             Assert.Equal("Seb", drivers[2].Name);
-            Assert.Equal(111111111, drivers[2].SSN.Value.Number);
+            Assert.Equal(111111111, drivers[2].SSN!.Value.Number);
 
             Assert.Equal("Valtteri", drivers[3].Name);
             Assert.False(drivers[3].SSN.HasValue);
@@ -72,13 +70,13 @@ public abstract class CustomConvertersTestBase<TFixture>(TFixture fixture) : Bui
             Assert.Equal(4, drivers.Count);
 
             Assert.Equal("Charles", drivers[0].Name);
-            Assert.Equal(222222222, drivers[0].SSN.Value.Number);
+            Assert.Equal(222222222, drivers[0].SSN!.Value.Number);
 
             Assert.Equal("Lewis", drivers[1].Name);
             Assert.False(drivers[1].SSN.HasValue);
 
             Assert.Equal("Seb", drivers[2].Name);
-            Assert.Equal(111111111, drivers[2].SSN.Value.Number);
+            Assert.Equal(111111111, drivers[2].SSN!.Value.Number);
 
             Assert.Equal("Valtteri", drivers[3].Name);
             Assert.False(drivers[3].SSN.HasValue);
@@ -98,7 +96,7 @@ public abstract class CustomConvertersTestBase<TFixture>(TFixture fixture) : Bui
     protected class Person
     {
         public int Id { get; set; }
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
         public SocialSecurityNumber? SSN { get; set; }
     }
 
@@ -143,7 +141,7 @@ public abstract class CustomConvertersTestBase<TFixture>(TFixture fixture) : Bui
     {
         public int? Id { get; set; }
 
-        public ICollection<NonNullableDependent> Dependents { get; set; }
+        public ICollection<NonNullableDependent> Dependents { get; set; } = null!;
     }
 
     protected class NonNullableDependent
@@ -151,7 +149,7 @@ public abstract class CustomConvertersTestBase<TFixture>(TFixture fixture) : Bui
         public int Id { get; set; }
 
         public int PrincipalId { get; set; }
-        public NullablePrincipal Principal { get; set; }
+        public NullablePrincipal Principal { get; set; } = null!;
     }
 
     [Fact]
@@ -193,8 +191,8 @@ public abstract class CustomConvertersTestBase<TFixture>(TFixture fixture) : Bui
         private Email(string value)
             => _value = value;
 
-        public override bool Equals(object obj)
-            => _value == ((Email)obj)?._value;
+        public override bool Equals(object? obj)
+            => _value == ((Email)obj!)?._value;
 
         public override int GetHashCode()
             => _value.GetHashCode();
@@ -302,7 +300,7 @@ public abstract class CustomConvertersTestBase<TFixture>(TFixture fixture) : Bui
     {
         public int Id { get; set; }
 
-        public IList<string> Strings { get; set; }
+        public IList<string> Strings { get; set; } = null!;
     }
 
     [Fact]
@@ -378,7 +376,7 @@ public abstract class CustomConvertersTestBase<TFixture>(TFixture fixture) : Bui
     public class SimpleCounter
     {
         public int CounterId { get; set; }
-        public string StyleKey { get; set; }
+        public string StyleKey { get; set; } = null!;
         public bool IsTest { get; set; }
         public IDictionary<string, string> Discriminator { get; set; } = new Dictionary<string, string>();
     }
@@ -565,7 +563,7 @@ public abstract class CustomConvertersTestBase<TFixture>(TFixture fixture) : Bui
     {
         public int Id { get; set; }
         public bool IsSoftDeleted { get; set; }
-        public List<MessageGroup> MessageGroups { get; set; }
+        public List<MessageGroup> MessageGroups { get; set; } = null!;
     }
 
     protected enum MessageGroup
@@ -579,9 +577,9 @@ public abstract class CustomConvertersTestBase<TFixture>(TFixture fixture) : Bui
         private bool _indexerVisible;
 
         public int BlogId { get; set; }
-        public string Url { get; set; }
+        public string Url { get; set; } = null!;
         public bool IsVisible { get; set; }
-        public List<Post> Posts { get; set; }
+        public List<Post> Posts { get; set; } = null!;
 
         public object this[string name]
         {
@@ -603,25 +601,25 @@ public abstract class CustomConvertersTestBase<TFixture>(TFixture fixture) : Bui
 
     protected class RssBlog : Blog
     {
-        public string RssUrl { get; set; }
+        public string RssUrl { get; set; } = null!;
     }
 
     protected class Post
     {
         public int PostId { get; set; }
         public int? BlogId { get; set; }
-        public Blog Blog { get; set; }
+        public Blog Blog { get; set; } = null!;
     }
 
     protected class EntityWithValueWrapper
     {
         public int Id { get; set; }
-        public ValueWrapper Wrapper { get; set; }
+        public ValueWrapper Wrapper { get; set; } = null!;
     }
 
     protected class ValueWrapper
     {
-        public string Value { get; set; }
+        public string Value { get; set; } = null!;
     }
 
     [Fact]
@@ -648,7 +646,7 @@ public abstract class CustomConvertersTestBase<TFixture>(TFixture fixture) : Bui
     protected class CollectionScalar
     {
         public int Id { get; set; }
-        public List<string> Tags { get; set; }
+        public List<string> Tags { get; set; } = null!;
     }
 
     [Fact]
@@ -665,7 +663,7 @@ public abstract class CustomConvertersTestBase<TFixture>(TFixture fixture) : Bui
     protected class CollectionEnum
     {
         public int Id { get; set; }
-        public ICollection<Roles> Roles { get; set; }
+        public ICollection<Roles> Roles { get; set; } = null!;
     }
 
     protected enum Roles
@@ -684,14 +682,14 @@ public abstract class CustomConvertersTestBase<TFixture>(TFixture fixture) : Bui
         Assert.Equal(
             "Nullable object must have a value.",
             (await Assert.ThrowsAsync<InvalidOperationException>(()
-                => context.Set<Parent>().Select(e => new { e.OwnedWithConverter.Value }).ToListAsync()))
+                => context.Set<Parent>().Select(e => new { e.OwnedWithConverter!.Value }).ToListAsync()))
             .Message);
     }
 
     protected class Parent
     {
         public int Id { get; set; }
-        public OwnedWithConverter OwnedWithConverter { get; set; }
+        public OwnedWithConverter? OwnedWithConverter { get; set; }
     }
 
     protected class OwnedWithConverter
@@ -712,14 +710,14 @@ public abstract class CustomConvertersTestBase<TFixture>(TFixture fixture) : Bui
     {
         public BookId Id { get; set; } = id;
 
-        public string Value { get; set; }
+        public string Value { get; set; } = null!;
     }
 
     public class BookId(int id)
     {
         public readonly int Id = id;
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => obj is BookId item && Id == item.Id;
 
         public override int GetHashCode()
@@ -745,7 +743,7 @@ public abstract class CustomConvertersTestBase<TFixture>(TFixture fixture) : Bui
     public class Dashboard
     {
         public int Id { get; set; }
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
         public List<Layout> Layouts { get; set; } = [];
     }
 
@@ -964,7 +962,7 @@ public abstract class CustomConvertersTestBase<TFixture>(TFixture fixture) : Bui
                     v => string.Join(",", v),
                     v => v.Split(new[] { ',' }).ToList(),
                     new ValueComparer<IList<string>>(
-                        (v1, v2) => v1.SequenceEqual(v2),
+                        (v1, v2) => v1!.SequenceEqual(v2!),
                         v => v.GetHashCode()));
 
                 b.Property(e => e.Id).ValueGeneratedNever();
@@ -984,7 +982,7 @@ public abstract class CustomConvertersTestBase<TFixture>(TFixture fixture) : Bui
                     d => StringToDictionarySerializer.Serialize(d),
                     json => StringToDictionarySerializer.Deserialize(json),
                     new ValueComparer<IDictionary<string, string>>(
-                        (v1, v2) => v1.SequenceEqual(v2),
+                        (v1, v2) => v1!.SequenceEqual(v2!),
                         v => v.GetHashCode(),
                         v => new Dictionary<string, string>(v)));
             });
@@ -1116,7 +1114,7 @@ public abstract class CustomConvertersTestBase<TFixture>(TFixture fixture) : Bui
                     v => LayoutsToStringSerializer.Serialize(v),
                     v => LayoutsToStringSerializer.Deserialize(v),
                     new ValueComparer<List<Layout>>(
-                        (v1, v2) => v1.SequenceEqual(v2),
+                        (v1, v2) => v1!.SequenceEqual(v2!),
                         v => v.GetHashCode(),
                         v => new List<Layout>(v)));
 
@@ -1179,7 +1177,7 @@ public abstract class CustomConvertersTestBase<TFixture>(TFixture fixture) : Bui
         )
         {
             public OrderIdEntityFrameworkValueConverter()
-                : this(null)
+                : this(null!)
             {
             }
         }

--- a/test/EFCore.Specification.Tests/DataAnnotationTestBase.cs
+++ b/test/EFCore.Specification.Tests/DataAnnotationTestBase.cs
@@ -9,8 +9,6 @@ using Microsoft.EntityFrameworkCore.Metadata.Internal;
 // ReSharper disable InconsistentNaming
 namespace Microsoft.EntityFrameworkCore;
 
-#nullable disable
-
 public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
     where TFixture : DataAnnotationTestBase<TFixture>.DataAnnotationFixtureBase, new()
 {
@@ -51,7 +49,7 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
         public int Id { get; set; }
 
         [StringLength(5)]
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
     }
 
     protected class Employee : Person;
@@ -128,7 +126,7 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
     }
 
     protected static IProperty GetProperty<TEntity>(IModel model, string name)
-        => model.FindEntityType(typeof(TEntity)).FindProperty(name);
+        => model.FindEntityType(typeof(TEntity))!.FindProperty(name)!;
 
     [Fact]
     public virtual void Duplicate_column_order_is_ignored()
@@ -148,7 +146,7 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
         [Column(Order = 1)]
         public int Key2 { get; set; }
 
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
     }
 
     [Fact]
@@ -176,7 +174,7 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
 
         [Key, Column("dsdsd", Order = 1, TypeName = "nvarchar(128)")]
         // ReSharper disable once UnusedAutoPropertyAccessor.Local
-        private string PersonFirstName { get; set; }
+        private string PersonFirstName { get; set; } = null!;
     }
 
     [Fact]
@@ -195,10 +193,10 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
 
     protected class FieldAnnotationClass
     {
-#pragma warning disable 169
+#pragma warning disable 169, 414
         [Key, Column("dsdsd", Order = 1, TypeName = "nvarchar(128)")]
-        private readonly string _personFirstName;
-#pragma warning restore 169
+        private readonly string _personFirstName = null!;
+#pragma warning restore 169, 414
     }
 
     [Fact]
@@ -231,12 +229,12 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
 
         Validate(modelBuilder);
 
-        Assert.Null(modelBuilder.Model.FindEntityType(typeof(AbstractBaseEntity1)).FindProperty("BaseClassProperty"));
-        Assert.NotNull(modelBuilder.Model.FindEntityType(typeof(BaseEntity1)).FindProperty("BaseClassProperty"));
-        Assert.NotNull(modelBuilder.Model.FindEntityType(typeof(Unit1)).FindProperty("BaseClassProperty"));
-        Assert.Null(modelBuilder.Model.FindEntityType(typeof(AbstractBaseEntity1)).FindProperty("VirtualBaseClassProperty"));
-        Assert.Null(modelBuilder.Model.FindEntityType(typeof(BaseEntity1)).FindProperty("VirtualBaseClassProperty"));
-        Assert.Null(modelBuilder.Model.FindEntityType(typeof(Unit1)).FindProperty("VirtualBaseClassProperty"));
+        Assert.Null(modelBuilder.Model.FindEntityType(typeof(AbstractBaseEntity1))!.FindProperty("BaseClassProperty"));
+        Assert.NotNull(modelBuilder.Model.FindEntityType(typeof(BaseEntity1))!.FindProperty("BaseClassProperty"));
+        Assert.NotNull(modelBuilder.Model.FindEntityType(typeof(Unit1))!.FindProperty("BaseClassProperty"));
+        Assert.Null(modelBuilder.Model.FindEntityType(typeof(AbstractBaseEntity1))!.FindProperty("VirtualBaseClassProperty"));
+        Assert.Null(modelBuilder.Model.FindEntityType(typeof(BaseEntity1))!.FindProperty("VirtualBaseClassProperty"));
+        Assert.Null(modelBuilder.Model.FindEntityType(typeof(Unit1))!.FindProperty("VirtualBaseClassProperty"));
     }
 
     protected abstract class AbstractBaseEntity1
@@ -248,23 +246,23 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
     protected class BaseEntity1 : AbstractBaseEntity1
     {
         [NotMapped]
-        public string BaseClassProperty { get; set; }
+        public string BaseClassProperty { get; set; } = null!;
 
         [NotMapped]
-        public virtual string VirtualBaseClassProperty { get; set; }
+        public virtual string VirtualBaseClassProperty { get; set; } = null!;
 
-        public override string AbstractBaseClassProperty { get; set; }
+        public override string AbstractBaseClassProperty { get; set; } = null!;
     }
 
     protected class Unit1 : BaseEntity1
     {
-        public override string VirtualBaseClassProperty { get; set; }
-        public virtual AbstractBaseEntity1 Related { get; set; }
+        public override string VirtualBaseClassProperty { get; set; } = null!;
+        public virtual AbstractBaseEntity1 Related { get; set; } = null!;
     }
 
     protected class DifferentUnit1 : BaseEntity1
     {
-        public new string VirtualBaseClassProperty { get; set; }
+        public new string VirtualBaseClassProperty { get; set; } = null!;
     }
 
     [Fact]
@@ -277,9 +275,9 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
 
         Validate(modelBuilder);
 
-        Assert.Null(modelBuilder.Model.FindEntityType(typeof(AbstractBaseEntity2)).FindProperty("VirtualBaseClassProperty"));
-        Assert.Null(modelBuilder.Model.FindEntityType(typeof(BaseEntity2)).FindProperty("VirtualBaseClassProperty"));
-        Assert.Null(modelBuilder.Model.FindEntityType(typeof(Unit2)).FindProperty("VirtualBaseClassProperty"));
+        Assert.Null(modelBuilder.Model.FindEntityType(typeof(AbstractBaseEntity2))!.FindProperty("VirtualBaseClassProperty"));
+        Assert.Null(modelBuilder.Model.FindEntityType(typeof(BaseEntity2))!.FindProperty("VirtualBaseClassProperty"));
+        Assert.Null(modelBuilder.Model.FindEntityType(typeof(Unit2))!.FindProperty("VirtualBaseClassProperty"));
     }
 
     protected abstract class AbstractBaseEntity2
@@ -290,25 +288,25 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
 
     protected class BaseEntity2 : AbstractBaseEntity2
     {
-        public string BaseClassProperty { get; set; }
+        public string BaseClassProperty { get; set; } = null!;
 
         [NotMapped]
-        public virtual string VirtualBaseClassProperty { get; set; }
+        public virtual string VirtualBaseClassProperty { get; set; } = null!;
 
-        public override string AbstractBaseClassProperty { get; set; }
+        public override string AbstractBaseClassProperty { get; set; } = null!;
     }
 
     protected class Unit2 : BaseEntity2
     {
         [NotMapped]
-        public override string VirtualBaseClassProperty { get; set; }
+        public override string VirtualBaseClassProperty { get; set; } = null!;
 
-        public virtual AbstractBaseEntity2 Related { get; set; }
+        public virtual AbstractBaseEntity2 Related { get; set; } = null!;
     }
 
     protected class DifferentUnit2 : BaseEntity2
     {
-        public new string VirtualBaseClassProperty { get; set; }
+        public new string VirtualBaseClassProperty { get; set; } = null!;
     }
 
     [Fact]
@@ -320,9 +318,9 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
 
         Validate(modelBuilder);
 
-        Assert.Null(modelBuilder.Model.FindEntityType(typeof(AbstractBaseEntity3)).FindProperty("AbstractBaseClassProperty"));
+        Assert.Null(modelBuilder.Model.FindEntityType(typeof(AbstractBaseEntity3))!.FindProperty("AbstractBaseClassProperty"));
         Assert.Null(modelBuilder.Model.FindEntityType(typeof(BaseEntity3)));
-        Assert.Null(modelBuilder.Model.FindEntityType(typeof(Unit3)).FindProperty("AbstractBaseClassProperty"));
+        Assert.Null(modelBuilder.Model.FindEntityType(typeof(Unit3))!.FindProperty("AbstractBaseClassProperty"));
     }
 
     [Fact]
@@ -333,7 +331,7 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
         modelBuilder.Entity<Unit3>();
         modelBuilder.Entity<BaseEntity3>();
 
-        Assert.NotNull(modelBuilder.Model.FindEntityType(typeof(Unit3)).FindProperty("VirtualBaseClassProperty"));
+        Assert.NotNull(modelBuilder.Model.FindEntityType(typeof(Unit3))!.FindProperty("VirtualBaseClassProperty"));
 
         Validate(modelBuilder);
     }
@@ -351,7 +349,7 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
 
         Assert.Null(modelBuilder.Model.FindEntityType(typeof(AbstractBaseEntity3)));
         Assert.Null(modelBuilder.Model.FindEntityType(typeof(BaseEntity3)));
-        Assert.Null(modelBuilder.Model.FindEntityType(typeof(Unit3)).FindProperty("VirtualBaseClassProperty"));
+        Assert.Null(modelBuilder.Model.FindEntityType(typeof(Unit3))!.FindProperty("VirtualBaseClassProperty"));
     }
 
     protected abstract class AbstractBaseEntity3
@@ -364,22 +362,22 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
 
     protected class BaseEntity3 : AbstractBaseEntity3
     {
-        public string BaseClassProperty { get; set; }
-        public virtual string VirtualBaseClassProperty { get; set; }
-        public override string AbstractBaseClassProperty { get; set; }
+        public string BaseClassProperty { get; set; } = null!;
+        public virtual string VirtualBaseClassProperty { get; set; } = null!;
+        public override string AbstractBaseClassProperty { get; set; } = null!;
     }
 
     protected class Unit3 : BaseEntity3
     {
         [NotMapped]
-        public override string VirtualBaseClassProperty { get; set; }
+        public override string VirtualBaseClassProperty { get; set; } = null!;
 
-        public virtual AbstractBaseEntity3 Related { get; set; }
+        public virtual AbstractBaseEntity3 Related { get; set; } = null!;
     }
 
     protected class DifferentUnit3 : BaseEntity3
     {
-        public new string VirtualBaseClassProperty { get; set; }
+        public new string VirtualBaseClassProperty { get; set; } = null!;
     }
 
     [Fact]
@@ -393,9 +391,9 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
 
         Validate(modelBuilder);
 
-        Assert.Null(modelBuilder.Model.FindEntityType(typeof(AbstractBaseEntity3)).FindProperty("AbstractBaseClassProperty"));
-        Assert.Null(modelBuilder.Model.FindEntityType(typeof(BaseEntity3)).FindProperty("AbstractBaseClassProperty"));
-        Assert.Null(modelBuilder.Model.FindEntityType(typeof(Unit3)).FindProperty("AbstractBaseClassProperty"));
+        Assert.Null(modelBuilder.Model.FindEntityType(typeof(AbstractBaseEntity3))!.FindProperty("AbstractBaseClassProperty"));
+        Assert.Null(modelBuilder.Model.FindEntityType(typeof(BaseEntity3))!.FindProperty("AbstractBaseClassProperty"));
+        Assert.Null(modelBuilder.Model.FindEntityType(typeof(Unit3))!.FindProperty("AbstractBaseClassProperty"));
     }
 
     [Fact]
@@ -410,7 +408,7 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
 
         Assert.Null(modelBuilder.Model.FindEntityType(typeof(AbstractBaseEntity2)));
         Assert.Null(modelBuilder.Model.FindEntityType(typeof(BaseEntity2)));
-        Assert.Null(modelBuilder.Model.FindEntityType(typeof(Unit2)).FindProperty("VirtualBaseClassProperty"));
+        Assert.Null(modelBuilder.Model.FindEntityType(typeof(Unit2))!.FindProperty("VirtualBaseClassProperty"));
     }
 
     [Fact]
@@ -426,7 +424,7 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
 
         Assert.Null(modelBuilder.Model.FindEntityType(typeof(AbstractBaseEntity1)));
         Assert.Null(modelBuilder.Model.FindEntityType(typeof(BaseEntity1)));
-        Assert.Null(modelBuilder.Model.FindEntityType(typeof(Unit1)).FindProperty("VirtualBaseClassProperty"));
+        Assert.Null(modelBuilder.Model.FindEntityType(typeof(Unit1))!.FindProperty("VirtualBaseClassProperty"));
     }
 
     [Fact]
@@ -441,7 +439,7 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
         Assert.Null(modelBuilder.Model.FindEntityType(typeof(AbstractBaseEntity5)));
         Assert.Null(modelBuilder.Model.FindEntityType(typeof(BaseEntity5)));
         Assert.Null(modelBuilder.Model.FindEntityType(typeof(Unit5)));
-        Assert.Null(modelBuilder.Model.FindEntityType(typeof(DifferentUnit5)).FindProperty("VirtualBaseClassProperty"));
+        Assert.Null(modelBuilder.Model.FindEntityType(typeof(DifferentUnit5))!.FindProperty("VirtualBaseClassProperty"));
     }
 
     protected abstract class AbstractBaseEntity5
@@ -452,21 +450,21 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
 
     protected class BaseEntity5 : AbstractBaseEntity5
     {
-        public string BaseClassProperty { get; set; }
-        public virtual string VirtualBaseClassProperty { get; set; }
-        public override string AbstractBaseClassProperty { get; set; }
+        public string BaseClassProperty { get; set; } = null!;
+        public virtual string VirtualBaseClassProperty { get; set; } = null!;
+        public override string AbstractBaseClassProperty { get; set; } = null!;
     }
 
     protected class Unit5 : BaseEntity5
     {
-        public override string VirtualBaseClassProperty { get; set; }
-        public virtual AbstractBaseEntity5 Related { get; set; }
+        public override string VirtualBaseClassProperty { get; set; } = null!;
+        public virtual AbstractBaseEntity5 Related { get; set; } = null!;
     }
 
     protected class DifferentUnit5 : BaseEntity5
     {
         [NotMapped]
-        public new string VirtualBaseClassProperty { get; set; }
+        public new string VirtualBaseClassProperty { get; set; } = null!;
     }
 
     [Fact]
@@ -487,10 +485,10 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
         public int Id { get; set; }
 
         [StringLength(500), MaxLength]
-        public string PersonFirstName { get; set; }
+        public string PersonFirstName { get; set; } = null!;
 
         [MaxLength, StringLength(500)]
-        public string PersonLastName { get; set; }
+        public string PersonLastName { get; set; } = null!;
     }
 
     [Fact]
@@ -511,10 +509,10 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
         public int Id { get; set; }
 
         [StringLength(500), MaxLength(30)]
-        public string PersonFirstName { get; set; }
+        public string PersonFirstName { get; set; } = null!;
 
         [MaxLength(30), StringLength(500)]
-        public string PersonLastName { get; set; }
+        public string PersonLastName { get; set; } = null!;
     }
 
     [Fact]
@@ -535,30 +533,30 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
         public int Login1Id { get; set; }
 
         [Key]
-        public string UserName { get; set; }
+        public string UserName { get; set; } = null!;
 
-        public virtual Profile1 Profile { get; set; }
+        public virtual Profile1 Profile { get; set; } = null!;
     }
 
     protected class Profile1
     {
         public int Profile1Id { get; set; }
-        public string Name { get; set; }
-        public string Email { get; set; }
-        public virtual Login1 User { get; set; }
+        public string Name { get; set; } = null!;
+        public string Email { get; set; } = null!;
+        public virtual Login1 User { get; set; } = null!;
     }
 
     protected class PrincipalA
     {
         public int Id { get; set; }
-        public DependantA Dependant { get; set; }
+        public DependantA Dependant { get; set; } = null!;
     }
 
     protected class DependantA
     {
         public int Id { get; set; }
         public int PrincipalId { get; set; }
-        public PrincipalA Principal { get; set; }
+        public PrincipalA Principal { get; set; } = null!;
     }
 
     protected class PrincipalB
@@ -584,7 +582,7 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
     protected class ColumnKeyAnnotationClass1
     {
         [Key, Column("dsdsd", Order = 1, TypeName = "nvarchar(128)")]
-        public string PersonFirstName { get; set; }
+        public string PersonFirstName { get; set; } = null!;
     }
 
     [Fact]
@@ -605,7 +603,7 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
     protected class ColumnKeyAnnotationClass2
     {
         [Key, MaxLength(64)]
-        public string PersonFirstName { get; set; }
+        public string PersonFirstName { get; set; } = null!;
     }
 
     [Fact]
@@ -653,8 +651,8 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
     {
         public int SRelatedId { get; set; }
 
-        public ICollection<OKeyBase> OKeyBases { get; set; }
-        public ICollection<DODerived> DADeriveds { get; set; }
+        public ICollection<OKeyBase> OKeyBases { get; set; } = null!;
+        public ICollection<DODerived> DADeriveds { get; set; } = null!;
     }
 
     protected class OKeyBase
@@ -667,8 +665,8 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
 
     protected class DODerived : OKeyBase
     {
-        public SRelated DARelated { get; set; }
-        public string Special { get; set; }
+        public SRelated DARelated { get; set; } = null!;
+        public string Special { get; set; } = null!;
     }
 
     [Fact]
@@ -693,10 +691,10 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
         public int Id { get; set; }
 
         [Key]
-        public ICollection<DASimple> Simples { get; set; }
+        public ICollection<DASimple> Simples { get; set; } = null!;
 
         [Key]
-        public DASimple SpecialSimple { get; set; }
+        public DASimple SpecialSimple { get; set; } = null!;
     }
 
     [Fact]
@@ -721,9 +719,9 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
         [Key, DatabaseGenerated(DatabaseGeneratedOption.Identity)]
         public int IdRow { get; set; }
 
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
 
-        public ICollection<Child> Children { get; set; }
+        public ICollection<Child> Children { get; set; } = null!;
     }
 
     public class Child
@@ -731,8 +729,8 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
         [Key, DatabaseGenerated(DatabaseGeneratedOption.Identity)]
         public int IdRow { get; set; }
 
-        public string Name { get; set; }
-        public ICollection<Toy> Toys { get; set; }
+        public string Name { get; set; } = null!;
+        public ICollection<Toy> Toys { get; set; } = null!;
     }
 
     public class Toy
@@ -740,7 +738,7 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
         [Key, DatabaseGenerated(DatabaseGeneratedOption.Identity)]
         public int IdRow { get; set; }
 
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
     }
 
     [Fact]
@@ -753,7 +751,7 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
         Validate(modelBuilder);
 
         var entityType = modelBuilder.Model.FindEntityType(typeof(CompositeKeyAttribute));
-        Assert.Equal(2, entityType.GetKeys().Single().Properties.Count);
+        Assert.Equal(2, entityType!.GetKeys().Single().Properties.Count);
         Assert.Equal(2, entityType.GetProperties().Count());
 
         return modelBuilder;
@@ -825,7 +823,7 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
         public int IdRow { get; set; }
 
         [Key]
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
         // ReSharper restore UnusedAutoPropertyAccessor.Local
     }
 
@@ -838,16 +836,16 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
 
         var entity = modelBuilder.Model.FindEntityType(typeof(GeneratedEntity));
 
-        var id = entity.FindProperty(nameof(GeneratedEntity.Id));
-        Assert.Equal(ValueGenerated.Never, id.ValueGenerated);
+        var id = entity!.FindProperty(nameof(GeneratedEntity.Id));
+        Assert.Equal(ValueGenerated.Never, id!.ValueGenerated);
         Assert.False(id.RequiresValueGenerator());
 
         var identity = entity.FindProperty(nameof(GeneratedEntity.Identity));
-        Assert.Equal(ValueGenerated.OnAdd, identity.ValueGenerated);
+        Assert.Equal(ValueGenerated.OnAdd, identity!.ValueGenerated);
         Assert.True(identity.RequiresValueGenerator());
 
         var version = entity.FindProperty(nameof(GeneratedEntity.Version));
-        Assert.Equal(ValueGenerated.OnAddOrUpdate, version.ValueGenerated);
+        Assert.Equal(ValueGenerated.OnAddOrUpdate, version!.ValueGenerated);
         Assert.False(version.RequiresValueGenerator());
 
         return Validate(modelBuilder);
@@ -879,16 +877,16 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
 
         var entity = modelBuilder.Model.FindEntityType(typeof(GeneratedEntityNonInteger));
 
-        var stringProperty = entity.FindProperty(nameof(GeneratedEntityNonInteger.String));
-        Assert.Equal(ValueGenerated.OnAdd, stringProperty.ValueGenerated);
+        var stringProperty = entity!.FindProperty(nameof(GeneratedEntityNonInteger.String));
+        Assert.Equal(ValueGenerated.OnAdd, stringProperty!.ValueGenerated);
         Assert.True(stringProperty.RequiresValueGenerator());
 
         var dateTimeProperty = entity.FindProperty(nameof(GeneratedEntityNonInteger.DateTime));
-        Assert.Equal(ValueGenerated.OnAdd, dateTimeProperty.ValueGenerated);
+        Assert.Equal(ValueGenerated.OnAdd, dateTimeProperty!.ValueGenerated);
         Assert.True(dateTimeProperty.RequiresValueGenerator());
 
         var guidProperty = entity.FindProperty(nameof(GeneratedEntityNonInteger.Guid));
-        Assert.Equal(ValueGenerated.OnAdd, guidProperty.ValueGenerated);
+        Assert.Equal(ValueGenerated.OnAdd, guidProperty!.ValueGenerated);
         Assert.True(guidProperty.RequiresValueGenerator());
 
         return Validate(modelBuilder);
@@ -899,7 +897,7 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
         public int Id { get; set; }
 
         [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
-        public string String { get; set; }
+        public string String { get; set; } = null!;
 
         [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
         public DateTime DateTime { get; set; }
@@ -926,10 +924,10 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
         public int Id { get; set; }
 
         [MaxLength, Timestamp]
-        public byte[] MaxTimestamp { get; set; }
+        public byte[] MaxTimestamp { get; set; } = null!;
 
         [MaxLength(100), Timestamp]
-        public byte[] NonMaxTimestamp { get; set; }
+        public byte[] NonMaxTimestamp { get; set; } = null!;
     }
 
     [Fact]
@@ -953,7 +951,7 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
     protected class StyledProduct : Product
     {
         [StringLength(150)]
-        public virtual string Style { get; set; }
+        public virtual string Style { get; set; } = null!;
     }
 
     [Fact]
@@ -974,20 +972,20 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
     protected class Login2
     {
         public int Login2Id { get; set; }
-        public string UserName { get; set; }
+        public string UserName { get; set; } = null!;
 
         [Required, ForeignKey("Login2Id")]
-        public virtual Profile2 Profile { get; set; }
+        public virtual Profile2 Profile { get; set; } = null!;
     }
 
     protected class Profile2
     {
         public int Profile2Id { get; set; }
-        public string Name { get; set; }
-        public string Email { get; set; }
+        public string Name { get; set; } = null!;
+        public string Email { get; set; } = null!;
 
         [Required]
-        public virtual Login2 User { get; set; }
+        public virtual Login2 User { get; set; } = null!;
     }
 
     [Fact]
@@ -1008,20 +1006,20 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
     protected class Login3
     {
         public int Login3Id { get; set; }
-        public string UserName { get; set; }
+        public string UserName { get; set; } = null!;
 
         [Required]
-        public virtual Profile3 Profile { get; set; }
+        public virtual Profile3 Profile { get; set; } = null!;
     }
 
     protected class Profile3
     {
         public int Profile3Id { get; set; }
-        public string Name { get; set; }
-        public string Email { get; set; }
+        public string Name { get; set; } = null!;
+        public string Email { get; set; } = null!;
 
         [Required, ForeignKey("Profile3Id")]
-        public virtual Login3 User { get; set; }
+        public virtual Login3 User { get; set; } = null!;
     }
 
     [Fact]
@@ -1066,21 +1064,21 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
     {
         public int Id { get; set; }
         public int Login4Id { get; set; }
-        public string UserName { get; set; }
+        public string UserName { get; set; } = null!;
 
         [Required, ForeignKey("Login4Id")]
-        public virtual Profile4 Profile { get; set; }
+        public virtual Profile4 Profile { get; set; } = null!;
     }
 
     protected class Profile4
     {
         public int Id { get; set; }
         public int Profile4Id { get; set; }
-        public string Name { get; set; }
-        public string Email { get; set; }
+        public string Name { get; set; } = null!;
+        public string Email { get; set; } = null!;
 
         [Required, ForeignKey("Profile4Id")]
-        public virtual Login4 User { get; set; }
+        public virtual Login4 User { get; set; } = null!;
     }
 
     [Fact]
@@ -1118,19 +1116,19 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
     protected class Login5
     {
         public int Login5Id { get; set; }
-        public string UserName { get; set; }
+        public string UserName { get; set; } = null!;
 
         [ForeignKey("Login5Id")]
-        public virtual Profile5 Profile { get; set; }
+        public virtual Profile5 Profile { get; set; } = null!;
     }
 
     protected class Profile5
     {
         public int Profile5Id { get; set; }
-        public string Name { get; set; }
-        public string Email { get; set; }
+        public string Name { get; set; } = null!;
+        public string Email { get; set; } = null!;
 
-        public virtual Login5 User { get; set; }
+        public virtual Login5 User { get; set; } = null!;
     }
 
     [Fact]
@@ -1151,19 +1149,19 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
     protected class Login6
     {
         public int Login6Id { get; set; }
-        public string UserName { get; set; }
+        public string UserName { get; set; } = null!;
 
         [Required, ForeignKey("Login6Id")]
-        public virtual Profile6 Profile { get; set; }
+        public virtual Profile6 Profile { get; set; } = null!;
     }
 
     protected class Profile6
     {
         public int Profile6Id { get; set; }
-        public string Name { get; set; }
-        public string Email { get; set; }
+        public string Name { get; set; } = null!;
+        public string Email { get; set; } = null!;
 
-        public virtual Login6 User { get; set; }
+        public virtual Login6? User { get; set; }
     }
 
     [Fact]
@@ -1182,19 +1180,19 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
     protected class Login7
     {
         public int Login7Id { get; set; }
-        public string UserName { get; set; }
+        public string UserName { get; set; } = null!;
 
-        public virtual Profile7 Profile { get; set; }
+        public virtual Profile7 Profile { get; set; } = null!;
     }
 
     protected class Profile7
     {
         public int Profile7Id { get; set; }
-        public string Name { get; set; }
-        public string Email { get; set; }
+        public string Name { get; set; } = null!;
+        public string Email { get; set; } = null!;
 
         [ForeignKey("Profile7Id")]
-        public virtual Login7 User { get; set; }
+        public virtual Login7 User { get; set; } = null!;
     }
 
     [Fact]
@@ -1215,19 +1213,19 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
     protected class Login8
     {
         public int Login8Id { get; set; }
-        public string UserName { get; set; }
+        public string UserName { get; set; } = null!;
 
-        public virtual Profile8 Profile { get; set; }
+        public virtual Profile8? Profile { get; set; }
     }
 
     protected class Profile8
     {
         public int Profile8Id { get; set; }
-        public string Name { get; set; }
-        public string Email { get; set; }
+        public string Name { get; set; } = null!;
+        public string Email { get; set; } = null!;
 
         [Required, ForeignKey("Profile8Id")]
-        public virtual Login8 User { get; set; }
+        public virtual Login8 User { get; set; } = null!;
     }
 
     [Fact]
@@ -1253,21 +1251,21 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
     {
         public int Id { get; set; }
         public int? Login9Id { get; set; }
-        public string UserName { get; set; }
+        public string UserName { get; set; } = null!;
 
         [ForeignKey("Login9Id")]
-        public virtual Profile9 Profile { get; set; }
+        public virtual Profile9 Profile { get; set; } = null!;
     }
 
     protected class Profile9
     {
         public int Id { get; set; }
         public int? Profile9Id { get; set; }
-        public string Name { get; set; }
-        public string Email { get; set; }
+        public string Name { get; set; } = null!;
+        public string Email { get; set; } = null!;
 
         [ForeignKey("Profile9Id")]
-        public virtual Login9 User { get; set; }
+        public virtual Login9 User { get; set; } = null!;
     }
 
     [Fact]
@@ -1290,7 +1288,7 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
         public int FkId { get; set; }
 
         [ForeignKey("FkId")]
-        public virtual Profile10 Login { get; set; }
+        public virtual Profile10 Login { get; set; } = null!;
     }
 
     public class Profile10
@@ -1300,7 +1298,7 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
         public int FkId { get; set; }
 
         [ForeignKey("FkId")]
-        public Login10 User { get; set; }
+        public Login10 User { get; set; } = null!;
     }
 
     [Fact]
@@ -1321,7 +1319,7 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
         public int Login11Id { get; set; }
 
         [ForeignKey(nameof(Profile11.Profile11Id))]
-        public virtual Profile11 Profile { get; set; }
+        public virtual Profile11 Profile { get; set; } = null!;
     }
 
     protected class Profile11
@@ -1329,7 +1327,7 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
         public int Profile11Id { get; set; }
 
         [ForeignKey(nameof(Profile11Id))]
-        public virtual Login11 User { get; set; }
+        public virtual Login11 User { get; set; } = null!;
     }
 
     [Fact]
@@ -1341,9 +1339,9 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
 
         var model = Validate(modelBuilder);
 
-        var fk = model.FindEntityType(typeof(Login13)).GetForeignKeys().Single();
+        var fk = model.FindEntityType(typeof(Login13))!.GetForeignKeys().Single();
 
-        Assert.Empty(model.FindEntityType(typeof(Profile13)).GetForeignKeys());
+        Assert.Empty(model.FindEntityType(typeof(Profile13))!.GetForeignKeys());
 
         Assert.True(fk.IsRequired);
         Assert.False(fk.IsRequiredDependent);
@@ -1360,9 +1358,9 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
 
         var model = Validate(modelBuilder);
 
-        Assert.Empty(model.FindEntityType(typeof(Login13)).GetForeignKeys());
+        Assert.Empty(model.FindEntityType(typeof(Login13))!.GetForeignKeys());
 
-        var fk = model.FindEntityType(typeof(Profile13)).GetForeignKeys().Single();
+        var fk = model.FindEntityType(typeof(Profile13))!.GetForeignKeys().Single();
 
         Assert.False(fk.IsRequired);
         Assert.True(fk.IsRequiredDependent);
@@ -1371,17 +1369,17 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
     protected class Login13
     {
         public int Id { get; set; }
-        public string UserName { get; set; }
+        public string UserName { get; set; } = null!;
 
         [Required]
-        public virtual Profile13 Profile { get; set; }
+        public virtual Profile13 Profile { get; set; } = null!;
     }
 
     protected class Profile13
     {
         public int Id { get; set; }
-        public string Name { get; set; }
-        public string Email { get; set; }
+        public string Name { get; set; } = null!;
+        public string Email { get; set; } = null!;
     }
 
     [Fact]
@@ -1394,8 +1392,8 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
         Validate(modelBuilder);
 
         var login = modelBuilder.Model.FindEntityType(typeof(Login12));
-        var fk1 = login.FindNavigation(nameof(Login12.Profile)).ForeignKey;
-        var fk2 = login.FindNavigation(nameof(Login12.ProfileDetails)).ForeignKey;
+        var fk1 = login!.FindNavigation(nameof(Login12.Profile))!.ForeignKey;
+        var fk2 = login.FindNavigation(nameof(Login12.ProfileDetails))!.ForeignKey;
 
         Assert.NotSame(fk1, fk2);
         Assert.Equal(nameof(Login12.ProfileId), fk1.Properties.Single().Name);
@@ -1408,10 +1406,10 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
         public int ProfileId { get; set; }
 
         [ForeignKey("ProfileId")]
-        public virtual Profile12 Profile { get; set; }
+        public virtual Profile12 Profile { get; set; } = null!;
 
         [ForeignKey("ProfileId")]
-        public virtual ProfileDetails12 ProfileDetails { get; set; }
+        public virtual ProfileDetails12 ProfileDetails { get; set; } = null!;
     }
 
     public class Profile12
@@ -1434,11 +1432,11 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
         var model = Validate(modelBuilder);
 
         var menuGroup = model.FindEntityType(typeof(MenuGroup));
-        var groupsNavigation = menuGroup.FindNavigation(nameof(MenuGroup.Groups));
-        Assert.Equal(nameof(MenuGroup.FkGroup), groupsNavigation.ForeignKey.Properties.Single().Name);
+        var groupsNavigation = menuGroup!.FindNavigation(nameof(MenuGroup.Groups));
+        Assert.Equal(nameof(MenuGroup.FkGroup), groupsNavigation!.ForeignKey.Properties.Single().Name);
 
         var pagesNavigation = menuGroup.FindNavigation(nameof(MenuGroup.Pages));
-        Assert.Equal(nameof(MenuPage.FkGroupNavigation), pagesNavigation.Inverse.Name);
+        Assert.Equal(nameof(MenuPage.FkGroupNavigation), pagesNavigation!.Inverse!.Name);
         Assert.Equal(nameof(MenuPage.FkGroup), pagesNavigation.ForeignKey.Properties.Single().Name);
     }
 
@@ -1448,10 +1446,10 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
         public Guid? FkGroup { get; set; }
 
         [InverseProperty(nameof(MenuPage.FkGroupNavigation))]
-        public virtual ICollection<MenuPage> Pages { get; set; }
+        public virtual ICollection<MenuPage> Pages { get; set; } = null!;
 
         [ForeignKey(nameof(FkGroup))]
-        public virtual ICollection<MenuGroup> Groups { get; set; }
+        public virtual ICollection<MenuGroup> Groups { get; set; } = null!;
     }
 
     protected class MenuPage
@@ -1461,7 +1459,7 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
         public Guid? FkGroup { get; set; }
 
         [ForeignKey(nameof(FkGroup)), InverseProperty(nameof(MenuGroup.Pages))]
-        public virtual MenuGroup FkGroupNavigation { get; set; }
+        public virtual MenuGroup FkGroupNavigation { get; set; } = null!;
     }
 
     [Fact]
@@ -1474,8 +1472,8 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
         Validate(modelBuilder);
 
         var login = modelBuilder.Model.FindEntityType(typeof(Login14));
-        Assert.Equal(nameof(Login14.Login1Id), login.FindNavigation(nameof(Login14.Login1)).ForeignKey.Properties.Single().Name);
-        Assert.Equal(nameof(Login14.Login1Id), login.FindNavigation(nameof(Login14.Login2)).ForeignKey.Properties.Single().Name);
+        Assert.Equal(nameof(Login14.Login1Id), login!.FindNavigation(nameof(Login14.Login1))!.ForeignKey.Properties.Single().Name);
+        Assert.Equal(nameof(Login14.Login1Id), login.FindNavigation(nameof(Login14.Login2))!.ForeignKey.Properties.Single().Name);
     }
 
     protected class Login14
@@ -1485,9 +1483,9 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
         public int Login1Id { get; set; }
 
         [ForeignKey(nameof(Login1Id))]
-        public virtual Login14 Login1 { get; set; }
+        public virtual Login14 Login1 { get; set; } = null!;
 
-        public virtual Login14 Login2 { get; set; }
+        public virtual Login14 Login2 { get; set; } = null!;
     }
 
     [Fact]
@@ -1501,9 +1499,9 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
 
         var profile = modelBuilder.Model.FindEntityType(typeof(Profile14));
         Assert.Equal(
-            nameof(Profile14.Profile1Id), profile.FindNavigation(nameof(Profile14.Profile1)).ForeignKey.Properties.Single().Name);
+            nameof(Profile14.Profile1Id), profile!.FindNavigation(nameof(Profile14.Profile1))!.ForeignKey.Properties.Single().Name);
         Assert.Equal(
-            nameof(Profile14.Profile1Id), profile.FindNavigation(nameof(Profile14.Profile2)).ForeignKey.Properties.Single().Name);
+            nameof(Profile14.Profile1Id), profile.FindNavigation(nameof(Profile14.Profile2))!.ForeignKey.Properties.Single().Name);
     }
 
     protected class Profile14
@@ -1513,9 +1511,9 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
         [ForeignKey(nameof(Profile1))]
         public int Profile1Id { get; set; }
 
-        public virtual Profile14 Profile1 { get; set; }
+        public virtual Profile14 Profile1 { get; set; } = null!;
 
-        public virtual Profile14 Profile2 { get; set; }
+        public virtual Profile14 Profile2 { get; set; } = null!;
     }
 
     [Fact]
@@ -1529,13 +1527,13 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
 
         var profile = modelBuilder.Model.FindEntityType(typeof(Profile15));
         Assert.Equal(
-            nameof(Profile15.Profile1Id), profile.FindNavigation(nameof(Profile15.Profile1)).ForeignKey.Properties.Single().Name);
+            nameof(Profile15.Profile1Id), profile!.FindNavigation(nameof(Profile15.Profile1))!.ForeignKey.Properties.Single().Name);
         Assert.Equal(
-            nameof(Profile15.Profile2Id), profile.FindNavigation(nameof(Profile15.Profile2)).ForeignKey.Properties.Single().Name);
+            nameof(Profile15.Profile2Id), profile.FindNavigation(nameof(Profile15.Profile2))!.ForeignKey.Properties.Single().Name);
         Assert.Equal(
-            nameof(Profile15.Profile1Id), profile.FindNavigation(nameof(Profile15.Profile3)).ForeignKey.Properties.Single().Name);
+            nameof(Profile15.Profile1Id), profile.FindNavigation(nameof(Profile15.Profile3))!.ForeignKey.Properties.Single().Name);
         Assert.Equal(
-            nameof(Profile15.Profile2Id), profile.FindNavigation(nameof(Profile15.Profile4)).ForeignKey.Properties.Single().Name);
+            nameof(Profile15.Profile2Id), profile.FindNavigation(nameof(Profile15.Profile4))!.ForeignKey.Properties.Single().Name);
     }
 
     protected class Profile15
@@ -1545,17 +1543,17 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
         [ForeignKey(nameof(Profile1)), InverseProperty(nameof(Profile3))]
         public int Profile1Id { get; set; }
 
-        public virtual Profile15 Profile1 { get; set; }
+        public virtual Profile15 Profile1 { get; set; } = null!;
 
         public int Profile2Id { get; set; }
 
         [ForeignKey(nameof(Profile2Id))]
-        public virtual Profile15 Profile2 { get; set; }
+        public virtual Profile15 Profile2 { get; set; } = null!;
 
-        public virtual Profile15 Profile3 { get; set; }
+        public virtual Profile15 Profile3 { get; set; } = null!;
 
         [InverseProperty(nameof(Profile2))]
-        public virtual Profile15 Profile4 { get; set; }
+        public virtual Profile15 Profile4 { get; set; } = null!;
     }
 
     [Fact]
@@ -1579,14 +1577,14 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
 
         var model = modelBuilder.FinalizeModel();
 
-        var fk1 = model.FindEntityType(typeof(PartialAnswer)).GetForeignKeys().Single();
-        Assert.Equal(nameof(PartialAnswer.Answer), fk1.DependentToPrincipal.Name);
-        Assert.Equal(nameof(MultipleAnswers.Answers), fk1.PrincipalToDependent.Name);
+        var fk1 = model.FindEntityType(typeof(PartialAnswer))!.GetForeignKeys().Single();
+        Assert.Equal(nameof(PartialAnswer.Answer), fk1.DependentToPrincipal!.Name);
+        Assert.Equal(nameof(MultipleAnswers.Answers), fk1.PrincipalToDependent!.Name);
         Assert.Equal(nameof(PartialAnswer.AnswerId), fk1.Properties.Single().Name);
 
-        var fk2 = model.FindEntityType(typeof(PartialAnswerRepeating)).GetForeignKeys().Single();
-        Assert.Equal(nameof(PartialAnswerRepeating.Answer), fk2.DependentToPrincipal.Name);
-        Assert.Equal(nameof(MultipleAnswersRepeating.Answers), fk2.PrincipalToDependent.Name);
+        var fk2 = model.FindEntityType(typeof(PartialAnswerRepeating))!.GetForeignKeys().Single();
+        Assert.Equal(nameof(PartialAnswerRepeating.Answer), fk2.DependentToPrincipal!.Name);
+        Assert.Equal(nameof(MultipleAnswersRepeating.Answers), fk2.PrincipalToDependent!.Name);
         Assert.Equal(nameof(PartialAnswerRepeating.AnswerId), fk2.Properties.Single().Name);
     }
 
@@ -1601,7 +1599,7 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
         public int AnswerId { get; set; }
 
         [ForeignKey("AnswerId")]
-        public virtual Answer Answer { get; set; }
+        public virtual Answer Answer { get; set; } = null!;
     }
 
     private class PartialAnswer : PartialAnswerBase;
@@ -1610,12 +1608,12 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
 
     private class MultipleAnswers : Answer
     {
-        public virtual ICollection<PartialAnswer> Answers { get; set; }
+        public virtual ICollection<PartialAnswer> Answers { get; set; } = null!;
     }
 
     private class MultipleAnswersRepeating : Answer
     {
-        public virtual ICollection<PartialAnswerRepeating> Answers { get; set; }
+        public virtual ICollection<PartialAnswerRepeating> Answers { get; set; } = null!;
     }
 
     [Fact]
@@ -1628,24 +1626,24 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
         var model = modelBuilder.FinalizeModel();
 
         var entityType = model.FindEntityType(typeof(Comment));
-        var fk1 = entityType.GetForeignKeys().Single(fk => fk.Properties.Single().Name == nameof(Comment.ParentCommentID));
-        Assert.Equal(nameof(Comment.ParentComment), fk1.DependentToPrincipal.Name);
+        var fk1 = entityType!.GetForeignKeys().Single(fk => fk.Properties.Single().Name == nameof(Comment.ParentCommentID));
+        Assert.Equal(nameof(Comment.ParentComment), fk1.DependentToPrincipal!.Name);
         Assert.Null(fk1.PrincipalToDependent);
 
         if (HasForeignKeyIndexes)
         {
             var index1 = entityType.FindIndex(fk1.Properties);
-            Assert.False(index1.IsUnique);
+            Assert.False(index1!.IsUnique);
         }
 
         var fk2 = entityType.GetForeignKeys().Single(fk => fk.Properties.Single().Name == nameof(Comment.ReplyCommentID));
-        Assert.Equal(nameof(Comment.ReplyComment), fk2.DependentToPrincipal.Name);
+        Assert.Equal(nameof(Comment.ReplyComment), fk2.DependentToPrincipal!.Name);
         Assert.Null(fk2.PrincipalToDependent);
 
         if (HasForeignKeyIndexes)
         {
             var index2 = entityType.FindIndex(fk2.Properties);
-            Assert.False(index2.IsUnique);
+            Assert.False(index2!.IsUnique);
         }
 
         Assert.Equal(2, entityType.GetForeignKeys().Count());
@@ -1662,10 +1660,10 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
         public long? ParentCommentID { get; set; }
 
         [ForeignKey("ParentCommentID")]
-        public virtual Comment ParentComment { get; set; }
+        public virtual Comment ParentComment { get; set; } = null!;
 
         [ForeignKey("ReplyCommentID")]
-        public virtual Comment ReplyComment { get; set; }
+        public virtual Comment ReplyComment { get; set; } = null!;
     }
 
     [Fact]
@@ -1685,12 +1683,12 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
     protected class TNAttrBase
     {
         public int Id { get; set; }
-        public string BaseData { get; set; }
+        public string BaseData { get; set; } = null!;
     }
 
     protected class TNAttrDerived : TNAttrBase
     {
-        public string DerivedData { get; set; }
+        public string DerivedData { get; set; } = null!;
     }
 
     [Fact]
@@ -1702,7 +1700,7 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
             clientRow.RequiredColumn = "ChangedData";
 
             using var innerContext = CreateContext();
-            UseTransaction(innerContext.Database, context.Database.CurrentTransaction);
+            UseTransaction(innerContext.Database, context.Database.CurrentTransaction!);
             var storeRow = innerContext.Set<One>().First(r => r.UniqueNo == 1);
             storeRow.RowVersion = new Guid("00000000-0000-0000-0003-000000000001");
             storeRow.RequiredColumn = "ModifiedData";
@@ -1788,7 +1786,7 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
         var modelBuilder = CreateModelBuilder();
         modelBuilder.Entity<One>();
 
-        Assert.Null(modelBuilder.Model.FindEntityType(typeof(One)).FindProperty("IgnoredProperty"));
+        Assert.Null(modelBuilder.Model.FindEntityType(typeof(One))!.FindProperty("IgnoredProperty"));
     }
 
     [Fact]
@@ -1797,7 +1795,7 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
         var modelBuilder = CreateModelBuilder();
         modelBuilder.Entity<EntityAnnotationBase>();
 
-        Assert.Empty(modelBuilder.Model.FindEntityType(typeof(EntityAnnotationBase)).GetProperties());
+        Assert.Empty(modelBuilder.Model.FindEntityType(typeof(EntityAnnotationBase))!.GetProperties());
     }
 
     protected interface IEntityBase
@@ -1818,9 +1816,9 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
         var model = modelBuilder.Model;
         modelBuilder.Entity<Book>();
 
-        Assert.Contains("Details", model.FindEntityType(typeof(Book)).GetNavigations().Select(nav => nav.Name));
-        Assert.Contains("AnotherBook", model.FindEntityType(typeof(BookDetails)).GetNavigations().Select(nav => nav.Name));
-        Assert.DoesNotContain("Book", model.FindEntityType(typeof(BookDetails)).GetNavigations().Select(nav => nav.Name));
+        Assert.Contains("Details", model.FindEntityType(typeof(Book))!.GetNavigations().Select(nav => nav.Name));
+        Assert.Contains("AnotherBook", model.FindEntityType(typeof(BookDetails))!.GetNavigations().Select(nav => nav.Name));
+        Assert.DoesNotContain("Book", model.FindEntityType(typeof(BookDetails))!.GetNavigations().Select(nav => nav.Name));
     }
 
     [Fact]
@@ -1831,19 +1829,19 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
         modelBuilder.Entity<BookDetailsBase>();
         modelBuilder.Entity<Book>();
 
-        Assert.Same(model.FindEntityType(typeof(BookDetailsBase)), model.FindEntityType(typeof(BookDetails)).BaseType);
-        Assert.Contains("Details", model.FindEntityType(typeof(Book)).GetNavigations().Select(nav => nav.Name).ToList());
-        Assert.Contains("AnotherBook", model.FindEntityType(typeof(BookDetails)).GetNavigations().Select(nav => nav.Name).ToList());
-        Assert.DoesNotContain("Book", model.FindEntityType(typeof(BookDetails)).GetNavigations().Select(nav => nav.Name).ToList());
+        Assert.Same(model.FindEntityType(typeof(BookDetailsBase)), model.FindEntityType(typeof(BookDetails))!.BaseType);
+        Assert.Contains("Details", model.FindEntityType(typeof(Book))!.GetNavigations().Select(nav => nav.Name).ToList());
+        Assert.Contains("AnotherBook", model.FindEntityType(typeof(BookDetails))!.GetNavigations().Select(nav => nav.Name).ToList());
+        Assert.DoesNotContain("Book", model.FindEntityType(typeof(BookDetails))!.GetNavigations().Select(nav => nav.Name).ToList());
 
-        modelBuilder.Entity<BookDetails>().HasBaseType((Type)null);
+        modelBuilder.Entity<BookDetails>().HasBaseType((Type)null!);
 
         Assert.Same(
             model.FindEntityType(typeof(BookDetails)),
-            model.FindEntityType(typeof(Book)).GetNavigations().Single(n => n.Name == "Details").ForeignKey.DeclaringEntityType);
-        Assert.Contains("Details", model.FindEntityType(typeof(Book)).GetNavigations().Select(nav => nav.Name).ToList());
-        Assert.Contains("AnotherBook", model.FindEntityType(typeof(BookDetails)).GetNavigations().Select(nav => nav.Name).ToList());
-        Assert.DoesNotContain("Book", model.FindEntityType(typeof(BookDetails)).GetNavigations().Select(nav => nav.Name).ToList());
+            model.FindEntityType(typeof(Book))!.GetNavigations().Single(n => n.Name == "Details").ForeignKey.DeclaringEntityType);
+        Assert.Contains("Details", model.FindEntityType(typeof(Book))!.GetNavigations().Select(nav => nav.Name).ToList());
+        Assert.Contains("AnotherBook", model.FindEntityType(typeof(BookDetails))!.GetNavigations().Select(nav => nav.Name).ToList());
+        Assert.DoesNotContain("Book", model.FindEntityType(typeof(BookDetails))!.GetNavigations().Select(nav => nav.Name).ToList());
     }
 
     [Fact]
@@ -1857,9 +1855,9 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
 
         Assert.Equal(
             nameof(Book.Label),
-            model.FindEntityType(typeof(BookLabel)).FindNavigation(nameof(BookLabel.Book)).Inverse?.Name);
+            model.FindEntityType(typeof(BookLabel))!.FindNavigation(nameof(BookLabel.Book))!.Inverse?.Name);
 
-        Assert.Null(model.FindEntityType(typeof(Book)).FindNavigation(nameof(Book.AlternateLabel)).Inverse);
+        Assert.Null(model.FindEntityType(typeof(Book))!.FindNavigation(nameof(Book.AlternateLabel))!.Inverse);
     }
 
     [Fact]
@@ -1869,20 +1867,20 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
         var model = modelBuilder.Model;
         modelBuilder.Entity<SpecialBookLabel>();
 
-        Assert.Same(model.FindEntityType(typeof(BookLabel)), model.FindEntityType(typeof(SpecialBookLabel)).BaseType);
+        Assert.Same(model.FindEntityType(typeof(BookLabel)), model.FindEntityType(typeof(SpecialBookLabel))!.BaseType);
 
         Assert.Equal(
-            nameof(Book.Label), model.FindEntityType(typeof(SpecialBookLabel))
-                .FindNavigation(nameof(SpecialBookLabel.Book)).Inverse?.Name);
-        Assert.Null(model.FindEntityType(typeof(Book)).FindNavigation(nameof(Book.AlternateLabel)).Inverse);
+            nameof(Book.Label), model.FindEntityType(typeof(SpecialBookLabel))!
+                .FindNavigation(nameof(SpecialBookLabel.Book))!.Inverse?.Name);
+        Assert.Null(model.FindEntityType(typeof(Book))!.FindNavigation(nameof(Book.AlternateLabel))!.Inverse);
 
-        modelBuilder.Entity<SpecialBookLabel>().HasBaseType((Type)null);
+        modelBuilder.Entity<SpecialBookLabel>().HasBaseType((Type)null!);
 
-        Assert.Null(model.FindEntityType(typeof(Book)).FindNavigation(nameof(Book.Label)));
-        Assert.Null(model.FindEntityType(typeof(Book)).FindNavigation(nameof(Book.AlternateLabel)));
-        Assert.Null(model.FindEntityType(typeof(BookLabel)).FindNavigation(nameof(SpecialBookLabel.Book)));
-        Assert.Null(model.FindEntityType(typeof(SpecialBookLabel)).FindNavigation(nameof(SpecialBookLabel.Book)));
-        Assert.Null(model.FindEntityType(typeof(AnotherBookLabel)).FindNavigation(nameof(SpecialBookLabel.Book)));
+        Assert.Null(model.FindEntityType(typeof(Book))!.FindNavigation(nameof(Book.Label)));
+        Assert.Null(model.FindEntityType(typeof(Book))!.FindNavigation(nameof(Book.AlternateLabel)));
+        Assert.Null(model.FindEntityType(typeof(BookLabel))!.FindNavigation(nameof(SpecialBookLabel.Book)));
+        Assert.Null(model.FindEntityType(typeof(SpecialBookLabel))!.FindNavigation(nameof(SpecialBookLabel.Book)));
+        Assert.Null(model.FindEntityType(typeof(AnotherBookLabel))!.FindNavigation(nameof(SpecialBookLabel.Book)));
     }
 
     [Fact]
@@ -1896,9 +1894,9 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
 
         Assert.Null(model.FindEntityType(typeof(BookLabel)));
         Assert.Equal(
-            nameof(Book.Label), model.FindEntityType(typeof(SpecialBookLabel))
-                .FindNavigation(nameof(SpecialBookLabel.Book)).Inverse?.Name);
-        Assert.Null(model.FindEntityType(typeof(Book)).FindNavigation(nameof(Book.AlternateLabel)));
+            nameof(Book.Label), model.FindEntityType(typeof(SpecialBookLabel))!
+                .FindNavigation(nameof(SpecialBookLabel.Book))!.Inverse?.Name);
+        Assert.Null(model.FindEntityType(typeof(Book))!.FindNavigation(nameof(Book.AlternateLabel)));
     }
 
     [Fact]
@@ -1911,9 +1909,9 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
         modelBuilder.Entity<SpecialBookLabel>();
         modelBuilder.Ignore<BookLabel>();
 
-        Assert.Null(model.FindEntityType(typeof(AnotherBookLabel)).FindNavigation(nameof(AnotherBookLabel.Book)));
-        Assert.Null(model.FindEntityType(typeof(SpecialBookLabel)).FindNavigation(nameof(SpecialBookLabel.Book)));
-        Assert.Empty(model.FindEntityType(typeof(Book)).GetNavigations());
+        Assert.Null(model.FindEntityType(typeof(AnotherBookLabel))!.FindNavigation(nameof(AnotherBookLabel.Book)));
+        Assert.Null(model.FindEntityType(typeof(SpecialBookLabel))!.FindNavigation(nameof(SpecialBookLabel.Book)));
+        Assert.Empty(model.FindEntityType(typeof(Book))!.GetNavigations());
     }
 
     [Fact]
@@ -1927,9 +1925,9 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
 
         Assert.Null(model.FindEntityType(typeof(BookLabel)));
         Assert.Equal(
-            nameof(Book.Label), model.FindEntityType(typeof(SpecialBookLabel))
-                .FindNavigation(nameof(SpecialBookLabel.Book)).Inverse?.Name);
-        Assert.Null(model.FindEntityType(typeof(Book)).FindNavigation(nameof(Book.AlternateLabel)));
+            nameof(Book.Label), model.FindEntityType(typeof(SpecialBookLabel))!
+                .FindNavigation(nameof(SpecialBookLabel.Book))!.Inverse?.Name);
+        Assert.Null(model.FindEntityType(typeof(Book))!.FindNavigation(nameof(Book.AlternateLabel)));
     }
 
     [Fact]
@@ -1945,29 +1943,29 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
 
         Assert.Null(model.FindEntityType(typeof(BookLabel)));
         Assert.Equal(
-            nameof(Book.Label), model.FindEntityType(typeof(ExtraSpecialBookLabel))
-                .FindNavigation(nameof(ExtraSpecialBookLabel.Book)).Inverse?.Name);
+            nameof(Book.Label), model.FindEntityType(typeof(ExtraSpecialBookLabel))!
+                .FindNavigation(nameof(ExtraSpecialBookLabel.Book))!.Inverse?.Name);
         Assert.Null(
-            model.FindEntityType(typeof(ExtraSpecialBookLabel))
-                .FindNavigation(nameof(ExtraSpecialBookLabel.ExtraSpecialBook)).Inverse);
+            model.FindEntityType(typeof(ExtraSpecialBookLabel))!
+                .FindNavigation(nameof(ExtraSpecialBookLabel.ExtraSpecialBook))!.Inverse);
     }
 
     protected class Book
     {
-        public static readonly PropertyInfo BookdDetailsNavigation = typeof(Book).GetTypeInfo().GetDeclaredProperty("Details");
+        public static readonly PropertyInfo BookdDetailsNavigation = typeof(Book).GetTypeInfo().GetDeclaredProperty("Details")!;
 
         public int Id { get; set; }
 
-        public BookLabel Label { get; set; }
+        public BookLabel Label { get; set; } = null!;
 
-        public BookLabel AlternateLabel { get; set; }
+        public BookLabel AlternateLabel { get; set; } = null!;
 
-        public BookDetails Details { get; set; }
+        public BookDetails Details { get; set; } = null!;
 
-        public Details AdditionalDetails { get; set; }
+        public Details AdditionalDetails { get; set; } = null!;
 
         [NotMapped]
-        public virtual UselessBookDetails UselessBookDetails { get; set; }
+        public virtual UselessBookDetails UselessBookDetails { get; set; } = null!;
     }
 
     protected abstract class BookDetailsBase
@@ -1977,7 +1975,7 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
         public int? AnotherBookId { get; set; }
 
         [Required]
-        public Book AnotherBook { get; set; }
+        public Book AnotherBook { get; set; } = null!;
     }
 
     protected class BookDetails : BookDetailsBase
@@ -1985,19 +1983,19 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
         public int? AdditionalBookDetailsId { get; set; }
 
         [NotMapped]
-        public Book Book { get; set; }
+        public Book Book { get; set; } = null!;
     }
 
     protected class AdditionalBookDetails : BookDetailsBase
     {
         [Required]
-        public virtual BookDetails BookDetails { get; set; }
+        public virtual BookDetails BookDetails { get; set; } = null!;
     }
 
     protected class UselessBookDetails : BookDetailsBase
     {
         [NotMapped]
-        public virtual Book Book { get; set; }
+        public virtual Book Book { get; set; } = null!;
     }
 
     protected class BookLabel
@@ -2005,23 +2003,23 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
         public int Id { get; set; }
 
         [InverseProperty("Label")]
-        public Book Book { get; set; }
+        public Book Book { get; set; } = null!;
 
         public int BookId { get; set; }
 
-        public SpecialBookLabel SpecialBookLabel { get; set; }
+        public SpecialBookLabel SpecialBookLabel { get; set; } = null!;
 
-        public AnotherBookLabel AnotherBookLabel { get; set; }
+        public AnotherBookLabel AnotherBookLabel { get; set; } = null!;
     }
 
     protected class SpecialBookLabel : BookLabel
     {
-        public BookLabel BookLabel { get; set; }
+        public BookLabel BookLabel { get; set; } = null!;
     }
 
     protected class ExtraSpecialBookLabel : SpecialBookLabel
     {
-        public Book ExtraSpecialBook { get; set; }
+        public Book ExtraSpecialBook { get; set; } = null!;
     }
 
     protected class AnotherBookLabel : BookLabel;
@@ -2033,11 +2031,11 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
         var model = modelBuilder.Model;
         modelBuilder.Entity<Relation>();
 
-        var accountNavigation = model.FindEntityType(typeof(Relation)).FindNavigation(nameof(Relation.AccountManager));
+        var accountNavigation = model.FindEntityType(typeof(Relation))!.FindNavigation(nameof(Relation.AccountManager));
         Assert.Equal(nameof(User.AccountManagerRelations), accountNavigation?.Inverse?.Name);
         Assert.Equal(nameof(Relation.AccountId), accountNavigation?.ForeignKey.Properties.First().Name);
 
-        var salesNavigation = model.FindEntityType(typeof(Relation)).FindNavigation(nameof(Relation.SalesManager));
+        var salesNavigation = model.FindEntityType(typeof(Relation))!.FindNavigation(nameof(Relation.SalesManager));
         Assert.Equal(nameof(User.SalesManagerRelations), salesNavigation?.Inverse?.Name);
         Assert.Equal(nameof(Relation.SalesId), salesNavigation?.ForeignKey.Properties.First().Name);
 
@@ -2050,24 +2048,24 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
         public int UserUId { get; set; }
 
         [InverseProperty(nameof(Relation.AccountManager))]
-        public virtual ICollection<Relation> AccountManagerRelations { get; set; }
+        public virtual ICollection<Relation> AccountManagerRelations { get; set; } = null!;
 
-        public virtual ICollection<Relation> SalesManagerRelations { get; set; }
+        public virtual ICollection<Relation> SalesManagerRelations { get; set; } = null!;
     }
 
     public class Relation
     {
-        public string Id { get; set; }
+        public string Id { get; set; } = null!;
 
         public int AccountId { get; set; }
 
         [ForeignKey(nameof(AccountId))]
-        public virtual User AccountManager { get; set; }
+        public virtual User AccountManager { get; set; } = null!;
 
         public int SalesId { get; set; }
 
         [ForeignKey(nameof(SalesId))]
-        public virtual User SalesManager { get; set; }
+        public virtual User SalesManager { get; set; } = null!;
     }
 
     [Fact]
@@ -2076,8 +2074,8 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
         var modelBuilder = CreateModelBuilder();
         var qEntity = modelBuilder.Entity<Q>().Metadata;
 
-        Assert.Equal(nameof(P.QRef), qEntity.FindNavigation(nameof(Q.PRef)).Inverse.Name);
-        Assert.Equal(nameof(E.QRefDerived), qEntity.FindNavigation(nameof(Q.ERef)).Inverse.Name);
+        Assert.Equal(nameof(P.QRef), qEntity.FindNavigation(nameof(Q.PRef))!.Inverse!.Name);
+        Assert.Equal(nameof(E.QRefDerived), qEntity.FindNavigation(nameof(Q.ERef))!.Inverse!.Name);
     }
 
     public class Q
@@ -2085,10 +2083,10 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
         public int Id { get; set; }
 
         [InverseProperty(nameof(E.QRefDerived))]
-        public virtual E ERef { get; set; }
+        public virtual E ERef { get; set; } = null!;
 
         [InverseProperty(nameof(P.QRef))]
-        public virtual P PRef { get; set; }
+        public virtual P PRef { get; set; } = null!;
     }
 
     public class P
@@ -2096,13 +2094,13 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
         public int Id { get; set; }
 
         [InverseProperty(nameof(Q.PRef))]
-        public virtual Q QRef { get; set; }
+        public virtual Q QRef { get; set; } = null!;
     }
 
     public class E : P
     {
         [InverseProperty(nameof(Q.ERef))]
-        public virtual Q QRefDerived { get; set; }
+        public virtual Q QRefDerived { get; set; } = null!;
     }
 
     [Fact]
@@ -2116,10 +2114,10 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
 
         Assert.Equal(
             nameof(Post7698.BlogNav),
-            model.FindEntityType(typeof(Blog7698)).FindNavigation(nameof(Blog7698.PostNav)).Inverse.Name);
+            model.FindEntityType(typeof(Blog7698))!.FindNavigation(nameof(Blog7698.PostNav))!.Inverse!.Name);
         Assert.Equal(
             nameof(SpecialPost7698.BlogInverseNav),
-            model.FindEntityType(typeof(Blog7698)).FindNavigation(nameof(Blog7698.ASpecialPostNav)).Inverse.Name);
+            model.FindEntityType(typeof(Blog7698))!.FindNavigation(nameof(Blog7698.ASpecialPostNav))!.Inverse!.Name);
     }
 
     protected class Blog7698
@@ -2127,10 +2125,10 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
         public int Id { get; set; }
 
         [InverseProperty(nameof(Post7698.BlogNav))]
-        public List<Post7698> PostNav { get; set; }
+        public List<Post7698> PostNav { get; set; } = null!;
 
         [InverseProperty(nameof(SpecialPost7698.BlogInverseNav))]
-        public List<SpecialPost7698> ASpecialPostNav { get; set; }
+        public List<SpecialPost7698> ASpecialPostNav { get; set; } = null!;
     }
 
     protected class Post7698
@@ -2138,13 +2136,13 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
         public int Id { get; set; }
 
         [InverseProperty(nameof(Blog7698.PostNav))]
-        public Blog7698 BlogNav { get; set; }
+        public Blog7698 BlogNav { get; set; } = null!;
     }
 
     protected class SpecialPost7698 : Post7698
     {
         [InverseProperty(nameof(Blog7698.ASpecialPostNav))]
-        public Blog7698 BlogInverseNav { get; set; }
+        public Blog7698 BlogInverseNav { get; set; } = null!;
     }
 
     [Fact]
@@ -2175,14 +2173,14 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
 
         var model = Validate(modelBuilder);
 
-        Assert.NotNull(model.FindEntityType(typeof(MultipleAnswersInverse)).FindNavigation(nameof(MultipleAnswersInverse.Answers)));
+        Assert.NotNull(model.FindEntityType(typeof(MultipleAnswersInverse))!.FindNavigation(nameof(MultipleAnswersInverse.Answers)));
     }
 
     private class PartialAnswerInverse
     {
         public int Id { get; set; }
         public int AnswerId { get; set; }
-        public virtual AnswerBaseInverse Answer { get; set; }
+        public virtual AnswerBaseInverse Answer { get; set; } = null!;
     }
 
     private class PartialAnswerRepeatingInverse : PartialAnswerInverse;
@@ -2195,13 +2193,13 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
     private class MultipleAnswersInverse : AnswerBaseInverse
     {
         [InverseProperty("Answer")]
-        public virtual ICollection<PartialAnswerInverse> Answers { get; set; }
+        public virtual ICollection<PartialAnswerInverse> Answers { get; set; } = null!;
     }
 
     private class MultipleAnswersRepeatingInverse : AnswerBaseInverse
     {
         [InverseProperty("Answer")]
-        public virtual IEnumerable<PartialAnswerRepeatingInverse> Answers { get; set; }
+        public virtual IEnumerable<PartialAnswerRepeatingInverse> Answers { get; set; } = null!;
     }
 
     [Fact]
@@ -2226,7 +2224,7 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
     protected class AmbiguousInversePropertyLeft
     {
         public int Id { get; set; }
-        public List<AmbiguousInversePropertyRight> BaseRights { get; set; }
+        public List<AmbiguousInversePropertyRight> BaseRights { get; set; } = null!;
     }
 
     protected class AmbiguousInversePropertyLeftDerived : AmbiguousInversePropertyLeft
@@ -2238,13 +2236,13 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
         public int Id { get; set; }
 
         [InverseProperty("BaseRights")]
-        public List<AmbiguousInversePropertyLeft> BaseLefts { get; set; }
+        public List<AmbiguousInversePropertyLeft> BaseLefts { get; set; } = null!;
     }
 
     protected class AmbiguousInversePropertyRightDerived : AmbiguousInversePropertyRight
     {
         [InverseProperty("BaseRights")]
-        public List<AmbiguousInversePropertyLeftDerived> DerivedLefts { get; set; }
+        public List<AmbiguousInversePropertyLeftDerived> DerivedLefts { get; set; } = null!;
     }
 
     [Fact]
@@ -2256,12 +2254,12 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
         modelBuilder.Ignore<AuthorDetails>();
         modelBuilder.Entity<Post>().Property("PostDetailsId");
 
-        Assert.Null(model.FindEntityType(typeof(Post)).FindNavigation("PostDetails").ForeignKey.PrincipalToDependent);
+        Assert.Null(model.FindEntityType(typeof(Post))!.FindNavigation("PostDetails")!.ForeignKey.PrincipalToDependent);
         Assert.Equal(
-            "PostDetailsId", model.FindEntityType(typeof(Post)).FindNavigation("PostDetails").ForeignKey.Properties.First().Name);
+            "PostDetailsId", model.FindEntityType(typeof(Post))!.FindNavigation("PostDetails")!.ForeignKey.Properties.First().Name);
 
-        Assert.Null(model.FindEntityType(typeof(PostDetails)).FindNavigation("Post").ForeignKey.PrincipalToDependent);
-        Assert.Equal("PostId", model.FindEntityType(typeof(PostDetails)).FindNavigation("Post").ForeignKey.Properties.First().Name);
+        Assert.Null(model.FindEntityType(typeof(PostDetails))!.FindNavigation("Post")!.ForeignKey.PrincipalToDependent);
+        Assert.Equal("PostId", model.FindEntityType(typeof(PostDetails))!.FindNavigation("Post")!.ForeignKey.Properties.First().Name);
 
         var logEntry = Fixture.ListLoggerFactory.Log.Single();
         Assert.Equal(LogLevel.Warning, logEntry.Level);
@@ -2282,11 +2280,11 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
         modelBuilder.Ignore<AuthorDetails>();
         modelBuilder.Entity<Post>().Property("PostDetailsId");
 
-        Assert.Null(model.FindEntityType(typeof(Post)).FindNavigation("Author").ForeignKey.PrincipalToDependent);
-        Assert.Equal("AuthorId", model.FindEntityType(typeof(Post)).FindNavigation("Author").ForeignKey.Properties.First().Name);
+        Assert.Null(model.FindEntityType(typeof(Post))!.FindNavigation("Author")!.ForeignKey.PrincipalToDependent);
+        Assert.Equal("AuthorId", model.FindEntityType(typeof(Post))!.FindNavigation("Author")!.ForeignKey.Properties.First().Name);
 
-        Assert.Null(model.FindEntityType(typeof(Author)).FindNavigation("Post").ForeignKey.PrincipalToDependent);
-        Assert.Equal("PostId", model.FindEntityType(typeof(Author)).FindNavigation("Post").ForeignKey.Properties.First().Name);
+        Assert.Null(model.FindEntityType(typeof(Author))!.FindNavigation("Post")!.ForeignKey.PrincipalToDependent);
+        Assert.Equal("PostId", model.FindEntityType(typeof(Author))!.FindNavigation("Post")!.ForeignKey.Properties.First().Name);
 
         var logEntry = Fixture.ListLoggerFactory.Log.Single();
         Assert.Equal(LogLevel.Warning, logEntry.Level);
@@ -2306,12 +2304,12 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
         modelBuilder.Entity<Author>();
 
         var authorDetails = model.FindEntityType(typeof(AuthorDetails));
-        var firstFk = authorDetails.FindNavigation(nameof(AuthorDetails.Author)).ForeignKey;
+        var firstFk = authorDetails!.FindNavigation(nameof(AuthorDetails.Author))!.ForeignKey;
         Assert.Equal(typeof(AuthorDetails), firstFk.DeclaringEntityType.ClrType);
         Assert.Equal("AuthorId", firstFk.Properties.First().Name);
 
         var author = model.FindEntityType(typeof(Author));
-        var secondFk = author.FindNavigation(nameof(Author.AuthorDetails)).ForeignKey;
+        var secondFk = author!.FindNavigation(nameof(Author.AuthorDetails))!.ForeignKey;
         Assert.Equal(typeof(Author), secondFk.DeclaringEntityType.ClrType);
         Assert.Equal("AuthorDetailsIdByAttribute", secondFk.Properties.First().Name);
 
@@ -2334,10 +2332,10 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
         [ForeignKey("PostDetails")]
         public int PostDetailsId;
 
-        public PostDetails PostDetails { get; set; }
+        public PostDetails PostDetails { get; set; } = null!;
 
         [ForeignKey("AuthorId")]
-        public Author Author { get; set; }
+        public Author Author { get; set; } = null!;
     }
 
     protected class PostDetails
@@ -2347,7 +2345,7 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
         [ForeignKey("Post")]
         public int PostId { get; set; }
 
-        public Post Post { get; set; }
+        public Post Post { get; set; } = null!;
     }
 
     protected class Author
@@ -2355,10 +2353,10 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
         public int Id { get; set; }
 
         [ForeignKey("PostId")]
-        public Post Post { get; set; }
+        public Post Post { get; set; } = null!;
 
         [ForeignKey("AuthorDetailsIdByAttribute")]
-        public AuthorDetails AuthorDetails { get; set; }
+        public AuthorDetails AuthorDetails { get; set; } = null!;
     }
 
     protected class AuthorDetails
@@ -2368,7 +2366,7 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
         [ForeignKey("Author")]
         public int AuthorId { get; set; }
 
-        public Author Author { get; set; }
+        public Author Author { get; set; } = null!;
     }
 
     [Fact]
@@ -2412,7 +2410,7 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
         [ForeignKey("B")]
         public int BId { get; set; }
 
-        public B B { get; set; }
+        public B B { get; set; } = null!;
     }
 
     protected class B
@@ -2423,7 +2421,7 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
         public int AId { get; set; }
 
         [InverseProperty("B")]
-        public A A { get; set; }
+        public A A { get; set; } = null!;
     }
 
     protected class C
@@ -2431,7 +2429,7 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
         public int Id { get; set; }
 
         [ForeignKey("DId"), InverseProperty("C")]
-        public D D { get; set; }
+        public D D { get; set; } = null!;
     }
 
     protected class D
@@ -2439,7 +2437,7 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
         public int Id { get; set; }
 
         [ForeignKey("CId")]
-        public C C { get; set; }
+        public C C { get; set; } = null!;
     }
 
     protected class ConflictingFKAttributes
@@ -2449,10 +2447,10 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
         [ForeignKey("A")]
         public int AId { get; set; }
 
-        public A A { get; set; }
+        public A A { get; set; } = null!;
 
         [ForeignKey("AId")]
-        public A As { get; set; }
+        public A As { get; set; } = null!;
     }
 
     [Fact]
@@ -2473,9 +2471,9 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
 
         var model = modelBuilder.FinalizeModel();
 
-        var fk = model.FindEntityType(typeof(Profile13694)).GetForeignKeys().Single();
-        Assert.Equal("_profiles", fk.PrincipalToDependent.Name);
-        Assert.Equal("User", fk.DependentToPrincipal.Name);
+        var fk = model.FindEntityType(typeof(Profile13694))!.GetForeignKeys().Single();
+        Assert.Equal("_profiles", fk.PrincipalToDependent!.Name);
+        Assert.Equal("User", fk.DependentToPrincipal!.Name);
         Assert.Equal("Email", fk.Properties[0].Name);
         Assert.Equal(typeof(string), fk.Properties[0].ClrType);
         Assert.Equal("_email", fk.PrincipalKey.Properties[0].Name);
@@ -2493,7 +2491,7 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
         public Guid Id { get; set; }
 
         [ForeignKey("Email")]
-        public User13694 User { get; set; }
+        public User13694? User { get; set; }
     }
 
     [Fact]
@@ -2539,7 +2537,7 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
             context.Set<One>().Add(
                 new One
                 {
-                    RequiredColumn = null,
+                    RequiredColumn = null!,
                     RowVersion = new Guid("00000000-0000-0000-0000-000000000002"),
                     Details = new Details { Name = "One" },
                     AdditionalDetails = new Details { Name = "Two" }
@@ -2581,7 +2579,7 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
             clientRow.Data = "ChangedData";
 
             using var innerContext = CreateContext();
-            UseTransaction(innerContext.Database, context.Database.CurrentTransaction);
+            UseTransaction(innerContext.Database, context.Database.CurrentTransaction!);
             var storeRow = innerContext.Set<Two>().First(r => r.Id == 1);
             storeRow.Data = "ModifiedData";
 
@@ -2615,16 +2613,16 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
         public int Id { get; set; }
 
         [Unicode]
-        public string PersonFirstName { get; set; }
+        public string PersonFirstName { get; set; } = null!;
 
         [Unicode(false)]
-        public string PersonLastName { get; set; }
+        public string PersonLastName { get; set; } = null!;
 
         [Unicode]
-        public string PersonMiddleName;
+        public string PersonMiddleName = null!;
 
         [Unicode(false)]
-        public string PersonAddress;
+        public string PersonAddress = null!;
     }
 
     [Fact]
@@ -2666,7 +2664,7 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
         public DateTimeOffset DateTimeOffsetProperty { get; set; }
 
         [Precision(10, 2)]
-        public string DecimalField;
+        public string DecimalField = null!;
 
         [Precision(5)]
         public DateTime DateTimeField;
@@ -2685,21 +2683,21 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
 
         Validate(modelBuilder);
 
-        Assert.True(model.FindEntityType(typeof(Order)).FindNavigation(nameof(Order.ShippingAddress)).ForeignKey.IsOwnership);
+        Assert.True(model.FindEntityType(typeof(Order))!.FindNavigation(nameof(Order.ShippingAddress))!.ForeignKey.IsOwnership);
     }
 
     [Owned]
     public class StreetAddress
     {
-        public string Street { get; set; }
-        public string City { get; set; }
+        public string Street { get; set; } = null!;
+        public string City { get; set; } = null!;
         public int ZipCode { get; set; }
     }
 
     public class Order
     {
         public int Id { get; set; }
-        public StreetAddress ShippingAddress { get; set; }
+        public StreetAddress ShippingAddress { get; set; } = null!;
     }
 
     [Fact]
@@ -2717,12 +2715,12 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
 
         Validate(modelBuilder);
 
-        Assert.True(model.FindEntityType(typeof(Book)).FindNavigation(nameof(Book.AdditionalDetails)).ForeignKey.IsOwnership);
+        Assert.True(model.FindEntityType(typeof(Book))!.FindNavigation(nameof(Book.AdditionalDetails))!.ForeignKey.IsOwnership);
         var one = model.FindEntityType(typeof(One));
-        var ownership1 = one.FindNavigation(nameof(One.Details)).ForeignKey;
+        var ownership1 = one!.FindNavigation(nameof(One.Details))!.ForeignKey;
         Assert.True(ownership1.IsOwnership);
         Assert.NotNull(ownership1.DeclaringEntityType.FindProperty(nameof(Details.Name)));
-        var ownership2 = one.FindNavigation(nameof(One.AdditionalDetails)).ForeignKey;
+        var ownership2 = one.FindNavigation(nameof(One.AdditionalDetails))!.ForeignKey;
         Assert.True(ownership2.IsOwnership);
         Assert.NotNull(ownership2.DeclaringEntityType.FindProperty(nameof(Details.Name)));
     }
@@ -2821,11 +2819,11 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
 
         public virtual Guid RowVersion { get; set; }
 
-        public virtual string IgnoredProperty { get; set; }
+        public virtual string IgnoredProperty { get; set; } = null!;
 
-        public virtual string RequiredColumn { get; set; }
+        public virtual string RequiredColumn { get; set; } = null!;
 
-        public virtual string MaxLengthProperty { get; set; }
+        public virtual string? MaxLengthProperty { get; set; }
     }
 
     [Table("Sample")]
@@ -2838,17 +2836,17 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
         public override Guid RowVersion { get; set; }
 
         [NotMapped]
-        public override string IgnoredProperty { get; set; }
+        public override string IgnoredProperty { get; set; } = null!;
 
         [Required, Column("Name")]
-        public override string RequiredColumn { get; set; }
+        public override string RequiredColumn { get; set; } = null!;
 
         [MaxLength(10)]
-        public override string MaxLengthProperty { get; set; }
+        public override string? MaxLengthProperty { get; set; }
 
-        public Details Details { get; set; }
+        public Details? Details { get; set; }
 
-        public Details AdditionalDetails { get; set; }
+        public Details? AdditionalDetails { get; set; }
     }
 
     protected class Two
@@ -2857,17 +2855,17 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
         public int Id { get; set; }
 
         [StringLength(16)]
-        public string Data { get; set; }
+        public string? Data { get; set; }
 
         [Timestamp]
-        public byte[] Timestamp { get; set; }
+        public byte[]? Timestamp { get; set; }
     }
 
     [Owned]
     protected class Details
     {
         public int Value { get; set; }
-        public string Name { get; set; }
+        public string? Name { get; set; }
     }
 
     [Keyless]
@@ -2899,7 +2897,7 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
         public int CPSchargePartnerId { get; set; }
 
         [ForeignKey(nameof(CPSchargePartnerId)), InverseProperty(nameof(Partner.CPSorders))]
-        public virtual Partner CPSchargePartner { get; set; }
+        public virtual Partner CPSchargePartner { get; set; } = null!;
     }
 
     protected class Partner
@@ -2907,7 +2905,7 @@ public abstract class DataAnnotationTestBase<TFixture> : IClassFixture<TFixture>
         public int Id { get; set; }
 
         [InverseProperty(nameof(CPSorder.CPSchargePartner))]
-        public virtual ICollection<CPSorder> CPSorders { get; set; }
+        public virtual ICollection<CPSorder> CPSorders { get; set; } = null!;
     }
 
     protected class SpecialOrder : CPSorder

--- a/test/EFCore.Specification.Tests/DataBindingTestBase.cs
+++ b/test/EFCore.Specification.Tests/DataBindingTestBase.cs
@@ -8,8 +8,6 @@ using Microsoft.EntityFrameworkCore.TestModels.ConcurrencyModel;
 // ReSharper disable InconsistentNaming
 namespace Microsoft.EntityFrameworkCore;
 
-#nullable disable
-
 public abstract class DataBindingTestBase<TFixture>(TFixture fixture) : IClassFixture<TFixture>
     where TFixture : F1FixtureBase<byte[]>, new()
 {
@@ -855,7 +853,7 @@ public abstract class DataBindingTestBase<TFixture>(TFixture fixture) : IClassFi
         var bindingList = testDrivers.Local.ToBindingList();
 
         ((IBindingList)bindingList).ApplySort(
-            TypeDescriptor.GetProperties(typeof(Driver))["Id"],
+            TypeDescriptor.GetProperties(typeof(Driver))["Id"]!,
             ListSortDirection.Ascending);
 
         Assert.Equal(1, bindingList[0].Id);
@@ -877,7 +875,7 @@ public abstract class DataBindingTestBase<TFixture>(TFixture fixture) : IClassFi
         var bindingList = context.Drivers.Local.ToBindingList();
 
         ((IBindingList)bindingList).ApplySort(
-            TypeDescriptor.GetProperties(typeof(Driver))["Id"],
+            TypeDescriptor.GetProperties(typeof(Driver))["Id"]!,
             ListSortDirection.Ascending);
 
         Assert.Equal(1, bindingList[0].Id);

--- a/test/EFCore.Specification.Tests/F1FixtureBase.cs
+++ b/test/EFCore.Specification.Tests/F1FixtureBase.cs
@@ -102,6 +102,8 @@ public abstract class F1FixtureBase<TRowVersion> : SharedStoreFixtureBase<F1Cont
 
         modelBuilder.Entity<Team>(b =>
         {
+            b.Property<int?>("EngineId");
+            b.HasOne(e => e.Engine).WithMany(e => e.Teams).HasForeignKey("EngineId").IsRequired(false);
             b.HasOne(e => e.Gearbox).WithOne().HasForeignKey<Team>(e => e.GearboxId);
             b.HasOne(e => e.Chassis).WithOne(e => e.Team).HasForeignKey<Chassis>(e => e.TeamId);
 

--- a/test/EFCore.Specification.Tests/FieldMappingTestBase.cs
+++ b/test/EFCore.Specification.Tests/FieldMappingTestBase.cs
@@ -10,8 +10,6 @@ using System.ComponentModel.DataAnnotations.Schema;
 // ReSharper disable InconsistentNaming
 namespace Microsoft.EntityFrameworkCore;
 
-#nullable disable
-
 public abstract class FieldMappingTestBase<TFixture>(TFixture fixture) : IClassFixture<TFixture>
     where TFixture : FieldMappingTestBase<TFixture>.FieldMappingFixtureBase, new()
 {
@@ -28,9 +26,9 @@ public abstract class FieldMappingTestBase<TFixture>(TFixture fixture) : IClassF
 
     protected class LoginSession
     {
-        private object _id;
-        private IUser2 _user;
-        private object _users;
+        private object _id = null!;
+        private IUser2 _user = null!;
+        private object _users = null!;
 
         public int Id
         {
@@ -60,7 +58,7 @@ public abstract class FieldMappingTestBase<TFixture>(TFixture fixture) : IClassF
         var entry = context.Entry(session);
 
         Assert.Same(session.User, entry.Reference(e => e.User).CurrentValue);
-        Assert.Same(session.Users.Single(), entry.Collection(e => e.Users).CurrentValue.Single());
+        Assert.Same(session.Users.Single(), entry.Collection(e => e.Users).CurrentValue!.Single());
         Assert.Equal(session.Id, entry.Property(e => e.Id).CurrentValue);
         Assert.Equal(session.Id, entry.Property(e => e.Id).OriginalValue);
 
@@ -798,8 +796,8 @@ public abstract class FieldMappingTestBase<TFixture>(TFixture fixture) : IClassF
         [DatabaseGenerated(DatabaseGeneratedOption.None)]
         public int Id { get; set; }
 
-        public string Title { get; set; }
-        public IEnumerable<PostAuto> Posts { get; set; }
+        public string Title { get; set; } = null!;
+        public IEnumerable<PostAuto> Posts { get; set; } = null!;
 
         int IBlogAccessor.AccessId
         {
@@ -825,10 +823,10 @@ public abstract class FieldMappingTestBase<TFixture>(TFixture fixture) : IClassF
         [DatabaseGenerated(DatabaseGeneratedOption.None)]
         public int Id { get; set; }
 
-        public string Title { get; set; }
+        public string Title { get; set; } = null!;
 
         public int BlogId { get; set; }
-        public BlogAuto Blog { get; set; }
+        public BlogAuto Blog { get; set; } = null!;
 
         int IPostAccessor.AccessId
         {
@@ -858,9 +856,9 @@ public abstract class FieldMappingTestBase<TFixture>(TFixture fixture) : IClassF
     protected class BlogFull : IBlogAccessor
     {
         private int _id;
-        private string _title;
+        private string _title = null!;
 #pragma warning disable 649
-        private List<PostFull> _posts;
+        private List<PostFull> _posts = null!;
 #pragma warning restore 649
 
         [DatabaseGenerated(DatabaseGeneratedOption.None)]
@@ -912,10 +910,10 @@ public abstract class FieldMappingTestBase<TFixture>(TFixture fixture) : IClassF
     protected class PostFull : IPostAccessor
     {
         private int _id;
-        private string _title;
+        private string _title = null!;
         private int _blogId;
 #pragma warning disable 649
-        private BlogFull _blog;
+        private BlogFull _blog = null!;
 #pragma warning restore 649
 
         [DatabaseGenerated(DatabaseGeneratedOption.None)]
@@ -981,8 +979,8 @@ public abstract class FieldMappingTestBase<TFixture>(TFixture fixture) : IClassF
         [DatabaseGenerated(DatabaseGeneratedOption.None)]
         private int _id;
 
-        private string _title;
-        private IList<PostNavFields> _posts;
+        private string _title = null!;
+        private IList<PostNavFields> _posts = null!;
 
         int IBlogAccessor.AccessId
         {
@@ -1008,10 +1006,10 @@ public abstract class FieldMappingTestBase<TFixture>(TFixture fixture) : IClassF
         [DatabaseGenerated(DatabaseGeneratedOption.None)]
         private int _id;
 
-        private string _title;
+        private string _title = null!;
         private int _blogId;
 
-        private BlogNavFields _blog;
+        private BlogNavFields _blog = null!;
 
         int IPostAccessor.AccessId
         {
@@ -1041,8 +1039,8 @@ public abstract class FieldMappingTestBase<TFixture>(TFixture fixture) : IClassF
     protected class BlogFullExplicit : IBlogAccessor
     {
         private int _myid;
-        private string _mytitle;
-        private IList<PostFullExplicit> _myposts;
+        private string _mytitle = null!;
+        private IList<PostFullExplicit> _myposts = null!;
 
         [DatabaseGenerated(DatabaseGeneratedOption.None)]
         public int Id
@@ -1085,9 +1083,9 @@ public abstract class FieldMappingTestBase<TFixture>(TFixture fixture) : IClassF
     protected class PostFullExplicit : IPostAccessor
     {
         private int _myid;
-        private string _mytitle;
+        private string _mytitle = null!;
         private int _myblogId;
-        private BlogFullExplicit _myblog;
+        private BlogFullExplicit _myblog = null!;
 
         [DatabaseGenerated(DatabaseGeneratedOption.None)]
         public int Id
@@ -1142,8 +1140,8 @@ public abstract class FieldMappingTestBase<TFixture>(TFixture fixture) : IClassF
     protected class BlogReadOnly : IBlogAccessor
     {
         private int _id;
-        private string _title;
-        private ObservableCollection<PostReadOnly> _posts;
+        private string _title = null!;
+        private ObservableCollection<PostReadOnly> _posts = null!;
 
         [DatabaseGenerated(DatabaseGeneratedOption.None)]
         public int Id
@@ -1177,9 +1175,9 @@ public abstract class FieldMappingTestBase<TFixture>(TFixture fixture) : IClassF
     protected class PostReadOnly : IPostAccessor
     {
         private int _id;
-        private string _title;
+        private string _title = null!;
         private int _blogId;
-        private BlogReadOnly _blog;
+        private BlogReadOnly _blog = null!;
 
         [DatabaseGenerated(DatabaseGeneratedOption.None)]
         public int Id
@@ -1222,8 +1220,8 @@ public abstract class FieldMappingTestBase<TFixture>(TFixture fixture) : IClassF
     protected class BlogWithReadOnlyCollection : IBlogAccessor
     {
         private int _id;
-        private string _title;
-        private ICollection<PostWithReadOnlyCollection> _posts;
+        private string _title = null!;
+        private ICollection<PostWithReadOnlyCollection> _posts = null!;
 
         [DatabaseGenerated(DatabaseGeneratedOption.None)]
         public int Id
@@ -1257,9 +1255,9 @@ public abstract class FieldMappingTestBase<TFixture>(TFixture fixture) : IClassF
     protected class PostWithReadOnlyCollection : IPostAccessor
     {
         private int _id;
-        private string _title;
+        private string _title = null!;
         private int _blogId;
-        private BlogWithReadOnlyCollection _blog;
+        private BlogWithReadOnlyCollection _blog = null!;
 
         [DatabaseGenerated(DatabaseGeneratedOption.None)]
         public int Id
@@ -1302,8 +1300,8 @@ public abstract class FieldMappingTestBase<TFixture>(TFixture fixture) : IClassF
     protected class BlogReadOnlyExplicit : IBlogAccessor
     {
         private int _myid;
-        private string _mytitle;
-        private Collection<PostReadOnlyExplicit> _myposts;
+        private string _mytitle = null!;
+        private Collection<PostReadOnlyExplicit> _myposts = null!;
 
         [DatabaseGenerated(DatabaseGeneratedOption.None)]
         public int Id
@@ -1337,9 +1335,9 @@ public abstract class FieldMappingTestBase<TFixture>(TFixture fixture) : IClassF
     protected class PostReadOnlyExplicit : IPostAccessor
     {
         private int _myid;
-        private string _mytitle;
+        private string _mytitle = null!;
         private int _myblogId;
-        private BlogReadOnlyExplicit _myblog;
+        private BlogReadOnlyExplicit _myblog = null!;
 
         [DatabaseGenerated(DatabaseGeneratedOption.None)]
         public int Id
@@ -1382,8 +1380,8 @@ public abstract class FieldMappingTestBase<TFixture>(TFixture fixture) : IClassF
     protected class BlogWriteOnly : IBlogAccessor
     {
         private int _id;
-        private string _title;
-        private IEnumerable<PostWriteOnly> _posts;
+        private string _title = null!;
+        private IEnumerable<PostWriteOnly> _posts = null!;
 
         [DatabaseGenerated(DatabaseGeneratedOption.None)]
         public int Id
@@ -1424,9 +1422,9 @@ public abstract class FieldMappingTestBase<TFixture>(TFixture fixture) : IClassF
     protected class PostWriteOnly : IPostAccessor
     {
         private int _id;
-        private string _title;
+        private string _title = null!;
         private int _blogId;
-        private BlogWriteOnly _blog;
+        private BlogWriteOnly _blog = null!;
 
         [DatabaseGenerated(DatabaseGeneratedOption.None)]
         public int Id
@@ -1477,8 +1475,8 @@ public abstract class FieldMappingTestBase<TFixture>(TFixture fixture) : IClassF
     protected class BlogWriteOnlyExplicit : IBlogAccessor
     {
         private int _myid;
-        private string _mytitle;
-        private ICollection<PostWriteOnlyExplicit> _myposts;
+        private string _mytitle = null!;
+        private ICollection<PostWriteOnlyExplicit> _myposts = null!;
 
         [DatabaseGenerated(DatabaseGeneratedOption.None)]
         public int Id
@@ -1518,9 +1516,9 @@ public abstract class FieldMappingTestBase<TFixture>(TFixture fixture) : IClassF
     protected class PostWriteOnlyExplicit : IPostAccessor
     {
         private int _myid;
-        private string _mytitle;
+        private string _mytitle = null!;
         private int _myblogId;
-        private BlogWriteOnlyExplicit _myblog;
+        private BlogWriteOnlyExplicit _myblog = null!;
 
         [DatabaseGenerated(DatabaseGeneratedOption.None)]
         public int Id
@@ -1573,9 +1571,9 @@ public abstract class FieldMappingTestBase<TFixture>(TFixture fixture) : IClassF
         [DatabaseGenerated(DatabaseGeneratedOption.None)]
         private int _id;
 
-        private string _title;
+        private string _title = null!;
 
-        public IEnumerable<PostFields> Posts { get; set; }
+        public IEnumerable<PostFields> Posts { get; set; } = null!;
 
         int IBlogAccessor.AccessId
         {
@@ -1601,10 +1599,10 @@ public abstract class FieldMappingTestBase<TFixture>(TFixture fixture) : IClassF
         [DatabaseGenerated(DatabaseGeneratedOption.None)]
         private int _id;
 
-        private string _title;
+        private string _title = null!;
         private int _blogId;
 
-        public BlogFields Blog { get; set; }
+        public BlogFields Blog { get; set; } = null!;
 
         int IPostAccessor.AccessId
         {
@@ -1692,8 +1690,8 @@ public abstract class FieldMappingTestBase<TFixture>(TFixture fixture) : IClassF
     {
         public object Id { get; set; } = 0;
 
-        public object Title { get; set; }
-        public object Posts { get; set; }
+        public object Title { get; set; } = null!;
+        public object Posts { get; set; } = null!;
     }
 
     protected class BlogHiding : BlogHidingBase, IBlogAccessor
@@ -1707,13 +1705,13 @@ public abstract class FieldMappingTestBase<TFixture>(TFixture fixture) : IClassF
 
         public new string Title
         {
-            get => base.Title is string value ? value : default;
+            get => base.Title is string value ? value : default!;
             set => base.Title = value;
         }
 
         public new IEnumerable<PostHiding> Posts
         {
-            get => base.Posts is IEnumerable<PostHiding> value ? value : default;
+            get => base.Posts is IEnumerable<PostHiding> value ? value : default!;
             set => base.Posts = value;
         }
 
@@ -1740,10 +1738,10 @@ public abstract class FieldMappingTestBase<TFixture>(TFixture fixture) : IClassF
     {
         public object Id { get; set; } = 0;
 
-        public object Title { get; set; }
+        public object Title { get; set; } = null!;
 
         public object BlogId { get; set; } = 0;
-        public object Blog { get; set; }
+        public object Blog { get; set; } = null!;
     }
 
     protected class PostHiding : PostHidingBase, IPostAccessor
@@ -1757,7 +1755,7 @@ public abstract class FieldMappingTestBase<TFixture>(TFixture fixture) : IClassF
 
         public new string Title
         {
-            get => base.Title is string value ? value : default;
+            get => base.Title is string value ? value : default!;
             set => base.Title = value;
         }
 
@@ -1769,7 +1767,7 @@ public abstract class FieldMappingTestBase<TFixture>(TFixture fixture) : IClassF
 
         public new BlogHiding Blog
         {
-            get => base.Blog is BlogHiding value ? value : default;
+            get => base.Blog is BlogHiding value ? value : default!;
             set => base.Blog = value;
         }
 
@@ -1803,9 +1801,9 @@ public abstract class FieldMappingTestBase<TFixture>(TFixture fixture) : IClassF
         [DatabaseGenerated(DatabaseGeneratedOption.None)]
         public int Id { get; set; }
 
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
 
-        public NavDependent _unconventionalDependent; // won't be picked up by convention
+        public NavDependent _unconventionalDependent = null!; // won't be picked up by convention
 
         public NavDependent Dependent
         {
@@ -1819,9 +1817,9 @@ public abstract class FieldMappingTestBase<TFixture>(TFixture fixture) : IClassF
         [DatabaseGenerated(DatabaseGeneratedOption.None)]
         public int Id { get; set; }
 
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
 
-        public OneToOneFieldNavPrincipal OneToOneFieldNavPrincipal { get; set; }
+        public OneToOneFieldNavPrincipal OneToOneFieldNavPrincipal { get; set; } = null!;
     }
 
     protected DbContext CreateContext()
@@ -1857,8 +1855,8 @@ public abstract class FieldMappingTestBase<TFixture>(TFixture fixture) : IClassF
                 b.HasMany(e => e.Posts).WithOne(e => e.Blog).HasForeignKey(e => e.BlogId);
             });
 
-            modelBuilder.Entity<PostFullExplicit>().Metadata.FindNavigation("Blog").SetField("_myblog");
-            modelBuilder.Entity<BlogFullExplicit>().Metadata.FindNavigation("Posts").SetField("_myposts");
+            modelBuilder.Entity<PostFullExplicit>().Metadata.FindNavigation("Blog")!.SetField("_myblog");
+            modelBuilder.Entity<BlogFullExplicit>().Metadata.FindNavigation("Posts")!.SetField("_myposts");
 
             modelBuilder.Entity<LoginSession>().UsePropertyAccessMode(PropertyAccessMode.Field);
 
@@ -1920,8 +1918,8 @@ public abstract class FieldMappingTestBase<TFixture>(TFixture fixture) : IClassF
                     b.HasMany(e => e.Posts).WithOne(e => e.Blog).HasForeignKey(e => e.BlogId);
                 });
 
-                modelBuilder.Entity<PostReadOnlyExplicit>().Metadata.FindNavigation("Blog").SetField("_myblog");
-                modelBuilder.Entity<BlogReadOnlyExplicit>().Metadata.FindNavigation("Posts").SetField("_myposts");
+                modelBuilder.Entity<PostReadOnlyExplicit>().Metadata.FindNavigation("Blog")!.SetField("_myblog");
+                modelBuilder.Entity<BlogReadOnlyExplicit>().Metadata.FindNavigation("Posts")!.SetField("_myposts");
 
                 modelBuilder.Entity<PostWriteOnly>(b =>
                 {
@@ -1952,8 +1950,8 @@ public abstract class FieldMappingTestBase<TFixture>(TFixture fixture) : IClassF
                     b.HasMany(typeof(PostWriteOnlyExplicit).DisplayName(), "Posts").WithOne("Blog").HasForeignKey("BlogId");
                 });
 
-                modelBuilder.Entity<PostWriteOnlyExplicit>().Metadata.FindNavigation("Blog").SetField("_myblog");
-                modelBuilder.Entity<BlogWriteOnlyExplicit>().Metadata.FindNavigation("Posts").SetField("_myposts");
+                modelBuilder.Entity<PostWriteOnlyExplicit>().Metadata.FindNavigation("Blog")!.SetField("_myblog");
+                modelBuilder.Entity<BlogWriteOnlyExplicit>().Metadata.FindNavigation("Posts")!.SetField("_myposts");
 
                 modelBuilder.Entity<PostFields>(b =>
                 {

--- a/test/EFCore.Specification.Tests/FieldsOnlyLoadTestBase.cs
+++ b/test/EFCore.Specification.Tests/FieldsOnlyLoadTestBase.cs
@@ -9,8 +9,6 @@ using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 // ReSharper disable InconsistentNaming
 namespace Microsoft.EntityFrameworkCore;
 
-#nullable disable
-
 public abstract class FieldsOnlyLoadTestBase<TFixture>(TFixture fixture) : IClassFixture<TFixture>
     where TFixture : FieldsOnlyLoadTestBase<TFixture>.FieldsOnlyLoadFixtureBase
 {
@@ -2748,7 +2746,7 @@ public abstract class FieldsOnlyLoadTestBase<TFixture>(TFixture fixture) : IClas
     {
         using var context = CreateContext();
         var child = context.Attach(
-            new ChildAk { Id = 767, ParentId = null }).Entity;
+            new ChildAk { Id = 767, ParentId = null! }).Entity;
 
         ClearLog();
 
@@ -2782,7 +2780,7 @@ public abstract class FieldsOnlyLoadTestBase<TFixture>(TFixture fixture) : IClas
     {
         using var context = CreateContext();
         var single = context.Attach(
-            new SingleAk { Id = 767, ParentId = null }).Entity;
+            new SingleAk { Id = 767, ParentId = null! }).Entity;
 
         ClearLog();
 
@@ -2817,7 +2815,7 @@ public abstract class FieldsOnlyLoadTestBase<TFixture>(TFixture fixture) : IClas
     {
         using var context = CreateContext();
         var child = context.Attach(
-            new ChildAk { Id = 767, ParentId = null }).Entity;
+            new ChildAk { Id = 767, ParentId = null! }).Entity;
 
         ClearLog();
 
@@ -2848,7 +2846,7 @@ public abstract class FieldsOnlyLoadTestBase<TFixture>(TFixture fixture) : IClas
     {
         using var context = CreateContext();
         var single = context.Attach(
-            new SingleAk { Id = 767, ParentId = null }).Entity;
+            new SingleAk { Id = 767, ParentId = null! }).Entity;
 
         ClearLog();
 
@@ -4167,78 +4165,78 @@ public abstract class FieldsOnlyLoadTestBase<TFixture>(TFixture fixture) : IClas
     protected class Parent
     {
         public int Id;
-        public string AlternateId;
-        public IEnumerable<Child> Children;
-        public SinglePkToPk SinglePkToPk;
-        public Single Single;
-        public IEnumerable<ChildAk> ChildrenAk;
-        public SingleAk SingleAk;
-        public IEnumerable<ChildShadowFk> ChildrenShadowFk;
-        public SingleShadowFk SingleShadowFk;
-        public IEnumerable<ChildCompositeKey> ChildrenCompositeKey;
-        public SingleCompositeKey SingleCompositeKey;
+        public string AlternateId = null!;
+        public IEnumerable<Child> Children = null!;
+        public SinglePkToPk SinglePkToPk = null!;
+        public Single Single = null!;
+        public IEnumerable<ChildAk> ChildrenAk = null!;
+        public SingleAk SingleAk = null!;
+        public IEnumerable<ChildShadowFk> ChildrenShadowFk = null!;
+        public SingleShadowFk SingleShadowFk = null!;
+        public IEnumerable<ChildCompositeKey> ChildrenCompositeKey = null!;
+        public SingleCompositeKey SingleCompositeKey = null!;
     }
 
     protected class Child
     {
         public int Id;
         public int? ParentId;
-        public Parent Parent;
+        public Parent Parent = null!;
     }
 
     protected class SinglePkToPk
     {
         public int Id;
-        public Parent Parent;
+        public Parent Parent = null!;
     }
 
     protected class Single
     {
         public int Id;
         public int? ParentId;
-        public Parent Parent;
+        public Parent Parent = null!;
     }
 
     protected class ChildAk
     {
         public int Id;
-        public string ParentId;
-        public Parent Parent;
+        public string ParentId = null!;
+        public Parent Parent = null!;
     }
 
     protected class SingleAk
     {
         public int Id;
-        public string ParentId;
-        public Parent Parent;
+        public string ParentId = null!;
+        public Parent Parent = null!;
     }
 
     protected class ChildShadowFk
     {
         public int Id;
-        public Parent Parent;
+        public Parent Parent = null!;
     }
 
     protected class SingleShadowFk
     {
         public int Id;
-        public Parent Parent;
+        public Parent Parent = null!;
     }
 
     protected class ChildCompositeKey
     {
         public int Id;
         public int? ParentId;
-        public string ParentAlternateId;
-        public Parent Parent;
+        public string ParentAlternateId = null!;
+        public Parent Parent = null!;
     }
 
     protected class SingleCompositeKey
     {
         public int Id;
         public int? ParentId;
-        public string ParentAlternateId;
-        public Parent Parent;
+        public string ParentAlternateId = null!;
+        public Parent Parent = null!;
     }
 
     protected DbContext CreateContext(bool noTracking = false)

--- a/test/EFCore.Specification.Tests/FindTestBase.cs
+++ b/test/EFCore.Specification.Tests/FindTestBase.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 
@@ -30,7 +28,7 @@ namespace Microsoft.EntityFrameworkCore
         public virtual void Find_int_key_from_store()
         {
             using var context = CreateContext();
-            Assert.Equal("Smokey", Finder.Find<IntKey>(context, 77).Foo);
+            Assert.Equal("Smokey", Finder.Find<IntKey>(context, 77)!.Foo);
         }
 
         [Fact]
@@ -54,7 +52,7 @@ namespace Microsoft.EntityFrameworkCore
         public virtual void Find_nullable_int_key_from_store()
         {
             using var context = CreateContext();
-            Assert.Equal("Smokey", Finder.Find<NullableIntKey>(context, 77).Foo);
+            Assert.Equal("Smokey", Finder.Find<NullableIntKey>(context, 77)!.Foo);
         }
 
         [Fact]
@@ -78,7 +76,7 @@ namespace Microsoft.EntityFrameworkCore
         public virtual void Find_string_key_from_store()
         {
             using var context = CreateContext();
-            Assert.Equal("Alice", Finder.Find<StringKey>(context, "Cat").Foo);
+            Assert.Equal("Alice", Finder.Find<StringKey>(context, "Cat")!.Foo);
         }
 
         [Fact]
@@ -102,7 +100,7 @@ namespace Microsoft.EntityFrameworkCore
         public virtual void Find_composite_key_from_store()
         {
             using var context = CreateContext();
-            Assert.Equal("Olive", Finder.Find<CompositeKey>(context, 77, "Dog").Foo);
+            Assert.Equal("Olive", Finder.Find<CompositeKey>(context, 77, "Dog")!.Foo);
         }
 
         [Fact]
@@ -126,7 +124,7 @@ namespace Microsoft.EntityFrameworkCore
         public virtual void Find_base_type_from_store()
         {
             using var context = CreateContext();
-            Assert.Equal("Baxter", Finder.Find<BaseType>(context, 77).Foo);
+            Assert.Equal("Baxter", Finder.Find<BaseType>(context, 77)!.Foo);
         }
 
         [Fact]
@@ -151,7 +149,7 @@ namespace Microsoft.EntityFrameworkCore
         {
             using var context = CreateContext();
             var derivedType = Finder.Find<DerivedType>(context, 78);
-            Assert.Equal("Strawberry", derivedType.Foo);
+            Assert.Equal("Strawberry", derivedType!.Foo);
             Assert.Equal("Cheesecake", derivedType.Boo);
         }
 
@@ -194,7 +192,7 @@ namespace Microsoft.EntityFrameworkCore
         {
             using var context = CreateContext();
             var derivedType = Finder.Find<BaseType>(context, 78);
-            Assert.Equal("Strawberry", derivedType.Foo);
+            Assert.Equal("Strawberry", derivedType!.Foo);
             Assert.Equal("Cheesecake", ((DerivedType)derivedType).Boo);
         }
 
@@ -213,7 +211,7 @@ namespace Microsoft.EntityFrameworkCore
         public virtual void Find_shadow_key_from_store()
         {
             using var context = CreateContext();
-            Assert.Equal("Clippy", Finder.Find<ShadowKey>(context, 77).Foo);
+            Assert.Equal("Clippy", Finder.Find<ShadowKey>(context, 77)!.Foo);
         }
 
         [Fact]
@@ -227,28 +225,28 @@ namespace Microsoft.EntityFrameworkCore
         public virtual void Returns_null_for_null_key_values_array()
         {
             using var context = CreateContext();
-            Assert.Null(Finder.Find<CompositeKey>(context, null));
+            Assert.Null(Finder.Find<CompositeKey>(context, null!));
         }
 
         [Fact]
         public virtual void Returns_null_for_null_key()
         {
             using var context = CreateContext();
-            Assert.Null(Finder.Find<IntKey>(context, [null]));
+            Assert.Null(Finder.Find<IntKey>(context, [null!]));
         }
 
         [Fact]
         public virtual void Returns_null_for_null_nullable_key()
         {
             using var context = CreateContext();
-            Assert.Null(Finder.Find<NullableIntKey>(context, [null]));
+            Assert.Null(Finder.Find<NullableIntKey>(context, [null!]));
         }
 
         [Fact]
         public virtual void Returns_null_for_null_in_composite_key()
         {
             using var context = CreateContext();
-            Assert.Null(Finder.Find<CompositeKey>(context, 77, null));
+            Assert.Null(Finder.Find<CompositeKey>(context, 77, null!));
         }
 
         [Fact]
@@ -330,15 +328,15 @@ namespace Microsoft.EntityFrameworkCore
 
             var entity = await Finder.FindAsync<IntKey>(cancellationType, context, [77]);
 
-            Assert.Equal("Smokey", entity.Foo);
-            Assert.Equal(7, entity.OwnedReference.Prop);
+            Assert.Equal("Smokey", entity!.Foo);
+            Assert.Equal(7, entity.OwnedReference!.Prop);
             Assert.Equal(2, entity.OwnedCollection.Count);
             Assert.Contains(71, entity.OwnedCollection.Select(e => e.Prop));
             Assert.Contains(72, entity.OwnedCollection.Select(e => e.Prop));
-            Assert.Equal("7", entity.OwnedReference.NestedOwned.Prop);
-            Assert.Equal(2, entity.OwnedReference.NestedOwnedCollection.Count);
-            Assert.Contains("71", entity.OwnedReference.NestedOwnedCollection.Select(e => e.Prop));
-            Assert.Contains("72", entity.OwnedReference.NestedOwnedCollection.Select(e => e.Prop));
+            Assert.Equal("7", entity.OwnedReference!.NestedOwned!.Prop);
+            Assert.Equal(2, entity.OwnedReference!.NestedOwnedCollection.Count);
+            Assert.Contains("71", entity.OwnedReference!.NestedOwnedCollection.Select(e => e.Prop));
+            Assert.Contains("72", entity.OwnedReference!.NestedOwnedCollection.Select(e => e.Prop));
         }
 
         [Theory, InlineData((int)CancellationType.Right), InlineData((int)CancellationType.Wrong),
@@ -365,7 +363,7 @@ namespace Microsoft.EntityFrameworkCore
         public virtual async Task Find_nullable_int_key_from_store_async(CancellationType cancellationType)
         {
             using var context = CreateContext();
-            Assert.Equal("Smokey", (await Finder.FindAsync<NullableIntKey>(cancellationType, context, [77])).Foo);
+            Assert.Equal("Smokey", (await Finder.FindAsync<NullableIntKey>(cancellationType, context, [77]))!.Foo);
         }
 
         [Theory, InlineData((int)CancellationType.Right), InlineData((int)CancellationType.Wrong),
@@ -392,7 +390,7 @@ namespace Microsoft.EntityFrameworkCore
         public virtual async Task Find_string_key_from_store_async(CancellationType cancellationType)
         {
             using var context = CreateContext();
-            Assert.Equal("Alice", (await Finder.FindAsync<StringKey>(cancellationType, context, ["Cat"])).Foo);
+            Assert.Equal("Alice", (await Finder.FindAsync<StringKey>(cancellationType, context, ["Cat"]))!.Foo);
         }
 
         [Theory, InlineData((int)CancellationType.Right), InlineData((int)CancellationType.Wrong),
@@ -419,7 +417,7 @@ namespace Microsoft.EntityFrameworkCore
         public virtual async Task Find_composite_key_from_store_async(CancellationType cancellationType)
         {
             using var context = CreateContext();
-            Assert.Equal("Olive", (await Finder.FindAsync<CompositeKey>(cancellationType, context, [77, "Dog"])).Foo);
+            Assert.Equal("Olive", (await Finder.FindAsync<CompositeKey>(cancellationType, context, [77, "Dog"]))!.Foo);
         }
 
         [Theory, InlineData((int)CancellationType.Right), InlineData((int)CancellationType.Wrong),
@@ -446,7 +444,7 @@ namespace Microsoft.EntityFrameworkCore
         public virtual async Task Find_base_type_from_store_async(CancellationType cancellationType)
         {
             using var context = CreateContext();
-            Assert.Equal("Baxter", (await Finder.FindAsync<BaseType>(cancellationType, context, [77])).Foo);
+            Assert.Equal("Baxter", (await Finder.FindAsync<BaseType>(cancellationType, context, [77]))!.Foo);
         }
 
         [Theory, InlineData((int)CancellationType.Right), InlineData((int)CancellationType.Wrong),
@@ -474,7 +472,7 @@ namespace Microsoft.EntityFrameworkCore
         {
             using var context = CreateContext();
             var derivedType = await Finder.FindAsync<DerivedType>(cancellationType, context, [78]);
-            Assert.Equal("Strawberry", derivedType.Foo);
+            Assert.Equal("Strawberry", derivedType!.Foo);
             Assert.Equal("Cheesecake", derivedType.Boo);
         }
 
@@ -522,7 +520,7 @@ namespace Microsoft.EntityFrameworkCore
         {
             using var context = CreateContext();
             var derivedType = await Finder.FindAsync<BaseType>(cancellationType, context, [78]);
-            Assert.Equal("Strawberry", derivedType.Foo);
+            Assert.Equal("Strawberry", derivedType!.Foo);
             Assert.Equal("Cheesecake", ((DerivedType)derivedType).Boo);
         }
 
@@ -543,7 +541,7 @@ namespace Microsoft.EntityFrameworkCore
         public virtual async Task Find_shadow_key_from_store_async(CancellationType cancellationType)
         {
             using var context = CreateContext();
-            Assert.Equal("Clippy", (await Finder.FindAsync<ShadowKey>(cancellationType, context, [77])).Foo);
+            Assert.Equal("Clippy", (await Finder.FindAsync<ShadowKey>(cancellationType, context, [77]))!.Foo);
         }
 
         [Theory, InlineData((int)CancellationType.Right), InlineData((int)CancellationType.Wrong),
@@ -559,7 +557,7 @@ namespace Microsoft.EntityFrameworkCore
         public virtual async Task Returns_null_for_null_key_values_array_async(CancellationType cancellationType)
         {
             using var context = CreateContext();
-            Assert.Null(await Finder.FindAsync<CompositeKey>(cancellationType, context, null));
+            Assert.Null(await Finder.FindAsync<CompositeKey>(cancellationType, context, null!));
         }
 
         [Theory, InlineData((int)CancellationType.Right), InlineData((int)CancellationType.Wrong),
@@ -567,7 +565,7 @@ namespace Microsoft.EntityFrameworkCore
         public virtual async Task Returns_null_for_null_key_async(CancellationType cancellationType)
         {
             using var context = CreateContext();
-            Assert.Null(await Finder.FindAsync<IntKey>(cancellationType, context, [null]));
+            Assert.Null(await Finder.FindAsync<IntKey>(cancellationType, context, [null!]));
         }
 
         [Theory, InlineData((int)CancellationType.Right), InlineData((int)CancellationType.Wrong),
@@ -575,7 +573,7 @@ namespace Microsoft.EntityFrameworkCore
         public virtual async Task Returns_null_for_null_in_composite_key_async(CancellationType cancellationType)
         {
             using var context = CreateContext();
-            Assert.Null(await Finder.FindAsync<CompositeKey>(cancellationType, context, [77, null]));
+            Assert.Null(await Finder.FindAsync<CompositeKey>(cancellationType, context, [77, null!]));
         }
 
         [Theory, InlineData((int)CancellationType.Right), InlineData((int)CancellationType.Wrong),
@@ -661,12 +659,12 @@ namespace Microsoft.EntityFrameworkCore
             [DatabaseGenerated(DatabaseGeneratedOption.None)]
             public int Id { get; set; }
 
-            public string Foo { get; set; }
+            public string Foo { get; set; } = null!;
         }
 
         protected class DerivedType : BaseType
         {
-            public string Boo { get; set; }
+            public string Boo { get; set; } = null!;
         }
 
         protected class IntKey
@@ -674,10 +672,10 @@ namespace Microsoft.EntityFrameworkCore
             [DatabaseGenerated(DatabaseGeneratedOption.None)]
             public int Id { get; set; }
 
-            public string Foo { get; set; }
+            public string Foo { get; set; } = null!;
 
-            public Owned1 OwnedReference { get; set; }
-            public List<Owned1> OwnedCollection { get; set; }
+            public Owned1? OwnedReference { get; set; }
+            public List<Owned1> OwnedCollection { get; set; } = null!;
         }
 
         protected class NullableIntKey
@@ -685,41 +683,41 @@ namespace Microsoft.EntityFrameworkCore
             [DatabaseGenerated(DatabaseGeneratedOption.None)]
             public int? Id { get; set; }
 
-            public string Foo { get; set; }
+            public string Foo { get; set; } = null!;
         }
 
         protected class StringKey
         {
-            public string Id { get; set; }
+            public string Id { get; set; } = null!;
 
-            public string Foo { get; set; }
+            public string Foo { get; set; } = null!;
         }
 
         protected class CompositeKey
         {
             public int Id1 { get; set; }
-            public string Id2 { get; set; }
-            public string Foo { get; set; }
+            public string Id2 { get; set; } = null!;
+            public string Foo { get; set; } = null!;
         }
 
         protected class ShadowKey
         {
-            public string Foo { get; set; }
+            public string Foo { get; set; } = null!;
         }
 
         [Owned]
         protected class Owned1
         {
             public int Prop { get; set; }
-            public Owned2 NestedOwned { get; set; }
-            public List<Owned2> NestedOwnedCollection { get; set; }
+            public Owned2? NestedOwned { get; set; }
+            public List<Owned2> NestedOwnedCollection { get; set; } = null!;
         }
 
         [Owned]
         protected class Owned2
         {
             [Required]
-            public string Prop { get; set; }
+            public string Prop { get; set; } = null!;
         }
 
         protected DbContext CreateContext()
@@ -783,10 +781,10 @@ namespace Microsoft.EntityFrameworkCore
 
         public abstract class TestFinder
         {
-            public abstract TEntity Find<TEntity>(DbContext context, params object[] keyValues)
+            public abstract TEntity? Find<TEntity>(DbContext context, params object[] keyValues)
                 where TEntity : class;
 
-            public abstract ValueTask<TEntity> FindAsync<TEntity>(
+            public abstract ValueTask<TEntity?> FindAsync<TEntity>(
                 CancellationType cancellationType,
                 DbContext context,
                 object[] keyValues,
@@ -796,14 +794,16 @@ namespace Microsoft.EntityFrameworkCore
 
         public class FindViaSetFinder : TestFinder
         {
-            public override TEntity Find<TEntity>(DbContext context, params object[] keyValues)
+            public override TEntity? Find<TEntity>(DbContext context, params object[] keyValues)
+                where TEntity : class
                 => context.Set<TEntity>().Find(keyValues);
 
-            public override ValueTask<TEntity> FindAsync<TEntity>(
+            public override ValueTask<TEntity?> FindAsync<TEntity>(
                 CancellationType cancellationType,
                 DbContext context,
                 object[] keyValues,
                 CancellationToken cancellationToken = default)
+                where TEntity : class
                 => cancellationType switch
                 {
                     CancellationType.Right => context.Set<TEntity>().FindAsync(keyValues, cancellationToken: cancellationToken),
@@ -816,35 +816,39 @@ namespace Microsoft.EntityFrameworkCore
 
         public class FindViaNonGenericContextFinder : TestFinder
         {
-            public override TEntity Find<TEntity>(DbContext context, params object[] keyValues)
-                => (TEntity)context.Find(typeof(TEntity), keyValues);
+            public override TEntity? Find<TEntity>(DbContext context, params object[] keyValues)
+                where TEntity : class
+                => (TEntity?)context.Find(typeof(TEntity), keyValues);
 
-            public override async ValueTask<TEntity> FindAsync<TEntity>(
+            public override async ValueTask<TEntity?> FindAsync<TEntity>(
                 CancellationType cancellationType,
                 DbContext context,
                 object[] keyValues,
                 CancellationToken cancellationToken = default)
+                where TEntity : class
                 => cancellationType switch
                 {
-                    CancellationType.Right => (TEntity)await context.FindAsync(
+                    CancellationType.Right => (TEntity?)await context.FindAsync(
                         typeof(TEntity), keyValues, cancellationToken: cancellationToken),
-                    CancellationType.Wrong => (TEntity)await context.FindAsync(
+                    CancellationType.Wrong => (TEntity?)await context.FindAsync(
                         typeof(TEntity), keyValues?.Concat([cancellationToken]).ToArray()),
-                    CancellationType.None => (TEntity)await context.FindAsync(typeof(TEntity), keyValues),
+                    CancellationType.None => (TEntity?)await context.FindAsync(typeof(TEntity), keyValues),
                     _ => throw new ArgumentOutOfRangeException(nameof(cancellationType), cancellationType, null)
                 };
         }
 
         public class FindViaContextFinder : TestFinder
         {
-            public override TEntity Find<TEntity>(DbContext context, params object[] keyValues)
+            public override TEntity? Find<TEntity>(DbContext context, params object[] keyValues)
+                where TEntity : class
                 => context.Find<TEntity>(keyValues);
 
-            public override ValueTask<TEntity> FindAsync<TEntity>(
+            public override ValueTask<TEntity?> FindAsync<TEntity>(
                 CancellationType cancellationType,
                 DbContext context,
                 object[] keyValues,
                 CancellationToken cancellationToken = default)
+                where TEntity : class
                 => cancellationType switch
                 {
                     CancellationType.Right => context.FindAsync<TEntity>(keyValues, cancellationToken: cancellationToken),
@@ -861,6 +865,6 @@ namespace Microsoft.EntityFrameworkCore.DifferentNamespace
 {
     internal class ShadowKey
     {
-        public string Foo { get; set; }
+        public string Foo { get; set; } = null!;
     }
 }

--- a/test/EFCore.Specification.Tests/GraphUpdates/GraphUpdatesTestBase.cs
+++ b/test/EFCore.Specification.Tests/GraphUpdates/GraphUpdatesTestBase.cs
@@ -12,8 +12,6 @@ using System.Runtime.CompilerServices;
 // ReSharper disable NonReadonlyMemberInGetHashCode
 namespace Microsoft.EntityFrameworkCore;
 
-#nullable disable
-
 public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) : IClassFixture<TFixture>
     where TFixture : GraphUpdatesTestBase<TFixture>.GraphUpdatesFixtureBase, new()
 {
@@ -190,7 +188,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
                         v => v.Value,
                         v => new MyDiscriminator(v),
                         new ValueComparer<MyDiscriminator>(
-                            (l, r) => l.Value == r.Value,
+                            (l, r) => l!.Value == r!.Value,
                             v => v.Value.GetHashCode(),
                             v => new MyDiscriminator(v.Value)))
                     .Metadata
@@ -910,7 +908,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
     protected IOrderedQueryable<Root> QueryRequiredGraph(DbContext context)
         => ModifyQueryRoot(context.Set<Root>())
             .Include(e => e.RequiredChildren).ThenInclude(e => e.Children)
-            .Include(e => e.RequiredSingle).ThenInclude(e => e.Single)
+            .Include(e => e.RequiredSingle).ThenInclude(e => e!.Single)
             .OrderBy(e => e.Id);
 
     protected Task<Root> LoadOptionalGraphAsync(DbContext context)
@@ -921,9 +919,9 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
         => ModifyQueryRoot(context.Set<Root>())
             .Include(e => e.OptionalChildren).ThenInclude(e => e.Children)
             .Include(e => e.OptionalChildren).ThenInclude(e => e.CompositeChildren)
-            .Include(e => e.OptionalSingle).ThenInclude(e => e.Single)
-            .Include(e => e.OptionalSingleDerived).ThenInclude(e => e.Single)
-            .Include(e => e.OptionalSingleMoreDerived).ThenInclude(e => e.Single)
+            .Include(e => e.OptionalSingle!).ThenInclude(e => e.Single)
+            .Include(e => e.OptionalSingleDerived!).ThenInclude(e => e.Single)
+            .Include(e => e.OptionalSingleMoreDerived!).ThenInclude(e => e.Single)
             .OrderBy(e => e.Id);
 
     protected Task<Root> LoadRequiredNonPkGraphAsync(DbContext context)
@@ -948,8 +946,8 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
         => ModifyQueryRoot(context.Set<Root>())
             .Include(e => e.RequiredChildrenAk).ThenInclude(e => e.Children)
             .Include(e => e.RequiredChildrenAk).ThenInclude(e => e.CompositeChildren)
-            .Include(e => e.RequiredSingleAk).ThenInclude(e => e.Single)
-            .Include(e => e.RequiredSingleAk).ThenInclude(e => e.SingleComposite)
+            .Include(e => e.RequiredSingleAk).ThenInclude(e => e!.Single)
+            .Include(e => e.RequiredSingleAk).ThenInclude(e => e!.SingleComposite)
             .OrderBy(e => e.Id);
 
     protected Task<Root> LoadOptionalAkGraphAsync(DbContext context)
@@ -960,10 +958,10 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
         => ModifyQueryRoot(context.Set<Root>())
             .Include(e => e.OptionalChildrenAk).ThenInclude(e => e.Children)
             .Include(e => e.OptionalChildrenAk).ThenInclude(e => e.CompositeChildren)
-            .Include(e => e.OptionalSingleAk).ThenInclude(e => e.Single)
-            .Include(e => e.OptionalSingleAk).ThenInclude(e => e.SingleComposite)
-            .Include(e => e.OptionalSingleAkDerived).ThenInclude(e => e.Single)
-            .Include(e => e.OptionalSingleAkMoreDerived).ThenInclude(e => e.Single)
+            .Include(e => e.OptionalSingleAk!).ThenInclude(e => e.Single)
+            .Include(e => e.OptionalSingleAk!).ThenInclude(e => e.SingleComposite)
+            .Include(e => e.OptionalSingleAkDerived!).ThenInclude(e => e.Single)
+            .Include(e => e.OptionalSingleAkMoreDerived!).ThenInclude(e => e.Single)
             .OrderBy(e => e.Id);
 
     protected Task<Root> LoadRequiredNonPkAkGraphAsync(DbContext context)
@@ -1151,11 +1149,11 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
         if (root.OptionalSingle != null)
         {
             Assert.Same(root, root.OptionalSingle.Root);
-            Assert.Same(root, root.OptionalSingleDerived.DerivedRoot);
-            Assert.Same(root, root.OptionalSingleMoreDerived.MoreDerivedRoot);
-            Assert.Same(root.OptionalSingle, root.OptionalSingle.Single.Back);
-            Assert.Same(root.OptionalSingleDerived, root.OptionalSingleDerived.Single.Back);
-            Assert.Same(root.OptionalSingleMoreDerived, root.OptionalSingleMoreDerived.Single.Back);
+            Assert.Same(root, root.OptionalSingleDerived!.DerivedRoot);
+            Assert.Same(root, root.OptionalSingleMoreDerived!.MoreDerivedRoot);
+            Assert.Same(root.OptionalSingle, root.OptionalSingle.Single!.Back);
+            Assert.Same(root.OptionalSingleDerived, root.OptionalSingleDerived.Single!.Back);
+            Assert.Same(root.OptionalSingleMoreDerived, root.OptionalSingleMoreDerived.Single!.Back);
         }
 
         if (root.RequiredNonPkSingle != null)
@@ -1192,12 +1190,12 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
         if (root.OptionalSingleAk != null)
         {
             Assert.Same(root, root.OptionalSingleAk.Root);
-            Assert.Same(root, root.OptionalSingleAkDerived.DerivedRoot);
-            Assert.Same(root, root.OptionalSingleAkMoreDerived.MoreDerivedRoot);
-            Assert.Same(root.OptionalSingleAk, root.OptionalSingleAk.Single.Back);
-            Assert.Same(root.OptionalSingleAk, root.OptionalSingleAk.SingleComposite.Back);
-            Assert.Same(root.OptionalSingleAkDerived, root.OptionalSingleAkDerived.Single.Back);
-            Assert.Same(root.OptionalSingleAkMoreDerived, root.OptionalSingleAkMoreDerived.Single.Back);
+            Assert.Same(root, root.OptionalSingleAkDerived!.DerivedRoot);
+            Assert.Same(root, root.OptionalSingleAkMoreDerived!.MoreDerivedRoot);
+            Assert.Same(root.OptionalSingleAk, root.OptionalSingleAk.Single!.Back);
+            Assert.Same(root.OptionalSingleAk, root.OptionalSingleAk.SingleComposite!.Back);
+            Assert.Same(root.OptionalSingleAkDerived, root.OptionalSingleAkDerived.Single!.Back);
+            Assert.Same(root.OptionalSingleAkMoreDerived, root.OptionalSingleAkMoreDerived.Single!.Back);
         }
 
         if (root.RequiredNonPkSingleAk != null)
@@ -1240,7 +1238,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
         if (root.OptionalSingle != null)
         {
             Assert.Same(root, root.OptionalSingle.Root);
-            Assert.Same(root.OptionalSingle, root.OptionalSingle.Single.Back);
+            Assert.Same(root.OptionalSingle, root.OptionalSingle.Single!.Back);
         }
 
         if (root.RequiredNonPkSingle != null)
@@ -1273,8 +1271,8 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
         if (root.OptionalSingleAk != null)
         {
             Assert.Same(root, root.OptionalSingleAk.Root);
-            Assert.Same(root.OptionalSingleAk, root.OptionalSingleAk.Single.Back);
-            Assert.Same(root.OptionalSingleAk, root.OptionalSingleAk.SingleComposite.Back);
+            Assert.Same(root.OptionalSingleAk, root.OptionalSingleAk.Single!.Back);
+            Assert.Same(root.OptionalSingleAk, root.OptionalSingleAk.SingleComposite!.Back);
         }
 
         if (root.RequiredNonPkSingleAk != null)
@@ -1310,7 +1308,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
             set => SetWithNotify(value, ref field);
         } = new ObservableHashSet<Optional1>(ReferenceEqualityComparer.Instance);
 
-        public RequiredSingle1 RequiredSingle
+        public RequiredSingle1? RequiredSingle
         {
             get;
             set => SetWithNotify(value, ref field);
@@ -1320,33 +1318,33 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
         {
             get;
             set => SetWithNotify(value, ref field);
-        }
+        } = null!;
 
         public RequiredNonPkSingle1Derived RequiredNonPkSingleDerived
         {
             get;
             set => SetWithNotify(value, ref field);
-        }
+        } = null!;
 
         public RequiredNonPkSingle1MoreDerived RequiredNonPkSingleMoreDerived
         {
             get;
             set => SetWithNotify(value, ref field);
-        }
+        } = null!;
 
-        public OptionalSingle1 OptionalSingle
+        public OptionalSingle1? OptionalSingle
         {
             get;
             set => SetWithNotify(value, ref field);
         }
 
-        public OptionalSingle1Derived OptionalSingleDerived
+        public OptionalSingle1Derived? OptionalSingleDerived
         {
             get;
             set => SetWithNotify(value, ref field);
         }
 
-        public OptionalSingle1MoreDerived OptionalSingleMoreDerived
+        public OptionalSingle1MoreDerived? OptionalSingleMoreDerived
         {
             get;
             set => SetWithNotify(value, ref field);
@@ -1364,7 +1362,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
             set => SetWithNotify(value, ref field);
         } = new ObservableHashSet<OptionalAk1>(ReferenceEqualityComparer.Instance);
 
-        public RequiredSingleAk1 RequiredSingleAk
+        public RequiredSingleAk1? RequiredSingleAk
         {
             get;
             set => SetWithNotify(value, ref field);
@@ -1374,33 +1372,33 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
         {
             get;
             set => SetWithNotify(value, ref field);
-        }
+        } = null!;
 
         public RequiredNonPkSingleAk1Derived RequiredNonPkSingleAkDerived
         {
             get;
             set => SetWithNotify(value, ref field);
-        }
+        } = null!;
 
         public RequiredNonPkSingleAk1MoreDerived RequiredNonPkSingleAkMoreDerived
         {
             get;
             set => SetWithNotify(value, ref field);
-        }
+        } = null!;
 
-        public OptionalSingleAk1 OptionalSingleAk
+        public OptionalSingleAk1? OptionalSingleAk
         {
             get;
             set => SetWithNotify(value, ref field);
         }
 
-        public OptionalSingleAk1Derived OptionalSingleAkDerived
+        public OptionalSingleAk1Derived? OptionalSingleAkDerived
         {
             get;
             set => SetWithNotify(value, ref field);
         }
 
-        public OptionalSingleAk1MoreDerived OptionalSingleAkMoreDerived
+        public OptionalSingleAk1MoreDerived? OptionalSingleAkMoreDerived
         {
             get;
             set => SetWithNotify(value, ref field);
@@ -1412,7 +1410,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
             set => SetWithNotify(value, ref field);
         } = new ObservableHashSet<RequiredComposite1>(ReferenceEqualityComparer.Instance);
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             var other = obj as Root;
             return Id == other?.Id;
@@ -1436,7 +1434,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
             set => SetWithNotify(value, ref field);
         }
 
-        public Root Parent
+        public Root? Parent
         {
             get;
             set => SetWithNotify(value, ref field);
@@ -1448,7 +1446,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
             set => SetWithNotify(value, ref field);
         } = new ObservableHashSet<Required2>(ReferenceEqualityComparer.Instance);
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             var other = obj as Required1;
             return Id == other?.Id;
@@ -1460,7 +1458,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
 
     protected class Required1Derived : Required1
     {
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => base.Equals(obj as Required1Derived);
 
         public override int GetHashCode()
@@ -1469,7 +1467,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
 
     protected class Required1MoreDerived : Required1Derived
     {
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => base.Equals(obj as Required1MoreDerived);
 
         public override int GetHashCode()
@@ -1494,9 +1492,9 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
         {
             get;
             set => SetWithNotify(value, ref field);
-        }
+        } = null!;
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             var other = obj as Required2;
             return Id == other?.Id;
@@ -1508,7 +1506,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
 
     protected class Required2Derived : Required2
     {
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => base.Equals(obj as Required2Derived);
 
         public override int GetHashCode()
@@ -1517,7 +1515,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
 
     protected class Required2MoreDerived : Required2Derived
     {
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => base.Equals(obj as Required2MoreDerived);
 
         public override int GetHashCode()
@@ -1542,7 +1540,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
         {
             get;
             set => SetWithNotify(value, ref field);
-        }
+        } = null!;
 
         public IEnumerable<Optional2> Children
         {
@@ -1556,7 +1554,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
             set => SetWithNotify(value, ref field);
         } = new ObservableHashSet<OptionalComposite2>(ReferenceEqualityComparer.Instance);
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             var other = obj as Optional1;
             return Id == other?.Id;
@@ -1568,7 +1566,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
 
     protected class Optional1Derived : Optional1
     {
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => base.Equals(obj as Optional1Derived);
 
         public override int GetHashCode()
@@ -1577,7 +1575,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
 
     protected class Optional1MoreDerived : Optional1Derived
     {
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => base.Equals(obj as Optional1MoreDerived);
 
         public override int GetHashCode()
@@ -1598,13 +1596,13 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
             set => SetWithNotify(value, ref field);
         }
 
-        public Optional1 Parent
+        public Optional1? Parent
         {
             get;
             set => SetWithNotify(value, ref field);
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             var other = obj as Optional2;
             return Id == other?.Id;
@@ -1616,7 +1614,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
 
     protected class Optional2Derived : Optional2
     {
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => base.Equals(obj as Optional2Derived);
 
         public override int GetHashCode()
@@ -1625,7 +1623,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
 
     protected class Optional2MoreDerived : Optional2Derived
     {
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => base.Equals(obj as Optional2MoreDerived);
 
         public override int GetHashCode()
@@ -1650,15 +1648,15 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
         {
             get;
             set => SetWithNotify(value, ref field);
-        }
+        } = null!;
 
         public RequiredSingle2 Single
         {
             get;
             set => SetWithNotify(value, ref field);
-        }
+        } = null!;
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             var other = obj as RequiredSingle1;
             return Id == other?.Id;
@@ -1686,9 +1684,9 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
         {
             get;
             set => SetWithNotify(value, ref field);
-        }
+        } = null!;
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             var other = obj as RequiredSingle2;
             return Id == other?.Id;
@@ -1716,15 +1714,15 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
         {
             get;
             set => SetWithNotify(value, ref field);
-        }
+        } = null!;
 
         public RequiredNonPkSingle2 Single
         {
             get;
             set => SetWithNotify(value, ref field);
-        }
+        } = null!;
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             var other = obj as RequiredNonPkSingle1;
             return Id == other?.Id;
@@ -1746,9 +1744,9 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
         {
             get;
             set => SetWithNotify(value, ref field);
-        }
+        } = null!;
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => base.Equals(obj as RequiredNonPkSingle1Derived);
 
         public override int GetHashCode()
@@ -1767,9 +1765,9 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
         {
             get;
             set => SetWithNotify(value, ref field);
-        }
+        } = null!;
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => base.Equals(obj as RequiredNonPkSingle1MoreDerived);
 
         public override int GetHashCode()
@@ -1794,9 +1792,9 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
         {
             get;
             set => SetWithNotify(value, ref field);
-        }
+        } = null!;
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             var other = obj as RequiredNonPkSingle2;
             return Id == other?.Id;
@@ -1808,7 +1806,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
 
     protected class RequiredNonPkSingle2Derived : RequiredNonPkSingle2
     {
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => base.Equals(obj as RequiredNonPkSingle2Derived);
 
         public override int GetHashCode()
@@ -1817,7 +1815,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
 
     protected class RequiredNonPkSingle2MoreDerived : RequiredNonPkSingle2Derived
     {
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => base.Equals(obj as RequiredNonPkSingle2MoreDerived);
 
         public override int GetHashCode()
@@ -1838,19 +1836,19 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
             set => SetWithNotify(value, ref field);
         }
 
-        public Root Root
+        public Root? Root
         {
             get;
             set => SetWithNotify(value, ref field);
         }
 
-        public OptionalSingle2 Single
+        public OptionalSingle2? Single
         {
             get;
             set => SetWithNotify(value, ref field);
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             var other = obj as OptionalSingle1;
             return Id == other?.Id;
@@ -1868,13 +1866,13 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
             set => SetWithNotify(value, ref field);
         }
 
-        public Root DerivedRoot
+        public Root? DerivedRoot
         {
             get;
             set => SetWithNotify(value, ref field);
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => base.Equals(obj as OptionalSingle1Derived);
 
         public override int GetHashCode()
@@ -1889,13 +1887,13 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
             set => SetWithNotify(value, ref field);
         }
 
-        public Root MoreDerivedRoot
+        public Root? MoreDerivedRoot
         {
             get;
             set => SetWithNotify(value, ref field);
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => base.Equals(obj as OptionalSingle1MoreDerived);
 
         public override int GetHashCode()
@@ -1920,15 +1918,15 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
         {
             get;
             set => SetWithNotify(value, ref field);
-        }
+        } = null!;
 
-        public OptionalSingle1 Back
+        public OptionalSingle1? Back
         {
             get;
             set => SetWithNotify(value, ref field);
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             var other = obj as OptionalSingle2;
             return Id == other?.Id;
@@ -1942,7 +1940,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
     {
         public int Value { get; } = value;
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => throw new InvalidOperationException();
 
         public override int GetHashCode()
@@ -1951,7 +1949,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
 
     protected class OptionalSingle2Derived : OptionalSingle2
     {
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => base.Equals(obj as OptionalSingle2Derived);
 
         public override int GetHashCode()
@@ -1960,7 +1958,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
 
     protected class OptionalSingle2MoreDerived : OptionalSingle2Derived
     {
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => base.Equals(obj as OptionalSingle2MoreDerived);
 
         public override int GetHashCode()
@@ -1991,7 +1989,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
         {
             get;
             set => SetWithNotify(value, ref field);
-        }
+        } = null!;
 
         public IEnumerable<RequiredAk2> Children
         {
@@ -2005,7 +2003,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
             set => SetWithNotify(value, ref field);
         } = new ObservableHashSet<RequiredComposite2>(ReferenceEqualityComparer.Instance);
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             var other = obj as RequiredAk1;
             return Id == other?.Id;
@@ -2017,7 +2015,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
 
     protected class RequiredAk1Derived : RequiredAk1
     {
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => base.Equals(obj as RequiredAk1Derived);
 
         public override int GetHashCode()
@@ -2026,7 +2024,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
 
     protected class RequiredAk1MoreDerived : RequiredAk1Derived
     {
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => base.Equals(obj as RequiredAk1MoreDerived);
 
         public override int GetHashCode()
@@ -2057,9 +2055,9 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
         {
             get;
             set => SetWithNotify(value, ref field);
-        }
+        } = null!;
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             var other = obj as RequiredAk2;
             return Id == other?.Id;
@@ -2087,9 +2085,9 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
         {
             get;
             set => SetWithNotify(value, ref field);
-        }
+        } = null!;
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             var other = obj as RequiredComposite1;
             return Id == other?.Id;
@@ -2125,7 +2123,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
             set => SetWithNotify(value, ref field);
         }
 
-        public RequiredComposite1 Parent
+        public RequiredComposite1? Parent
         {
             get;
             set => SetWithNotify(value, ref field);
@@ -2135,9 +2133,9 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
         {
             get;
             set => SetWithNotify(value, ref field);
-        }
+        } = null!;
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             var other = obj as OptionalOverlapping2;
             return Id == other?.Id;
@@ -2171,9 +2169,9 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
         {
             get;
             set => SetWithNotify(value, ref field);
-        }
+        } = null!;
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             var other = obj as RequiredComposite2;
             return Id == other?.Id;
@@ -2185,7 +2183,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
 
     protected class RequiredAk2Derived : RequiredAk2
     {
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => base.Equals(obj as RequiredAk2Derived);
 
         public override int GetHashCode()
@@ -2194,7 +2192,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
 
     protected class RequiredAk2MoreDerived : RequiredAk2Derived
     {
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => base.Equals(obj as RequiredAk2MoreDerived);
 
         public override int GetHashCode()
@@ -2221,7 +2219,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
             set => SetWithNotify(value, ref field);
         }
 
-        public Root Parent
+        public Root? Parent
         {
             get;
             set => SetWithNotify(value, ref field);
@@ -2239,7 +2237,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
             set => SetWithNotify(value, ref field);
         } = new ObservableHashSet<OptionalComposite2>(ReferenceEqualityComparer.Instance);
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             var other = obj as OptionalAk1;
             return Id == other?.Id;
@@ -2251,7 +2249,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
 
     protected class OptionalAk1Derived : OptionalAk1
     {
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => base.Equals(obj as OptionalAk1Derived);
 
         public override int GetHashCode()
@@ -2260,7 +2258,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
 
     protected class OptionalAk1MoreDerived : OptionalAk1Derived
     {
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => base.Equals(obj as OptionalAk1MoreDerived);
 
         public override int GetHashCode()
@@ -2287,13 +2285,13 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
             set => SetWithNotify(value, ref field);
         }
 
-        public OptionalAk1 Parent
+        public OptionalAk1? Parent
         {
             get;
             set => SetWithNotify(value, ref field);
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             var other = obj as OptionalAk2;
             return Id == other?.Id;
@@ -2323,7 +2321,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
             set => SetWithNotify(value, ref field);
         }
 
-        public OptionalAk1 Parent
+        public OptionalAk1? Parent
         {
             get;
             set => SetWithNotify(value, ref field);
@@ -2335,13 +2333,13 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
             set => SetWithNotify(value, ref field);
         }
 
-        public Optional1 Parent2
+        public Optional1? Parent2
         {
             get;
             set => SetWithNotify(value, ref field);
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             var other = obj as OptionalComposite2;
             return Id == other?.Id;
@@ -2353,7 +2351,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
 
     protected class OptionalAk2Derived : OptionalAk2
     {
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => base.Equals(obj as OptionalAk2Derived);
 
         public override int GetHashCode()
@@ -2362,7 +2360,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
 
     protected class OptionalAk2MoreDerived : OptionalAk2Derived
     {
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => base.Equals(obj as OptionalAk2MoreDerived);
 
         public override int GetHashCode()
@@ -2393,21 +2391,21 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
         {
             get;
             set => SetWithNotify(value, ref field);
-        }
+        } = null!;
 
         public RequiredSingleAk2 Single
         {
             get;
             set => SetWithNotify(value, ref field);
-        }
+        } = null!;
 
         public RequiredSingleComposite2 SingleComposite
         {
             get;
             set => SetWithNotify(value, ref field);
-        }
+        } = null!;
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             var other = obj as RequiredSingleAk1;
             return Id == other?.Id;
@@ -2441,9 +2439,9 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
         {
             get;
             set => SetWithNotify(value, ref field);
-        }
+        } = null!;
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             var other = obj as RequiredSingleAk2;
             return Id == other?.Id;
@@ -2477,9 +2475,9 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
         {
             get;
             set => SetWithNotify(value, ref field);
-        }
+        } = null!;
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             var other = obj as RequiredSingleComposite2;
             return Id == other?.Id;
@@ -2513,15 +2511,15 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
         {
             get;
             set => SetWithNotify(value, ref field);
-        }
+        } = null!;
 
         public RequiredNonPkSingleAk2 Single
         {
             get;
             set => SetWithNotify(value, ref field);
-        }
+        } = null!;
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             var other = obj as RequiredNonPkSingleAk1;
             return Id == other?.Id;
@@ -2543,9 +2541,9 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
         {
             get;
             set => SetWithNotify(value, ref field);
-        }
+        } = null!;
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => base.Equals(obj as RequiredNonPkSingleAk1Derived);
 
         public override int GetHashCode()
@@ -2564,9 +2562,9 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
         {
             get;
             set => SetWithNotify(value, ref field);
-        }
+        } = null!;
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => base.Equals(obj as RequiredNonPkSingleAk1MoreDerived);
 
         public override int GetHashCode()
@@ -2597,9 +2595,9 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
         {
             get;
             set => SetWithNotify(value, ref field);
-        }
+        } = null!;
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             var other = obj as RequiredNonPkSingleAk2;
             return Id == other?.Id;
@@ -2611,7 +2609,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
 
     protected class RequiredNonPkSingleAk2Derived : RequiredNonPkSingleAk2
     {
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => base.Equals(obj as RequiredNonPkSingleAk2Derived);
 
         public override int GetHashCode()
@@ -2620,7 +2618,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
 
     protected class RequiredNonPkSingleAk2MoreDerived : RequiredNonPkSingleAk2Derived
     {
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => base.Equals(obj as RequiredNonPkSingleAk2MoreDerived);
 
         public override int GetHashCode()
@@ -2647,25 +2645,25 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
             set => SetWithNotify(value, ref field);
         }
 
-        public Root Root
+        public Root? Root
         {
             get;
             set => SetWithNotify(value, ref field);
         }
 
-        public OptionalSingleComposite2 SingleComposite
+        public OptionalSingleComposite2? SingleComposite
         {
             get;
             set => SetWithNotify(value, ref field);
         }
 
-        public OptionalSingleAk2 Single
+        public OptionalSingleAk2? Single
         {
             get;
             set => SetWithNotify(value, ref field);
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             var other = obj as OptionalSingleAk1;
             return Id == other?.Id;
@@ -2683,13 +2681,13 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
             set => SetWithNotify(value, ref field);
         }
 
-        public Root DerivedRoot
+        public Root? DerivedRoot
         {
             get;
             set => SetWithNotify(value, ref field);
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => base.Equals(obj as OptionalSingleAk1Derived);
 
         public override int GetHashCode()
@@ -2704,13 +2702,13 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
             set => SetWithNotify(value, ref field);
         }
 
-        public Root MoreDerivedRoot
+        public Root? MoreDerivedRoot
         {
             get;
             set => SetWithNotify(value, ref field);
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => base.Equals(obj as OptionalSingleAk1MoreDerived);
 
         public override int GetHashCode()
@@ -2737,13 +2735,13 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
             set => SetWithNotify(value, ref field);
         }
 
-        public OptionalSingleAk1 Back
+        public OptionalSingleAk1? Back
         {
             get;
             set => SetWithNotify(value, ref field);
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             var other = obj as OptionalSingleAk2;
             return Id == other?.Id;
@@ -2773,13 +2771,13 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
             set => SetWithNotify(value, ref field);
         }
 
-        public OptionalSingleAk1 Back
+        public OptionalSingleAk1? Back
         {
             get;
             set => SetWithNotify(value, ref field);
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             var other = obj as OptionalSingleComposite2;
             return Id == other?.Id;
@@ -2791,7 +2789,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
 
     protected class OptionalSingleAk2Derived : OptionalSingleAk2
     {
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => base.Equals(obj as OptionalSingleAk2Derived);
 
         public override int GetHashCode()
@@ -2800,7 +2798,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
 
     protected class OptionalSingleAk2MoreDerived : OptionalSingleAk2Derived
     {
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => base.Equals(obj as OptionalSingleAk2MoreDerived);
 
         public override int GetHashCode()
@@ -2819,9 +2817,9 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
         {
             get;
             set => SetWithNotify(value, ref field);
-        }
+        } = null!;
 
-        public OwnedOptionalSingle1 OptionalSingle
+        public OwnedOptionalSingle1? OptionalSingle
         {
             get;
             set => SetWithNotify(value, ref field);
@@ -2847,7 +2845,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
         {
             get;
             set => SetWithNotify(value, ref field);
-        }
+        } = null!;
 
         public ICollection<OwnedRequired2> Children
         {
@@ -2863,7 +2861,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
         {
             get;
             set => SetWithNotify(value, ref field);
-        }
+        } = null!;
     }
 
     protected class OwnedOptional1 : NotifyingEntity
@@ -2873,7 +2871,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
         {
             get;
             set => SetWithNotify(value, ref field);
-        }
+        } = null!;
 
         public ICollection<OwnedOptional2> Children
         {
@@ -2889,7 +2887,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
         {
             get;
             set => SetWithNotify(value, ref field);
-        }
+        } = null!;
     }
 
     protected class OwnedRequiredSingle1 : NotifyingEntity
@@ -2899,13 +2897,13 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
         {
             get;
             set => SetWithNotify(value, ref field);
-        }
+        } = null!;
 
         public OwnedRequiredSingle2 Single
         {
             get;
             set => SetWithNotify(value, ref field);
-        }
+        } = null!;
     }
 
     protected class OwnedRequiredSingle2 : NotifyingEntity
@@ -2915,7 +2913,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
         {
             get;
             set => SetWithNotify(value, ref field);
-        }
+        } = null!;
     }
 
     protected class OwnedOptionalSingle1 : NotifyingEntity
@@ -2925,9 +2923,9 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
         {
             get;
             set => SetWithNotify(value, ref field);
-        }
+        } = null!;
 
-        public OwnedOptionalSingle2 Single
+        public OwnedOptionalSingle2? Single
         {
             get;
             set => SetWithNotify(value, ref field);
@@ -2941,7 +2939,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
         {
             get;
             set => SetWithNotify(value, ref field);
-        }
+        } = null!;
     }
 
     protected class BadCustomer : NotifyingEntity
@@ -2979,7 +2977,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
             set => SetWithNotify(value, ref field);
         }
 
-        public BadCustomer BadCustomer
+        public BadCustomer? BadCustomer
         {
             get;
             set => SetWithNotify(value, ref field);
@@ -3031,7 +3029,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
             set => SetWithNotify(value, ref field);
         }
 
-        public ChildAsAParent ChildAsAParent
+        public ChildAsAParent? ChildAsAParent
         {
             get;
             set => SetWithNotify(value, ref field);
@@ -3048,7 +3046,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
             set => SetWithNotify(value, ref field);
         }
 
-        public ParentAsAChild ParentAsAChild
+        public ParentAsAChild? ParentAsAChild
         {
             get;
             set => SetWithNotify(value, ref field);
@@ -3076,7 +3074,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
         {
             get;
             set => SetWithNotify(value, ref field);
-        }
+        } = null!;
 
         public int BarCode
         {
@@ -3116,7 +3114,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
             set => SetWithNotify(value, ref field);
         }
 
-        public Bloog Bloog
+        public Bloog? Bloog
         {
             get;
             set => SetWithNotify(value, ref field);
@@ -3170,7 +3168,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
             set => SetWithNotify(value, ref field);
         } = null!;
 
-        public SharedFkDependant Dependant
+        public SharedFkDependant? Dependant
         {
             get;
             set => SetWithNotify(value, ref field);
@@ -3197,11 +3195,11 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
             set => SetWithNotify(value, ref field);
         } = null!;
 
-        public SharedFkParent Parent
+        public SharedFkParent? Parent
         {
             get;
             set => SetWithNotify(value, ref field);
-        } = null!;
+        }
     }
 
     protected class Owner : NotifyingEntity
@@ -3216,7 +3214,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
         {
             get;
             set => SetWithNotify(value, ref field);
-        }
+        } = null!;
 
         public ICollection<Owned> OwnedCollection
         {
@@ -3234,11 +3232,11 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
             set => SetWithNotify(value, ref field);
         }
 
-        public string Bar
+        public string? Bar
         {
             get;
             set => SetWithNotify(value, ref field);
-        }
+        } = null!;
     }
 
     protected class OwnerWithKeyedCollection : NotifyingEntity
@@ -3253,13 +3251,13 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
         {
             get;
             set => SetWithNotify(value, ref field);
-        }
+        } = null!;
 
         public OwnedWithKey OwnedWithKey
         {
             get;
             set => SetWithNotify(value, ref field);
-        }
+        } = null!;
 
         public ICollection<OwnedWithKey> OwnedCollection
         {
@@ -3289,11 +3287,11 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
             set => SetWithNotify(value, ref field);
         }
 
-        public string Bar
+        public string? Bar
         {
             get;
             set => SetWithNotify(value, ref field);
-        }
+        } = null!;
     }
 
     [Owned]
@@ -3311,11 +3309,11 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
             set => SetWithNotify(value, ref field);
         }
 
-        public string Bar
+        public string? Bar
         {
             get;
             set => SetWithNotify(value, ref field);
-        }
+        } = null!;
     }
 
     protected class OwnerWithNonCompositeOwnedCollection : NotifyingEntity
@@ -3339,7 +3337,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
         {
             get;
             set => SetWithNotify(value, ref field);
-        }
+        } = null!;
     }
 
     protected class OwnerNoKeyGeneration : NotifyingEntity
@@ -3354,7 +3352,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
         {
             get;
             set => SetWithNotify(value, ref field);
-        }
+        } = null!;
 
         public ICollection<OwnedNoKeyGeneration> OwnedCollection
         {
@@ -3372,11 +3370,11 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
             set => SetWithNotify(value, ref field);
         }
 
-        public string Bar
+        public string? Bar
         {
             get;
             set => SetWithNotify(value, ref field);
-        }
+        } = null!;
     }
 
     [PrimaryKey("PartnerId", "ProviderId")]
@@ -3386,7 +3384,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
         {
             get;
             set => SetWithNotify(value, ref field);
-        }
+        } = null!;
     }
 
     protected class ProviderContract1 : ProviderContract
@@ -3395,7 +3393,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
         {
             get;
             set => SetWithNotify(value, ref field);
-        }
+        } = null!;
     }
 
     protected class ProviderContract2 : ProviderContract
@@ -3404,7 +3402,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
         {
             get;
             set => SetWithNotify(value, ref field);
-        }
+        } = null!;
     }
 
     protected class Partner : NotifyingEntity
@@ -3413,7 +3411,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
         {
             get;
             set => SetWithNotify(value, ref field);
-        }
+        } = null!;
     }
 
     protected class Provider : NotifyingEntity
@@ -3422,7 +3420,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
         {
             get;
             set => SetWithNotify(value, ref field);
-        }
+        } = null!;
     }
 
     protected class EventDescriptorZ : NotifyingEntity
@@ -3437,7 +3435,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
         {
             get;
             set => SetWithNotify(value, ref field);
-        }
+        } = null!;
     }
 
     protected class EntityZ : NotifyingEntity
@@ -3481,7 +3479,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
 
     protected class Cruiser : NotifyingEntity
     {
-        private AccessState _userState;
+        private AccessState _userState = null!;
 
         public int CruiserId
         {
@@ -3521,7 +3519,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
 
     protected class CruiserWithSentinel : NotifyingEntity
     {
-        private AccessStateWithSentinel _userState;
+        private AccessStateWithSentinel _userState = null!;
 
         public int CruiserWithSentinelId
         {
@@ -3578,7 +3576,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
 
     protected class ChildWithClientSetDefault : NotifyingEntity
     {
-        private ParentWithClientSetDefault _parent;
+        private ParentWithClientSetDefault _parent = null!;
 
         public int Id
         {
@@ -3611,14 +3609,14 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
         {
             get;
             set => SetWithNotify(value, ref field);
-        }
+        } = null!;
     }
 
     protected class Something : NotifyingEntity
     {
-        private SomethingCategory _somethingCategory;
-        private SomethingOfCategoryA _somethingOfCategoryA;
-        private SomethingOfCategoryB _somethingOfCategoryB;
+        private SomethingCategory _somethingCategory = null!;
+        private SomethingOfCategoryA _somethingOfCategoryA = null!;
+        private SomethingOfCategoryB _somethingOfCategoryB = null!;
 
         public int Id
         {
@@ -3636,7 +3634,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
         {
             get;
             set => SetWithNotify(value, ref field);
-        }
+        } = null!;
 
         public virtual SomethingCategory SomethingCategory
         {
@@ -3659,7 +3657,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
 
     protected class SomethingOfCategoryA : NotifyingEntity
     {
-        private Something _something;
+        private Something _something = null!;
 
         public int SomethingId
         {
@@ -3671,7 +3669,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
         {
             get;
             set => SetWithNotify(value, ref field);
-        }
+        } = null!;
 
         public virtual Something Something
         {
@@ -3682,8 +3680,8 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
 
     protected class SomethingOfCategoryB : NotifyingEntity
     {
-        private SomethingCategory _somethingCategory;
-        private Something _something;
+        private SomethingCategory _somethingCategory = null!;
+        private Something _something = null!;
 
         public int SomethingId
         {
@@ -3701,7 +3699,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
         {
             get;
             set => SetWithNotify(value, ref field);
-        }
+        } = null!;
 
         public virtual SomethingCategory SomethingCategory
         {
@@ -3724,13 +3722,13 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
             set => SetWithNotify(value, ref field);
         }
 
-        public Carrot Carrot
+        public Carrot? Carrot
         {
             get;
             set => SetWithNotify(value, ref field);
         }
 
-        public Swede Swede
+        public Swede? Swede
         {
             get;
             set => SetWithNotify(value, ref field);
@@ -3755,7 +3753,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
         {
             get;
             set => SetWithNotify(value, ref field);
-        }
+        } = null!;
 
         public ICollection<Turnip> Turnips
         {
@@ -3778,7 +3776,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
             set => SetWithNotify(value, ref field);
         }
 
-        public Carrot Carrot
+        public Carrot? Carrot
         {
             get;
             set => SetWithNotify(value, ref field);
@@ -3803,7 +3801,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
         {
             get;
             set => SetWithNotify(value, ref field);
-        }
+        } = null!;
 
         public ICollection<TurnipSwede> TurnipSwedes
         {
@@ -3826,7 +3824,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
             set => SetWithNotify(value, ref field);
         }
 
-        public Swede Swede
+        public Swede? Swede
         {
             get;
             set => SetWithNotify(value, ref field);
@@ -3842,7 +3840,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
         {
             get;
             set => SetWithNotify(value, ref field);
-        }
+        } = null!;
     }
 
     protected class Bayaz : NotifyingEntity
@@ -3860,7 +3858,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
         {
             get;
             set => SetWithNotify(value, ref field);
-        }
+        } = null!;
 
         public virtual ICollection<FirstLaw> FirstLaw
         {
@@ -3885,7 +3883,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
         {
             get;
             set => SetWithNotify(value, ref field);
-        }
+        } = null!;
 
         public int BayazId
         {
@@ -3919,7 +3917,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
         {
             get;
             set => SetWithNotify(value, ref field);
-        }
+        } = null!;
 
         public int FirstLawId
         {
@@ -3952,7 +3950,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
         {
             get;
             set => SetWithNotify(value, ref field);
-        }
+        } = null!;
 
         public int SecondLawId
         {
@@ -4015,7 +4013,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
 
     protected class Lettuce2 : Parsnip2
     {
-        public Beetroot2 Root
+        public Beetroot2? Root
         {
             get;
             set => SetWithNotify(value, ref field);
@@ -4066,7 +4064,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
         {
             get;
             set => SetWithNotify(value, ref field);
-        }
+        } = null!;
     }
 
     protected abstract class ChildBaseEntity32084 : NotifyingEntity
@@ -4090,7 +4088,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
         {
             get;
             set => SetWithNotify(value, ref field);
-        }
+        } = null!;
     }
 
     protected class StableParent32084 : NotifyingEntity
@@ -4105,7 +4103,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
         {
             get;
             set => SetWithNotify(value, ref field);
-        }
+        } = null!;
     }
 
     protected class StableChild32084 : NotifyingEntity
@@ -4137,7 +4135,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
             set => SetWithNotify(value, ref field);
         }
 
-        public StableParent32084 Brother
+        public StableParent32084? Brother
         {
             get;
             set => SetWithNotify(value, ref field);
@@ -4163,7 +4161,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
         {
             get;
             set => SetWithNotify(value, ref field);
-        }
+        } = default!;
     }
 
     protected class BoolOnlyKey<T> : NotifyingEntity
@@ -4173,7 +4171,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
         {
             get;
             set => SetWithNotify(value, ref field);
-        }
+        } = default!;
     }
 
     protected class NotifyingEntity : INotifyPropertyChanging, INotifyPropertyChanged
@@ -4185,8 +4183,8 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
             NotifyChanged(propertyName);
         }
 
-        public event PropertyChangingEventHandler PropertyChanging;
-        public event PropertyChangedEventHandler PropertyChanged;
+        public event PropertyChangingEventHandler? PropertyChanging;
+        public event PropertyChangedEventHandler? PropertyChanged;
 
         private void NotifyChanged(string propertyName)
             => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
@@ -4200,9 +4198,9 @@ public abstract partial class GraphUpdatesTestBase<TFixture>(TFixture fixture) :
 
     protected virtual Task ExecuteWithStrategyInTransactionAsync(
         Func<DbContext, Task> testOperation,
-        Func<DbContext, Task> nestedTestOperation1 = null,
-        Func<DbContext, Task> nestedTestOperation2 = null,
-        Func<DbContext, Task> nestedTestOperation3 = null)
+        Func<DbContext, Task>? nestedTestOperation1 = null,
+        Func<DbContext, Task>? nestedTestOperation2 = null,
+        Func<DbContext, Task>? nestedTestOperation3 = null)
         => TestHelpers.ExecuteWithStrategyInTransactionAsync(
             CreateContext, UseTransaction,
             testOperation, nestedTestOperation1, nestedTestOperation2, nestedTestOperation3);

--- a/test/EFCore.Specification.Tests/GraphUpdates/GraphUpdatesTestBaseMiscellaneous.cs
+++ b/test/EFCore.Specification.Tests/GraphUpdates/GraphUpdatesTestBaseMiscellaneous.cs
@@ -8,8 +8,6 @@
 
 namespace Microsoft.EntityFrameworkCore;
 
-#nullable disable
-
 public abstract partial class GraphUpdatesTestBase<TFixture>
     where TFixture : GraphUpdatesTestBase<TFixture>.GraphUpdatesFixtureBase, new()
 {
@@ -841,11 +839,11 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
 
                 if (nullPrincipal)
                 {
-                    dependent.Parent = null;
+                    dependent.Parent = null!;
                 }
                 else
                 {
-                    parent.Dependant = null;
+                    parent.Dependant = null!;
                 }
 
                 context.ChangeTracker.DetectChanges();
@@ -974,7 +972,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
 
                 if ((changeMechanism & ChangeMechanism.Dependent) != 0)
                 {
-                    entity.Root = null;
+                    entity.Root = null!;
                 }
 
                 context.ChangeTracker.DetectChanges();
@@ -1052,7 +1050,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
                     if (loadNewParent)
                     {
                         Assert.Same(newParent, child.Parent);
-                        Assert.Contains(child, newParent.Children);
+                        Assert.Contains(child, newParent!.Children);
                     }
                     else
                     {
@@ -1069,12 +1067,12 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
                     var child = await context.Set<Optional2>().FindAsync(childId);
                     var newParent = loadNewParent ? await context.Set<Optional1>().FindAsync(newFk) : null;
 
-                    Assert.Equal(newFk, child.ParentId);
+                    Assert.Equal(newFk, child!.ParentId);
 
                     if (loadNewParent)
                     {
                         Assert.Same(newParent, child.Parent);
-                        Assert.Contains(child, newParent.Children);
+                        Assert.Contains(child, newParent!.Children);
                     }
                     else
                     {
@@ -1099,7 +1097,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
 
         Assert.False(context.ChangeTracker.HasChanges());
 
-        existing.Parent = null;
+        existing.Parent = null!;
         existing.ParentId = null;
         ((ICollection<Optional1>)root.OptionalChildren).Remove(existing);
 
@@ -1195,7 +1193,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
                 Assert.Null(poost2.Bloog);
             }
 
-            poost1.Bloog = null;
+            poost1.Bloog = null!;
 
             Assert.Equal(2, bloog.Poosts.Count());
 
@@ -1237,15 +1235,15 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
             await LoadOptionalOneToManyGraphAsync(context);
             await LoadRequiredNonPkAkGraphAsync(context);
 
-            var optionalSingle = root.OptionalSingle;
-            var requiredSingle = root.RequiredSingle;
-            var optionalSingleAk = root.OptionalSingleAk;
-            var optionalSingleDerived = root.OptionalSingleDerived;
-            var requiredSingleAk = root.RequiredSingleAk;
-            var optionalSingleAkDerived = root.OptionalSingleAkDerived;
-            var optionalSingleMoreDerived = root.OptionalSingleMoreDerived;
+            var optionalSingle = root.OptionalSingle!;
+            var requiredSingle = root.RequiredSingle!;
+            var optionalSingleAk = root.OptionalSingleAk!;
+            var optionalSingleDerived = root.OptionalSingleDerived!;
+            var requiredSingleAk = root.RequiredSingleAk!;
+            var optionalSingleAkDerived = root.OptionalSingleAkDerived!;
+            var optionalSingleMoreDerived = root.OptionalSingleMoreDerived!;
             var requiredNonPkSingle = root.RequiredNonPkSingle;
-            var optionalSingleAkMoreDerived = root.OptionalSingleAkMoreDerived;
+            var optionalSingleAkMoreDerived = root.OptionalSingleAkMoreDerived!;
             var requiredNonPkSingleAk = root.RequiredNonPkSingleAk;
             var requiredNonPkSingleDerived = root.RequiredNonPkSingleDerived;
             var requiredNonPkSingleAkDerived = root.RequiredNonPkSingleAkDerived;
@@ -1327,15 +1325,15 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
             await LoadOptionalOneToManyGraphAsync(context);
             await LoadRequiredNonPkAkGraphAsync(context);
 
-            var optionalSingle = root.OptionalSingle;
-            var requiredSingle = root.RequiredSingle;
-            var optionalSingleAk = root.OptionalSingleAk;
-            var optionalSingleDerived = root.OptionalSingleDerived;
-            var requiredSingleAk = root.RequiredSingleAk;
-            var optionalSingleAkDerived = root.OptionalSingleAkDerived;
-            var optionalSingleMoreDerived = root.OptionalSingleMoreDerived;
+            var optionalSingle = root.OptionalSingle!;
+            var requiredSingle = root.RequiredSingle!;
+            var optionalSingleAk = root.OptionalSingleAk!;
+            var optionalSingleDerived = root.OptionalSingleDerived!;
+            var requiredSingleAk = root.RequiredSingleAk!;
+            var optionalSingleAkDerived = root.OptionalSingleAkDerived!;
+            var optionalSingleMoreDerived = root.OptionalSingleMoreDerived!;
             var requiredNonPkSingle = root.RequiredNonPkSingle;
-            var optionalSingleAkMoreDerived = root.OptionalSingleAkMoreDerived;
+            var optionalSingleAkMoreDerived = root.OptionalSingleAkMoreDerived!;
             var requiredNonPkSingleAk = root.RequiredNonPkSingleAk;
             var requiredNonPkSingleDerived = root.RequiredNonPkSingleDerived;
             var requiredNonPkSingleAkDerived = root.RequiredNonPkSingleAkDerived;
@@ -1473,7 +1471,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
 
                 var parent = await context.Set<ParentAsAChild>().Include(p => p.ChildAsAParent).SingleAsync();
 
-                var oldChild = parent.ChildAsAParent;
+                var oldChild = parent.ChildAsAParent!;
                 oldId = oldChild.Id;
 
                 context.Remove(oldChild);
@@ -1506,7 +1504,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
                 var parent = await context.Set<ParentAsAChild>().Include(p => p.ChildAsAParent).SingleAsync();
 
                 Assert.Equal(newId, parent.ChildAsAParentId);
-                Assert.Equal(newId, parent.ChildAsAParent.Id);
+                Assert.Equal(newId, parent.ChildAsAParent!.Id);
                 Assert.Null(context.Set<ChildAsAParent>().Find(oldId));
             });
     }
@@ -1653,13 +1651,13 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
         {
             var swedes = await context.Set<Parsnip>()
                 .Include(x => x.Carrot)
-                .ThenInclude(x => x.Turnips)
+                .ThenInclude(x => x!.Turnips)
                 .Include(x => x.Swede)
-                .ThenInclude(x => x.TurnipSwedes)
+                .ThenInclude(x => x!.TurnipSwedes)
                 .SingleAsync(x => x.Id == 1);
 
-            swedes.Carrot.Turnips.Clear();
-            swedes.Swede.TurnipSwedes.Clear();
+            swedes.Carrot!.Turnips.Clear();
+            swedes.Swede!.TurnipSwedes.Clear();
 
             _ = async
                 ? await context.SaveChangesAsync()
@@ -1686,7 +1684,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
 
                 if (Fixture.ForceClientNoAction)
                 {
-                    context.Entry(root.OptionalSingle.Single).State = EntityState.Deleted;
+                    context.Entry(root.OptionalSingle!.Single!).State = EntityState.Deleted;
                     context.Entry(root.OptionalSingle).State = EntityState.Deleted;
                     context.Entry(root.RequiredSingle.Single).State = EntityState.Deleted;
                     context.Entry(root.RequiredSingle).State = EntityState.Deleted;
@@ -1701,15 +1699,15 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
 
                 Assert.False(context.ChangeTracker.HasChanges());
 
-                Assert.Equal("OS`", root.OptionalSingle.Name);
-                Assert.Equal("OS2`", root.OptionalSingle.Single.Name);
+                Assert.Equal("OS`", root.OptionalSingle!.Name);
+                Assert.Equal("OS2`", root.OptionalSingle.Single!.Name);
                 Assert.Equal("RS`", root.RequiredSingle.Name);
                 Assert.Equal("RS2`", root.RequiredSingle.Single.Name);
             }, async context =>
             {
                 var root = await context.Set<OwnerRoot>().SingleAsync();
-                Assert.Equal("OS`", root.OptionalSingle.Name);
-                Assert.Equal("OS2`", root.OptionalSingle.Single.Name);
+                Assert.Equal("OS`", root.OptionalSingle!.Name);
+                Assert.Equal("OS2`", root.OptionalSingle.Single!.Name);
                 Assert.Equal("RS`", root.RequiredSingle.Name);
                 Assert.Equal("RS2`", root.RequiredSingle.Single.Name);
             });
@@ -2331,7 +2329,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
             set => SetWithNotify(value, ref field);
         }
 
-        public GroupMember37310 GroupOwner
+        public GroupMember37310? GroupOwner
         {
             get;
             set => SetWithNotify(value, ref field);
@@ -2356,7 +2354,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
         {
             get;
             set => SetWithNotify(value, ref field);
-        }
+        } = null!;
 
         public int UserId
         {
@@ -2368,7 +2366,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
         {
             get;
             set => SetWithNotify(value, ref field);
-        }
+        } = null!;
     }
 
     #endregion

--- a/test/EFCore.Specification.Tests/GraphUpdates/GraphUpdatesTestBaseOneToMany.cs
+++ b/test/EFCore.Specification.Tests/GraphUpdates/GraphUpdatesTestBaseOneToMany.cs
@@ -7,8 +7,6 @@
 
 namespace Microsoft.EntityFrameworkCore;
 
-#nullable disable
-
 public abstract partial class GraphUpdatesTestBase<TFixture>
     where TFixture : GraphUpdatesTestBase<TFixture>.GraphUpdatesFixtureBase, new()
 {
@@ -81,8 +79,8 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
         var new2b = new Optional2();
         var new2d = new Optional2Derived();
         var new2dd = new Optional2MoreDerived();
-        Root root = null;
-        IReadOnlyList<EntityEntry> entries = null;
+        Root root = null!;
+        IReadOnlyList<EntityEntry> entries = null!;
 
         return ExecuteWithStrategyInTransactionAsync(
             async context =>
@@ -182,8 +180,8 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
             {
                 var loadedRoot = await LoadOptionalGraphAsync(context);
 
-                AssertEntries(entries, context.ChangeTracker.Entries().ToList());
-                AssertKeys(root, loadedRoot);
+                AssertEntries(entries!, context.ChangeTracker.Entries().ToList());
+                AssertKeys(root!, loadedRoot);
                 AssertNavigations(loadedRoot);
             });
     }
@@ -258,8 +256,8 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
         var new2b = new Required2 { Parent = new1 };
         var new2d = new Required2Derived { Parent = new1 };
         var new2dd = new Required2MoreDerived { Parent = new1 };
-        Root root = null;
-        IReadOnlyList<EntityEntry> entries = null;
+        Root root = null!;
+        IReadOnlyList<EntityEntry> entries = null!;
 
         return ExecuteWithStrategyInTransactionAsync(
             async context =>
@@ -288,9 +286,9 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
                 }
                 else
                 {
-                    new1.Parent = null;
-                    new1d.Parent = null;
-                    new1dd.Parent = null;
+                    new1.Parent = null!;
+                    new1d.Parent = null!;
+                    new1dd.Parent = null!;
 
                     context.AddRange(new1, new1d, new1dd, new2a, new2d, new2dd, new2b);
                 }
@@ -363,8 +361,8 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
             {
                 var loadedRoot = await LoadRequiredGraphAsync(context);
 
-                AssertEntries(entries, context.ChangeTracker.Entries().ToList());
-                AssertKeys(root, loadedRoot);
+                AssertEntries(entries!, context.ChangeTracker.Entries().ToList());
+                AssertKeys(root!, loadedRoot);
                 AssertNavigations(loadedRoot);
             });
     }
@@ -401,7 +399,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
         ChangeMechanism changeMechanism,
         CascadeTiming? deleteOrphansTiming)
     {
-        Root root = null;
+        Root root = null!;
         return ExecuteWithStrategyInTransactionAsync(
             async context =>
             {
@@ -421,8 +419,8 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
 
                 if ((changeMechanism & ChangeMechanism.Dependent) != 0)
                 {
-                    removed2.Parent = null;
-                    removed1.Parent = null;
+                    removed2.Parent = null!;
+                    removed1.Parent = null!;
                 }
 
                 if ((changeMechanism & ChangeMechanism.Fk) != 0)
@@ -450,7 +448,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
                 {
                     var loadedRoot = await LoadOptionalGraphAsync(context);
 
-                    AssertKeys(root, loadedRoot);
+                    AssertKeys(root!, loadedRoot);
                     AssertNavigations(loadedRoot);
 
                     Assert.Single(loadedRoot.OptionalChildren);
@@ -494,7 +492,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
     {
         var removed1Id = 0;
         var removed2Id = 0;
-        List<int> removed1ChildrenIds = null;
+        List<int> removed1ChildrenIds = null!;
 
         return ExecuteWithStrategyInTransactionAsync(
             async context =>
@@ -519,8 +517,8 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
 
                 if ((changeMechanism & ChangeMechanism.Dependent) != 0)
                 {
-                    removed2.Parent = null;
-                    removed1.Parent = null;
+                    removed2.Parent = null!;
+                    removed1.Parent = null!;
                 }
 
                 if (Fixture.ForceClientNoAction
@@ -609,7 +607,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
 
                     Assert.Empty(context.Set<Required1>().Where(e => e.Id == removed1Id));
                     Assert.Empty(context.Set<Required2>().Where(e => e.Id == removed2Id));
-                    Assert.Empty(context.Set<Required2>().Where(e => removed1ChildrenIds.Contains(e.Id)));
+                    Assert.Empty(context.Set<Required2>().Where(e => removed1ChildrenIds!.Contains(e.Id)));
                 }
             });
     }
@@ -676,13 +674,13 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
         bool useExistingParent,
         CascadeTiming? deleteOrphansTiming)
     {
-        Root root = null;
-        IReadOnlyList<EntityEntry> entries = null;
+        Root root = null!;
+        IReadOnlyList<EntityEntry> entries = null!;
         var compositeCount = 0;
-        OptionalAk1 oldParent = null;
-        OptionalComposite2 oldComposite1 = null;
-        OptionalComposite2 oldComposite2 = null;
-        Optional1 newParent = null;
+        OptionalAk1 oldParent = null!;
+        OptionalComposite2 oldComposite1 = null!;
+        OptionalComposite2 oldComposite2 = null!;
+        Optional1 newParent = null!;
 
         return ExecuteWithStrategyInTransactionAsync(
             async context =>
@@ -716,7 +714,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
                 }
                 else
                 {
-                    newParent = await context.Set<Optional1>().SingleAsync(e => e.Id == newParent.Id);
+                    newParent = await context.Set<Optional1>().SingleAsync(e => e.Id == newParent!.Id);
                     newParent.Parent = root;
                 }
 
@@ -728,7 +726,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
 
                 if ((changeMechanism & ChangeMechanism.Dependent) != 0)
                 {
-                    oldComposite1.Parent = null;
+                    oldComposite1.Parent = null!;
                     oldComposite1.Parent2 = newParent;
                 }
 
@@ -767,14 +765,14 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
 
                     Assert.False(context.ChangeTracker.HasChanges());
 
-                    AssertKeys(root, loadedRoot);
+                    AssertKeys(root!, loadedRoot);
                     AssertNavigations(loadedRoot);
 
-                    oldParent = await context.Set<OptionalAk1>().SingleAsync(e => e.Id == oldParent.Id);
-                    newParent = await context.Set<Optional1>().SingleAsync(e => e.Id == newParent.Id);
+                    oldParent = await context.Set<OptionalAk1>().SingleAsync(e => e.Id == oldParent!.Id);
+                    newParent = await context.Set<Optional1>().SingleAsync(e => e.Id == newParent!.Id);
 
-                    oldComposite1 = context.Set<OptionalComposite2>().Single(e => e.Id == oldComposite1.Id);
-                    oldComposite2 = context.Set<OptionalComposite2>().Single(e => e.Id == oldComposite2.Id);
+                    oldComposite1 = context.Set<OptionalComposite2>().Single(e => e.Id == oldComposite1!.Id);
+                    oldComposite2 = context.Set<OptionalComposite2>().Single(e => e.Id == oldComposite2!.Id);
 
                     Assert.Same(oldComposite2, oldParent.CompositeChildren.Single());
                     Assert.Same(oldParent, oldComposite2.Parent);
@@ -788,7 +786,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
                     Assert.Null(oldComposite1.Parent);
                     Assert.Null(oldComposite1.ParentId);
 
-                    AssertEntries(entries, context.ChangeTracker.Entries().ToList());
+                    AssertEntries(entries!, context.ChangeTracker.Entries().ToList());
 
                     Assert.Equal(compositeCount, context.Set<OptionalComposite2>().Count());
                 }
@@ -828,9 +826,9 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
         ChangeMechanism changeMechanism,
         CascadeTiming? deleteOrphansTiming)
     {
-        Required1 oldParent = null;
-        Required1 newParent = null;
-        Required2 child = null;
+        Required1 oldParent = null!;
+        Required1 newParent = null!;
+        Required2 child = null!;
 
         return ExecuteWithStrategyInTransactionAsync(
             async context =>
@@ -899,9 +897,9 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
 
                     Assert.False(context.ChangeTracker.HasChanges());
 
-                    oldParent = root.RequiredChildren.First(e => e.Id == oldParent.Id);
-                    newParent = root.RequiredChildren.First(e => e.Id == newParent.Id);
-                    child = newParent.Children.First(e => e.Id == child.Id);
+                    oldParent = root.RequiredChildren.First(e => e.Id == oldParent!.Id);
+                    newParent = root.RequiredChildren.First(e => e.Id == newParent!.Id);
+                    child = newParent.Children.First(e => e.Id == child!.Id);
 
                     Assert.DoesNotContain(child, oldParent.Children);
                     Assert.Contains(child, newParent.Children);
@@ -946,9 +944,9 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
         ChangeMechanism changeMechanism,
         CascadeTiming? deleteOrphansTiming)
     {
-        RequiredAk1 oldParent = null;
-        RequiredAk1 newParent = null;
-        RequiredAk2 child = null;
+        RequiredAk1 oldParent = null!;
+        RequiredAk1 newParent = null!;
+        RequiredAk2 child = null!;
 
         return ExecuteWithStrategyInTransactionAsync(
             async context =>
@@ -1017,9 +1015,9 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
 
                     Assert.False(context.ChangeTracker.HasChanges());
 
-                    oldParent = root.RequiredChildrenAk.First(e => e.Id == oldParent.Id);
-                    newParent = root.RequiredChildrenAk.First(e => e.Id == newParent.Id);
-                    child = newParent.Children.First(e => e.Id == child.Id);
+                    oldParent = root.RequiredChildrenAk.First(e => e.Id == oldParent!.Id);
+                    newParent = root.RequiredChildrenAk.First(e => e.Id == newParent!.Id);
+                    child = newParent.Children.First(e => e.Id == child!.Id);
 
                     Assert.DoesNotContain(child, oldParent.Children);
                     Assert.Contains(child, newParent.Children);
@@ -1093,13 +1091,13 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
         bool useExistingParent,
         CascadeTiming? deleteOrphansTiming)
     {
-        Root root = null;
-        IReadOnlyList<EntityEntry> entries = null;
+        Root root = null!;
+        IReadOnlyList<EntityEntry> entries = null!;
         var childCount = 0;
-        RequiredComposite1 oldParent = null;
-        OptionalOverlapping2 oldChild1 = null;
-        OptionalOverlapping2 oldChild2 = null;
-        RequiredComposite1 newParent = null;
+        RequiredComposite1 oldParent = null!;
+        OptionalOverlapping2 oldChild1 = null!;
+        OptionalOverlapping2 oldChild2 = null!;
+        RequiredComposite1 newParent = null!;
 
         return ExecuteWithStrategyInTransactionAsync(
             async context =>
@@ -1140,7 +1138,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
                 }
                 else
                 {
-                    newParent = await context.Set<RequiredComposite1>().SingleAsync(e => e.Id == newParent.Id);
+                    newParent = await context.Set<RequiredComposite1>().SingleAsync(e => e.Id == newParent!.Id);
                     newParent.Parent = root;
                 }
 
@@ -1188,14 +1186,14 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
             {
                 var loadedRoot = await LoadRequiredCompositeGraphAsync(context);
 
-                AssertKeys(root, loadedRoot);
+                AssertKeys(root!, loadedRoot);
                 AssertNavigations(loadedRoot);
 
-                oldParent = await context.Set<RequiredComposite1>().SingleAsync(e => e.Id == oldParent.Id);
-                newParent = await context.Set<RequiredComposite1>().SingleAsync(e => e.Id == newParent.Id);
+                oldParent = await context.Set<RequiredComposite1>().SingleAsync(e => e.Id == oldParent!.Id);
+                newParent = await context.Set<RequiredComposite1>().SingleAsync(e => e.Id == newParent!.Id);
 
-                oldChild1 = await context.Set<OptionalOverlapping2>().SingleAsync(e => e.Id == oldChild1.Id);
-                oldChild2 = await context.Set<OptionalOverlapping2>().SingleAsync(e => e.Id == oldChild2.Id);
+                oldChild1 = await context.Set<OptionalOverlapping2>().SingleAsync(e => e.Id == oldChild1!.Id);
+                oldChild2 = await context.Set<OptionalOverlapping2>().SingleAsync(e => e.Id == oldChild2!.Id);
 
                 Assert.Same(oldChild2, oldParent.CompositeChildren.Single());
                 Assert.Same(oldParent, oldChild2.Parent);
@@ -1209,7 +1207,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
                 Assert.Equal(oldParent.ParentAlternateId, oldChild1.ParentAlternateId);
                 Assert.Equal(root.AlternateId, oldChild1.ParentAlternateId);
 
-                AssertEntries(entries, context.ChangeTracker.Entries().ToList());
+                AssertEntries(entries!, context.ChangeTracker.Entries().ToList());
 
                 Assert.Equal(childCount, context.Set<OptionalOverlapping2>().Count());
             });
@@ -1287,7 +1285,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
         CascadeTiming? deleteOrphansTiming)
     {
         var removedId = 0;
-        List<int> orphanedIds = null;
+        List<int> orphanedIds = null!;
 
         return ExecuteWithStrategyInTransactionAsync(
             async context =>
@@ -1359,7 +1357,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
                     Assert.DoesNotContain(removedId, root.RequiredChildren.Select(e => e.Id));
 
                     Assert.Empty(context.Set<Required1>().Where(e => e.Id == removedId));
-                    Assert.Empty(context.Set<Required2>().Where(e => orphanedIds.Contains(e.Id)));
+                    Assert.Empty(context.Set<Required2>().Where(e => orphanedIds!.Contains(e.Id)));
                 }
             });
     }
@@ -1443,7 +1441,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
         CascadeTiming? deleteOrphansTiming)
     {
         var removedId = 0;
-        List<int> orphanedIds = null;
+        List<int> orphanedIds = null!;
 
         return ExecuteWithStrategyInTransactionAsync(
             async context =>
@@ -1528,7 +1526,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
                     Assert.DoesNotContain(removedId, root.OptionalChildren.Select(e => e.Id));
 
                     Assert.Empty(context.Set<Optional1>().Where(e => e.Id == removedId));
-                    Assert.Equal(orphanedIds.Count, context.Set<Optional2>().Count(e => orphanedIds.Contains(e.Id)));
+                    Assert.Equal(orphanedIds!.Count, context.Set<Optional2>().Count(e => orphanedIds.Contains(e.Id)));
                 }
             });
     }
@@ -1675,7 +1673,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
         CascadeTiming? deleteOrphansTiming)
     {
         var removedId = 0;
-        List<int> orphanedIds = null;
+        List<int> orphanedIds = null!;
 
         return ExecuteWithStrategyInTransactionAsync(
             async context =>
@@ -1696,7 +1694,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
 
                 var removed = root.RequiredChildren.Single(e => e.Id == removedId);
 
-                Assert.Equal(2, orphanedIds.Count);
+                Assert.Equal(2, orphanedIds!.Count);
 
                 context.Remove(removed);
 
@@ -1740,7 +1738,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
                     Assert.DoesNotContain(removedId, root.RequiredChildren.Select(e => e.Id));
 
                     Assert.Empty(context.Set<Required1>().Where(e => e.Id == removedId));
-                    Assert.Empty(context.Set<Required2>().Where(e => orphanedIds.Contains(e.Id)));
+                    Assert.Empty(context.Set<Required2>().Where(e => orphanedIds!.Contains(e.Id)));
                 }
             });
     }
@@ -1761,7 +1759,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
         CascadeTiming? deleteOrphansTiming)
     {
         var removedId = 0;
-        List<int> orphanedIds = null;
+        List<int> orphanedIds = null!;
 
         return ExecuteWithStrategyInTransactionAsync(
             async context =>
@@ -1782,7 +1780,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
 
                 var removed = root.OptionalChildren.First(e => e.Id == removedId);
 
-                Assert.Equal(2, orphanedIds.Count);
+                Assert.Equal(2, orphanedIds!.Count);
 
                 context.Remove(removed);
 
@@ -1828,8 +1826,8 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
 
                     Assert.Empty(context.Set<Optional1>().Where(e => e.Id == removedId));
 
-                    var orphaned = context.Set<Optional2>().Where(e => orphanedIds.Contains(e.Id)).ToList();
-                    Assert.Equal(orphanedIds.Count, orphaned.Count);
+                    var orphaned = context.Set<Optional2>().Where(e => orphanedIds!.Contains(e.Id)).ToList();
+                    Assert.Equal(orphanedIds!.Count, orphaned.Count);
                     Assert.True(orphaned.All(e => e.ParentId == null));
                 }
             });
@@ -1851,8 +1849,8 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
         CascadeTiming? deleteOrphansTiming)
     {
         var removedId = 0;
-        List<int> orphanedIds = null;
-        Root root = null;
+        List<int> orphanedIds = null!;
+        Root root = null!;
 
         return ExecuteWithStrategyInTransactionAsync(
             async context =>
@@ -1865,7 +1863,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
                 context.ChangeTracker.CascadeDeleteTiming = cascadeDeleteTiming ?? CascadeTiming.Never;
                 context.ChangeTracker.DeleteOrphansTiming = deleteOrphansTiming ?? CascadeTiming.Never;
 
-                var removed = root.RequiredChildren.First();
+                var removed = root!.RequiredChildren.First();
 
                 removedId = removed.Id;
                 var cascadeRemoved = removed.Children.ToList();
@@ -1924,7 +1922,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
                     Assert.DoesNotContain(removedId, root.RequiredChildren.Select(e => e.Id));
 
                     Assert.Empty(context.Set<Required1>().Where(e => e.Id == removedId));
-                    Assert.Empty(context.Set<Required2>().Where(e => orphanedIds.Contains(e.Id)));
+                    Assert.Empty(context.Set<Required2>().Where(e => orphanedIds!.Contains(e.Id)));
                 }
             });
     }
@@ -1945,8 +1943,8 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
         CascadeTiming? deleteOrphansTiming)
     {
         var removedId = 0;
-        List<int> orphanedIds = null;
-        Root root = null;
+        List<int> orphanedIds = null!;
+        Root root = null!;
 
         return ExecuteWithStrategyInTransactionAsync(
             async context =>
@@ -1959,7 +1957,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
                 context.ChangeTracker.CascadeDeleteTiming = cascadeDeleteTiming ?? CascadeTiming.Never;
                 context.ChangeTracker.DeleteOrphansTiming = deleteOrphansTiming ?? CascadeTiming.Never;
 
-                var removed = root.OptionalChildren.First();
+                var removed = root!.OptionalChildren.First();
 
                 removedId = removed.Id;
                 var orphaned = removed.Children.ToList();
@@ -2028,7 +2026,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
                     Assert.DoesNotContain(removedId, root.OptionalChildren.Select(e => e.Id));
 
                     Assert.Empty(context.Set<Optional1>().Where(e => e.Id == removedId));
-                    Assert.Equal(orphanedIds.Count, context.Set<Optional2>().Count(e => orphanedIds.Contains(e.Id)));
+                    Assert.Equal(orphanedIds!.Count, context.Set<Optional2>().Count(e => orphanedIds.Contains(e.Id)));
                 }
             });
     }
@@ -2049,7 +2047,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
         CascadeTiming? deleteOrphansTiming)
     {
         var removedId = 0;
-        List<int> orphanedIds = null;
+        List<int> orphanedIds = null!;
 
         return ExecuteWithStrategyInTransactionAsync(
             async context =>
@@ -2139,7 +2137,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
                     Assert.DoesNotContain(removedId, root.RequiredChildren.Select(e => e.Id));
 
                     Assert.Empty(context.Set<Required1>().Where(e => e.Id == removedId));
-                    Assert.Empty(context.Set<Required2>().Where(e => orphanedIds.Contains(e.Id)));
+                    Assert.Empty(context.Set<Required2>().Where(e => orphanedIds!.Contains(e.Id)));
                 }
             });
     }

--- a/test/EFCore.Specification.Tests/GraphUpdates/GraphUpdatesTestBaseOneToManyAk.cs
+++ b/test/EFCore.Specification.Tests/GraphUpdates/GraphUpdatesTestBaseOneToManyAk.cs
@@ -7,8 +7,6 @@
 
 namespace Microsoft.EntityFrameworkCore;
 
-#nullable disable
-
 public abstract partial class GraphUpdatesTestBase<TFixture>
     where TFixture : GraphUpdatesTestBase<TFixture>.GraphUpdatesFixtureBase, new()
 {
@@ -84,8 +82,8 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
         var new2cb = new OptionalComposite2();
         var new2d = new OptionalAk2Derived { AlternateId = Guid.NewGuid() };
         var new2dd = new OptionalAk2MoreDerived { AlternateId = Guid.NewGuid() };
-        Root root = null;
-        IReadOnlyList<EntityEntry> entries = null;
+        Root root = null!;
+        IReadOnlyList<EntityEntry> entries = null!;
 
         return ExecuteWithStrategyInTransactionAsync(
             async context =>
@@ -203,8 +201,8 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
             {
                 var loadedRoot = await LoadOptionalAkGraphAsync(context);
 
-                AssertEntries(entries, context.ChangeTracker.Entries().ToList());
-                AssertKeys(root, loadedRoot);
+                AssertEntries(entries!, context.ChangeTracker.Entries().ToList());
+                AssertKeys(root!, loadedRoot);
                 AssertNavigations(loadedRoot);
             });
     }
@@ -281,8 +279,8 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
         var new2cb = new RequiredComposite2 { Parent = new1 };
         var new2d = new RequiredAk2Derived { AlternateId = Guid.NewGuid(), Parent = new1 };
         var new2dd = new RequiredAk2MoreDerived { AlternateId = Guid.NewGuid(), Parent = new1 };
-        Root root = null;
-        IReadOnlyList<EntityEntry> entries = null;
+        Root root = null!;
+        IReadOnlyList<EntityEntry> entries = null!;
 
         return ExecuteWithStrategyInTransactionAsync(
             async context =>
@@ -313,9 +311,9 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
                 }
                 else
                 {
-                    new1.Parent = null;
-                    new1d.Parent = null;
-                    new1dd.Parent = null;
+                    new1.Parent = null!;
+                    new1d.Parent = null!;
+                    new1dd.Parent = null!;
 
                     var old1 = root.RequiredChildrenAk.OrderBy(c => c.Id).Last();
 
@@ -411,8 +409,8 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
             {
                 var loadedRoot = await LoadRequiredAkGraphAsync(context);
 
-                AssertEntries(entries, context.ChangeTracker.Entries().ToList());
-                AssertKeys(root, loadedRoot);
+                AssertEntries(entries!, context.ChangeTracker.Entries().ToList());
+                AssertKeys(root!, loadedRoot);
                 AssertNavigations(loadedRoot);
             });
     }
@@ -450,7 +448,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
         ChangeMechanism changeMechanism,
         CascadeTiming? deleteOrphansTiming)
     {
-        Root root = null;
+        Root root = null!;
         return ExecuteWithStrategyInTransactionAsync(
             async context =>
             {
@@ -474,9 +472,9 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
 
                 if ((changeMechanism & ChangeMechanism.Dependent) != 0)
                 {
-                    removed2.Parent = null;
-                    removed2c.Parent = null;
-                    removed1.Parent = null;
+                    removed2.Parent = null!;
+                    removed2c.Parent = null!;
+                    removed1.Parent = null!;
                 }
 
                 if ((changeMechanism & ChangeMechanism.Fk) != 0)
@@ -509,7 +507,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
                 {
                     var loadedRoot = await LoadOptionalAkGraphAsync(context);
 
-                    AssertKeys(root, loadedRoot);
+                    AssertKeys(root!, loadedRoot);
                     AssertNavigations(loadedRoot);
 
                     Assert.Single(loadedRoot.OptionalChildrenAk);
@@ -535,10 +533,10 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
         ChangeMechanism changeMechanism,
         CascadeTiming? deleteOrphansTiming)
     {
-        Root root = null;
-        RequiredAk2 removed2 = null;
-        RequiredComposite2 removed2c = null;
-        RequiredAk1 removed1 = null;
+        Root root = null!;
+        RequiredAk2 removed2 = null!;
+        RequiredComposite2 removed2c = null!;
+        RequiredAk1 removed1 = null!;
 
         return ExecuteWithStrategyInTransactionAsync(
             async context =>
@@ -563,9 +561,9 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
 
                 if ((changeMechanism & ChangeMechanism.Dependent) != 0)
                 {
-                    removed2.Parent = null;
-                    removed2c.Parent = null;
-                    removed1.Parent = null;
+                    removed2.Parent = null!;
+                    removed2c.Parent = null!;
+                    removed1.Parent = null!;
                 }
 
                 if ((changeMechanism & ChangeMechanism.Fk) != 0)
@@ -629,12 +627,12 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
                 {
                     var loadedRoot = await LoadRequiredAkGraphAsync(context);
 
-                    AssertKeys(root, loadedRoot);
+                    AssertKeys(root!, loadedRoot);
                     AssertNavigations(loadedRoot);
 
-                    Assert.False(context.Set<RequiredAk1>().Any(e => e.Id == removed1.Id));
-                    Assert.False(context.Set<RequiredAk2>().Any(e => e.Id == removed2.Id));
-                    Assert.False(context.Set<RequiredComposite2>().Any(e => e.Id == removed2c.Id));
+                    Assert.False(context.Set<RequiredAk1>().Any(e => e.Id == removed1!.Id));
+                    Assert.False(context.Set<RequiredAk2>().Any(e => e.Id == removed2!.Id));
+                    Assert.False(context.Set<RequiredComposite2>().Any(e => e.Id == removed2c!.Id));
 
                     Assert.Single(loadedRoot.RequiredChildrenAk);
                     Assert.Single(loadedRoot.RequiredChildrenAk.OrderBy(c => c.Id).First().Children);
@@ -659,7 +657,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
         CascadeTiming? deleteOrphansTiming)
     {
         var removedId = 0;
-        List<int> orphanedIds = null;
+        List<int> orphanedIds = null!;
 
         return ExecuteWithStrategyInTransactionAsync(
             async context =>
@@ -726,7 +724,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
                     Assert.DoesNotContain(removedId, root.OptionalChildrenAk.Select(e => e.Id));
 
                     Assert.Empty(context.Set<OptionalAk1>().Where(e => e.Id == removedId));
-                    Assert.Equal(orphanedIds.Count, context.Set<OptionalAk2>().Count(e => orphanedIds.Contains(e.Id)));
+                    Assert.Equal(orphanedIds!.Count, context.Set<OptionalAk2>().Count(e => orphanedIds.Contains(e.Id)));
                 }
             });
     }
@@ -747,8 +745,8 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
         CascadeTiming? deleteOrphansTiming)
     {
         var removedId = 0;
-        List<int> orphanedIds = null;
-        List<int> orphanedIdCs = null;
+        List<int> orphanedIds = null!;
+        List<int> orphanedIdCs = null!;
 
         return ExecuteWithStrategyInTransactionAsync(
             async context =>
@@ -832,8 +830,8 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
                     Assert.DoesNotContain(removedId, root.RequiredChildrenAk.Select(e => e.Id));
 
                     Assert.Empty(context.Set<RequiredAk1>().Where(e => e.Id == removedId));
-                    Assert.Empty(context.Set<RequiredAk2>().Where(e => orphanedIds.Contains(e.Id)));
-                    Assert.Empty(context.Set<RequiredComposite2>().Where(e => orphanedIdCs.Contains(e.Id)));
+                    Assert.Empty(context.Set<RequiredAk2>().Where(e => orphanedIds!.Contains(e.Id)));
+                    Assert.Empty(context.Set<RequiredComposite2>().Where(e => orphanedIdCs!.Contains(e.Id)));
                 }
             });
     }
@@ -854,8 +852,8 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
         CascadeTiming? deleteOrphansTiming)
     {
         var removedId = 0;
-        List<int> orphanedIds = null;
-        List<int> orphanedIdCs = null;
+        List<int> orphanedIds = null!;
+        List<int> orphanedIdCs = null!;
 
         return ExecuteWithStrategyInTransactionAsync(
             async context =>
@@ -904,8 +902,8 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
                     Assert.DoesNotContain(removedId, root.RequiredChildrenAk.Select(e => e.Id));
 
                     Assert.Empty(context.Set<RequiredAk1>().Where(e => e.Id == removedId));
-                    Assert.Empty(context.Set<RequiredAk2>().Where(e => orphanedIds.Contains(e.Id)));
-                    Assert.Empty(context.Set<RequiredComposite2>().Where(e => orphanedIdCs.Contains(e.Id)));
+                    Assert.Empty(context.Set<RequiredAk2>().Where(e => orphanedIds!.Contains(e.Id)));
+                    Assert.Empty(context.Set<RequiredComposite2>().Where(e => orphanedIdCs!.Contains(e.Id)));
 
                     Assert.Same(root, removed.Parent);
                     Assert.Empty(removed.Children); // Never loaded
@@ -921,8 +919,8 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
                     Assert.DoesNotContain(removedId, root.RequiredChildrenAk.Select(e => e.Id));
 
                     Assert.Empty(context.Set<RequiredAk1>().Where(e => e.Id == removedId));
-                    Assert.Empty(context.Set<RequiredAk2>().Where(e => orphanedIds.Contains(e.Id)));
-                    Assert.Empty(context.Set<RequiredComposite2>().Where(e => orphanedIdCs.Contains(e.Id)));
+                    Assert.Empty(context.Set<RequiredAk2>().Where(e => orphanedIds!.Contains(e.Id)));
+                    Assert.Empty(context.Set<RequiredComposite2>().Where(e => orphanedIdCs!.Contains(e.Id)));
                 }
             });
     }
@@ -943,8 +941,8 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
         CascadeTiming? deleteOrphansTiming)
     {
         var removedId = 0;
-        List<int> orphanedIds = null;
-        List<int> orphanedIdCs = null;
+        List<int> orphanedIds = null!;
+        List<int> orphanedIdCs = null!;
 
         return ExecuteWithStrategyInTransactionAsync(
             async context =>
@@ -969,7 +967,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
 
                 context.Remove(removed);
 
-                foreach (var toOrphan in await context.Set<OptionalComposite2>().Where(e => orphanedIdCs.Contains(e.Id)).ToListAsync())
+                foreach (var toOrphan in await context.Set<OptionalComposite2>().Where(e => orphanedIdCs!.Contains(e.Id)).ToListAsync())
                 {
                     toOrphan.ParentId = null;
                 }
@@ -998,12 +996,12 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
 
                     Assert.Empty(context.Set<OptionalAk1>().Where(e => e.Id == removedId));
 
-                    var orphaned = await context.Set<OptionalAk2>().Where(e => orphanedIds.Contains(e.Id)).ToListAsync();
-                    Assert.Equal(orphanedIds.Count, orphaned.Count);
+                    var orphaned = await context.Set<OptionalAk2>().Where(e => orphanedIds!.Contains(e.Id)).ToListAsync();
+                    Assert.Equal(orphanedIds!.Count, orphaned.Count);
                     Assert.True(orphaned.All(e => e.ParentId == null));
 
-                    var orphanedC = await context.Set<OptionalComposite2>().Where(e => orphanedIdCs.Contains(e.Id)).ToListAsync();
-                    Assert.Equal(orphanedIdCs.Count, orphanedC.Count);
+                    var orphanedC = await context.Set<OptionalComposite2>().Where(e => orphanedIdCs!.Contains(e.Id)).ToListAsync();
+                    Assert.Equal(orphanedIdCs!.Count, orphanedC.Count);
                     Assert.True(orphanedC.All(e => e.ParentId == null));
 
                     Assert.Same(root, removed.Parent);
@@ -1020,12 +1018,12 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
 
                     Assert.Empty(context.Set<OptionalAk1>().Where(e => e.Id == removedId));
 
-                    var orphaned = await context.Set<OptionalAk2>().Where(e => orphanedIds.Contains(e.Id)).ToListAsync();
-                    Assert.Equal(orphanedIds.Count, orphaned.Count);
+                    var orphaned = await context.Set<OptionalAk2>().Where(e => orphanedIds!.Contains(e.Id)).ToListAsync();
+                    Assert.Equal(orphanedIds!.Count, orphaned.Count);
                     Assert.True(orphaned.All(e => e.ParentId == null));
 
-                    var orphanedC = await context.Set<OptionalComposite2>().Where(e => orphanedIdCs.Contains(e.Id)).ToListAsync();
-                    Assert.Equal(orphanedIdCs.Count, orphanedC.Count);
+                    var orphanedC = await context.Set<OptionalComposite2>().Where(e => orphanedIdCs!.Contains(e.Id)).ToListAsync();
+                    Assert.Equal(orphanedIdCs!.Count, orphanedC.Count);
                     Assert.True(orphanedC.All(e => e.ParentId == null));
                 }
             });
@@ -1047,9 +1045,9 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
         CascadeTiming? deleteOrphansTiming)
     {
         var removedId = 0;
-        List<int> orphanedIds = null;
-        List<int> orphanedIdCs = null;
-        Root root = null;
+        List<int> orphanedIds = null!;
+        List<int> orphanedIdCs = null!;
+        Root root = null!;
 
         return ExecuteWithStrategyInTransactionAsync(
             async context =>
@@ -1062,7 +1060,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
                 context.ChangeTracker.CascadeDeleteTiming = cascadeDeleteTiming ?? CascadeTiming.Never;
                 context.ChangeTracker.DeleteOrphansTiming = deleteOrphansTiming ?? CascadeTiming.Never;
 
-                var removed = root.OptionalChildrenAk.OrderBy(c => c.Id).First();
+                var removed = root!.OptionalChildrenAk.OrderBy(c => c.Id).First();
 
                 removedId = removed.Id;
                 var orphaned = removed.Children.ToList();
@@ -1122,8 +1120,8 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
                     Assert.DoesNotContain(removedId, root.OptionalChildrenAk.Select(e => e.Id));
 
                     Assert.Empty(context.Set<OptionalAk1>().Where(e => e.Id == removedId));
-                    Assert.Equal(orphanedIds.Count, context.Set<OptionalAk2>().Count(e => orphanedIds.Contains(e.Id)));
-                    Assert.Equal(orphanedIdCs.Count, context.Set<OptionalComposite2>().Count(e => orphanedIdCs.Contains(e.Id)));
+                    Assert.Equal(orphanedIds!.Count, context.Set<OptionalAk2>().Count(e => orphanedIds.Contains(e.Id)));
+                    Assert.Equal(orphanedIdCs!.Count, context.Set<OptionalComposite2>().Count(e => orphanedIdCs.Contains(e.Id)));
                 }
             });
     }
@@ -1144,9 +1142,9 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
         CascadeTiming? deleteOrphansTiming)
     {
         var removedId = 0;
-        List<int> orphanedIds = null;
-        List<int> orphanedIdCs = null;
-        Root root = null;
+        List<int> orphanedIds = null!;
+        List<int> orphanedIdCs = null!;
+        Root root = null!;
 
         return ExecuteWithStrategyInTransactionAsync(
             async context =>
@@ -1159,7 +1157,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
                 context.ChangeTracker.CascadeDeleteTiming = cascadeDeleteTiming ?? CascadeTiming.Never;
                 context.ChangeTracker.DeleteOrphansTiming = deleteOrphansTiming ?? CascadeTiming.Never;
 
-                var removed = root.RequiredChildrenAk.OrderBy(c => c.Id).First();
+                var removed = root!.RequiredChildrenAk.OrderBy(c => c.Id).First();
 
                 removedId = removed.Id;
                 var cascadeRemoved = removed.Children.ToList();
@@ -1223,8 +1221,8 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
                     Assert.DoesNotContain(removedId, root.RequiredChildrenAk.Select(e => e.Id));
 
                     Assert.Empty(context.Set<RequiredAk1>().Where(e => e.Id == removedId));
-                    Assert.Empty(context.Set<RequiredAk2>().Where(e => orphanedIds.Contains(e.Id)));
-                    Assert.Empty(context.Set<RequiredComposite2>().Where(e => orphanedIdCs.Contains(e.Id)));
+                    Assert.Empty(context.Set<RequiredAk2>().Where(e => orphanedIds!.Contains(e.Id)));
+                    Assert.Empty(context.Set<RequiredComposite2>().Where(e => orphanedIdCs!.Contains(e.Id)));
                 }
             });
     }
@@ -1245,8 +1243,8 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
         CascadeTiming? deleteOrphansTiming)
     {
         var removedId = 0;
-        List<int> orphanedIds = null;
-        List<int> orphanedIdCs = null;
+        List<int> orphanedIds = null!;
+        List<int> orphanedIdCs = null!;
 
         return ExecuteWithStrategyInTransactionAsync(
             async context =>
@@ -1351,8 +1349,8 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
                     Assert.DoesNotContain(removedId, root.RequiredChildrenAk.Select(e => e.Id));
 
                     Assert.Empty(context.Set<RequiredAk1>().Where(e => e.Id == removedId));
-                    Assert.Empty(context.Set<RequiredAk2>().Where(e => orphanedIds.Contains(e.Id)));
-                    Assert.Empty(context.Set<RequiredComposite2>().Where(e => orphanedIdCs.Contains(e.Id)));
+                    Assert.Empty(context.Set<RequiredAk2>().Where(e => orphanedIds!.Contains(e.Id)));
+                    Assert.Empty(context.Set<RequiredComposite2>().Where(e => orphanedIdCs!.Contains(e.Id)));
                 }
             });
     }

--- a/test/EFCore.Specification.Tests/GraphUpdates/GraphUpdatesTestBaseOneToOne.cs
+++ b/test/EFCore.Specification.Tests/GraphUpdates/GraphUpdatesTestBaseOneToOne.cs
@@ -7,8 +7,6 @@
 
 namespace Microsoft.EntityFrameworkCore;
 
-#nullable disable
-
 public abstract partial class GraphUpdatesTestBase<TFixture>
     where TFixture : GraphUpdatesTestBase<TFixture>.GraphUpdatesFixtureBase, new()
 {
@@ -102,14 +100,14 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
         var new1 = new OptionalSingle1 { Single = new2 };
         var new1d = new OptionalSingle1Derived { Single = new2d };
         var new1dd = new OptionalSingle1MoreDerived { Single = new2dd };
-        Root root = null;
-        IReadOnlyList<EntityEntry> entries = null;
-        OptionalSingle1 old1 = null;
-        OptionalSingle1Derived old1d = null;
-        OptionalSingle1MoreDerived old1dd = null;
-        OptionalSingle2 old2 = null;
-        OptionalSingle2Derived old2d = null;
-        OptionalSingle2MoreDerived old2dd = null;
+        Root root = null!;
+        IReadOnlyList<EntityEntry> entries = null!;
+        OptionalSingle1 old1 = null!;
+        OptionalSingle1Derived old1d = null!;
+        OptionalSingle1MoreDerived old1dd = null!;
+        OptionalSingle2 old2 = null!;
+        OptionalSingle2Derived old2d = null!;
+        OptionalSingle2MoreDerived old2dd = null!;
 
         return ExecuteWithStrategyInTransactionAsync(
             async context =>
@@ -125,12 +123,12 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
 
                 root = await LoadOptionalGraphAsync(context);
 
-                old1 = root.OptionalSingle;
-                old1d = root.OptionalSingleDerived;
-                old1dd = root.OptionalSingleMoreDerived;
-                old2 = root.OptionalSingle.Single;
-                old2d = (OptionalSingle2Derived)root.OptionalSingleDerived.Single;
-                old2dd = (OptionalSingle2MoreDerived)root.OptionalSingleMoreDerived.Single;
+                old1 = root.OptionalSingle!;
+                old1d = root.OptionalSingleDerived!;
+                old1dd = root.OptionalSingleMoreDerived!;
+                old2 = old1.Single!;
+                old2d = (OptionalSingle2Derived)old1d.Single!;
+                old2dd = (OptionalSingle2MoreDerived)old1dd.Single!;
 
                 if (useExistingEntities)
                 {
@@ -204,17 +202,17 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
             {
                 var loadedRoot = await LoadOptionalGraphAsync(context);
 
-                AssertKeys(root, loadedRoot);
+                AssertKeys(root!, loadedRoot);
                 AssertNavigations(loadedRoot);
 
-                var loaded1 = await context.Set<OptionalSingle1>().SingleAsync(e => e.Id == old1.Id);
-                var loaded1d = await context.Set<OptionalSingle1>().SingleAsync(e => e.Id == old1d.Id);
-                var loaded1dd = await context.Set<OptionalSingle1>().SingleAsync(e => e.Id == old1dd.Id);
-                var loaded2 = await context.Set<OptionalSingle2>().SingleAsync(e => e.Id == old2.Id);
-                var loaded2d = await context.Set<OptionalSingle2>().SingleAsync(e => e.Id == old2d.Id);
-                var loaded2dd = await context.Set<OptionalSingle2>().SingleAsync(e => e.Id == old2dd.Id);
+                var loaded1 = await context.Set<OptionalSingle1>().SingleAsync(e => e.Id == old1!.Id);
+                var loaded1d = await context.Set<OptionalSingle1>().SingleAsync(e => e.Id == old1d!.Id);
+                var loaded1dd = await context.Set<OptionalSingle1>().SingleAsync(e => e.Id == old1dd!.Id);
+                var loaded2 = await context.Set<OptionalSingle2>().SingleAsync(e => e.Id == old2!.Id);
+                var loaded2d = await context.Set<OptionalSingle2>().SingleAsync(e => e.Id == old2d!.Id);
+                var loaded2dd = await context.Set<OptionalSingle2>().SingleAsync(e => e.Id == old2dd!.Id);
 
-                AssertEntries(entries, context.ChangeTracker.Entries().ToList());
+                AssertEntries(entries!, context.ChangeTracker.Entries().ToList());
 
                 Assert.Null(loaded1.Root);
                 Assert.Null(loaded1d.Root);
@@ -264,9 +262,9 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
         ChangeMechanism changeMechanism,
         CascadeTiming? deleteOrphansTiming)
     {
-        Root root = null;
-        OptionalSingle1 old1 = null;
-        OptionalSingle2 old2 = null;
+        Root root = null!;
+        OptionalSingle1 old1 = null!;
+        OptionalSingle2 old2 = null!;
         return ExecuteWithStrategyInTransactionAsync(
             async context =>
             {
@@ -274,8 +272,8 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
 
                 root = await LoadOptionalGraphAsync(context);
 
-                old1 = root.OptionalSingle;
-                old2 = root.OptionalSingle.Single;
+                old1 = root.OptionalSingle!;
+                old2 = old1.Single!;
 
                 if ((changeMechanism & ChangeMechanism.Principal) != 0)
                 {
@@ -310,11 +308,11 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
                 {
                     var loadedRoot = await LoadOptionalGraphAsync(context);
 
-                    AssertKeys(root, loadedRoot);
+                    AssertKeys(root!, loadedRoot);
                     AssertPossiblyNullNavigations(loadedRoot);
 
-                    var loaded1 = await context.Set<OptionalSingle1>().SingleAsync(e => e.Id == old1.Id);
-                    var loaded2 = await context.Set<OptionalSingle2>().SingleAsync(e => e.Id == old2.Id);
+                    var loaded1 = await context.Set<OptionalSingle1>().SingleAsync(e => e.Id == old1!.Id);
+                    var loaded2 = await context.Set<OptionalSingle2>().SingleAsync(e => e.Id == old2!.Id);
 
                     Assert.Null(loaded1.Root);
                     Assert.Same(loaded1, loaded2.Back);
@@ -387,9 +385,9 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
         CascadeTiming? deleteOrphansTiming)
     {
         var newRoot = new Root();
-        Root root = null;
-        OptionalSingle1 old1 = null;
-        OptionalSingle2 old2 = null;
+        Root root = null!;
+        OptionalSingle1 old1 = null!;
+        OptionalSingle2 old2 = null!;
 
         return ExecuteWithStrategyInTransactionAsync(
             async context =>
@@ -407,8 +405,8 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
 
                 context.Entry(newRoot).State = useExistingRoot ? EntityState.Unchanged : EntityState.Added;
 
-                old1 = root.OptionalSingle;
-                old2 = root.OptionalSingle.Single;
+                old1 = root.OptionalSingle!;
+                old2 = old1.Single!;
 
                 if ((changeMechanism & ChangeMechanism.Principal) != 0)
                 {
@@ -441,12 +439,12 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
             {
                 var loadedRoot = await LoadOptionalGraphAsync(context);
 
-                AssertKeys(root, loadedRoot);
+                AssertKeys(root!, loadedRoot);
                 AssertPossiblyNullNavigations(loadedRoot);
 
                 newRoot = await context.Set<Root>().SingleAsync(e => e.Id == newRoot.Id);
-                var loaded1 = await context.Set<OptionalSingle1>().SingleAsync(e => e.Id == old1.Id);
-                var loaded2 = await context.Set<OptionalSingle2>().SingleAsync(e => e.Id == old2.Id);
+                var loaded1 = await context.Set<OptionalSingle1>().SingleAsync(e => e.Id == old1!.Id);
+                var loaded2 = await context.Set<OptionalSingle2>().SingleAsync(e => e.Id == old2!.Id);
 
                 Assert.Same(newRoot, loaded1.Root);
                 Assert.Same(loaded1, loaded2.Back);
@@ -481,10 +479,10 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
 
                 var root = await LoadOptionalGraphAsync(context);
 
-                var removed = root.OptionalSingle;
+                var removed = root.OptionalSingle!;
 
                 removedId = removed.Id;
-                var orphaned = removed.Single;
+                var orphaned = removed.Single!;
                 orphanedId = orphaned.Id;
 
                 context.Remove(removed);
@@ -560,9 +558,9 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
                 context.ChangeTracker.DeleteOrphansTiming = deleteOrphansTiming ?? CascadeTiming.Never;
 
                 var root = await LoadOptionalGraphAsync(context);
-                var parent = root.OptionalSingle;
+                var parent = root.OptionalSingle!;
 
-                var removed = parent.Single;
+                var removed = parent.Single!;
 
                 removedId = removed.Id;
 
@@ -587,7 +585,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
             }, async context =>
             {
                 var root = await LoadOptionalGraphAsync(context);
-                var parent = root.OptionalSingle;
+                var parent = root.OptionalSingle!;
 
                 Assert.Null(parent.Single);
                 Assert.Empty(context.Set<OptionalSingle2>().Where(e => e.Id == removedId));
@@ -615,10 +613,10 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
         return ExecuteWithStrategyInTransactionAsync(
             async context =>
             {
-                var removed = (await LoadOptionalGraphAsync(context)).OptionalSingle;
+                var removed = (await LoadOptionalGraphAsync(context)).OptionalSingle!;
 
                 removedId = removed.Id;
-                orphanedId = removed.Single.Id;
+                orphanedId = removed.Single!.Id;
             }, async context =>
             {
                 context.ChangeTracker.CascadeDeleteTiming = cascadeDeleteTiming ?? CascadeTiming.Never;
@@ -626,8 +624,8 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
 
                 var root = await context.Set<Root>().Include(e => e.OptionalSingle).SingleAsync(IsTheRoot);
 
-                var removed = root.OptionalSingle;
-                var orphaned = removed.Single;
+                var removed = root.OptionalSingle!;
+                var orphaned = removed.Single!;
 
                 context.Remove(removed);
 
@@ -689,7 +687,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
     {
         var removedId = 0;
         var orphanedId = 0;
-        Root root = null;
+        Root root = null!;
 
         return ExecuteWithStrategyInTransactionAsync(
             async context => root = await LoadOptionalGraphAsync(context), async context =>
@@ -697,10 +695,10 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
                 context.ChangeTracker.CascadeDeleteTiming = cascadeDeleteTiming ?? CascadeTiming.Never;
                 context.ChangeTracker.DeleteOrphansTiming = deleteOrphansTiming ?? CascadeTiming.Never;
 
-                var removed = root.OptionalSingle;
+                var removed = root!.OptionalSingle!;
 
                 removedId = removed.Id;
-                var orphaned = removed.Single;
+                var orphaned = removed.Single!;
                 orphanedId = orphaned.Id;
 
                 context.Remove(removed);
@@ -814,16 +812,16 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
         // entity. EF7 can't track two different instances of the same entity, so this has to be
         // done in two steps.
 
-        Root oldRoot = null;
-        IReadOnlyList<EntityEntry> entries = null;
-        RequiredSingle1 old1 = null;
-        RequiredSingle2 old2 = null;
+        Root oldRoot = null!;
+        IReadOnlyList<EntityEntry> entries = null!;
+        RequiredSingle1 old1 = null!;
+        RequiredSingle2 old2 = null!;
         await ExecuteWithStrategyInTransactionAsync(async context =>
         {
             oldRoot = await LoadRequiredGraphAsync(context);
 
-            old1 = oldRoot.RequiredSingle;
-            old2 = oldRoot.RequiredSingle.Single;
+            old1 = oldRoot.RequiredSingle!;
+            old2 = old1.Single;
         });
 
         var new2 = new RequiredSingle2();
@@ -883,8 +881,8 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
                     Assert.Same(root, new1.Root);
                     Assert.Same(new1, new2.Back);
 
-                    Assert.Same(oldRoot, old1.Root);
-                    Assert.Same(old1, old2.Back);
+                    Assert.Same(oldRoot, old1!.Root);
+                    Assert.Same(old1, old2!.Back);
                     Assert.Equal(old1.Id, old2.Id);
 
                     entries = context.ChangeTracker.Entries().ToList();
@@ -896,8 +894,8 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
                 {
                     var loadedRoot = await LoadRequiredGraphAsync(context);
 
-                    AssertEntries(entries, context.ChangeTracker.Entries().ToList());
-                    AssertKeys(oldRoot, loadedRoot);
+                    AssertEntries(entries!, context.ChangeTracker.Entries().ToList());
+                    AssertKeys(oldRoot!, loadedRoot);
                     AssertNavigations(loadedRoot);
                 }
             });
@@ -982,14 +980,14 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
             RequiredNonPkSingleDerived = new1d,
             RequiredNonPkSingleMoreDerived = new1dd
         };
-        Root root = null;
-        IReadOnlyList<EntityEntry> entries = null;
-        RequiredNonPkSingle1 old1 = null;
-        RequiredNonPkSingle1Derived old1d = null;
-        RequiredNonPkSingle1MoreDerived old1dd = null;
-        RequiredNonPkSingle2 old2 = null;
-        RequiredNonPkSingle2Derived old2d = null;
-        RequiredNonPkSingle2MoreDerived old2dd = null;
+        Root root = null!;
+        IReadOnlyList<EntityEntry> entries = null!;
+        RequiredNonPkSingle1 old1 = null!;
+        RequiredNonPkSingle1Derived old1d = null!;
+        RequiredNonPkSingle1MoreDerived old1dd = null!;
+        RequiredNonPkSingle2 old2 = null!;
+        RequiredNonPkSingle2Derived old2d = null!;
+        RequiredNonPkSingle2MoreDerived old2dd = null!;
 
         return ExecuteWithStrategyInTransactionAsync(
             async context =>
@@ -1127,16 +1125,16 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
                 {
                     var loadedRoot = await LoadRequiredNonPkGraphAsync(context);
 
-                    AssertEntries(entries, context.ChangeTracker.Entries().ToList());
-                    AssertKeys(root, loadedRoot);
+                    AssertEntries(entries!, context.ChangeTracker.Entries().ToList());
+                    AssertKeys(root!, loadedRoot);
                     AssertNavigations(loadedRoot);
 
-                    Assert.False(context.Set<RequiredNonPkSingle1>().Any(e => e.Id == old1.Id));
-                    Assert.False(context.Set<RequiredNonPkSingle1>().Any(e => e.Id == old1d.Id));
-                    Assert.False(context.Set<RequiredNonPkSingle1>().Any(e => e.Id == old1dd.Id));
-                    Assert.False(context.Set<RequiredNonPkSingle2>().Any(e => e.Id == old2.Id));
-                    Assert.False(context.Set<RequiredNonPkSingle2>().Any(e => e.Id == old2d.Id));
-                    Assert.False(context.Set<RequiredNonPkSingle2>().Any(e => e.Id == old2dd.Id));
+                    Assert.False(context.Set<RequiredNonPkSingle1>().Any(e => e.Id == old1!.Id));
+                    Assert.False(context.Set<RequiredNonPkSingle1>().Any(e => e.Id == old1d!.Id));
+                    Assert.False(context.Set<RequiredNonPkSingle1>().Any(e => e.Id == old1dd!.Id));
+                    Assert.False(context.Set<RequiredNonPkSingle2>().Any(e => e.Id == old2!.Id));
+                    Assert.False(context.Set<RequiredNonPkSingle2>().Any(e => e.Id == old2d!.Id));
+                    Assert.False(context.Set<RequiredNonPkSingle2>().Any(e => e.Id == old2dd!.Id));
                 }
             });
     }
@@ -1158,9 +1156,9 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
         ChangeMechanism changeMechanism,
         CascadeTiming? deleteOrphansTiming)
     {
-        Root root = null;
-        RequiredSingle1 old1 = null;
-        RequiredSingle2 old2 = null;
+        Root root = null!;
+        RequiredSingle1 old1 = null!;
+        RequiredSingle2 old2 = null!;
         return ExecuteWithStrategyInTransactionAsync(
             async context =>
             {
@@ -1168,8 +1166,8 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
 
                 root = await LoadRequiredGraphAsync(context);
 
-                old1 = root.RequiredSingle;
-                old2 = root.RequiredSingle.Single;
+                old1 = root.RequiredSingle!;
+                old2 = old1.Single;
 
                 if ((changeMechanism & ChangeMechanism.Principal) != 0)
                 {
@@ -1178,7 +1176,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
 
                 if ((changeMechanism & ChangeMechanism.Dependent) != 0)
                 {
-                    old1.Root = null;
+                    old1.Root = null!;
                 }
 
                 if ((changeMechanism & ChangeMechanism.Fk) != 0)
@@ -1220,19 +1218,19 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
                 {
                     var loadedRoot = await LoadRequiredGraphAsync(context);
 
-                    AssertKeys(root, loadedRoot);
+                    AssertKeys(root!, loadedRoot);
                     AssertPossiblyNullNavigations(loadedRoot);
 
-                    var removedCount = context.Set<Root>().Select(r => r.RequiredSingle).Count(e => e.Id == old1.Id);
+                    var removedCount = context.Set<Root>().Select(r => r.RequiredSingle!).Count(e => e.Id == old1!.Id);
                     Assert.Equal(0, removedCount);
 
                     Assert.False(context.Set<Root>().Any(r => r.RequiredSingle != null));
 
-                    var orphanedCount = context.Set<Root>().Select(r => r.RequiredSingle).Select(r => r.Single)
-                        .Count(e => e.Id == old2.Id);
+                    var orphanedCount = context.Set<Root>().Select(r => r.RequiredSingle!).Select(r => r.Single)
+                        .Count(e => e.Id == old2!.Id);
                     Assert.Equal(0, orphanedCount);
 
-                    Assert.False(context.Set<Root>().Select(r => r.RequiredSingle).Any(r => r.Single != null));
+                    Assert.False(context.Set<Root>().Select(r => r.RequiredSingle!).Any(r => r.Single != null));
                 }
             });
     }
@@ -1254,9 +1252,9 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
         ChangeMechanism changeMechanism,
         CascadeTiming? deleteOrphansTiming)
     {
-        Root root = null;
-        RequiredNonPkSingle1 old1 = null;
-        RequiredNonPkSingle2 old2 = null;
+        Root root = null!;
+        RequiredNonPkSingle1 old1 = null!;
+        RequiredNonPkSingle2 old2 = null!;
         return ExecuteWithStrategyInTransactionAsync(
             async context =>
             {
@@ -1269,12 +1267,12 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
 
                 if ((changeMechanism & ChangeMechanism.Principal) != 0)
                 {
-                    root.RequiredNonPkSingle = null;
+                    root.RequiredNonPkSingle = null!;
                 }
 
                 if ((changeMechanism & ChangeMechanism.Dependent) != 0)
                 {
-                    old1.Root = null;
+                    old1.Root = null!;
                 }
 
                 if ((changeMechanism & ChangeMechanism.Fk) != 0)
@@ -1333,11 +1331,11 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
                 {
                     var loadedRoot = await LoadRequiredNonPkGraphAsync(context);
 
-                    AssertKeys(root, loadedRoot);
+                    AssertKeys(root!, loadedRoot);
                     AssertPossiblyNullNavigations(loadedRoot);
 
-                    Assert.False(context.Set<RequiredNonPkSingle1>().Any(e => e.Id == old1.Id));
-                    Assert.False(context.Set<RequiredNonPkSingle2>().Any(e => e.Id == old2.Id));
+                    Assert.False(context.Set<RequiredNonPkSingle1>().Any(e => e.Id == old1!.Id));
+                    Assert.False(context.Set<RequiredNonPkSingle2>().Any(e => e.Id == old2!.Id));
                 }
             });
     }
@@ -1435,12 +1433,12 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
 
                         if ((changeMechanism & ChangeMechanism.Dependent) != 0)
                         {
-                            root.RequiredSingle.Root = newRoot;
+                            root.RequiredSingle!.Root = newRoot;
                         }
 
                         if ((changeMechanism & ChangeMechanism.Fk) != 0)
                         {
-                            root.RequiredSingle.Id = newRoot.Id;
+                            root.RequiredSingle!.Id = newRoot.Id;
                         }
 
                         newRoot.RequiredSingle = root.RequiredSingle;
@@ -1513,9 +1511,9 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
         CascadeTiming? deleteOrphansTiming)
     {
         var newRoot = new Root();
-        Root root = null;
-        RequiredNonPkSingle1 old1 = null;
-        RequiredNonPkSingle2 old2 = null;
+        Root root = null!;
+        RequiredNonPkSingle1 old1 = null!;
+        RequiredNonPkSingle2 old2 = null!;
 
         return ExecuteWithStrategyInTransactionAsync(
             async context =>
@@ -1567,12 +1565,12 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
             {
                 var loadedRoot = await LoadRequiredNonPkGraphAsync(context);
 
-                AssertKeys(root, loadedRoot);
+                AssertKeys(root!, loadedRoot);
                 AssertPossiblyNullNavigations(loadedRoot);
 
                 newRoot = await context.Set<Root>().SingleAsync(e => e.Id == newRoot.Id);
-                var loaded1 = await context.Set<RequiredNonPkSingle1>().SingleAsync(e => e.Id == old1.Id);
-                var loaded2 = await context.Set<RequiredNonPkSingle2>().SingleAsync(e => e.Id == old2.Id);
+                var loaded1 = await context.Set<RequiredNonPkSingle1>().SingleAsync(e => e.Id == old1!.Id);
+                var loaded2 = await context.Set<RequiredNonPkSingle2>().SingleAsync(e => e.Id == old2!.Id);
 
                 Assert.Same(newRoot, loaded1.Root);
                 Assert.Same(loaded1, loaded2.Back);
@@ -1607,7 +1605,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
 
                 var root = await LoadRequiredGraphAsync(context);
 
-                var removed = root.RequiredSingle;
+                var removed = root.RequiredSingle!;
 
                 removedId = removed.Id;
                 var orphaned = removed.Single;
@@ -1658,16 +1656,16 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
 
                     Assert.Null(root.RequiredSingle);
 
-                    var removedCount = context.Set<Root>().Select(r => r.RequiredSingle).Count(e => e.Id == removedId);
+                    var removedCount = context.Set<Root>().Select(r => r.RequiredSingle!).Count(e => e.Id == removedId);
                     Assert.Equal(0, removedCount);
 
                     Assert.False(context.Set<Root>().Any(r => r.RequiredSingle != null));
 
-                    var orphanedCount = context.Set<Root>().Select(r => r.RequiredSingle).Select(r => r.Single)
+                    var orphanedCount = context.Set<Root>().Select(r => r.RequiredSingle!).Select(r => r.Single)
                         .Count(e => e.Id == orphanedId);
                     Assert.Equal(0, orphanedCount);
 
-                    Assert.False(context.Set<Root>().Select(r => r.RequiredSingle).Any(r => r.Single != null));
+                    Assert.False(context.Set<Root>().Select(r => r.RequiredSingle!).Any(r => r.Single != null));
                 }
             });
     }
@@ -1696,7 +1694,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
                 context.ChangeTracker.DeleteOrphansTiming = deleteOrphansTiming ?? CascadeTiming.Never;
 
                 var root = await LoadRequiredGraphAsync(context);
-                var parent = root.RequiredSingle;
+                var parent = root.RequiredSingle!;
 
                 var removed = parent.Single;
 
@@ -1722,15 +1720,15 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
             }, async context =>
             {
                 var root = await LoadRequiredGraphAsync(context);
-                var parent = root.RequiredSingle;
+                var parent = root.RequiredSingle!;
 
                 Assert.Null(parent.Single);
 
-                var removedCount = context.Set<Root>().Select(r => r.RequiredSingle).Select(r => r.Single)
+                var removedCount = context.Set<Root>().Select(r => r.RequiredSingle!).Select(r => r.Single)
                     .Count(e => e.Id == removedId);
                 Assert.Equal(0, removedCount);
 
-                Assert.False(context.Set<Root>().Select(r => r.RequiredSingle).Any(r => r.Single != null));
+                Assert.False(context.Set<Root>().Select(r => r.RequiredSingle!).Any(r => r.Single != null));
             });
     }
 
@@ -1898,7 +1896,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
         return ExecuteWithStrategyInTransactionAsync(
             async context =>
             {
-                var removed = (await LoadRequiredGraphAsync(context)).RequiredSingle;
+                var removed = (await LoadRequiredGraphAsync(context)).RequiredSingle!;
 
                 removedId = removed.Id;
                 orphanedId = removed.Single.Id;
@@ -1909,7 +1907,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
 
                 var root = await context.Set<Root>().Include(e => e.RequiredSingle).SingleAsync(IsTheRoot);
 
-                var removed = root.RequiredSingle;
+                var removed = root.RequiredSingle!;
                 var orphaned = removed.Single;
 
                 context.Remove(removed);
@@ -2051,7 +2049,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
     {
         var removedId = 0;
         var orphanedId = 0;
-        Root root = null;
+        Root root = null!;
 
         return ExecuteWithStrategyInTransactionAsync(
             async context => root = await LoadRequiredGraphAsync(context), async context =>
@@ -2059,7 +2057,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
                 context.ChangeTracker.CascadeDeleteTiming = cascadeDeleteTiming ?? CascadeTiming.Never;
                 context.ChangeTracker.DeleteOrphansTiming = deleteOrphansTiming ?? CascadeTiming.Never;
 
-                var removed = root.RequiredSingle;
+                var removed = root!.RequiredSingle!;
 
                 removedId = removed.Id;
                 var orphaned = removed.Single;
@@ -2111,18 +2109,18 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
                 if (!Fixture.ForceClientNoAction
                     && cascadeDeleteTiming != CascadeTiming.Never)
                 {
-                    Assert.Null(root.RequiredSingle);
+                    Assert.Null(root!.RequiredSingle);
 
-                    var removedCount = context.Set<Root>().Select(r => r.RequiredSingle).Count(e => e.Id == removedId);
+                    var removedCount = context.Set<Root>().Select(r => r.RequiredSingle!).Count(e => e.Id == removedId);
                     Assert.Equal(0, removedCount);
 
                     Assert.False(context.Set<Root>().Any(r => r.RequiredSingle != null));
 
-                    var orphanedCount = context.Set<Root>().Select(r => r.RequiredSingle).Select(r => r.Single)
+                    var orphanedCount = context.Set<Root>().Select(r => r.RequiredSingle!).Select(r => r.Single)
                         .Count(e => e.Id == orphanedId);
                     Assert.Equal(0, orphanedCount);
 
-                    Assert.False(context.Set<Root>().Select(r => r.RequiredSingle).Any(r => r.Single != null));
+                    Assert.False(context.Set<Root>().Select(r => r.RequiredSingle!).Any(r => r.Single != null));
                 }
 
                 return Task.CompletedTask;
@@ -2146,7 +2144,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
     {
         var removedId = 0;
         var orphanedId = 0;
-        Root root = null;
+        Root root = null!;
 
         return ExecuteWithStrategyInTransactionAsync(
             async context => root = await LoadRequiredNonPkGraphAsync(context), async context =>
@@ -2154,7 +2152,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
                 context.ChangeTracker.CascadeDeleteTiming = cascadeDeleteTiming ?? CascadeTiming.Never;
                 context.ChangeTracker.DeleteOrphansTiming = deleteOrphansTiming ?? CascadeTiming.Never;
 
-                var removed = root.RequiredNonPkSingle;
+                var removed = root!.RequiredNonPkSingle;
 
                 removedId = removed.Id;
                 var orphaned = removed.Single;
@@ -2241,7 +2239,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
 
                 var root = await LoadRequiredGraphAsync(context);
 
-                var removed = root.RequiredSingle;
+                var removed = root.RequiredSingle!;
 
                 removedId = removed.Id;
                 var orphaned = removed.Single;
@@ -2308,16 +2306,16 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
 
                     Assert.Null(root.RequiredSingle);
 
-                    var removedCount = context.Set<Root>().Select(r => r.RequiredSingle).Count(e => e.Id == removedId);
+                    var removedCount = context.Set<Root>().Select(r => r.RequiredSingle!).Count(e => e.Id == removedId);
                     Assert.Equal(0, removedCount);
 
                     Assert.False(context.Set<Root>().Any(r => r.RequiredSingle != null));
 
-                    var orphanedCount = context.Set<Root>().Select(r => r.RequiredSingle).Select(r => r.Single)
+                    var orphanedCount = context.Set<Root>().Select(r => r.RequiredSingle!).Select(r => r.Single)
                         .Count(e => e.Id == orphanedId);
                     Assert.Equal(0, orphanedCount);
 
-                    Assert.False(context.Set<Root>().Select(r => r.RequiredSingle).Any(r => r.Single != null));
+                    Assert.False(context.Set<Root>().Select(r => r.RequiredSingle!).Any(r => r.Single != null));
                 }
             });
     }

--- a/test/EFCore.Specification.Tests/GraphUpdates/GraphUpdatesTestBaseOneToOneAk.cs
+++ b/test/EFCore.Specification.Tests/GraphUpdates/GraphUpdatesTestBaseOneToOneAk.cs
@@ -7,8 +7,6 @@
 
 namespace Microsoft.EntityFrameworkCore;
 
-#nullable disable
-
 public abstract partial class GraphUpdatesTestBase<TFixture>
     where TFixture : GraphUpdatesTestBase<TFixture>.GraphUpdatesFixtureBase, new()
 {
@@ -107,15 +105,15 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
         };
         var new1d = new OptionalSingleAk1Derived { AlternateId = Guid.NewGuid(), Single = new2d };
         var new1dd = new OptionalSingleAk1MoreDerived { AlternateId = Guid.NewGuid(), Single = new2dd };
-        Root root = null;
-        IReadOnlyList<EntityEntry> entries = null;
-        OptionalSingleAk1 old1 = null;
-        OptionalSingleAk1Derived old1d = null;
-        OptionalSingleAk1MoreDerived old1dd = null;
-        OptionalSingleAk2 old2 = null;
-        OptionalSingleComposite2 old2c = null;
-        OptionalSingleAk2Derived old2d = null;
-        OptionalSingleAk2MoreDerived old2dd = null;
+        Root root = null!;
+        IReadOnlyList<EntityEntry> entries = null!;
+        OptionalSingleAk1 old1 = null!;
+        OptionalSingleAk1Derived old1d = null!;
+        OptionalSingleAk1MoreDerived old1dd = null!;
+        OptionalSingleAk2 old2 = null!;
+        OptionalSingleComposite2 old2c = null!;
+        OptionalSingleAk2Derived old2d = null!;
+        OptionalSingleAk2MoreDerived old2dd = null!;
 
         return ExecuteWithStrategyInTransactionAsync(
             async context =>
@@ -131,13 +129,13 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
 
                 root = await LoadOptionalAkGraphAsync(context);
 
-                old1 = root.OptionalSingleAk;
-                old1d = root.OptionalSingleAkDerived;
-                old1dd = root.OptionalSingleAkMoreDerived;
-                old2 = root.OptionalSingleAk.Single;
-                old2c = root.OptionalSingleAk.SingleComposite;
-                old2d = (OptionalSingleAk2Derived)root.OptionalSingleAkDerived.Single;
-                old2dd = (OptionalSingleAk2MoreDerived)root.OptionalSingleAkMoreDerived.Single;
+                old1 = root.OptionalSingleAk!;
+                old1d = root.OptionalSingleAkDerived!;
+                old1dd = root.OptionalSingleAkMoreDerived!;
+                old2 = old1.Single!;
+                old2c = old1.SingleComposite!;
+                old2d = (OptionalSingleAk2Derived)old1d.Single!;
+                old2dd = (OptionalSingleAk2MoreDerived)old1dd.Single!;
 
                 if (useExistingEntities)
                 {
@@ -218,18 +216,18 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
             {
                 var loadedRoot = await LoadOptionalAkGraphAsync(context);
 
-                AssertKeys(root, loadedRoot);
+                AssertKeys(root!, loadedRoot);
                 AssertNavigations(loadedRoot);
 
-                var loaded1 = await context.Set<OptionalSingleAk1>().SingleAsync(e => e.Id == old1.Id);
-                var loaded1d = await context.Set<OptionalSingleAk1>().SingleAsync(e => e.Id == old1d.Id);
-                var loaded1dd = await context.Set<OptionalSingleAk1>().SingleAsync(e => e.Id == old1dd.Id);
-                var loaded2 = await context.Set<OptionalSingleAk2>().SingleAsync(e => e.Id == old2.Id);
-                var loaded2d = await context.Set<OptionalSingleAk2>().SingleAsync(e => e.Id == old2d.Id);
-                var loaded2dd = await context.Set<OptionalSingleAk2>().SingleAsync(e => e.Id == old2dd.Id);
-                var loaded2c = await context.Set<OptionalSingleComposite2>().SingleAsync(e => e.Id == old2c.Id);
+                var loaded1 = await context.Set<OptionalSingleAk1>().SingleAsync(e => e.Id == old1!.Id);
+                var loaded1d = await context.Set<OptionalSingleAk1>().SingleAsync(e => e.Id == old1d!.Id);
+                var loaded1dd = await context.Set<OptionalSingleAk1>().SingleAsync(e => e.Id == old1dd!.Id);
+                var loaded2 = await context.Set<OptionalSingleAk2>().SingleAsync(e => e.Id == old2!.Id);
+                var loaded2d = await context.Set<OptionalSingleAk2>().SingleAsync(e => e.Id == old2d!.Id);
+                var loaded2dd = await context.Set<OptionalSingleAk2>().SingleAsync(e => e.Id == old2dd!.Id);
+                var loaded2c = await context.Set<OptionalSingleComposite2>().SingleAsync(e => e.Id == old2c!.Id);
 
-                AssertEntries(entries, context.ChangeTracker.Entries().ToList());
+                AssertEntries(entries!, context.ChangeTracker.Entries().ToList());
 
                 Assert.Null(loaded1.Root);
                 Assert.Null(loaded1d.Root);
@@ -264,32 +262,32 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
         };
         var new1d = new OptionalSingleAk1Derived { AlternateId = Guid.NewGuid(), Single = new2d };
         var new1dd = new OptionalSingleAk1MoreDerived { AlternateId = Guid.NewGuid(), Single = new2dd };
-        Root root = null;
-        IReadOnlyList<EntityEntry> entries = null;
-        OptionalSingleAk1 old1 = null;
-        OptionalSingleAk1Derived old1d = null;
-        OptionalSingleAk1MoreDerived old1dd = null;
-        OptionalSingleAk2 old2 = null;
-        OptionalSingleComposite2 old2c = null;
-        OptionalSingleAk2Derived old2d = null;
-        OptionalSingleAk2MoreDerived old2dd = null;
+        Root root = null!;
+        IReadOnlyList<EntityEntry> entries = null!;
+        OptionalSingleAk1 old1 = null!;
+        OptionalSingleAk1Derived old1d = null!;
+        OptionalSingleAk1MoreDerived old1dd = null!;
+        OptionalSingleAk2 old2 = null!;
+        OptionalSingleComposite2 old2c = null!;
+        OptionalSingleAk2Derived old2d = null!;
+        OptionalSingleAk2MoreDerived old2dd = null!;
 
         return ExecuteWithStrategyInTransactionAsync(
             async context =>
             {
                 root = await LoadOptionalAkGraphAsync(context);
 
-                old1 = root.OptionalSingleAk;
-                old1d = root.OptionalSingleAkDerived;
-                old1dd = root.OptionalSingleAkMoreDerived;
-                old2 = root.OptionalSingleAk.Single;
-                old2c = root.OptionalSingleAk.SingleComposite;
-                old2d = (OptionalSingleAk2Derived)root.OptionalSingleAkDerived.Single;
-                old2dd = (OptionalSingleAk2MoreDerived)root.OptionalSingleAkMoreDerived.Single;
+                old1 = root.OptionalSingleAk!;
+                old1d = root.OptionalSingleAkDerived!;
+                old1dd = root.OptionalSingleAkMoreDerived!;
+                old2 = old1.Single!;
+                old2c = old1.SingleComposite!;
+                old2d = (OptionalSingleAk2Derived)old1d.Single!;
+                old2dd = (OptionalSingleAk2MoreDerived)old1dd.Single!;
 
                 using (var context2 = CreateContext())
                 {
-                    UseTransaction(context2.Database, context.Database.CurrentTransaction);
+                    UseTransaction(context2.Database, context.Database.CurrentTransaction!);
                     var root2 = await LoadOptionalAkGraphAsync(context2);
 
                     context2.AddRange(new1, new1d, new1dd, new2, new2d, new2dd, new2c);
@@ -387,18 +385,18 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
             {
                 var loadedRoot = await LoadOptionalAkGraphAsync(context);
 
-                AssertKeys(root, loadedRoot);
+                AssertKeys(root!, loadedRoot);
                 AssertNavigations(loadedRoot);
 
-                var loaded1 = await context.Set<OptionalSingleAk1>().SingleAsync(e => e.Id == old1.Id);
-                var loaded1d = await context.Set<OptionalSingleAk1>().SingleAsync(e => e.Id == old1d.Id);
-                var loaded1dd = await context.Set<OptionalSingleAk1>().SingleAsync(e => e.Id == old1dd.Id);
-                var loaded2 = await context.Set<OptionalSingleAk2>().SingleAsync(e => e.Id == old2.Id);
-                var loaded2d = await context.Set<OptionalSingleAk2>().SingleAsync(e => e.Id == old2d.Id);
-                var loaded2dd = await context.Set<OptionalSingleAk2>().SingleAsync(e => e.Id == old2dd.Id);
-                var loaded2c = await context.Set<OptionalSingleComposite2>().SingleAsync(e => e.Id == old2c.Id);
+                var loaded1 = await context.Set<OptionalSingleAk1>().SingleAsync(e => e.Id == old1!.Id);
+                var loaded1d = await context.Set<OptionalSingleAk1>().SingleAsync(e => e.Id == old1d!.Id);
+                var loaded1dd = await context.Set<OptionalSingleAk1>().SingleAsync(e => e.Id == old1dd!.Id);
+                var loaded2 = await context.Set<OptionalSingleAk2>().SingleAsync(e => e.Id == old2!.Id);
+                var loaded2d = await context.Set<OptionalSingleAk2>().SingleAsync(e => e.Id == old2d!.Id);
+                var loaded2dd = await context.Set<OptionalSingleAk2>().SingleAsync(e => e.Id == old2dd!.Id);
+                var loaded2c = await context.Set<OptionalSingleComposite2>().SingleAsync(e => e.Id == old2c!.Id);
 
-                AssertEntries(entries, context.ChangeTracker.Entries().ToList());
+                AssertEntries(entries!, context.ChangeTracker.Entries().ToList());
 
                 Assert.Null(loaded1.Root);
                 Assert.Null(loaded1d.Root);
@@ -451,10 +449,10 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
         ChangeMechanism changeMechanism,
         CascadeTiming? deleteOrphansTiming)
     {
-        Root root = null;
-        OptionalSingleAk1 old1 = null;
-        OptionalSingleAk2 old2 = null;
-        OptionalSingleComposite2 old2c = null;
+        Root root = null!;
+        OptionalSingleAk1 old1 = null!;
+        OptionalSingleAk2 old2 = null!;
+        OptionalSingleComposite2 old2c = null!;
         return ExecuteWithStrategyInTransactionAsync(
             async context =>
             {
@@ -462,9 +460,9 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
 
                 root = await LoadOptionalAkGraphAsync(context);
 
-                old1 = root.OptionalSingleAk;
-                old2 = root.OptionalSingleAk.Single;
-                old2c = root.OptionalSingleAk.SingleComposite;
+                old1 = root.OptionalSingleAk!;
+                old2 = old1.Single!;
+                old2c = old1.SingleComposite!;
 
                 if ((changeMechanism & ChangeMechanism.Principal) != 0)
                 {
@@ -502,12 +500,12 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
                 {
                     var loadedRoot = await LoadOptionalAkGraphAsync(context);
 
-                    AssertKeys(root, loadedRoot);
+                    AssertKeys(root!, loadedRoot);
                     AssertPossiblyNullNavigations(loadedRoot);
 
-                    var loaded1 = await context.Set<OptionalSingleAk1>().SingleAsync(e => e.Id == old1.Id);
-                    var loaded2 = await context.Set<OptionalSingleAk2>().SingleAsync(e => e.Id == old2.Id);
-                    var loaded2c = await context.Set<OptionalSingleComposite2>().SingleAsync(e => e.Id == old2c.Id);
+                    var loaded1 = await context.Set<OptionalSingleAk1>().SingleAsync(e => e.Id == old1!.Id);
+                    var loaded2 = await context.Set<OptionalSingleAk2>().SingleAsync(e => e.Id == old2!.Id);
+                    var loaded2c = await context.Set<OptionalSingleComposite2>().SingleAsync(e => e.Id == old2c!.Id);
 
                     Assert.Null(loaded1.Root);
                     Assert.Same(loaded1, loaded2.Back);
@@ -583,10 +581,10 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
         CascadeTiming? deleteOrphansTiming)
     {
         var newRoot = new Root { AlternateId = Guid.NewGuid() };
-        Root root = null;
-        OptionalSingleAk1 old1 = null;
-        OptionalSingleAk2 old2 = null;
-        OptionalSingleComposite2 old2c = null;
+        Root root = null!;
+        OptionalSingleAk1 old1 = null!;
+        OptionalSingleAk2 old2 = null!;
+        OptionalSingleComposite2 old2c = null!;
 
         return ExecuteWithStrategyInTransactionAsync(
             async context =>
@@ -604,9 +602,9 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
 
                 context.Entry(newRoot).State = useExistingRoot ? EntityState.Unchanged : EntityState.Added;
 
-                old1 = root.OptionalSingleAk;
-                old2 = root.OptionalSingleAk.Single;
-                old2c = root.OptionalSingleAk.SingleComposite;
+                old1 = root.OptionalSingleAk!;
+                old2 = old1.Single!;
+                old2c = old1.SingleComposite!;
 
                 if ((changeMechanism & ChangeMechanism.Principal) != 0)
                 {
@@ -642,13 +640,13 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
             {
                 var loadedRoot = await LoadOptionalAkGraphAsync(context);
 
-                AssertKeys(root, loadedRoot);
+                AssertKeys(root!, loadedRoot);
                 AssertPossiblyNullNavigations(loadedRoot);
 
                 newRoot = await context.Set<Root>().SingleAsync(e => e.Id == newRoot.Id);
-                var loaded1 = await context.Set<OptionalSingleAk1>().SingleAsync(e => e.Id == old1.Id);
-                var loaded2 = await context.Set<OptionalSingleAk2>().SingleAsync(e => e.Id == old2.Id);
-                var loaded2c = await context.Set<OptionalSingleComposite2>().SingleAsync(e => e.Id == old2c.Id);
+                var loaded1 = await context.Set<OptionalSingleAk1>().SingleAsync(e => e.Id == old1!.Id);
+                var loaded2 = await context.Set<OptionalSingleAk2>().SingleAsync(e => e.Id == old2!.Id);
+                var loaded2c = await context.Set<OptionalSingleComposite2>().SingleAsync(e => e.Id == old2c!.Id);
 
                 Assert.Same(newRoot, loaded1.Root);
                 Assert.Same(loaded1, loaded2.Back);
@@ -687,11 +685,11 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
 
                 var root = await LoadOptionalAkGraphAsync(context);
 
-                var removed = root.OptionalSingleAk;
+                var removed = root.OptionalSingleAk!;
 
                 removedId = removed.Id;
-                var orphaned = removed.Single;
-                var orphanedC = removed.SingleComposite;
+                var orphaned = removed.Single!;
+                var orphanedC = removed.SingleComposite!;
                 orphanedId = orphaned.Id;
                 orphanedIdC = orphanedC.Id;
 
@@ -778,11 +776,11 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
         return ExecuteWithStrategyInTransactionAsync(
             async context =>
             {
-                var removed = (await LoadOptionalAkGraphAsync(context)).OptionalSingleAk;
+                var removed = (await LoadOptionalAkGraphAsync(context)).OptionalSingleAk!;
 
                 removedId = removed.Id;
-                orphanedId = removed.Single.Id;
-                orphanedIdC = removed.SingleComposite.Id;
+                orphanedId = removed.Single!.Id;
+                orphanedIdC = removed.SingleComposite!.Id;
             }, async context =>
             {
                 context.ChangeTracker.CascadeDeleteTiming = cascadeDeleteTiming ?? CascadeTiming.Never;
@@ -790,8 +788,8 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
 
                 var root = await context.Set<Root>().Include(e => e.OptionalSingleAk).SingleAsync(IsTheRoot);
 
-                var removed = root.OptionalSingleAk;
-                var orphaned = removed.Single;
+                var removed = root.OptionalSingleAk!;
+                var orphaned = removed.Single!;
 
                 context.Remove(removed);
 
@@ -860,7 +858,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
         var removedId = 0;
         var orphanedId = 0;
         var orphanedIdC = 0;
-        Root root = null;
+        Root root = null!;
 
         return ExecuteWithStrategyInTransactionAsync(
             async context => root = await LoadOptionalAkGraphAsync(context), async context =>
@@ -868,11 +866,11 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
                 context.ChangeTracker.CascadeDeleteTiming = cascadeDeleteTiming ?? CascadeTiming.Never;
                 context.ChangeTracker.DeleteOrphansTiming = deleteOrphansTiming ?? CascadeTiming.Never;
 
-                var removed = root.OptionalSingleAk;
+                var removed = root!.OptionalSingleAk!;
 
                 removedId = removed.Id;
-                var orphaned = removed.Single;
-                var orphanedC = removed.SingleComposite;
+                var orphaned = removed.Single!;
+                var orphanedC = removed.SingleComposite!;
                 orphanedId = orphaned.Id;
                 orphanedIdC = orphanedC.Id;
 
@@ -991,11 +989,11 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
             SingleComposite = new2c
         };
         var newRoot = new Root { AlternateId = Guid.NewGuid(), RequiredSingleAk = new1 };
-        Root root = null;
-        IReadOnlyList<EntityEntry> entries = null;
-        RequiredSingleAk1 old1 = null;
-        RequiredSingleAk2 old2 = null;
-        RequiredSingleComposite2 old2c = null;
+        Root root = null!;
+        IReadOnlyList<EntityEntry> entries = null!;
+        RequiredSingleAk1 old1 = null!;
+        RequiredSingleAk2 old2 = null!;
+        RequiredSingleComposite2 old2c = null!;
 
         return ExecuteWithStrategyInTransactionAsync(
             async context =>
@@ -1011,19 +1009,19 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
 
                 root = await LoadRequiredAkGraphAsync(context);
 
-                old1 = root.RequiredSingleAk;
-                old2 = root.RequiredSingleAk.Single;
-                old2c = root.RequiredSingleAk.SingleComposite;
+                old1 = root.RequiredSingleAk!;
+                old2 = old1.Single;
+                old2c = old1.SingleComposite;
 
                 if (useExistingEntities)
                 {
                     newRoot = await context.Set<Root>()
-                        .Include(e => e.RequiredSingleAk).ThenInclude(e => e.Single)
-                        .Include(e => e.RequiredSingleAk).ThenInclude(e => e.SingleComposite)
+                        .Include(e => e.RequiredSingleAk).ThenInclude(e => e!.Single)
+                        .Include(e => e.RequiredSingleAk).ThenInclude(e => e!.SingleComposite)
                         .OrderBy(e => e.Id)
                         .SingleAsync(e => e.Id == newRoot.Id);
 
-                    new1 = newRoot.RequiredSingleAk;
+                    new1 = newRoot.RequiredSingleAk!;
                     new2 = new1.Single;
                     new2c = new1.SingleComposite;
                 }
@@ -1121,30 +1119,30 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
                 {
                     var loadedRoot = await LoadRequiredAkGraphAsync(context);
 
-                    AssertEntries(entries, context.ChangeTracker.Entries().ToList());
-                    AssertKeys(root, loadedRoot);
+                    AssertEntries(entries!, context.ChangeTracker.Entries().ToList());
+                    AssertKeys(root!, loadedRoot);
                     AssertNavigations(loadedRoot);
 
-                    var removedCount = context.Set<Root>().Select(r => r.RequiredSingleAk).Count(e => e.Id == old1.Id);
+                    var removedCount = context.Set<Root>().Select(r => r.RequiredSingleAk!).Count(e => e.Id == old1!.Id);
                     Assert.Equal(0, removedCount);
 
-                    Assert.False(context.Set<Root>().Any(r => r.RequiredSingleAk != null && r.RequiredSingleAk.Id == old1.Id));
+                    Assert.False(context.Set<Root>().Any(r => r.RequiredSingleAk != null && r.RequiredSingleAk.Id == old1!.Id));
 
-                    var orphanedCount = context.Set<Root>().Select(r => r.RequiredSingleAk).Select(r => r.Single)
-                        .Count(e => e.Id == old2.Id);
+                    var orphanedCount = context.Set<Root>().Select(r => r.RequiredSingleAk!).Select(r => r.Single)
+                        .Count(e => e.Id == old2!.Id);
                     Assert.Equal(0, orphanedCount);
 
                     Assert.False(
-                        context.Set<Root>().Select(r => r.RequiredSingleAk)
-                            .Any(r => r.Single != null && r.Single.Id == old2.Id));
+                        context.Set<Root>().Select(r => r.RequiredSingleAk!)
+                            .Any(r => r.Single != null && r.Single.Id == old2!.Id));
 
-                    var orphanedCCount = context.Set<Root>().Select(r => r.RequiredSingleAk).Select(r => r.SingleComposite)
-                        .Count(e => e.Id == old2c.Id);
+                    var orphanedCCount = context.Set<Root>().Select(r => r.RequiredSingleAk!).Select(r => r.SingleComposite)
+                        .Count(e => e.Id == old2c!.Id);
                     Assert.Equal(0, orphanedCCount);
 
                     Assert.False(
-                        context.Set<Root>().Select(r => r.RequiredSingleAk)
-                            .Any(r => r.SingleComposite != null && r.SingleComposite.Id == old2c.Id));
+                        context.Set<Root>().Select(r => r.RequiredSingleAk!)
+                            .Any(r => r.SingleComposite != null && r.SingleComposite.Id == old2c!.Id));
                 }
             });
     }
@@ -1235,14 +1233,14 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
             RequiredNonPkSingleAkDerived = new1d,
             RequiredNonPkSingleAkMoreDerived = new1dd
         };
-        Root root = null;
-        IReadOnlyList<EntityEntry> entries = null;
-        RequiredNonPkSingleAk1 old1 = null;
-        RequiredNonPkSingleAk1Derived old1d = null;
-        RequiredNonPkSingleAk1MoreDerived old1dd = null;
-        RequiredNonPkSingleAk2 old2 = null;
-        RequiredNonPkSingleAk2Derived old2d = null;
-        RequiredNonPkSingleAk2MoreDerived old2dd = null;
+        Root root = null!;
+        IReadOnlyList<EntityEntry> entries = null!;
+        RequiredNonPkSingleAk1 old1 = null!;
+        RequiredNonPkSingleAk1Derived old1d = null!;
+        RequiredNonPkSingleAk1MoreDerived old1dd = null!;
+        RequiredNonPkSingleAk2 old2 = null!;
+        RequiredNonPkSingleAk2Derived old2d = null!;
+        RequiredNonPkSingleAk2MoreDerived old2dd = null!;
 
         return ExecuteWithStrategyInTransactionAsync(
             async context =>
@@ -1382,16 +1380,16 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
                 {
                     var loadedRoot = await LoadRequiredNonPkAkGraphAsync(context);
 
-                    AssertEntries(entries, context.ChangeTracker.Entries().ToList());
-                    AssertKeys(root, loadedRoot);
+                    AssertEntries(entries!, context.ChangeTracker.Entries().ToList());
+                    AssertKeys(root!, loadedRoot);
                     AssertNavigations(loadedRoot);
 
-                    Assert.False(context.Set<RequiredNonPkSingleAk1>().Any(e => e.Id == old1.Id));
-                    Assert.False(context.Set<RequiredNonPkSingleAk1>().Any(e => e.Id == old1d.Id));
-                    Assert.False(context.Set<RequiredNonPkSingleAk1>().Any(e => e.Id == old1dd.Id));
-                    Assert.False(context.Set<RequiredNonPkSingleAk2>().Any(e => e.Id == old2.Id));
-                    Assert.False(context.Set<RequiredNonPkSingleAk2>().Any(e => e.Id == old2d.Id));
-                    Assert.False(context.Set<RequiredNonPkSingleAk2>().Any(e => e.Id == old2dd.Id));
+                    Assert.False(context.Set<RequiredNonPkSingleAk1>().Any(e => e.Id == old1!.Id));
+                    Assert.False(context.Set<RequiredNonPkSingleAk1>().Any(e => e.Id == old1d!.Id));
+                    Assert.False(context.Set<RequiredNonPkSingleAk1>().Any(e => e.Id == old1dd!.Id));
+                    Assert.False(context.Set<RequiredNonPkSingleAk2>().Any(e => e.Id == old2!.Id));
+                    Assert.False(context.Set<RequiredNonPkSingleAk2>().Any(e => e.Id == old2d!.Id));
+                    Assert.False(context.Set<RequiredNonPkSingleAk2>().Any(e => e.Id == old2dd!.Id));
                 }
             });
     }
@@ -1413,10 +1411,10 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
         ChangeMechanism changeMechanism,
         CascadeTiming? deleteOrphansTiming)
     {
-        Root root = null;
-        RequiredSingleAk1 old1 = null;
-        RequiredSingleAk2 old2 = null;
-        RequiredSingleComposite2 old2c = null;
+        Root root = null!;
+        RequiredSingleAk1 old1 = null!;
+        RequiredSingleAk2 old2 = null!;
+        RequiredSingleComposite2 old2c = null!;
         return ExecuteWithStrategyInTransactionAsync(
             async context =>
             {
@@ -1424,9 +1422,9 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
 
                 root = await LoadRequiredAkGraphAsync(context);
 
-                old1 = root.RequiredSingleAk;
-                old2 = root.RequiredSingleAk.Single;
-                old2c = root.RequiredSingleAk.SingleComposite;
+                old1 = root.RequiredSingleAk!;
+                old2 = old1.Single;
+                old2c = old1.SingleComposite;
 
                 if ((changeMechanism & ChangeMechanism.Principal) != 0)
                 {
@@ -1435,7 +1433,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
 
                 if ((changeMechanism & ChangeMechanism.Dependent) != 0)
                 {
-                    old1.Root = null;
+                    old1.Root = null!;
                 }
 
                 if ((changeMechanism & ChangeMechanism.Fk) != 0)
@@ -1502,29 +1500,29 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
                 {
                     var loadedRoot = await LoadRequiredAkGraphAsync(context);
 
-                    AssertKeys(root, loadedRoot);
+                    AssertKeys(root!, loadedRoot);
                     AssertPossiblyNullNavigations(loadedRoot);
 
-                    var removedCount = context.Set<Root>().Select(r => r.RequiredSingleAk).Count(e => e.Id == old1.Id);
+                    var removedCount = context.Set<Root>().Select(r => r.RequiredSingleAk!).Count(e => e.Id == old1!.Id);
                     Assert.Equal(0, removedCount);
 
-                    Assert.False(context.Set<Root>().Any(r => r.RequiredSingleAk != null && r.RequiredSingleAk.Id == old1.Id));
+                    Assert.False(context.Set<Root>().Any(r => r.RequiredSingleAk != null && r.RequiredSingleAk.Id == old1!.Id));
 
-                    var orphanedCount = context.Set<Root>().Select(r => r.RequiredSingleAk).Select(r => r.Single)
-                        .Count(e => e.Id == old2.Id);
+                    var orphanedCount = context.Set<Root>().Select(r => r.RequiredSingleAk!).Select(r => r.Single)
+                        .Count(e => e.Id == old2!.Id);
                     Assert.Equal(0, orphanedCount);
 
                     Assert.False(
-                        context.Set<Root>().Select(r => r.RequiredSingleAk)
-                            .Any(r => r.Single != null && r.Single.Id == old2.Id));
+                        context.Set<Root>().Select(r => r.RequiredSingleAk!)
+                            .Any(r => r.Single != null && r.Single.Id == old2!.Id));
 
-                    var orphanedCCount = context.Set<Root>().Select(r => r.RequiredSingleAk).Select(r => r.SingleComposite)
-                        .Count(e => e.Id == old2c.Id);
+                    var orphanedCCount = context.Set<Root>().Select(r => r.RequiredSingleAk!).Select(r => r.SingleComposite)
+                        .Count(e => e.Id == old2c!.Id);
                     Assert.Equal(0, orphanedCCount);
 
                     Assert.False(
-                        context.Set<Root>().Select(r => r.RequiredSingleAk)
-                            .Any(r => r.SingleComposite != null && r.SingleComposite.Id == old2c.Id));
+                        context.Set<Root>().Select(r => r.RequiredSingleAk!)
+                            .Any(r => r.SingleComposite != null && r.SingleComposite.Id == old2c!.Id));
                 }
             });
     }
@@ -1546,9 +1544,9 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
         ChangeMechanism changeMechanism,
         CascadeTiming? deleteOrphansTiming)
     {
-        Root root = null;
-        RequiredNonPkSingleAk1 old1 = null;
-        RequiredNonPkSingleAk2 old2 = null;
+        Root root = null!;
+        RequiredNonPkSingleAk1 old1 = null!;
+        RequiredNonPkSingleAk2 old2 = null!;
         return ExecuteWithStrategyInTransactionAsync(
             async context =>
             {
@@ -1561,12 +1559,12 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
 
                 if ((changeMechanism & ChangeMechanism.Principal) != 0)
                 {
-                    root.RequiredNonPkSingleAk = null;
+                    root.RequiredNonPkSingleAk = null!;
                 }
 
                 if ((changeMechanism & ChangeMechanism.Dependent) != 0)
                 {
-                    old1.Root = null;
+                    old1.Root = null!;
                 }
 
                 if ((changeMechanism & ChangeMechanism.Fk) != 0)
@@ -1627,11 +1625,11 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
                 {
                     var loadedRoot = await LoadRequiredNonPkAkGraphAsync(context);
 
-                    AssertKeys(root, loadedRoot);
+                    AssertKeys(root!, loadedRoot);
                     AssertPossiblyNullNavigations(loadedRoot);
 
-                    Assert.False(context.Set<RequiredNonPkSingleAk1>().Any(e => e.Id == old1.Id));
-                    Assert.False(context.Set<RequiredNonPkSingleAk2>().Any(e => e.Id == old2.Id));
+                    Assert.False(context.Set<RequiredNonPkSingleAk1>().Any(e => e.Id == old1!.Id));
+                    Assert.False(context.Set<RequiredNonPkSingleAk2>().Any(e => e.Id == old2!.Id));
                 }
             });
     }
@@ -1699,10 +1697,10 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
         CascadeTiming? deleteOrphansTiming)
     {
         var newRoot = new Root { AlternateId = Guid.NewGuid() };
-        Root root = null;
-        RequiredSingleAk1 old1 = null;
-        RequiredSingleAk2 old2 = null;
-        RequiredSingleComposite2 old2c = null;
+        Root root = null!;
+        RequiredSingleAk1 old1 = null!;
+        RequiredSingleAk2 old2 = null!;
+        RequiredSingleComposite2 old2c = null!;
 
         return ExecuteWithStrategyInTransactionAsync(
             async context =>
@@ -1720,9 +1718,9 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
 
                 context.Entry(newRoot).State = useExistingRoot ? EntityState.Unchanged : EntityState.Added;
 
-                old1 = root.RequiredSingleAk;
-                old2 = root.RequiredSingleAk.Single;
-                old2c = root.RequiredSingleAk.SingleComposite;
+                old1 = root.RequiredSingleAk!;
+                old2 = old1.Single;
+                old2c = old1.SingleComposite;
 
                 if ((changeMechanism & ChangeMechanism.Principal) != 0)
                 {
@@ -1758,21 +1756,21 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
             {
                 var loadedRoot = await LoadRequiredAkGraphAsync(context);
 
-                AssertKeys(root, loadedRoot);
+                AssertKeys(root!, loadedRoot);
                 AssertPossiblyNullNavigations(loadedRoot);
 
                 newRoot = await context.Set<Root>()
-                    .Include(r => r.RequiredSingleAk.Single)
-                    .Include(r => r.RequiredSingleAk.SingleComposite)
+                    .Include(r => r.RequiredSingleAk!.Single)
+                    .Include(r => r.RequiredSingleAk!.SingleComposite)
                     .SingleAsync(e => e.Id == newRoot.Id);
 
-                var loaded1 = newRoot.RequiredSingleAk;
+                var loaded1 = newRoot.RequiredSingleAk!;
                 var loaded2 = loaded1.Single;
                 var loaded2c = loaded1.SingleComposite;
 
-                Assert.Equal(old1.Id, loaded1.Id);
-                Assert.Equal(old2.Id, loaded2.Id);
-                Assert.Equal(old2c.Id, loaded2c.Id);
+                Assert.Equal(old1!.Id, loaded1.Id);
+                Assert.Equal(old2!.Id, loaded2.Id);
+                Assert.Equal(old2c!.Id, loaded2c.Id);
 
                 Assert.Same(newRoot, loaded1.Root);
                 Assert.Same(loaded1, loaded2.Back);
@@ -1846,9 +1844,9 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
         CascadeTiming? deleteOrphansTiming)
     {
         var newRoot = new Root { AlternateId = Guid.NewGuid() };
-        Root root = null;
-        RequiredNonPkSingleAk1 old1 = null;
-        RequiredNonPkSingleAk2 old2 = null;
+        Root root = null!;
+        RequiredNonPkSingleAk1 old1 = null!;
+        RequiredNonPkSingleAk2 old2 = null!;
 
         return ExecuteWithStrategyInTransactionAsync(
             async context =>
@@ -1900,12 +1898,12 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
             {
                 var loadedRoot = await LoadRequiredNonPkAkGraphAsync(context);
 
-                AssertKeys(root, loadedRoot);
+                AssertKeys(root!, loadedRoot);
                 AssertPossiblyNullNavigations(loadedRoot);
 
                 newRoot = await context.Set<Root>().SingleAsync(e => e.Id == newRoot.Id);
-                var loaded1 = await context.Set<RequiredNonPkSingleAk1>().SingleAsync(e => e.Id == old1.Id);
-                var loaded2 = await context.Set<RequiredNonPkSingleAk2>().SingleAsync(e => e.Id == old2.Id);
+                var loaded1 = await context.Set<RequiredNonPkSingleAk1>().SingleAsync(e => e.Id == old1!.Id);
+                var loaded2 = await context.Set<RequiredNonPkSingleAk2>().SingleAsync(e => e.Id == old2!.Id);
 
                 Assert.Same(newRoot, loaded1.Root);
                 Assert.Same(loaded1, loaded2.Back);
@@ -1941,7 +1939,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
 
                 var root = await LoadRequiredAkGraphAsync(context);
 
-                var removed = root.RequiredSingleAk;
+                var removed = root.RequiredSingleAk!;
 
                 removedId = removed.Id;
                 var orphaned = removed.Single;
@@ -2004,22 +2002,22 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
 
                     Assert.Null(root.RequiredSingleAk);
 
-                    var removedCount = context.Set<Root>().Select(r => r.RequiredSingleAk).Count(e => e.Id == removedId);
+                    var removedCount = context.Set<Root>().Select(r => r.RequiredSingleAk!).Count(e => e.Id == removedId);
                     Assert.Equal(0, removedCount);
 
                     Assert.False(context.Set<Root>().Any(r => r.RequiredSingleAk != null));
 
-                    var orphanedCount = context.Set<Root>().Select(r => r.RequiredSingleAk).Select(r => r.Single)
+                    var orphanedCount = context.Set<Root>().Select(r => r.RequiredSingleAk!).Select(r => r.Single)
                         .Count(e => e.Id == orphanedId);
                     Assert.Equal(0, orphanedCount);
 
-                    Assert.False(context.Set<Root>().Select(r => r.RequiredSingleAk).Any(r => r.Single != null));
+                    Assert.False(context.Set<Root>().Select(r => r.RequiredSingleAk!).Any(r => r.Single != null));
 
-                    var orphanedCCount = context.Set<Root>().Select(r => r.RequiredSingleAk).Select(r => r.SingleComposite)
+                    var orphanedCCount = context.Set<Root>().Select(r => r.RequiredSingleAk!).Select(r => r.SingleComposite)
                         .Count(e => e.Id == orphanedId);
                     Assert.Equal(0, orphanedCCount);
 
-                    Assert.False(context.Set<Root>().Select(r => r.RequiredSingleAk).Any(r => r.SingleComposite != null));
+                    Assert.False(context.Set<Root>().Select(r => r.RequiredSingleAk!).Any(r => r.SingleComposite != null));
                 }
             });
     }
@@ -2132,7 +2130,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
         return ExecuteWithStrategyInTransactionAsync(
             async context =>
             {
-                var removed = (await LoadRequiredAkGraphAsync(context)).RequiredSingleAk;
+                var removed = (await LoadRequiredAkGraphAsync(context)).RequiredSingleAk!;
 
                 removedId = removed.Id;
                 orphanedId = removed.Single.Id;
@@ -2144,7 +2142,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
 
                 var root = await context.Set<Root>().Include(e => e.RequiredSingleAk).SingleAsync(IsTheRoot);
 
-                var removed = root.RequiredSingleAk;
+                var removed = root.RequiredSingleAk!;
                 var orphaned = removed.Single;
 
                 context.Remove(removed);
@@ -2288,7 +2286,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
         var removedId = 0;
         var orphanedId = 0;
         var orphanedIdC = 0;
-        Root root = null;
+        Root root = null!;
 
         return ExecuteWithStrategyInTransactionAsync(
             async context => root = await LoadRequiredAkGraphAsync(context), async context =>
@@ -2296,7 +2294,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
                 context.ChangeTracker.CascadeDeleteTiming = cascadeDeleteTiming ?? CascadeTiming.Never;
                 context.ChangeTracker.DeleteOrphansTiming = deleteOrphansTiming ?? CascadeTiming.Never;
 
-                var removed = root.RequiredSingleAk;
+                var removed = root!.RequiredSingleAk!;
 
                 removedId = removed.Id;
                 var orphaned = removed.Single;
@@ -2356,22 +2354,22 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
 
                     Assert.Null(root.RequiredSingleAk);
 
-                    var removedCount = context.Set<Root>().Select(r => r.RequiredSingleAk).Count(e => e.Id == removedId);
+                    var removedCount = context.Set<Root>().Select(r => r.RequiredSingleAk!).Count(e => e.Id == removedId);
                     Assert.Equal(0, removedCount);
 
                     Assert.False(context.Set<Root>().Any(r => r.RequiredSingleAk != null));
 
-                    var orphanedCount = context.Set<Root>().Select(r => r.RequiredSingleAk).Select(r => r.Single)
+                    var orphanedCount = context.Set<Root>().Select(r => r.RequiredSingleAk!).Select(r => r.Single)
                         .Count(e => e.Id == orphanedId);
                     Assert.Equal(0, orphanedCount);
 
-                    Assert.False(context.Set<Root>().Select(r => r.RequiredSingleAk).Any(r => r.Single != null));
+                    Assert.False(context.Set<Root>().Select(r => r.RequiredSingleAk!).Any(r => r.Single != null));
 
-                    var orphanedCCount = context.Set<Root>().Select(r => r.RequiredSingleAk).Select(r => r.SingleComposite)
+                    var orphanedCCount = context.Set<Root>().Select(r => r.RequiredSingleAk!).Select(r => r.SingleComposite)
                         .Count(e => e.Id == orphanedId);
                     Assert.Equal(0, orphanedCCount);
 
-                    Assert.False(context.Set<Root>().Select(r => r.RequiredSingleAk).Any(r => r.SingleComposite != null));
+                    Assert.False(context.Set<Root>().Select(r => r.RequiredSingleAk!).Any(r => r.SingleComposite != null));
                 }
             });
     }
@@ -2393,7 +2391,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
     {
         var removedId = 0;
         var orphanedId = 0;
-        Root root = null;
+        Root root = null!;
 
         return ExecuteWithStrategyInTransactionAsync(
             async context => root = await LoadRequiredNonPkAkGraphAsync(context), async context =>
@@ -2401,7 +2399,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
                 context.ChangeTracker.CascadeDeleteTiming = cascadeDeleteTiming ?? CascadeTiming.Never;
                 context.ChangeTracker.DeleteOrphansTiming = deleteOrphansTiming ?? CascadeTiming.Never;
 
-                var removed = root.RequiredNonPkSingleAk;
+                var removed = root!.RequiredNonPkSingleAk;
 
                 removedId = removed.Id;
                 var orphaned = removed.Single;
@@ -2489,7 +2487,7 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
 
                 var root = await LoadRequiredAkGraphAsync(context);
 
-                var removed = root.RequiredSingleAk;
+                var removed = root.RequiredSingleAk!;
                 removedId = removed.Id;
 
                 var orphaned = removed.Single;
@@ -2567,22 +2565,22 @@ public abstract partial class GraphUpdatesTestBase<TFixture>
 
                     Assert.Null(root.RequiredSingleAk);
 
-                    var removedCount = context.Set<Root>().Select(r => r.RequiredSingleAk).Count(e => e.Id == removedId);
+                    var removedCount = context.Set<Root>().Select(r => r.RequiredSingleAk!).Count(e => e.Id == removedId);
                     Assert.Equal(0, removedCount);
 
                     Assert.False(context.Set<Root>().Any(r => r.RequiredSingleAk != null));
 
-                    var orphanedCount = context.Set<Root>().Select(r => r.RequiredSingleAk).Select(r => r.Single)
+                    var orphanedCount = context.Set<Root>().Select(r => r.RequiredSingleAk!).Select(r => r.Single)
                         .Count(e => e.Id == orphanedId);
                     Assert.Equal(0, orphanedCount);
 
-                    Assert.False(context.Set<Root>().Select(r => r.RequiredSingleAk).Any(r => r.Single != null));
+                    Assert.False(context.Set<Root>().Select(r => r.RequiredSingleAk!).Any(r => r.Single != null));
 
-                    var orphanedCCount = context.Set<Root>().Select(r => r.RequiredSingleAk).Select(r => r.SingleComposite)
+                    var orphanedCCount = context.Set<Root>().Select(r => r.RequiredSingleAk!).Select(r => r.SingleComposite)
                         .Count(e => e.Id == orphanedId);
                     Assert.Equal(0, orphanedCCount);
 
-                    Assert.False(context.Set<Root>().Select(r => r.RequiredSingleAk).Any(r => r.SingleComposite != null));
+                    Assert.False(context.Set<Root>().Select(r => r.RequiredSingleAk!).Any(r => r.SingleComposite != null));
                 }
             });
     }

--- a/test/EFCore.Specification.Tests/GraphUpdates/ProxyGraphUpdatesFixtureBase.cs
+++ b/test/EFCore.Specification.Tests/GraphUpdates/ProxyGraphUpdatesFixtureBase.cs
@@ -3,8 +3,6 @@
 
 namespace Microsoft.EntityFrameworkCore;
 
-#nullable disable
-
 public abstract partial class ProxyGraphUpdatesTestBase<TFixture>(TFixture fixture) : IClassFixture<TFixture>
     where TFixture : ProxyGraphUpdatesTestBase<TFixture>.ProxyGraphUpdatesFixtureBase, new()
 {
@@ -640,9 +638,9 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture>(TFixture fixtu
         => context.Set<Root>()
             .Include(e => e.OptionalChildren).ThenInclude(e => e.Children)
             .Include(e => e.OptionalChildren).ThenInclude(e => e.CompositeChildren)
-            .Include(e => e.OptionalSingle).ThenInclude(e => e.Single)
-            .Include(e => e.OptionalSingleDerived).ThenInclude(e => e.Single)
-            .Include(e => e.OptionalSingleMoreDerived).ThenInclude(e => e.Single)
+            .Include(e => e.OptionalSingle!).ThenInclude(e => e.Single)
+            .Include(e => e.OptionalSingleDerived!).ThenInclude(e => e.Single)
+            .Include(e => e.OptionalSingleMoreDerived!).ThenInclude(e => e.Single)
             .OrderBy(e => e.Id);
 
     protected Task<Root> LoadRequiredNonPkGraphAsync(DbContext context)
@@ -679,10 +677,10 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture>(TFixture fixtu
         => context.Set<Root>()
             .Include(e => e.OptionalChildrenAk).ThenInclude(e => e.Children)
             .Include(e => e.OptionalChildrenAk).ThenInclude(e => e.CompositeChildren)
-            .Include(e => e.OptionalSingleAk).ThenInclude(e => e.Single)
-            .Include(e => e.OptionalSingleAk).ThenInclude(e => e.SingleComposite)
-            .Include(e => e.OptionalSingleAkDerived).ThenInclude(e => e.Single)
-            .Include(e => e.OptionalSingleAkMoreDerived).ThenInclude(e => e.Single)
+            .Include(e => e.OptionalSingleAk!).ThenInclude(e => e.Single)
+            .Include(e => e.OptionalSingleAk!).ThenInclude(e => e.SingleComposite)
+            .Include(e => e.OptionalSingleAkDerived!).ThenInclude(e => e.Single)
+            .Include(e => e.OptionalSingleAkMoreDerived!).ThenInclude(e => e.Single)
             .OrderBy(e => e.Id);
 
     protected Task<Root> LoadRequiredNonPkAkGraphAsync(DbContext context)
@@ -744,19 +742,19 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture>(TFixture fixtu
         public virtual IEnumerable<Optional1> OptionalChildren { get; set; }
             = new ObservableHashSet<Optional1>(ReferenceEqualityComparer.Instance);
 
-        public virtual RequiredSingle1 RequiredSingle { get; set; }
+        public virtual RequiredSingle1 RequiredSingle { get; set; } = null!;
 
-        public virtual RequiredNonPkSingle1 RequiredNonPkSingle { get; set; }
+        public virtual RequiredNonPkSingle1 RequiredNonPkSingle { get; set; } = null!;
 
-        public virtual RequiredNonPkSingle1Derived RequiredNonPkSingleDerived { get; set; }
+        public virtual RequiredNonPkSingle1Derived RequiredNonPkSingleDerived { get; set; } = null!;
 
-        public virtual RequiredNonPkSingle1MoreDerived RequiredNonPkSingleMoreDerived { get; set; }
+        public virtual RequiredNonPkSingle1MoreDerived RequiredNonPkSingleMoreDerived { get; set; } = null!;
 
-        public virtual OptionalSingle1 OptionalSingle { get; set; }
+        public virtual OptionalSingle1? OptionalSingle { get; set; }
 
-        public virtual OptionalSingle1Derived OptionalSingleDerived { get; set; }
+        public virtual OptionalSingle1Derived? OptionalSingleDerived { get; set; }
 
-        public virtual OptionalSingle1MoreDerived OptionalSingleMoreDerived { get; set; }
+        public virtual OptionalSingle1MoreDerived? OptionalSingleMoreDerived { get; set; }
 
         public virtual IEnumerable<RequiredAk1> RequiredChildrenAk { get; set; }
             = new ObservableHashSet<RequiredAk1>(ReferenceEqualityComparer.Instance);
@@ -764,24 +762,24 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture>(TFixture fixtu
         public virtual IEnumerable<OptionalAk1> OptionalChildrenAk { get; set; }
             = new ObservableHashSet<OptionalAk1>(ReferenceEqualityComparer.Instance);
 
-        public virtual RequiredSingleAk1 RequiredSingleAk { get; set; }
+        public virtual RequiredSingleAk1 RequiredSingleAk { get; set; } = null!;
 
-        public virtual RequiredNonPkSingleAk1 RequiredNonPkSingleAk { get; set; }
+        public virtual RequiredNonPkSingleAk1 RequiredNonPkSingleAk { get; set; } = null!;
 
-        public virtual RequiredNonPkSingleAk1Derived RequiredNonPkSingleAkDerived { get; set; }
+        public virtual RequiredNonPkSingleAk1Derived RequiredNonPkSingleAkDerived { get; set; } = null!;
 
-        public virtual RequiredNonPkSingleAk1MoreDerived RequiredNonPkSingleAkMoreDerived { get; set; }
+        public virtual RequiredNonPkSingleAk1MoreDerived RequiredNonPkSingleAkMoreDerived { get; set; } = null!;
 
-        public virtual OptionalSingleAk1 OptionalSingleAk { get; set; }
+        public virtual OptionalSingleAk1? OptionalSingleAk { get; set; }
 
-        public virtual OptionalSingleAk1Derived OptionalSingleAkDerived { get; set; }
+        public virtual OptionalSingleAk1Derived? OptionalSingleAkDerived { get; set; }
 
-        public virtual OptionalSingleAk1MoreDerived OptionalSingleAkMoreDerived { get; set; }
+        public virtual OptionalSingleAk1MoreDerived? OptionalSingleAkMoreDerived { get; set; }
 
         public virtual IEnumerable<RequiredComposite1> RequiredCompositeChildren { get; set; }
             = new ObservableHashSet<RequiredComposite1>(ReferenceEqualityComparer.Instance);
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             var other = obj as Root;
             return Id == other?.Id;
@@ -801,12 +799,12 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture>(TFixture fixtu
 
         public virtual int ParentId { get; set; }
 
-        public virtual Root Parent { get; set; }
+        public virtual Root? Parent { get; set; }
 
         public virtual IEnumerable<Required2> Children { get; set; }
             = new ObservableHashSet<Required2>(ReferenceEqualityComparer.Instance);
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             var other = obj as Required1;
             return Id == other?.Id;
@@ -822,7 +820,7 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture>(TFixture fixtu
         {
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => base.Equals(obj as Required1Derived);
 
         public override int GetHashCode()
@@ -835,7 +833,7 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture>(TFixture fixtu
         {
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => base.Equals(obj as Required1MoreDerived);
 
         public override int GetHashCode()
@@ -852,9 +850,9 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture>(TFixture fixtu
 
         public virtual int ParentId { get; set; }
 
-        public virtual Required1 Parent { get; set; }
+        public virtual Required1 Parent { get; set; } = null!;
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             var other = obj as Required2;
             return Id == other?.Id;
@@ -870,7 +868,7 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture>(TFixture fixtu
         {
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => base.Equals(obj as Required2Derived);
 
         public override int GetHashCode()
@@ -883,7 +881,7 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture>(TFixture fixtu
         {
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => base.Equals(obj as Required2MoreDerived);
 
         public override int GetHashCode()
@@ -900,7 +898,7 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture>(TFixture fixtu
 
         public virtual int? ParentId { get; set; }
 
-        public virtual Root Parent { get; set; }
+        public virtual Root Parent { get; set; } = null!;
 
         public virtual IEnumerable<Optional2> Children { get; set; }
             = new ObservableHashSet<Optional2>(ReferenceEqualityComparer.Instance);
@@ -908,7 +906,7 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture>(TFixture fixtu
         public virtual ICollection<OptionalComposite2> CompositeChildren { get; set; }
             = new ObservableHashSet<OptionalComposite2>(ReferenceEqualityComparer.Instance);
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             var other = obj as Optional1;
             return Id == other?.Id;
@@ -924,7 +922,7 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture>(TFixture fixtu
         {
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => base.Equals(obj as Optional1Derived);
 
         public override int GetHashCode()
@@ -937,7 +935,7 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture>(TFixture fixtu
         {
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => base.Equals(obj as Optional1MoreDerived);
 
         public override int GetHashCode()
@@ -954,9 +952,9 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture>(TFixture fixtu
 
         public virtual int? ParentId { get; set; }
 
-        public virtual Optional1 Parent { get; set; }
+        public virtual Optional1? Parent { get; set; }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             var other = obj as Optional2;
             return Id == other?.Id;
@@ -972,7 +970,7 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture>(TFixture fixtu
         {
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => base.Equals(obj as Optional2Derived);
 
         public override int GetHashCode()
@@ -985,7 +983,7 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture>(TFixture fixtu
         {
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => base.Equals(obj as Optional2MoreDerived);
 
         public override int GetHashCode()
@@ -1000,11 +998,11 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture>(TFixture fixtu
 
         public virtual int Id { get; set; }
 
-        public virtual Root Root { get; set; }
+        public virtual Root Root { get; set; } = null!;
 
-        public virtual RequiredSingle2 Single { get; set; }
+        public virtual RequiredSingle2 Single { get; set; } = null!;
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             var other = obj as RequiredSingle1;
             return Id == other?.Id;
@@ -1022,9 +1020,9 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture>(TFixture fixtu
 
         public virtual int Id { get; set; }
 
-        public virtual RequiredSingle1 Back { get; set; }
+        public virtual RequiredSingle1 Back { get; set; } = null!;
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             var other = obj as RequiredSingle2;
             return Id == other?.Id;
@@ -1044,11 +1042,11 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture>(TFixture fixtu
 
         public virtual int RootId { get; set; }
 
-        public virtual Root Root { get; set; }
+        public virtual Root Root { get; set; } = null!;
 
-        public virtual RequiredNonPkSingle2 Single { get; set; }
+        public virtual RequiredNonPkSingle2 Single { get; set; } = null!;
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             var other = obj as RequiredNonPkSingle1;
             return Id == other?.Id;
@@ -1066,9 +1064,9 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture>(TFixture fixtu
 
         public virtual int DerivedRootId { get; set; }
 
-        public virtual Root DerivedRoot { get; set; }
+        public virtual Root DerivedRoot { get; set; } = null!;
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => base.Equals(obj as RequiredNonPkSingle1Derived);
 
         public override int GetHashCode()
@@ -1083,9 +1081,9 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture>(TFixture fixtu
 
         public virtual int MoreDerivedRootId { get; set; }
 
-        public virtual Root MoreDerivedRoot { get; set; }
+        public virtual Root MoreDerivedRoot { get; set; } = null!;
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => base.Equals(obj as RequiredNonPkSingle1MoreDerived);
 
         public override int GetHashCode()
@@ -1102,9 +1100,9 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture>(TFixture fixtu
 
         public virtual int BackId { get; set; }
 
-        public virtual RequiredNonPkSingle1 Back { get; set; }
+        public virtual RequiredNonPkSingle1 Back { get; set; } = null!;
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             var other = obj as RequiredNonPkSingle2;
             return Id == other?.Id;
@@ -1120,7 +1118,7 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture>(TFixture fixtu
         {
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => base.Equals(obj as RequiredNonPkSingle2Derived);
 
         public override int GetHashCode()
@@ -1133,7 +1131,7 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture>(TFixture fixtu
         {
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => base.Equals(obj as RequiredNonPkSingle2MoreDerived);
 
         public override int GetHashCode()
@@ -1150,11 +1148,11 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture>(TFixture fixtu
 
         public virtual int? RootId { get; set; }
 
-        public virtual Root Root { get; set; }
+        public virtual Root? Root { get; set; }
 
-        public virtual OptionalSingle2 Single { get; set; }
+        public virtual OptionalSingle2? Single { get; set; }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             var other = obj as OptionalSingle1;
             return Id == other?.Id;
@@ -1172,9 +1170,9 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture>(TFixture fixtu
 
         public virtual int? DerivedRootId { get; set; }
 
-        public virtual Root DerivedRoot { get; set; }
+        public virtual Root? DerivedRoot { get; set; }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => base.Equals(obj as OptionalSingle1Derived);
 
         public override int GetHashCode()
@@ -1189,9 +1187,9 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture>(TFixture fixtu
 
         public virtual int? MoreDerivedRootId { get; set; }
 
-        public virtual Root MoreDerivedRoot { get; set; }
+        public virtual Root? MoreDerivedRoot { get; set; }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => base.Equals(obj as OptionalSingle1MoreDerived);
 
         public override int GetHashCode()
@@ -1208,9 +1206,9 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture>(TFixture fixtu
 
         public virtual int? BackId { get; set; }
 
-        public virtual OptionalSingle1 Back { get; set; }
+        public virtual OptionalSingle1? Back { get; set; }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             var other = obj as OptionalSingle2;
             return Id == other?.Id;
@@ -1226,7 +1224,7 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture>(TFixture fixtu
         {
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => base.Equals(obj as OptionalSingle2Derived);
 
         public override int GetHashCode()
@@ -1239,7 +1237,7 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture>(TFixture fixtu
         {
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => base.Equals(obj as OptionalSingle2MoreDerived);
 
         public override int GetHashCode()
@@ -1258,7 +1256,7 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture>(TFixture fixtu
 
         public virtual Guid ParentId { get; set; }
 
-        public virtual Root Parent { get; set; }
+        public virtual Root? Parent { get; set; }
 
         public virtual IEnumerable<RequiredAk2> Children { get; set; }
             = new ObservableHashSet<RequiredAk2>(ReferenceEqualityComparer.Instance);
@@ -1266,7 +1264,7 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture>(TFixture fixtu
         public virtual IEnumerable<RequiredComposite2> CompositeChildren { get; set; }
             = new ObservableHashSet<RequiredComposite2>(ReferenceEqualityComparer.Instance);
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             var other = obj as RequiredAk1;
             return Id == other?.Id;
@@ -1282,7 +1280,7 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture>(TFixture fixtu
         {
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => base.Equals(obj as RequiredAk1Derived);
 
         public override int GetHashCode()
@@ -1295,7 +1293,7 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture>(TFixture fixtu
         {
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => base.Equals(obj as RequiredAk1MoreDerived);
 
         public override int GetHashCode()
@@ -1314,9 +1312,9 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture>(TFixture fixtu
 
         public virtual Guid ParentId { get; set; }
 
-        public virtual RequiredAk1 Parent { get; set; }
+        public virtual RequiredAk1 Parent { get; set; } = null!;
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             var other = obj as RequiredAk2;
             return Id == other?.Id;
@@ -1336,9 +1334,9 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture>(TFixture fixtu
 
         public virtual Guid ParentAlternateId { get; set; }
 
-        public virtual Root Parent { get; set; }
+        public virtual Root Parent { get; set; } = null!;
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             var other = obj as RequiredComposite1;
             return Id == other?.Id;
@@ -1363,11 +1361,11 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture>(TFixture fixtu
 
         public virtual int? ParentId { get; set; }
 
-        public virtual RequiredComposite1 Parent { get; set; }
+        public virtual RequiredComposite1 Parent { get; set; } = null!;
 
-        public virtual Root Root { get; set; }
+        public virtual Root Root { get; set; } = null!;
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             var other = obj as OptionalOverlapping2;
             return Id == other?.Id;
@@ -1389,9 +1387,9 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture>(TFixture fixtu
 
         public virtual int ParentId { get; set; }
 
-        public virtual RequiredAk1 Parent { get; set; }
+        public virtual RequiredAk1 Parent { get; set; } = null!;
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             var other = obj as RequiredComposite2;
             return Id == other?.Id;
@@ -1407,7 +1405,7 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture>(TFixture fixtu
         {
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => base.Equals(obj as RequiredAk2Derived);
 
         public override int GetHashCode()
@@ -1420,7 +1418,7 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture>(TFixture fixtu
         {
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => base.Equals(obj as RequiredAk2MoreDerived);
 
         public override int GetHashCode()
@@ -1439,7 +1437,7 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture>(TFixture fixtu
 
         public virtual Guid? ParentId { get; set; }
 
-        public virtual Root Parent { get; set; }
+        public virtual Root Parent { get; set; } = null!;
 
         public virtual IEnumerable<OptionalAk2> Children { get; set; }
             = new ObservableHashSet<OptionalAk2>(ReferenceEqualityComparer.Instance);
@@ -1447,7 +1445,7 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture>(TFixture fixtu
         public virtual ICollection<OptionalComposite2> CompositeChildren { get; set; }
             = new ObservableHashSet<OptionalComposite2>(ReferenceEqualityComparer.Instance);
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             var other = obj as OptionalAk1;
             return Id == other?.Id;
@@ -1463,7 +1461,7 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture>(TFixture fixtu
         {
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => base.Equals(obj as OptionalAk1Derived);
 
         public override int GetHashCode()
@@ -1476,7 +1474,7 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture>(TFixture fixtu
         {
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => base.Equals(obj as OptionalAk1MoreDerived);
 
         public override int GetHashCode()
@@ -1495,9 +1493,9 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture>(TFixture fixtu
 
         public virtual Guid? ParentId { get; set; }
 
-        public virtual OptionalAk1 Parent { get; set; }
+        public virtual OptionalAk1? Parent { get; set; }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             var other = obj as OptionalAk2;
             return Id == other?.Id;
@@ -1519,13 +1517,13 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture>(TFixture fixtu
 
         public virtual int? ParentId { get; set; }
 
-        public virtual OptionalAk1 Parent { get; set; }
+        public virtual OptionalAk1? Parent { get; set; }
 
         public virtual int? Parent2Id { get; set; }
 
-        public virtual Optional1 Parent2 { get; set; }
+        public virtual Optional1? Parent2 { get; set; }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             var other = obj as OptionalComposite2;
             return Id == other?.Id;
@@ -1541,7 +1539,7 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture>(TFixture fixtu
         {
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => base.Equals(obj as OptionalAk2Derived);
 
         public override int GetHashCode()
@@ -1554,7 +1552,7 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture>(TFixture fixtu
         {
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => base.Equals(obj as OptionalAk2MoreDerived);
 
         public override int GetHashCode()
@@ -1573,13 +1571,13 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture>(TFixture fixtu
 
         public virtual Guid RootId { get; set; }
 
-        public virtual Root Root { get; set; }
+        public virtual Root Root { get; set; } = null!;
 
-        public virtual RequiredSingleAk2 Single { get; set; }
+        public virtual RequiredSingleAk2 Single { get; set; } = null!;
 
-        public virtual RequiredSingleComposite2 SingleComposite { get; set; }
+        public virtual RequiredSingleComposite2 SingleComposite { get; set; } = null!;
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             var other = obj as RequiredSingleAk1;
             return Id == other?.Id;
@@ -1601,9 +1599,9 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture>(TFixture fixtu
 
         public virtual Guid BackId { get; set; }
 
-        public virtual RequiredSingleAk1 Back { get; set; }
+        public virtual RequiredSingleAk1 Back { get; set; } = null!;
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             var other = obj as RequiredSingleAk2;
             return Id == other?.Id;
@@ -1625,9 +1623,9 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture>(TFixture fixtu
 
         public virtual int BackId { get; set; }
 
-        public virtual RequiredSingleAk1 Back { get; set; }
+        public virtual RequiredSingleAk1 Back { get; set; } = null!;
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             var other = obj as RequiredSingleComposite2;
             return Id == other?.Id;
@@ -1649,11 +1647,11 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture>(TFixture fixtu
 
         public virtual Guid RootId { get; set; }
 
-        public virtual Root Root { get; set; }
+        public virtual Root Root { get; set; } = null!;
 
-        public virtual RequiredNonPkSingleAk2 Single { get; set; }
+        public virtual RequiredNonPkSingleAk2 Single { get; set; } = null!;
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             var other = obj as RequiredNonPkSingleAk1;
             return Id == other?.Id;
@@ -1671,9 +1669,9 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture>(TFixture fixtu
 
         public virtual Guid DerivedRootId { get; set; }
 
-        public virtual Root DerivedRoot { get; set; }
+        public virtual Root DerivedRoot { get; set; } = null!;
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => base.Equals(obj as RequiredNonPkSingleAk1Derived);
 
         public override int GetHashCode()
@@ -1688,9 +1686,9 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture>(TFixture fixtu
 
         public virtual Guid MoreDerivedRootId { get; set; }
 
-        public virtual Root MoreDerivedRoot { get; set; }
+        public virtual Root MoreDerivedRoot { get; set; } = null!;
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => base.Equals(obj as RequiredNonPkSingleAk1MoreDerived);
 
         public override int GetHashCode()
@@ -1709,9 +1707,9 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture>(TFixture fixtu
 
         public virtual Guid BackId { get; set; }
 
-        public virtual RequiredNonPkSingleAk1 Back { get; set; }
+        public virtual RequiredNonPkSingleAk1 Back { get; set; } = null!;
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             var other = obj as RequiredNonPkSingleAk2;
             return Id == other?.Id;
@@ -1727,7 +1725,7 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture>(TFixture fixtu
         {
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => base.Equals(obj as RequiredNonPkSingleAk2Derived);
 
         public override int GetHashCode()
@@ -1740,7 +1738,7 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture>(TFixture fixtu
         {
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => base.Equals(obj as RequiredNonPkSingleAk2MoreDerived);
 
         public override int GetHashCode()
@@ -1759,13 +1757,13 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture>(TFixture fixtu
 
         public virtual Guid? RootId { get; set; }
 
-        public virtual Root Root { get; set; }
+        public virtual Root? Root { get; set; }
 
-        public virtual OptionalSingleComposite2 SingleComposite { get; set; }
+        public virtual OptionalSingleComposite2? SingleComposite { get; set; }
 
-        public virtual OptionalSingleAk2 Single { get; set; }
+        public virtual OptionalSingleAk2? Single { get; set; }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             var other = obj as OptionalSingleAk1;
             return Id == other?.Id;
@@ -1783,9 +1781,9 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture>(TFixture fixtu
 
         public virtual Guid? DerivedRootId { get; set; }
 
-        public virtual Root DerivedRoot { get; set; }
+        public virtual Root? DerivedRoot { get; set; }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => base.Equals(obj as OptionalSingleAk1Derived);
 
         public override int GetHashCode()
@@ -1800,9 +1798,9 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture>(TFixture fixtu
 
         public virtual Guid? MoreDerivedRootId { get; set; }
 
-        public virtual Root MoreDerivedRoot { get; set; }
+        public virtual Root? MoreDerivedRoot { get; set; }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => base.Equals(obj as OptionalSingleAk1MoreDerived);
 
         public override int GetHashCode()
@@ -1821,9 +1819,9 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture>(TFixture fixtu
 
         public virtual Guid? BackId { get; set; }
 
-        public virtual OptionalSingleAk1 Back { get; set; }
+        public virtual OptionalSingleAk1? Back { get; set; }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             var other = obj as OptionalSingleAk2;
             return Id == other?.Id;
@@ -1845,9 +1843,9 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture>(TFixture fixtu
 
         public virtual int? BackId { get; set; }
 
-        public virtual OptionalSingleAk1 Back { get; set; }
+        public virtual OptionalSingleAk1? Back { get; set; }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             var other = obj as OptionalSingleComposite2;
             return Id == other?.Id;
@@ -1863,7 +1861,7 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture>(TFixture fixtu
         {
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => base.Equals(obj as OptionalSingleAk2Derived);
 
         public override int GetHashCode()
@@ -1876,7 +1874,7 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture>(TFixture fixtu
         {
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => base.Equals(obj as OptionalSingleAk2MoreDerived);
 
         public override int GetHashCode()
@@ -1907,14 +1905,14 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture>(TFixture fixtu
 
         public virtual int? BadCustomerId { get; set; }
 
-        public virtual BadCustomer BadCustomer { get; set; }
+        public virtual BadCustomer? BadCustomer { get; set; }
     }
 
     public class SharedFkRoot
     {
         public virtual long Id { get; set; }
-        public virtual ICollection<SharedFkDependant> Dependants { get; set; }
-        public virtual ICollection<SharedFkParent> Parents { get; set; }
+        public virtual ICollection<SharedFkDependant> Dependants { get; set; } = null!;
+        public virtual ICollection<SharedFkParent> Parents { get; set; } = null!;
     }
 
     public class SharedFkParent
@@ -1922,28 +1920,28 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture>(TFixture fixtu
         public virtual long Id { get; set; }
         public virtual long? DependantId { get; set; }
         public virtual long RootId { get; set; }
-        public virtual SharedFkRoot Root { get; set; }
-        public virtual SharedFkDependant Dependant { get; set; }
+        public virtual SharedFkRoot Root { get; set; } = null!;
+        public virtual SharedFkDependant? Dependant { get; set; }
     }
 
     public class SharedFkDependant
     {
         public virtual long Id { get; set; }
         public virtual long RootId { get; set; }
-        public virtual SharedFkRoot Root { get; set; }
-        public virtual SharedFkParent Parent { get; set; }
+        public virtual SharedFkRoot Root { get; set; } = null!;
+        public virtual SharedFkParent? Parent { get; set; }
     }
 
     public class Car
     {
         public virtual Guid Id { get; set; }
-        public virtual Person Owner { get; set; }
+        public virtual Person Owner { get; set; } = null!;
     }
 
     public class Person
     {
         public virtual Guid Id { get; set; }
-        public virtual Car Vehicle { get; set; }
+        public virtual Car Vehicle { get; set; } = null!;
     }
 
     public record RecordBase
@@ -1953,7 +1951,7 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture>(TFixture fixtu
 
     public record RecordCar : RecordBase
     {
-        public virtual RecordPerson Owner { get; set; }
+        public virtual RecordPerson? Owner { get; set; }
         public virtual int? OwnerId { get; set; }
     }
 
@@ -1968,9 +1966,9 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture>(TFixture fixtu
 
     protected virtual Task ExecuteWithStrategyInTransactionAsync(
         Func<DbContext, Task> testOperation,
-        Func<DbContext, Task> nestedTestOperation1 = null,
-        Func<DbContext, Task> nestedTestOperation2 = null,
-        Func<DbContext, Task> nestedTestOperation3 = null)
+        Func<DbContext, Task>? nestedTestOperation1 = null,
+        Func<DbContext, Task>? nestedTestOperation2 = null,
+        Func<DbContext, Task>? nestedTestOperation3 = null)
         => TestHelpers.ExecuteWithStrategyInTransactionAsync(
             CreateContext, UseTransaction,
             testOperation, nestedTestOperation1, nestedTestOperation2, nestedTestOperation3);

--- a/test/EFCore.Specification.Tests/GraphUpdates/ProxyGraphUpdatesTestBaseMiscellaneous.cs
+++ b/test/EFCore.Specification.Tests/GraphUpdates/ProxyGraphUpdatesTestBaseMiscellaneous.cs
@@ -78,7 +78,7 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture>
                     context.Entry(car).Reference(e => e.Owner).Load();
                 }
 
-                Assert.Equal(car.Owner.Id, car.OwnerId);
+                Assert.Equal(car.Owner!.Id, car.OwnerId);
                 Assert.Same(car, car.Owner.Vehicles.Single());
                 return Task.CompletedTask;
             });
@@ -215,11 +215,11 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture>
 
                 if (nullPrincipal)
                 {
-                    dependent.Parent = null;
+                    dependent.Parent = null!;
                 }
                 else
                 {
-                    parent.Dependant = null;
+                    parent.Dependant = null!;
                 }
 
                 Assert.Equal(3, context.ChangeTracker.Entries().Count());
@@ -288,7 +288,7 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture>
 
         var existing = root.OptionalChildren.OrderBy(e => e.Id).First();
 
-        existing.Parent = null;
+        existing.Parent = null!;
         existing.ParentId = null;
         ((ICollection<Optional1>)root.OptionalChildren).Remove(existing);
 

--- a/test/EFCore.Specification.Tests/GraphUpdates/ProxyGraphUpdatesTestBaseOneToMany.cs
+++ b/test/EFCore.Specification.Tests/GraphUpdates/ProxyGraphUpdatesTestBaseOneToMany.cs
@@ -7,8 +7,6 @@
 
 namespace Microsoft.EntityFrameworkCore;
 
-#nullable disable
-
 public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixture<TFixture>
     where TFixture : ProxyGraphUpdatesTestBase<TFixture>.ProxyGraphUpdatesFixtureBase, new()
 {
@@ -25,13 +23,13 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
      InlineData((int)(ChangeMechanism.Principal | ChangeMechanism.Dependent | ChangeMechanism.Fk), true)]
     public virtual Task Save_optional_many_to_one_dependents(ChangeMechanism changeMechanism, bool useExistingEntities)
     {
-        Optional1 new1 = null;
-        Optional1Derived new1d = null;
-        Optional1MoreDerived new1dd = null;
-        Optional2 new2a = null;
-        Optional2 new2b = null;
-        Optional2Derived new2d = null;
-        Optional2MoreDerived new2dd = null;
+        Optional1 new1 = null!;
+        Optional1Derived new1d = null!;
+        Optional1MoreDerived new1dd = null!;
+        Optional2 new2a = null!;
+        Optional2 new2b = null!;
+        Optional2Derived new2d = null!;
+        Optional2MoreDerived new2dd = null!;
 
         return ExecuteWithStrategyInTransactionAsync(
             context =>
@@ -64,17 +62,17 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
 
                 if (useExistingEntities)
                 {
-                    new1 = context.Set<Optional1>().Single(e => e.Id == new1.Id);
-                    new1d = (Optional1Derived)context.Set<Optional1>().Single(e => e.Id == new1d.Id);
-                    new1dd = (Optional1MoreDerived)context.Set<Optional1>().Single(e => e.Id == new1dd.Id);
-                    new2a = context.Set<Optional2>().Single(e => e.Id == new2a.Id);
-                    new2b = context.Set<Optional2>().Single(e => e.Id == new2b.Id);
-                    new2d = (Optional2Derived)context.Set<Optional2>().Single(e => e.Id == new2d.Id);
-                    new2dd = (Optional2MoreDerived)context.Set<Optional2>().Single(e => e.Id == new2dd.Id);
+                    new1 = context.Set<Optional1>().Single(e => e.Id == new1!.Id);
+                    new1d = (Optional1Derived)context.Set<Optional1>().Single(e => e.Id == new1d!.Id);
+                    new1dd = (Optional1MoreDerived)context.Set<Optional1>().Single(e => e.Id == new1dd!.Id);
+                    new2a = context.Set<Optional2>().Single(e => e.Id == new2a!.Id);
+                    new2b = context.Set<Optional2>().Single(e => e.Id == new2b!.Id);
+                    new2d = (Optional2Derived)context.Set<Optional2>().Single(e => e.Id == new2d!.Id);
+                    new2dd = (Optional2MoreDerived)context.Set<Optional2>().Single(e => e.Id == new2dd!.Id);
                 }
                 else
                 {
-                    context.AddRange(new1, new1d, new1dd, new2a, new2d, new2dd, new2b);
+                    context.AddRange(new1!, new1d!, new1dd!, new2a!, new2d!, new2dd!, new2b!);
                 }
 
                 if ((changeMechanism & ChangeMechanism.Principal) != 0)
@@ -156,13 +154,13 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
     public virtual Task Save_required_many_to_one_dependents(ChangeMechanism changeMechanism, bool useExistingEntities)
     {
         Root newRoot;
-        Required1 new1 = null;
-        Required1Derived new1d = null;
-        Required1MoreDerived new1dd = null;
-        Required2 new2a = null;
-        Required2 new2b = null;
-        Required2Derived new2d = null;
-        Required2MoreDerived new2dd = null;
+        Required1 new1 = null!;
+        Required1Derived new1d = null!;
+        Required1MoreDerived new1dd = null!;
+        Required2 new2a = null!;
+        Required2 new2b = null!;
+        Required2Derived new2d = null!;
+        Required2MoreDerived new2dd = null!;
 
         return ExecuteWithStrategyInTransactionAsync(
             context =>
@@ -196,21 +194,21 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
 
                 if (useExistingEntities)
                 {
-                    new1 = context.Set<Required1>().Single(e => e.Id == new1.Id);
-                    new1d = (Required1Derived)context.Set<Required1>().Single(e => e.Id == new1d.Id);
-                    new1dd = (Required1MoreDerived)context.Set<Required1>().Single(e => e.Id == new1dd.Id);
-                    new2a = context.Set<Required2>().Single(e => e.Id == new2a.Id);
-                    new2b = context.Set<Required2>().Single(e => e.Id == new2b.Id);
-                    new2d = (Required2Derived)context.Set<Required2>().Single(e => e.Id == new2d.Id);
-                    new2dd = (Required2MoreDerived)context.Set<Required2>().Single(e => e.Id == new2dd.Id);
+                    new1 = context.Set<Required1>().Single(e => e.Id == new1!.Id);
+                    new1d = (Required1Derived)context.Set<Required1>().Single(e => e.Id == new1d!.Id);
+                    new1dd = (Required1MoreDerived)context.Set<Required1>().Single(e => e.Id == new1dd!.Id);
+                    new2a = context.Set<Required2>().Single(e => e.Id == new2a!.Id);
+                    new2b = context.Set<Required2>().Single(e => e.Id == new2b!.Id);
+                    new2d = (Required2Derived)context.Set<Required2>().Single(e => e.Id == new2d!.Id);
+                    new2dd = (Required2MoreDerived)context.Set<Required2>().Single(e => e.Id == new2dd!.Id);
                 }
                 else
                 {
-                    new1.Parent = null;
-                    new1d.Parent = null;
-                    new1dd.Parent = null;
+                    new1!.Parent = null!;
+                    new1d!.Parent = null!;
+                    new1dd!.Parent = null!;
 
-                    context.AddRange(new1, new1d, new1dd, new2a, new2d, new2dd, new2b);
+                    context.AddRange(new1, new1d, new1dd, new2a!, new2d!, new2dd!, new2b!);
                 }
 
                 if ((changeMechanism & ChangeMechanism.Principal) != 0)
@@ -308,8 +306,8 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
 
                 if ((changeMechanism & ChangeMechanism.Dependent) != 0)
                 {
-                    removed2.Parent = null;
-                    removed1.Parent = null;
+                    removed2.Parent = null!;
+                    removed1.Parent = null!;
                 }
 
                 if ((changeMechanism & ChangeMechanism.Fk) != 0)
@@ -357,7 +355,7 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
     {
         var removed1Id = 0;
         var removed2Id = 0;
-        List<int> removed1ChildrenIds = null;
+        List<int> removed1ChildrenIds = null!;
 
         return ExecuteWithStrategyInTransactionAsync(
             async context =>
@@ -386,8 +384,8 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
 
                 if ((changeMechanism & ChangeMechanism.Dependent) != 0)
                 {
-                    removed2.Parent = null;
-                    removed1.Parent = null;
+                    removed2.Parent = null!;
+                    removed1.Parent = null!;
                 }
 
                 if ((changeMechanism & ChangeMechanism.Fk) != 0)
@@ -415,7 +413,7 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
 
                 Assert.Empty(context.Set<Required1>().Where(e => e.Id == removed1Id));
                 Assert.Empty(context.Set<Required2>().Where(e => e.Id == removed2Id));
-                Assert.Empty(context.Set<Required2>().Where(e => removed1ChildrenIds.Contains(e.Id)));
+                Assert.Empty(context.Set<Required2>().Where(e => removed1ChildrenIds!.Contains(e.Id)));
             });
     }
 
@@ -433,10 +431,10 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
     public virtual Task Reparent_to_different_one_to_many(ChangeMechanism changeMechanism, bool useExistingParent)
     {
         var compositeCount = 0;
-        OptionalAk1 oldParent = null;
-        OptionalComposite2 oldComposite1 = null;
-        OptionalComposite2 oldComposite2 = null;
-        Optional1 newParent = null;
+        OptionalAk1 oldParent = null!;
+        OptionalComposite2 oldComposite1 = null!;
+        OptionalComposite2 oldComposite2 = null!;
+        Optional1 newParent = null!;
 
         return ExecuteWithStrategyInTransactionAsync(
             context =>
@@ -479,7 +477,7 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
                 }
                 else
                 {
-                    newParent = context.Set<Optional1>().Single(e => e.Id == newParent.Id);
+                    newParent = context.Set<Optional1>().Single(e => e.Id == newParent!.Id);
                     newParent.Parent = root;
                 }
 
@@ -496,7 +494,7 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
 
                 if ((changeMechanism & ChangeMechanism.Dependent) != 0)
                 {
-                    oldComposite1.Parent = null;
+                    oldComposite1.Parent = null!;
                     oldComposite1.Parent2 = newParent;
                 }
 
@@ -531,11 +529,11 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
                 {
                     var loadedRoot = await LoadRootAsync(context);
 
-                    oldParent = context.Set<OptionalAk1>().Single(e => e.Id == oldParent.Id);
-                    newParent = context.Set<Optional1>().Single(e => e.Id == newParent.Id);
+                    oldParent = context.Set<OptionalAk1>().Single(e => e.Id == oldParent!.Id);
+                    newParent = context.Set<Optional1>().Single(e => e.Id == newParent!.Id);
 
-                    oldComposite1 = context.Set<OptionalComposite2>().Single(e => e.Id == oldComposite1.Id);
-                    oldComposite2 = context.Set<OptionalComposite2>().Single(e => e.Id == oldComposite2.Id);
+                    oldComposite1 = context.Set<OptionalComposite2>().Single(e => e.Id == oldComposite1!.Id);
+                    oldComposite2 = context.Set<OptionalComposite2>().Single(e => e.Id == oldComposite2!.Id);
 
                     Assert.Same(oldComposite2, oldParent.CompositeChildren.Single());
                     Assert.Same(oldParent, oldComposite2.Parent);
@@ -567,12 +565,12 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
      InlineData((int)(ChangeMechanism.Principal | ChangeMechanism.Dependent | ChangeMechanism.Fk), true)]
     public virtual Task Reparent_one_to_many_overlapping(ChangeMechanism changeMechanism, bool useExistingParent)
     {
-        Root root = null;
+        Root root = null!;
         var childCount = 0;
-        RequiredComposite1 oldParent = null;
-        OptionalOverlapping2 oldChild1 = null;
-        OptionalOverlapping2 oldChild2 = null;
-        RequiredComposite1 newParent = null;
+        RequiredComposite1 oldParent = null!;
+        OptionalOverlapping2 oldChild1 = null!;
+        OptionalOverlapping2 oldChild2 = null!;
+        RequiredComposite1 newParent = null!;
 
         return ExecuteWithStrategyInTransactionAsync(
             context =>
@@ -624,7 +622,7 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
                 }
                 else
                 {
-                    newParent = context.Set<RequiredComposite1>().Single(e => e.Id == newParent.Id);
+                    newParent = context.Set<RequiredComposite1>().Single(e => e.Id == newParent!.Id);
                     newParent.Parent = root;
                 }
 
@@ -675,11 +673,11 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
             {
                 var loadedRoot = await LoadRootAsync(context);
 
-                oldParent = context.Set<RequiredComposite1>().Single(e => e.Id == oldParent.Id);
-                newParent = context.Set<RequiredComposite1>().Single(e => e.Id == newParent.Id);
+                oldParent = context.Set<RequiredComposite1>().Single(e => e.Id == oldParent!.Id);
+                newParent = context.Set<RequiredComposite1>().Single(e => e.Id == newParent!.Id);
 
-                oldChild1 = context.Set<OptionalOverlapping2>().Single(e => e.Id == oldChild1.Id);
-                oldChild2 = context.Set<OptionalOverlapping2>().Single(e => e.Id == oldChild2.Id);
+                oldChild1 = context.Set<OptionalOverlapping2>().Single(e => e.Id == oldChild1!.Id);
+                oldChild2 = context.Set<OptionalOverlapping2>().Single(e => e.Id == oldChild2!.Id);
 
                 if (!DoesLazyLoading)
                 {
@@ -691,7 +689,7 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
                 Assert.Same(oldParent, oldChild2.Parent);
                 Assert.Equal(oldParent.Id, oldChild2.ParentId);
                 Assert.Equal(oldParent.ParentAlternateId, oldChild2.ParentAlternateId);
-                Assert.Equal(root.AlternateId, oldChild2.ParentAlternateId);
+                Assert.Equal(root!.AlternateId, oldChild2.ParentAlternateId);
 
                 Assert.Same(oldChild1, newParent.CompositeChildren.Single(e => e.Id == oldChild1.Id));
                 Assert.Same(newParent, oldChild1.Parent);
@@ -713,7 +711,7 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
         CascadeTiming deleteOrphansTiming)
     {
         var removedId = 0;
-        List<int> orphanedIds = null;
+        List<int> orphanedIds = null!;
 
         return ExecuteWithStrategyInTransactionAsync(
             async context =>
@@ -784,7 +782,7 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
                     Assert.DoesNotContain(removedId, root.RequiredChildren.Select(e => e.Id));
 
                     Assert.Empty(context.Set<Required1>().Where(e => e.Id == removedId));
-                    Assert.Empty(context.Set<Required2>().Where(e => orphanedIds.Contains(e.Id)));
+                    Assert.Empty(context.Set<Required2>().Where(e => orphanedIds!.Contains(e.Id)));
                 }
             });
     }
@@ -799,7 +797,7 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
         CascadeTiming deleteOrphansTiming)
     {
         var removedId = 0;
-        List<int> orphanedIds = null;
+        List<int> orphanedIds = null!;
 
         return ExecuteWithStrategyInTransactionAsync(
             async context =>
@@ -882,7 +880,7 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
                 Assert.DoesNotContain(removedId, root.OptionalChildren.Select(e => e.Id));
 
                 Assert.Empty(context.Set<Optional1>().Where(e => e.Id == removedId));
-                Assert.Equal(orphanedIds.Count, context.Set<Optional2>().Count(e => orphanedIds.Contains(e.Id)));
+                Assert.Equal(orphanedIds!.Count, context.Set<Optional2>().Count(e => orphanedIds.Contains(e.Id)));
             });
     }
 
@@ -949,7 +947,7 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
         CascadeTiming deleteOrphansTiming)
     {
         var removedId = 0;
-        List<int> orphanedIds = null;
+        List<int> orphanedIds = null!;
 
         return ExecuteWithStrategyInTransactionAsync(
             async context =>
@@ -982,7 +980,7 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
 
                 var removed = root.RequiredChildren.Single(e => e.Id == removedId);
 
-                Assert.Equal(2, orphanedIds.Count);
+                Assert.Equal(2, orphanedIds!.Count);
 
                 context.Remove(removed);
 
@@ -1016,7 +1014,7 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
                 Assert.DoesNotContain(removedId, root.RequiredChildren.Select(e => e.Id));
 
                 Assert.Empty(context.Set<Required1>().Where(e => e.Id == removedId));
-                Assert.Empty(context.Set<Required2>().Where(e => orphanedIds.Contains(e.Id)));
+                Assert.Empty(context.Set<Required2>().Where(e => orphanedIds!.Contains(e.Id)));
             });
     }
 
@@ -1030,7 +1028,7 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
         CascadeTiming deleteOrphansTiming)
     {
         var removedId = 0;
-        List<int> orphanedIds = null;
+        List<int> orphanedIds = null!;
 
         return ExecuteWithStrategyInTransactionAsync(
             async context =>
@@ -1063,7 +1061,7 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
 
                 var removed = root.OptionalChildren.First(e => e.Id == removedId);
 
-                Assert.Equal(2, orphanedIds.Count);
+                Assert.Equal(2, orphanedIds!.Count);
 
                 context.Remove(removed);
 
@@ -1101,8 +1099,8 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
 
                 Assert.Empty(context.Set<Optional1>().Where(e => e.Id == removedId));
 
-                var orphaned = context.Set<Optional2>().Where(e => orphanedIds.Contains(e.Id)).ToList();
-                Assert.Equal(orphanedIds.Count, orphaned.Count);
+                var orphaned = context.Set<Optional2>().Where(e => orphanedIds!.Contains(e.Id)).ToList();
+                Assert.Equal(orphanedIds!.Count, orphaned.Count);
                 Assert.True(orphaned.All(e => e.ParentId == null));
             });
     }
@@ -1117,10 +1115,10 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
         CascadeTiming deleteOrphansTiming)
     {
         var removedId = 0;
-        List<int> orphanedIds = null;
-        Root root = null;
-        Required1 removed = null;
-        List<Required2> cascadeRemoved = null;
+        List<int> orphanedIds = null!;
+        Root root = null!;
+        Required1 removed = null!;
+        List<Required2> cascadeRemoved = null!;
 
         return ExecuteWithStrategyInTransactionAsync(
             async context =>
@@ -1148,8 +1146,8 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
                 context.ChangeTracker.CascadeDeleteTiming = cascadeDeleteTiming;
                 context.ChangeTracker.DeleteOrphansTiming = deleteOrphansTiming;
 
-                removedId = removed.Id;
-                orphanedIds = cascadeRemoved.Select(e => e.Id).ToList();
+                removedId = removed!.Id;
+                orphanedIds = cascadeRemoved!.Select(e => e.Id).ToList();
 
                 Assert.Equal(2, orphanedIds.Count);
 
@@ -1198,7 +1196,7 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
                     Assert.DoesNotContain(removedId, root.RequiredChildren.Select(e => e.Id));
 
                     Assert.Empty(context.Set<Required1>().Where(e => e.Id == removedId));
-                    Assert.Empty(context.Set<Required2>().Where(e => orphanedIds.Contains(e.Id)));
+                    Assert.Empty(context.Set<Required2>().Where(e => orphanedIds!.Contains(e.Id)));
                 }
             });
     }
@@ -1213,10 +1211,10 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
         CascadeTiming deleteOrphansTiming)
     {
         var removedId = 0;
-        List<int> orphanedIds = null;
-        Root root = null;
-        Optional1 removed = null;
-        List<Optional2> orphaned = null;
+        List<int> orphanedIds = null!;
+        Root root = null!;
+        Optional1 removed = null!;
+        List<Optional2> orphaned = null!;
 
         return ExecuteWithStrategyInTransactionAsync(
             async context =>
@@ -1244,8 +1242,8 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
                 context.ChangeTracker.CascadeDeleteTiming = cascadeDeleteTiming;
                 context.ChangeTracker.DeleteOrphansTiming = deleteOrphansTiming;
 
-                removedId = removed.Id;
-                orphanedIds = orphaned.Select(e => e.Id).ToList();
+                removedId = removed!.Id;
+                orphanedIds = orphaned!.Select(e => e.Id).ToList();
 
                 Assert.Equal(2, orphanedIds.Count);
 
@@ -1299,7 +1297,7 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
                 Assert.DoesNotContain(removedId, root.OptionalChildren.Select(e => e.Id));
 
                 Assert.Empty(context.Set<Optional1>().Where(e => e.Id == removedId));
-                Assert.Equal(orphanedIds.Count, context.Set<Optional2>().Count(e => orphanedIds.Contains(e.Id)));
+                Assert.Equal(orphanedIds!.Count, context.Set<Optional2>().Count(e => orphanedIds.Contains(e.Id)));
             });
     }
 
@@ -1313,7 +1311,7 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
         CascadeTiming deleteOrphansTiming)
     {
         var removedId = 0;
-        List<int> orphanedIds = null;
+        List<int> orphanedIds = null!;
 
         return ExecuteWithStrategyInTransactionAsync(
             async context =>
@@ -1406,7 +1404,7 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
                     Assert.DoesNotContain(removedId, root.RequiredChildren.Select(e => e.Id));
 
                     Assert.Empty(context.Set<Required1>().Where(e => e.Id == removedId));
-                    Assert.Empty(context.Set<Required2>().Where(e => orphanedIds.Contains(e.Id)));
+                    Assert.Empty(context.Set<Required2>().Where(e => orphanedIds!.Contains(e.Id)));
                 }
             });
     }

--- a/test/EFCore.Specification.Tests/GraphUpdates/ProxyGraphUpdatesTestBaseOneToManyAk.cs
+++ b/test/EFCore.Specification.Tests/GraphUpdates/ProxyGraphUpdatesTestBaseOneToManyAk.cs
@@ -7,8 +7,6 @@
 
 namespace Microsoft.EntityFrameworkCore;
 
-#nullable disable
-
 public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixture<TFixture>
     where TFixture : ProxyGraphUpdatesTestBase<TFixture>.ProxyGraphUpdatesFixtureBase, new()
 {
@@ -27,15 +25,15 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
         ChangeMechanism changeMechanism,
         bool useExistingEntities)
     {
-        OptionalAk1 new1 = null;
-        OptionalAk1Derived new1d = null;
-        OptionalAk1MoreDerived new1dd = null;
-        OptionalAk2 new2a = null;
-        OptionalAk2 new2b = null;
-        OptionalComposite2 new2ca = null;
-        OptionalComposite2 new2cb = null;
-        OptionalAk2Derived new2d = null;
-        OptionalAk2MoreDerived new2dd = null;
+        OptionalAk1 new1 = null!;
+        OptionalAk1Derived new1d = null!;
+        OptionalAk1MoreDerived new1dd = null!;
+        OptionalAk2 new2a = null!;
+        OptionalAk2 new2b = null!;
+        OptionalComposite2 new2ca = null!;
+        OptionalComposite2 new2cb = null!;
+        OptionalAk2Derived new2d = null!;
+        OptionalAk2MoreDerived new2dd = null!;
 
         return ExecuteWithStrategyInTransactionAsync(
             context =>
@@ -70,19 +68,19 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
 
                 if (useExistingEntities)
                 {
-                    new1 = context.Set<OptionalAk1>().Single(e => e.Id == new1.Id);
-                    new1d = (OptionalAk1Derived)context.Set<OptionalAk1>().Single(e => e.Id == new1d.Id);
-                    new1dd = (OptionalAk1MoreDerived)context.Set<OptionalAk1>().Single(e => e.Id == new1dd.Id);
-                    new2a = context.Set<OptionalAk2>().Single(e => e.Id == new2a.Id);
-                    new2b = context.Set<OptionalAk2>().Single(e => e.Id == new2b.Id);
-                    new2ca = context.Set<OptionalComposite2>().Single(e => e.Id == new2ca.Id);
-                    new2cb = context.Set<OptionalComposite2>().Single(e => e.Id == new2cb.Id);
-                    new2d = (OptionalAk2Derived)context.Set<OptionalAk2>().Single(e => e.Id == new2d.Id);
-                    new2dd = (OptionalAk2MoreDerived)context.Set<OptionalAk2>().Single(e => e.Id == new2dd.Id);
+                    new1 = context.Set<OptionalAk1>().Single(e => e.Id == new1!.Id);
+                    new1d = (OptionalAk1Derived)context.Set<OptionalAk1>().Single(e => e.Id == new1d!.Id);
+                    new1dd = (OptionalAk1MoreDerived)context.Set<OptionalAk1>().Single(e => e.Id == new1dd!.Id);
+                    new2a = context.Set<OptionalAk2>().Single(e => e.Id == new2a!.Id);
+                    new2b = context.Set<OptionalAk2>().Single(e => e.Id == new2b!.Id);
+                    new2ca = context.Set<OptionalComposite2>().Single(e => e.Id == new2ca!.Id);
+                    new2cb = context.Set<OptionalComposite2>().Single(e => e.Id == new2cb!.Id);
+                    new2d = (OptionalAk2Derived)context.Set<OptionalAk2>().Single(e => e.Id == new2d!.Id);
+                    new2dd = (OptionalAk2MoreDerived)context.Set<OptionalAk2>().Single(e => e.Id == new2dd!.Id);
                 }
                 else
                 {
-                    context.AddRange(new1, new1d, new1dd, new2a, new2d, new2dd, new2b, new2ca, new2cb);
+                    context.AddRange(new1!, new1d!, new1dd!, new2a!, new2d!, new2dd!, new2b!, new2ca!, new2cb!);
                 }
 
                 if ((changeMechanism & ChangeMechanism.Principal) != 0)
@@ -182,15 +180,15 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
         bool useExistingEntities)
     {
         Root newRoot;
-        RequiredAk1 new1 = null;
-        RequiredAk1Derived new1d = null;
-        RequiredAk1MoreDerived new1dd = null;
-        RequiredAk2 new2a = null;
-        RequiredAk2 new2b = null;
-        RequiredComposite2 new2ca = null;
-        RequiredComposite2 new2cb = null;
-        RequiredAk2Derived new2d = null;
-        RequiredAk2MoreDerived new2dd = null;
+        RequiredAk1 new1 = null!;
+        RequiredAk1Derived new1d = null!;
+        RequiredAk1MoreDerived new1dd = null!;
+        RequiredAk2 new2a = null!;
+        RequiredAk2 new2b = null!;
+        RequiredComposite2 new2ca = null!;
+        RequiredComposite2 new2cb = null!;
+        RequiredAk2Derived new2d = null!;
+        RequiredAk2MoreDerived new2dd = null!;
 
         return ExecuteWithStrategyInTransactionAsync(
             context =>
@@ -254,23 +252,23 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
 
                 if (useExistingEntities)
                 {
-                    new1 = context.Set<RequiredAk1>().Single(e => e.Id == new1.Id);
-                    new1d = (RequiredAk1Derived)context.Set<RequiredAk1>().Single(e => e.Id == new1d.Id);
-                    new1dd = (RequiredAk1MoreDerived)context.Set<RequiredAk1>().Single(e => e.Id == new1dd.Id);
-                    new2a = context.Set<RequiredAk2>().Single(e => e.Id == new2a.Id);
-                    new2b = context.Set<RequiredAk2>().Single(e => e.Id == new2b.Id);
-                    new2ca = context.Set<RequiredComposite2>().Single(e => e.Id == new2ca.Id);
-                    new2cb = context.Set<RequiredComposite2>().Single(e => e.Id == new2cb.Id);
-                    new2d = (RequiredAk2Derived)context.Set<RequiredAk2>().Single(e => e.Id == new2d.Id);
-                    new2dd = (RequiredAk2MoreDerived)context.Set<RequiredAk2>().Single(e => e.Id == new2dd.Id);
+                    new1 = context.Set<RequiredAk1>().Single(e => e.Id == new1!.Id);
+                    new1d = (RequiredAk1Derived)context.Set<RequiredAk1>().Single(e => e.Id == new1d!.Id);
+                    new1dd = (RequiredAk1MoreDerived)context.Set<RequiredAk1>().Single(e => e.Id == new1dd!.Id);
+                    new2a = context.Set<RequiredAk2>().Single(e => e.Id == new2a!.Id);
+                    new2b = context.Set<RequiredAk2>().Single(e => e.Id == new2b!.Id);
+                    new2ca = context.Set<RequiredComposite2>().Single(e => e.Id == new2ca!.Id);
+                    new2cb = context.Set<RequiredComposite2>().Single(e => e.Id == new2cb!.Id);
+                    new2d = (RequiredAk2Derived)context.Set<RequiredAk2>().Single(e => e.Id == new2d!.Id);
+                    new2dd = (RequiredAk2MoreDerived)context.Set<RequiredAk2>().Single(e => e.Id == new2dd!.Id);
                 }
                 else
                 {
-                    new1.Parent = null;
-                    new1d.Parent = null;
-                    new1dd.Parent = null;
+                    new1!.Parent = null!;
+                    new1d!.Parent = null!;
+                    new1dd!.Parent = null!;
 
-                    context.AddRange(new1, new1d, new1dd, new2a, new2d, new2dd, new2b, new2ca, new2cb);
+                    context.AddRange(new1, new1d, new1dd, new2a!, new2d!, new2dd!, new2b!, new2ca!, new2cb!);
                 }
 
                 if ((changeMechanism & ChangeMechanism.Principal) != 0)
@@ -388,9 +386,9 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
 
                 if ((changeMechanism & ChangeMechanism.Dependent) != 0)
                 {
-                    removed2.Parent = null;
-                    removed2c.Parent = null;
-                    removed1.Parent = null;
+                    removed2.Parent = null!;
+                    removed2c.Parent = null!;
+                    removed1.Parent = null!;
                 }
 
                 if ((changeMechanism & ChangeMechanism.Fk) != 0)
@@ -439,10 +437,10 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
      InlineData((int)(ChangeMechanism.Principal | ChangeMechanism.Dependent))]
     public virtual Task Save_removed_required_many_to_one_dependents_with_alternate_key(ChangeMechanism changeMechanism)
     {
-        Root root = null;
-        RequiredAk2 removed2 = null;
-        RequiredComposite2 removed2c = null;
-        RequiredAk1 removed1 = null;
+        Root root = null!;
+        RequiredAk2 removed2 = null!;
+        RequiredComposite2 removed2c = null!;
+        RequiredAk1 removed1 = null!;
 
         return ExecuteWithStrategyInTransactionAsync(
             async context =>
@@ -471,9 +469,9 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
 
                 if ((changeMechanism & ChangeMechanism.Dependent) != 0)
                 {
-                    removed2.Parent = null;
-                    removed2c.Parent = null;
-                    removed1.Parent = null;
+                    removed2.Parent = null!;
+                    removed2c.Parent = null!;
+                    removed1.Parent = null!;
                 }
 
                 if ((changeMechanism & ChangeMechanism.Fk) != 0)
@@ -505,9 +503,9 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
                     context.Entry(loadedRoot.RequiredChildrenAk.First()).Collection(e => e.CompositeChildren).Load();
                 }
 
-                Assert.False(context.Set<RequiredAk1>().Any(e => e.Id == removed1.Id));
-                Assert.False(context.Set<RequiredAk2>().Any(e => e.Id == removed2.Id));
-                Assert.False(context.Set<RequiredComposite2>().Any(e => e.Id == removed2c.Id));
+                Assert.False(context.Set<RequiredAk1>().Any(e => e.Id == removed1!.Id));
+                Assert.False(context.Set<RequiredAk2>().Any(e => e.Id == removed2!.Id));
+                Assert.False(context.Set<RequiredComposite2>().Any(e => e.Id == removed2c!.Id));
 
                 Assert.Single(loadedRoot.RequiredChildrenAk);
                 Assert.Single(loadedRoot.RequiredChildrenAk.First().Children);
@@ -525,7 +523,7 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
         CascadeTiming deleteOrphansTiming)
     {
         var removedId = 0;
-        List<int> orphanedIds = null;
+        List<int> orphanedIds = null!;
 
         return ExecuteWithStrategyInTransactionAsync(
             async context =>
@@ -588,7 +586,7 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
                 Assert.DoesNotContain(removedId, root.OptionalChildrenAk.Select(e => e.Id));
 
                 Assert.Empty(context.Set<OptionalAk1>().Where(e => e.Id == removedId));
-                Assert.Equal(orphanedIds.Count, context.Set<OptionalAk2>().Count(e => orphanedIds.Contains(e.Id)));
+                Assert.Equal(orphanedIds!.Count, context.Set<OptionalAk2>().Count(e => orphanedIds.Contains(e.Id)));
             });
     }
 
@@ -602,8 +600,8 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
         CascadeTiming deleteOrphansTiming)
     {
         var removedId = 0;
-        List<int> orphanedIds = null;
-        List<int> orphanedIdCs = null;
+        List<int> orphanedIds = null!;
+        List<int> orphanedIdCs = null!;
 
         return ExecuteWithStrategyInTransactionAsync(
             async context =>
@@ -679,8 +677,8 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
                     Assert.DoesNotContain(removedId, root.RequiredChildrenAk.Select(e => e.Id));
 
                     Assert.Empty(context.Set<RequiredAk1>().Where(e => e.Id == removedId));
-                    Assert.Empty(context.Set<RequiredAk2>().Where(e => orphanedIds.Contains(e.Id)));
-                    Assert.Empty(context.Set<RequiredComposite2>().Where(e => orphanedIdCs.Contains(e.Id)));
+                    Assert.Empty(context.Set<RequiredAk2>().Where(e => orphanedIds!.Contains(e.Id)));
+                    Assert.Empty(context.Set<RequiredComposite2>().Where(e => orphanedIdCs!.Contains(e.Id)));
                 }
             });
     }
@@ -695,8 +693,8 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
         CascadeTiming deleteOrphansTiming)
     {
         var removedId = 0;
-        List<int> orphanedIds = null;
-        List<int> orphanedIdCs = null;
+        List<int> orphanedIds = null!;
+        List<int> orphanedIdCs = null!;
 
         return ExecuteWithStrategyInTransactionAsync(
             async context =>
@@ -746,8 +744,8 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
                 Assert.DoesNotContain(removedId, root.RequiredChildrenAk.Select(e => e.Id));
 
                 Assert.Empty(context.Set<RequiredAk1>().Where(e => e.Id == removedId));
-                Assert.Empty(context.Set<RequiredAk2>().Where(e => orphanedIds.Contains(e.Id)));
-                Assert.Empty(context.Set<RequiredComposite2>().Where(e => orphanedIdCs.Contains(e.Id)));
+                Assert.Empty(context.Set<RequiredAk2>().Where(e => orphanedIds!.Contains(e.Id)));
+                Assert.Empty(context.Set<RequiredComposite2>().Where(e => orphanedIdCs!.Contains(e.Id)));
 
                 Assert.Same(root, removed.Parent);
                 Assert.Empty(removed.Children); // Never loaded
@@ -765,8 +763,8 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
                 Assert.DoesNotContain(removedId, root.RequiredChildrenAk.Select(e => e.Id));
 
                 Assert.Empty(context.Set<RequiredAk1>().Where(e => e.Id == removedId));
-                Assert.Empty(context.Set<RequiredAk2>().Where(e => orphanedIds.Contains(e.Id)));
-                Assert.Empty(context.Set<RequiredComposite2>().Where(e => orphanedIdCs.Contains(e.Id)));
+                Assert.Empty(context.Set<RequiredAk2>().Where(e => orphanedIds!.Contains(e.Id)));
+                Assert.Empty(context.Set<RequiredComposite2>().Where(e => orphanedIdCs!.Contains(e.Id)));
             });
     }
 
@@ -780,8 +778,8 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
         CascadeTiming deleteOrphansTiming)
     {
         var removedId = 0;
-        List<int> orphanedIds = null;
-        List<int> orphanedIdCs = null;
+        List<int> orphanedIds = null!;
+        List<int> orphanedIdCs = null!;
 
         return ExecuteWithStrategyInTransactionAsync(
             async context =>
@@ -819,7 +817,7 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
 
                 context.Remove(removed);
 
-                foreach (var toOrphan in context.Set<OptionalComposite2>().Where(e => orphanedIdCs.Contains(e.Id)).ToList())
+                foreach (var toOrphan in context.Set<OptionalComposite2>().Where(e => orphanedIdCs!.Contains(e.Id)).ToList())
                 {
                     toOrphan.ParentId = null;
                 }
@@ -837,12 +835,12 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
 
                 Assert.Empty(context.Set<OptionalAk1>().Where(e => e.Id == removedId));
 
-                var orphaned = context.Set<OptionalAk2>().Where(e => orphanedIds.Contains(e.Id)).ToList();
-                Assert.Equal(orphanedIds.Count, orphaned.Count);
+                var orphaned = context.Set<OptionalAk2>().Where(e => orphanedIds!.Contains(e.Id)).ToList();
+                Assert.Equal(orphanedIds!.Count, orphaned.Count);
                 Assert.True(orphaned.All(e => e.ParentId == null));
 
-                var orphanedC = context.Set<OptionalComposite2>().Where(e => orphanedIdCs.Contains(e.Id)).ToList();
-                Assert.Equal(orphanedIdCs.Count, orphanedC.Count);
+                var orphanedC = context.Set<OptionalComposite2>().Where(e => orphanedIdCs!.Contains(e.Id)).ToList();
+                Assert.Equal(orphanedIdCs!.Count, orphanedC.Count);
                 Assert.True(orphanedC.All(e => e.ParentId == null));
 
                 Assert.Same(root, removed.Parent);
@@ -862,12 +860,12 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
 
                 Assert.Empty(context.Set<OptionalAk1>().Where(e => e.Id == removedId));
 
-                var orphaned = context.Set<OptionalAk2>().Where(e => orphanedIds.Contains(e.Id)).ToList();
-                Assert.Equal(orphanedIds.Count, orphaned.Count);
+                var orphaned = context.Set<OptionalAk2>().Where(e => orphanedIds!.Contains(e.Id)).ToList();
+                Assert.Equal(orphanedIds!.Count, orphaned.Count);
                 Assert.True(orphaned.All(e => e.ParentId == null));
 
-                var orphanedC = context.Set<OptionalComposite2>().Where(e => orphanedIdCs.Contains(e.Id)).ToList();
-                Assert.Equal(orphanedIdCs.Count, orphanedC.Count);
+                var orphanedC = context.Set<OptionalComposite2>().Where(e => orphanedIdCs!.Contains(e.Id)).ToList();
+                Assert.Equal(orphanedIdCs!.Count, orphanedC.Count);
                 Assert.True(orphanedC.All(e => e.ParentId == null));
             });
     }
@@ -882,12 +880,12 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
         CascadeTiming deleteOrphansTiming)
     {
         var removedId = 0;
-        List<int> orphanedIds = null;
-        List<int> orphanedIdCs = null;
-        Root root = null;
-        OptionalAk1 removed = null;
-        List<OptionalAk2> orphaned = null;
-        List<OptionalComposite2> orphanedC = null;
+        List<int> orphanedIds = null!;
+        List<int> orphanedIdCs = null!;
+        Root root = null!;
+        OptionalAk1 removed = null!;
+        List<OptionalAk2> orphaned = null!;
+        List<OptionalComposite2> orphanedC = null!;
 
         return ExecuteWithStrategyInTransactionAsync(
             async context =>
@@ -917,9 +915,9 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
                 context.ChangeTracker.CascadeDeleteTiming = cascadeDeleteTiming;
                 context.ChangeTracker.DeleteOrphansTiming = deleteOrphansTiming;
 
-                removedId = removed.Id;
-                orphanedIds = orphaned.Select(e => e.Id).ToList();
-                orphanedIdCs = orphanedC.Select(e => e.Id).ToList();
+                removedId = removed!.Id;
+                orphanedIds = orphaned!.Select(e => e.Id).ToList();
+                orphanedIdCs = orphanedC!.Select(e => e.Id).ToList();
 
                 Assert.Equal(2, orphanedIds.Count);
                 Assert.Equal(2, orphanedIdCs.Count);
@@ -961,8 +959,8 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
                 Assert.DoesNotContain(removedId, root.OptionalChildrenAk.Select(e => e.Id));
 
                 Assert.Empty(context.Set<OptionalAk1>().Where(e => e.Id == removedId));
-                Assert.Equal(orphanedIds.Count, context.Set<OptionalAk2>().Count(e => orphanedIds.Contains(e.Id)));
-                Assert.Equal(orphanedIdCs.Count, context.Set<OptionalComposite2>().Count(e => orphanedIdCs.Contains(e.Id)));
+                Assert.Equal(orphanedIds!.Count, context.Set<OptionalAk2>().Count(e => orphanedIds.Contains(e.Id)));
+                Assert.Equal(orphanedIdCs!.Count, context.Set<OptionalComposite2>().Count(e => orphanedIdCs.Contains(e.Id)));
             });
     }
 
@@ -976,12 +974,12 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
         CascadeTiming deleteOrphansTiming)
     {
         var removedId = 0;
-        List<int> orphanedIds = null;
-        List<int> orphanedIdCs = null;
-        Root root = null;
-        RequiredAk1 removed = null;
-        List<RequiredAk2> cascadeRemoved = null;
-        List<RequiredComposite2> cascadeRemovedC = null;
+        List<int> orphanedIds = null!;
+        List<int> orphanedIdCs = null!;
+        Root root = null!;
+        RequiredAk1 removed = null!;
+        List<RequiredAk2> cascadeRemoved = null!;
+        List<RequiredComposite2> cascadeRemovedC = null!;
 
         return ExecuteWithStrategyInTransactionAsync(
             async context =>
@@ -1011,9 +1009,9 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
                 context.ChangeTracker.CascadeDeleteTiming = cascadeDeleteTiming;
                 context.ChangeTracker.DeleteOrphansTiming = deleteOrphansTiming;
 
-                removedId = removed.Id;
-                orphanedIds = cascadeRemoved.Select(e => e.Id).ToList();
-                orphanedIdCs = cascadeRemovedC.Select(e => e.Id).ToList();
+                removedId = removed!.Id;
+                orphanedIds = cascadeRemoved!.Select(e => e.Id).ToList();
+                orphanedIdCs = cascadeRemovedC!.Select(e => e.Id).ToList();
 
                 Assert.Equal(2, orphanedIds.Count);
 
@@ -1064,8 +1062,8 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
                     Assert.DoesNotContain(removedId, root.RequiredChildrenAk.Select(e => e.Id));
 
                     Assert.Empty(context.Set<RequiredAk1>().Where(e => e.Id == removedId));
-                    Assert.Empty(context.Set<RequiredAk2>().Where(e => orphanedIds.Contains(e.Id)));
-                    Assert.Empty(context.Set<RequiredComposite2>().Where(e => orphanedIdCs.Contains(e.Id)));
+                    Assert.Empty(context.Set<RequiredAk2>().Where(e => orphanedIds!.Contains(e.Id)));
+                    Assert.Empty(context.Set<RequiredComposite2>().Where(e => orphanedIdCs!.Contains(e.Id)));
                 }
             });
     }
@@ -1080,8 +1078,8 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
         CascadeTiming deleteOrphansTiming)
     {
         var removedId = 0;
-        List<int> orphanedIds = null;
-        List<int> orphanedIdCs = null;
+        List<int> orphanedIds = null!;
+        List<int> orphanedIdCs = null!;
 
         return ExecuteWithStrategyInTransactionAsync(
             async context =>
@@ -1187,8 +1185,8 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
                     Assert.DoesNotContain(removedId, root.RequiredChildrenAk.Select(e => e.Id));
 
                     Assert.Empty(context.Set<RequiredAk1>().Where(e => e.Id == removedId));
-                    Assert.Empty(context.Set<RequiredAk2>().Where(e => orphanedIds.Contains(e.Id)));
-                    Assert.Empty(context.Set<RequiredComposite2>().Where(e => orphanedIdCs.Contains(e.Id)));
+                    Assert.Empty(context.Set<RequiredAk2>().Where(e => orphanedIds!.Contains(e.Id)));
+                    Assert.Empty(context.Set<RequiredComposite2>().Where(e => orphanedIdCs!.Contains(e.Id)));
                 }
             });
     }

--- a/test/EFCore.Specification.Tests/GraphUpdates/ProxyGraphUpdatesTestBaseOneToOne.cs
+++ b/test/EFCore.Specification.Tests/GraphUpdates/ProxyGraphUpdatesTestBaseOneToOne.cs
@@ -7,8 +7,6 @@
 
 namespace Microsoft.EntityFrameworkCore;
 
-#nullable disable
-
 public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixture<TFixture>
     where TFixture : ProxyGraphUpdatesTestBase<TFixture>.ProxyGraphUpdatesFixtureBase, new()
 {
@@ -73,18 +71,18 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
      InlineData((int)(ChangeMechanism.Principal | ChangeMechanism.Dependent | ChangeMechanism.Fk), true)]
     public virtual Task Save_changed_optional_one_to_one(ChangeMechanism changeMechanism, bool useExistingEntities)
     {
-        OptionalSingle2 new2 = null;
-        OptionalSingle2Derived new2d = null;
-        OptionalSingle2MoreDerived new2dd = null;
-        OptionalSingle1 new1 = null;
-        OptionalSingle1Derived new1d = null;
-        OptionalSingle1MoreDerived new1dd = null;
-        OptionalSingle1 old1 = null;
-        OptionalSingle1Derived old1d = null;
-        OptionalSingle1MoreDerived old1dd = null;
-        OptionalSingle2 old2 = null;
-        OptionalSingle2Derived old2d = null;
-        OptionalSingle2MoreDerived old2dd = null;
+        OptionalSingle2 new2 = null!;
+        OptionalSingle2Derived new2d = null!;
+        OptionalSingle2MoreDerived new2dd = null!;
+        OptionalSingle1 new1 = null!;
+        OptionalSingle1Derived new1d = null!;
+        OptionalSingle1MoreDerived new1dd = null!;
+        OptionalSingle1 old1 = null!;
+        OptionalSingle1Derived old1d = null!;
+        OptionalSingle1MoreDerived old1dd = null!;
+        OptionalSingle2 old2 = null!;
+        OptionalSingle2Derived old2d = null!;
+        OptionalSingle2MoreDerived old2dd = null!;
 
         return ExecuteWithStrategyInTransactionAsync(
             context =>
@@ -114,9 +112,9 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
                     context.Entry(root).Reference(e => e.OptionalSingleMoreDerived).Load();
                 }
 
-                old1 = root.OptionalSingle;
-                old1d = root.OptionalSingleDerived;
-                old1dd = root.OptionalSingleMoreDerived;
+                old1 = root.OptionalSingle!;
+                old1d = root.OptionalSingleDerived!;
+                old1dd = root.OptionalSingleMoreDerived!;
 
                 if (!DoesLazyLoading)
                 {
@@ -125,22 +123,22 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
                     context.Entry(old1dd).Reference(e => e.Single).Load();
                 }
 
-                old2 = root.OptionalSingle.Single;
-                old2d = (OptionalSingle2Derived)root.OptionalSingleDerived.Single;
-                old2dd = (OptionalSingle2MoreDerived)root.OptionalSingleMoreDerived.Single;
+                old2 = old1.Single!;
+                old2d = (OptionalSingle2Derived)old1d.Single!;
+                old2dd = (OptionalSingle2MoreDerived)old1dd.Single!;
 
                 if (useExistingEntities)
                 {
-                    new1 = context.Set<OptionalSingle1>().Single(e => e.Id == new1.Id);
-                    new1d = (OptionalSingle1Derived)context.Set<OptionalSingle1>().Single(e => e.Id == new1d.Id);
-                    new1dd = (OptionalSingle1MoreDerived)context.Set<OptionalSingle1>().Single(e => e.Id == new1dd.Id);
-                    new2 = context.Set<OptionalSingle2>().Single(e => e.Id == new2.Id);
-                    new2d = (OptionalSingle2Derived)context.Set<OptionalSingle2>().Single(e => e.Id == new2d.Id);
-                    new2dd = (OptionalSingle2MoreDerived)context.Set<OptionalSingle2>().Single(e => e.Id == new2dd.Id);
+                    new1 = context.Set<OptionalSingle1>().Single(e => e.Id == new1!.Id);
+                    new1d = (OptionalSingle1Derived)context.Set<OptionalSingle1>().Single(e => e.Id == new1d!.Id);
+                    new1dd = (OptionalSingle1MoreDerived)context.Set<OptionalSingle1>().Single(e => e.Id == new1dd!.Id);
+                    new2 = context.Set<OptionalSingle2>().Single(e => e.Id == new2!.Id);
+                    new2d = (OptionalSingle2Derived)context.Set<OptionalSingle2>().Single(e => e.Id == new2d!.Id);
+                    new2dd = (OptionalSingle2MoreDerived)context.Set<OptionalSingle2>().Single(e => e.Id == new2dd!.Id);
                 }
                 else
                 {
-                    context.AddRange(new1, new1d, new1dd, new2, new2d, new2dd);
+                    context.AddRange(new1!, new1d!, new1dd!, new2!, new2d!, new2dd!);
                 }
 
                 if ((changeMechanism & ChangeMechanism.Principal) != 0)
@@ -199,12 +197,12 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
             {
                 await LoadRootAsync(context);
 
-                var loaded1 = context.Set<OptionalSingle1>().Single(e => e.Id == old1.Id);
-                var loaded1d = context.Set<OptionalSingle1>().Single(e => e.Id == old1d.Id);
-                var loaded1dd = context.Set<OptionalSingle1>().Single(e => e.Id == old1dd.Id);
-                var loaded2 = context.Set<OptionalSingle2>().Single(e => e.Id == old2.Id);
-                var loaded2d = context.Set<OptionalSingle2>().Single(e => e.Id == old2d.Id);
-                var loaded2dd = context.Set<OptionalSingle2>().Single(e => e.Id == old2dd.Id);
+                var loaded1 = context.Set<OptionalSingle1>().Single(e => e.Id == old1!.Id);
+                var loaded1d = context.Set<OptionalSingle1>().Single(e => e.Id == old1d!.Id);
+                var loaded1dd = context.Set<OptionalSingle1>().Single(e => e.Id == old1dd!.Id);
+                var loaded2 = context.Set<OptionalSingle2>().Single(e => e.Id == old2!.Id);
+                var loaded2d = context.Set<OptionalSingle2>().Single(e => e.Id == old2d!.Id);
+                var loaded2dd = context.Set<OptionalSingle2>().Single(e => e.Id == old2dd!.Id);
 
                 Assert.Null(loaded1.Root);
                 Assert.Null(loaded1d.Root);
@@ -227,11 +225,11 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
      InlineData((int)(ChangeMechanism.Principal | ChangeMechanism.Dependent | ChangeMechanism.Fk))]
     public virtual async Task Save_required_one_to_one_changed_by_reference(ChangeMechanism changeMechanism)
     {
-        RequiredSingle1 old1 = null;
-        RequiredSingle2 old2 = null;
+        RequiredSingle1 old1 = null!;
+        RequiredSingle2 old2 = null!;
         Root oldRoot;
-        RequiredSingle2 new2 = null;
-        RequiredSingle1 new1 = null;
+        RequiredSingle2 new2 = null!;
+        RequiredSingle1 new1 = null!;
         await ExecuteWithStrategyInTransactionAsync(async context =>
         {
             oldRoot = await LoadRootAsync(context);
@@ -267,21 +265,21 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
 
             if ((changeMechanism & ChangeMechanism.Principal) != 0)
             {
-                root.RequiredSingle = new1;
+                root.RequiredSingle = new1!;
             }
 
             if ((changeMechanism & ChangeMechanism.Dependent) != 0)
             {
-                context.Add(new1);
-                new1.Root = root;
+                context.Add(new1!);
+                new1!.Root = root;
             }
 
             if ((changeMechanism & ChangeMechanism.Fk) != 0)
             {
-                context.Add(new1);
-                new1.Id = root.Id;
+                context.Add(new1!);
+                new1!.Id = root.Id;
                 context.Entry(new1).Property(e => e.Id).IsTemporary = false;
-                context.Entry(new2).Property(e => e.Id).IsTemporary = false;
+                context.Entry(new2!).Property(e => e.Id).IsTemporary = false;
             }
 
             Assert.True(context.ChangeTracker.HasChanges());
@@ -290,13 +288,13 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
 
             Assert.False(context.ChangeTracker.HasChanges());
 
-            Assert.Equal(root.Id, new1.Id);
-            Assert.Equal(new1.Id, new2.Id);
+            Assert.Equal(root.Id, new1!.Id);
+            Assert.Equal(new1.Id, new2!.Id);
             Assert.Same(root, new1.Root);
             Assert.Same(new1, new2.Back);
 
-            Assert.NotNull(old1.Root);
-            Assert.Same(old1, old2.Back);
+            Assert.NotNull(old1!.Root);
+            Assert.Same(old1, old2!.Back);
             Assert.Equal(old1.Id, old2.Id);
             return Task.CompletedTask;
         });
@@ -315,19 +313,19 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
      InlineData((int)(ChangeMechanism.Principal | ChangeMechanism.Dependent | ChangeMechanism.Fk), true)]
     public virtual Task Save_required_non_PK_one_to_one_changed_by_reference(ChangeMechanism changeMechanism, bool useExistingEntities)
     {
-        RequiredNonPkSingle2 new2 = null;
-        RequiredNonPkSingle2Derived new2d = null;
-        RequiredNonPkSingle2MoreDerived new2dd = null;
-        RequiredNonPkSingle1 new1 = null;
-        RequiredNonPkSingle1Derived new1d = null;
-        RequiredNonPkSingle1MoreDerived new1dd = null;
+        RequiredNonPkSingle2 new2 = null!;
+        RequiredNonPkSingle2Derived new2d = null!;
+        RequiredNonPkSingle2MoreDerived new2dd = null!;
+        RequiredNonPkSingle1 new1 = null!;
+        RequiredNonPkSingle1Derived new1d = null!;
+        RequiredNonPkSingle1MoreDerived new1dd = null!;
         Root newRoot;
-        RequiredNonPkSingle1 old1 = null;
-        RequiredNonPkSingle1Derived old1d = null;
-        RequiredNonPkSingle1MoreDerived old1dd = null;
-        RequiredNonPkSingle2 old2 = null;
-        RequiredNonPkSingle2Derived old2d = null;
-        RequiredNonPkSingle2MoreDerived old2dd = null;
+        RequiredNonPkSingle1 old1 = null!;
+        RequiredNonPkSingle1Derived old1d = null!;
+        RequiredNonPkSingle1MoreDerived old1dd = null!;
+        RequiredNonPkSingle2 old2 = null!;
+        RequiredNonPkSingle2Derived old2d = null!;
+        RequiredNonPkSingle2MoreDerived old2dd = null!;
 
         return ExecuteWithStrategyInTransactionAsync(
             context =>
@@ -395,12 +393,12 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
 
                 if (useExistingEntities)
                 {
-                    new1 = context.Set<RequiredNonPkSingle1>().Single(e => e.Id == new1.Id);
-                    new1d = (RequiredNonPkSingle1Derived)context.Set<RequiredNonPkSingle1>().Single(e => e.Id == new1d.Id);
-                    new1dd = (RequiredNonPkSingle1MoreDerived)context.Set<RequiredNonPkSingle1>().Single(e => e.Id == new1dd.Id);
-                    new2 = context.Set<RequiredNonPkSingle2>().Single(e => e.Id == new2.Id);
-                    new2d = (RequiredNonPkSingle2Derived)context.Set<RequiredNonPkSingle2>().Single(e => e.Id == new2d.Id);
-                    new2dd = (RequiredNonPkSingle2MoreDerived)context.Set<RequiredNonPkSingle2>().Single(e => e.Id == new2dd.Id);
+                    new1 = context.Set<RequiredNonPkSingle1>().Single(e => e.Id == new1!.Id);
+                    new1d = (RequiredNonPkSingle1Derived)context.Set<RequiredNonPkSingle1>().Single(e => e.Id == new1d!.Id);
+                    new1dd = (RequiredNonPkSingle1MoreDerived)context.Set<RequiredNonPkSingle1>().Single(e => e.Id == new1dd!.Id);
+                    new2 = context.Set<RequiredNonPkSingle2>().Single(e => e.Id == new2!.Id);
+                    new2d = (RequiredNonPkSingle2Derived)context.Set<RequiredNonPkSingle2>().Single(e => e.Id == new2d!.Id);
+                    new2dd = (RequiredNonPkSingle2MoreDerived)context.Set<RequiredNonPkSingle2>().Single(e => e.Id == new2dd!.Id);
 
                     new1d.RootId = old1d.RootId;
                     new1dd.RootId = old1dd.RootId;
@@ -408,10 +406,10 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
                 }
                 else
                 {
-                    new1d.RootId = old1d.RootId;
-                    new1dd.RootId = old1dd.RootId;
+                    new1d!.RootId = old1d.RootId;
+                    new1dd!.RootId = old1dd.RootId;
                     new1dd.DerivedRootId = old1dd.DerivedRootId;
-                    context.AddRange(new1, new1d, new1dd, new2, new2d, new2dd);
+                    context.AddRange(new1!, new1d, new1dd, new2!, new2d!, new2dd!);
                 }
 
                 if ((changeMechanism & ChangeMechanism.Principal) != 0)
@@ -467,12 +465,12 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
             {
                 var loadedRoot = await LoadRootAsync(context);
 
-                Assert.False(context.Set<RequiredNonPkSingle1>().Any(e => e.Id == old1.Id));
-                Assert.False(context.Set<RequiredNonPkSingle1>().Any(e => e.Id == old1d.Id));
-                Assert.False(context.Set<RequiredNonPkSingle1>().Any(e => e.Id == old1dd.Id));
-                Assert.False(context.Set<RequiredNonPkSingle2>().Any(e => e.Id == old2.Id));
-                Assert.False(context.Set<RequiredNonPkSingle2>().Any(e => e.Id == old2d.Id));
-                Assert.False(context.Set<RequiredNonPkSingle2>().Any(e => e.Id == old2dd.Id));
+                Assert.False(context.Set<RequiredNonPkSingle1>().Any(e => e.Id == old1!.Id));
+                Assert.False(context.Set<RequiredNonPkSingle1>().Any(e => e.Id == old1d!.Id));
+                Assert.False(context.Set<RequiredNonPkSingle1>().Any(e => e.Id == old1dd!.Id));
+                Assert.False(context.Set<RequiredNonPkSingle2>().Any(e => e.Id == old2!.Id));
+                Assert.False(context.Set<RequiredNonPkSingle2>().Any(e => e.Id == old2d!.Id));
+                Assert.False(context.Set<RequiredNonPkSingle2>().Any(e => e.Id == old2dd!.Id));
             });
     }
 
@@ -483,8 +481,8 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
     public virtual Task Sever_optional_one_to_one(ChangeMechanism changeMechanism)
     {
         Root root;
-        OptionalSingle1 old1 = null;
-        OptionalSingle2 old2 = null;
+        OptionalSingle1 old1 = null!;
+        OptionalSingle2 old2 = null!;
         return ExecuteWithStrategyInTransactionAsync(
             async context =>
             {
@@ -495,14 +493,14 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
                     context.Entry(root).Reference(e => e.OptionalSingle).Load();
                 }
 
-                old1 = root.OptionalSingle;
+                old1 = root.OptionalSingle!;
 
                 if (!DoesLazyLoading)
                 {
                     context.Entry(old1).Reference(e => e.Single).Load();
                 }
 
-                old2 = root.OptionalSingle.Single;
+                old2 = old1.Single!;
 
                 if ((changeMechanism & ChangeMechanism.Principal) != 0)
                 {
@@ -537,8 +535,8 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
                 {
                     await LoadRootAsync(context);
 
-                    var loaded1 = context.Set<OptionalSingle1>().Single(e => e.Id == old1.Id);
-                    var loaded2 = context.Set<OptionalSingle2>().Single(e => e.Id == old2.Id);
+                    var loaded1 = context.Set<OptionalSingle1>().Single(e => e.Id == old1!.Id);
+                    var loaded2 = context.Set<OptionalSingle2>().Single(e => e.Id == old2!.Id);
 
                     Assert.Null(loaded1.Root);
                     Assert.Same(loaded1, loaded2.Back);
@@ -552,9 +550,9 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
      InlineData((int)(ChangeMechanism.Principal | ChangeMechanism.Dependent))]
     public virtual Task Sever_required_one_to_one(ChangeMechanism changeMechanism)
     {
-        Root root = null;
-        RequiredSingle1 old1 = null;
-        RequiredSingle2 old2 = null;
+        Root root = null!;
+        RequiredSingle1 old1 = null!;
+        RequiredSingle2 old2 = null!;
         return ExecuteWithStrategyInTransactionAsync(
             async context =>
             {
@@ -576,12 +574,12 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
 
                 if ((changeMechanism & ChangeMechanism.Principal) != 0)
                 {
-                    root.RequiredSingle = null;
+                    root.RequiredSingle = null!;
                 }
 
                 if ((changeMechanism & ChangeMechanism.Dependent) != 0)
                 {
-                    old1.Root = null;
+                    old1.Root = null!;
                 }
 
                 if ((changeMechanism & ChangeMechanism.Fk) != 0)
@@ -604,8 +602,8 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
             {
                 await LoadRootAsync(context);
 
-                Assert.False(context.Set<RequiredSingle1>().Any(e => e.Id == old1.Id));
-                Assert.False(context.Set<RequiredSingle2>().Any(e => e.Id == old2.Id));
+                Assert.False(context.Set<RequiredSingle1>().Any(e => e.Id == old1!.Id));
+                Assert.False(context.Set<RequiredSingle2>().Any(e => e.Id == old2!.Id));
             });
     }
 
@@ -614,8 +612,8 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
     public virtual Task Sever_required_non_PK_one_to_one(ChangeMechanism changeMechanism)
     {
         Root root;
-        RequiredNonPkSingle1 old1 = null;
-        RequiredNonPkSingle2 old2 = null;
+        RequiredNonPkSingle1 old1 = null!;
+        RequiredNonPkSingle2 old2 = null!;
         return ExecuteWithStrategyInTransactionAsync(
             async context =>
             {
@@ -637,12 +635,12 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
 
                 if ((changeMechanism & ChangeMechanism.Principal) != 0)
                 {
-                    root.RequiredNonPkSingle = null;
+                    root.RequiredNonPkSingle = null!;
                 }
 
                 if ((changeMechanism & ChangeMechanism.Dependent) != 0)
                 {
-                    old1.Root = null;
+                    old1.Root = null!;
                 }
 
                 if ((changeMechanism & ChangeMechanism.Fk) != 0)
@@ -665,8 +663,8 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
             {
                 await LoadRootAsync(context);
 
-                Assert.False(context.Set<RequiredNonPkSingle1>().Any(e => e.Id == old1.Id));
-                Assert.False(context.Set<RequiredNonPkSingle2>().Any(e => e.Id == old2.Id));
+                Assert.False(context.Set<RequiredNonPkSingle1>().Any(e => e.Id == old1!.Id));
+                Assert.False(context.Set<RequiredNonPkSingle2>().Any(e => e.Id == old2!.Id));
             });
     }
 
@@ -683,10 +681,10 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
      InlineData((int)(ChangeMechanism.Principal | ChangeMechanism.Dependent | ChangeMechanism.Fk), true)]
     public virtual Task Reparent_optional_one_to_one(ChangeMechanism changeMechanism, bool useExistingRoot)
     {
-        Root newRoot = null;
+        Root newRoot = null!;
         Root root;
-        OptionalSingle1 old1 = null;
-        OptionalSingle2 old2 = null;
+        OptionalSingle1 old1 = null!;
+        OptionalSingle2 old2 = null!;
 
         return ExecuteWithStrategyInTransactionAsync(
             context =>
@@ -704,35 +702,35 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
             {
                 root = await LoadRootAsync(context);
 
-                context.Entry(newRoot).State = useExistingRoot ? EntityState.Unchanged : EntityState.Added;
+                context.Entry(newRoot!).State = useExistingRoot ? EntityState.Unchanged : EntityState.Added;
 
                 if (!DoesLazyLoading)
                 {
                     context.Entry(root).Reference(e => e.OptionalSingle).Load();
                 }
 
-                old1 = root.OptionalSingle;
+                old1 = root.OptionalSingle!;
 
                 if (!DoesLazyLoading)
                 {
                     context.Entry(old1).Reference(e => e.Single).Load();
                 }
 
-                old2 = root.OptionalSingle.Single;
+                old2 = old1.Single!;
 
                 if ((changeMechanism & ChangeMechanism.Principal) != 0)
                 {
-                    newRoot.OptionalSingle = old1;
+                    newRoot!.OptionalSingle = old1;
                 }
 
                 if ((changeMechanism & ChangeMechanism.Dependent) != 0)
                 {
-                    old1.Root = newRoot;
+                    old1.Root = newRoot!;
                 }
 
                 if ((changeMechanism & ChangeMechanism.Fk) != 0)
                 {
-                    old1.RootId = context.Entry(newRoot).Property(e => e.Id).CurrentValue;
+                    old1.RootId = context.Entry(newRoot!).Property(e => e.Id).CurrentValue;
                 }
 
                 Assert.True(context.ChangeTracker.HasChanges());
@@ -745,15 +743,15 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
 
                 Assert.Same(newRoot, old1.Root);
                 Assert.Same(old1, old2.Back);
-                Assert.Equal(newRoot.Id, old1.RootId);
+                Assert.Equal(newRoot!.Id, old1.RootId);
                 Assert.Equal(old1.Id, old2.BackId);
             }, async context =>
             {
                 var loadedRoot = await LoadRootAsync(context);
 
-                newRoot = context.Set<Root>().Single(e => e.Id == newRoot.Id);
-                var loaded1 = context.Set<OptionalSingle1>().Single(e => e.Id == old1.Id);
-                var loaded2 = context.Set<OptionalSingle2>().Single(e => e.Id == old2.Id);
+                newRoot = context.Set<Root>().Single(e => e.Id == newRoot!.Id);
+                var loaded1 = context.Set<OptionalSingle1>().Single(e => e.Id == old1!.Id);
+                var loaded2 = context.Set<OptionalSingle2>().Single(e => e.Id == old2!.Id);
 
                 Assert.Same(newRoot, loaded1.Root);
                 Assert.Same(loaded1, loaded2.Back);
@@ -775,7 +773,7 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
      InlineData((int)(ChangeMechanism.Principal | ChangeMechanism.Dependent | ChangeMechanism.Fk), true)]
     public virtual Task Reparent_required_one_to_one(ChangeMechanism changeMechanism, bool useExistingRoot)
     {
-        Root newRoot = null;
+        Root newRoot = null!;
 
         return ExecuteWithStrategyInTransactionAsync(
             context =>
@@ -798,7 +796,7 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
                     context.Entry(root).Reference(e => e.RequiredSingle).Load();
                 }
 
-                context.Entry(newRoot).State = useExistingRoot ? EntityState.Unchanged : EntityState.Added;
+                context.Entry(newRoot!).State = useExistingRoot ? EntityState.Unchanged : EntityState.Added;
 
                 Assert.Equal(
                     CoreStrings.KeyReadOnly("Id", nameof(RequiredSingle1)),
@@ -806,20 +804,20 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
                     {
                         if ((changeMechanism & ChangeMechanism.Principal) != 0)
                         {
-                            newRoot.RequiredSingle = root.RequiredSingle;
+                            newRoot!.RequiredSingle = root.RequiredSingle;
                         }
 
                         if ((changeMechanism & ChangeMechanism.Dependent) != 0)
                         {
-                            root.RequiredSingle.Root = newRoot;
+                            root.RequiredSingle.Root = newRoot!;
                         }
 
                         if ((changeMechanism & ChangeMechanism.Fk) != 0)
                         {
-                            root.RequiredSingle.Id = newRoot.Id;
+                            root.RequiredSingle.Id = newRoot!.Id;
                         }
 
-                        newRoot.RequiredSingle = root.RequiredSingle;
+                        newRoot!.RequiredSingle = root.RequiredSingle;
 
                         context.SaveChanges();
                     }).Message);
@@ -839,10 +837,10 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
      InlineData((int)(ChangeMechanism.Principal | ChangeMechanism.Dependent | ChangeMechanism.Fk), true)]
     public virtual Task Reparent_required_non_PK_one_to_one(ChangeMechanism changeMechanism, bool useExistingRoot)
     {
-        Root newRoot = null;
+        Root newRoot = null!;
         Root root;
-        RequiredNonPkSingle1 old1 = null;
-        RequiredNonPkSingle2 old2 = null;
+        RequiredNonPkSingle1 old1 = null!;
+        RequiredNonPkSingle2 old2 = null!;
 
         return ExecuteWithStrategyInTransactionAsync(
             context =>
@@ -860,7 +858,7 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
             {
                 root = await LoadRootAsync(context);
 
-                context.Entry(newRoot).State = useExistingRoot ? EntityState.Unchanged : EntityState.Added;
+                context.Entry(newRoot!).State = useExistingRoot ? EntityState.Unchanged : EntityState.Added;
 
                 if (!DoesLazyLoading)
                 {
@@ -878,17 +876,17 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
 
                 if ((changeMechanism & ChangeMechanism.Principal) != 0)
                 {
-                    newRoot.RequiredNonPkSingle = old1;
+                    newRoot!.RequiredNonPkSingle = old1;
                 }
 
                 if ((changeMechanism & ChangeMechanism.Dependent) != 0)
                 {
-                    old1.Root = newRoot;
+                    old1.Root = newRoot!;
                 }
 
                 if ((changeMechanism & ChangeMechanism.Fk) != 0)
                 {
-                    old1.RootId = context.Entry(newRoot).Property(e => e.Id).CurrentValue;
+                    old1.RootId = context.Entry(newRoot!).Property(e => e.Id).CurrentValue;
                 }
 
                 Assert.True(context.ChangeTracker.HasChanges());
@@ -901,15 +899,15 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
 
                 Assert.Same(newRoot, old1.Root);
                 Assert.Same(old1, old2.Back);
-                Assert.Equal(newRoot.Id, old1.RootId);
+                Assert.Equal(newRoot!.Id, old1.RootId);
                 Assert.Equal(old1.Id, old2.BackId);
             }, async context =>
             {
                 var loadedRoot = await LoadRootAsync(context);
 
-                newRoot = context.Set<Root>().Single(e => e.Id == newRoot.Id);
-                var loaded1 = context.Set<RequiredNonPkSingle1>().Single(e => e.Id == old1.Id);
-                var loaded2 = context.Set<RequiredNonPkSingle2>().Single(e => e.Id == old2.Id);
+                newRoot = context.Set<Root>().Single(e => e.Id == newRoot!.Id);
+                var loaded1 = context.Set<RequiredNonPkSingle1>().Single(e => e.Id == old1!.Id);
+                var loaded2 = context.Set<RequiredNonPkSingle2>().Single(e => e.Id == old2!.Id);
 
                 Assert.Same(newRoot, loaded1.Root);
                 Assert.Same(loaded1, loaded2.Back);
@@ -943,7 +941,7 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
                     context.Entry(root).Reference(e => e.OptionalSingle).Load();
                 }
 
-                var removed = root.OptionalSingle;
+                var removed = root.OptionalSingle!;
 
                 if (!DoesLazyLoading)
                 {
@@ -951,7 +949,7 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
                 }
 
                 removedId = removed.Id;
-                var orphaned = removed.Single;
+                var orphaned = removed.Single!;
                 orphanedId = orphaned.Id;
 
                 context.Remove(removed);
@@ -1361,7 +1359,7 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
                     context.Entry(root).Reference(e => e.OptionalSingle).Load();
                 }
 
-                var removed = root.OptionalSingle;
+                var removed = root.OptionalSingle!;
 
                 if (!DoesLazyLoading)
                 {
@@ -1369,7 +1367,7 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
                 }
 
                 removedId = removed.Id;
-                orphanedId = removed.Single.Id;
+                orphanedId = removed.Single!.Id;
             },
             context =>
             {
@@ -1378,14 +1376,14 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
 
                 var root = context.Set<Root>().Include(e => e.OptionalSingle).Single(IsTheRoot);
 
-                var removed = root.OptionalSingle;
+                var removed = root.OptionalSingle!;
 
                 if (!DoesLazyLoading)
                 {
                     context.Entry(removed).Reference(e => e.Single).Load();
                 }
 
-                var orphaned = removed.Single;
+                var orphaned = removed.Single!;
 
                 context.Remove(removed);
 
@@ -1432,9 +1430,9 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
     {
         var removedId = 0;
         var orphanedId = 0;
-        Root root = null;
-        OptionalSingle1 removed = null;
-        OptionalSingle2 orphaned = null;
+        Root root = null!;
+        OptionalSingle1 removed = null!;
+        OptionalSingle2 orphaned = null!;
 
         return ExecuteWithStrategyInTransactionAsync(
             async context =>
@@ -1446,22 +1444,22 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
                     context.Entry(root).Reference(e => e.OptionalSingle).Load();
                 }
 
-                removed = root.OptionalSingle;
+                removed = root.OptionalSingle!;
 
                 if (!DoesLazyLoading)
                 {
                     context.Entry(removed).Reference(e => e.Single).Load();
                 }
 
-                orphaned = removed.Single;
+                orphaned = removed.Single!;
             },
             context =>
             {
                 context.ChangeTracker.CascadeDeleteTiming = cascadeDeleteTiming;
                 context.ChangeTracker.DeleteOrphansTiming = deleteOrphansTiming;
 
-                removedId = removed.Id;
-                orphanedId = orphaned.Id;
+                removedId = removed!.Id;
+                orphanedId = orphaned!.Id;
 
                 context.Remove(removed);
 
@@ -1512,9 +1510,9 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
     {
         var removedId = 0;
         var orphanedId = 0;
-        Root root = null;
-        RequiredSingle1 removed = null;
-        RequiredSingle2 orphaned = null;
+        Root root = null!;
+        RequiredSingle1 removed = null!;
+        RequiredSingle2 orphaned = null!;
 
         return ExecuteWithStrategyInTransactionAsync(
             async context =>
@@ -1540,8 +1538,8 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
                 context.ChangeTracker.CascadeDeleteTiming = cascadeDeleteTiming;
                 context.ChangeTracker.DeleteOrphansTiming = deleteOrphansTiming;
 
-                removedId = removed.Id;
-                orphanedId = orphaned.Id;
+                removedId = removed!.Id;
+                orphanedId = orphaned!.Id;
 
                 context.Remove(removed);
 
@@ -1603,9 +1601,9 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
     {
         var removedId = 0;
         var orphanedId = 0;
-        Root root = null;
-        RequiredNonPkSingle1 removed = null;
-        RequiredNonPkSingle2 orphaned = null;
+        Root root = null!;
+        RequiredNonPkSingle1 removed = null!;
+        RequiredNonPkSingle2 orphaned = null!;
 
         return ExecuteWithStrategyInTransactionAsync(
             async context =>
@@ -1631,8 +1629,8 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
                 context.ChangeTracker.CascadeDeleteTiming = cascadeDeleteTiming;
                 context.ChangeTracker.DeleteOrphansTiming = deleteOrphansTiming;
 
-                removedId = removed.Id;
-                orphanedId = orphaned.Id;
+                removedId = removed!.Id;
+                orphanedId = orphaned!.Id;
 
                 context.Remove(removed);
 

--- a/test/EFCore.Specification.Tests/GraphUpdates/ProxyGraphUpdatesTestBaseOneToOneAk.cs
+++ b/test/EFCore.Specification.Tests/GraphUpdates/ProxyGraphUpdatesTestBaseOneToOneAk.cs
@@ -7,8 +7,6 @@
 
 namespace Microsoft.EntityFrameworkCore;
 
-#nullable disable
-
 public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixture<TFixture>
     where TFixture : ProxyGraphUpdatesTestBase<TFixture>.ProxyGraphUpdatesFixtureBase, new()
 {
@@ -29,20 +27,20 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
      InlineData((int)(ChangeMechanism.Principal | ChangeMechanism.Dependent | ChangeMechanism.Fk), true)]
     public virtual Task Save_changed_optional_one_to_one_with_alternate_key(ChangeMechanism changeMechanism, bool useExistingEntities)
     {
-        OptionalSingleAk2 new2 = null;
-        OptionalSingleAk2Derived new2d = null;
-        OptionalSingleAk2MoreDerived new2dd = null;
-        OptionalSingleComposite2 new2c = null;
-        OptionalSingleAk1 new1 = null;
-        OptionalSingleAk1Derived new1d = null;
-        OptionalSingleAk1MoreDerived new1dd = null;
-        OptionalSingleAk1 old1 = null;
-        OptionalSingleAk1Derived old1d = null;
-        OptionalSingleAk1MoreDerived old1dd = null;
-        OptionalSingleAk2 old2 = null;
-        OptionalSingleComposite2 old2c = null;
-        OptionalSingleAk2Derived old2d = null;
-        OptionalSingleAk2MoreDerived old2dd = null;
+        OptionalSingleAk2 new2 = null!;
+        OptionalSingleAk2Derived new2d = null!;
+        OptionalSingleAk2MoreDerived new2dd = null!;
+        OptionalSingleComposite2 new2c = null!;
+        OptionalSingleAk1 new1 = null!;
+        OptionalSingleAk1Derived new1d = null!;
+        OptionalSingleAk1MoreDerived new1dd = null!;
+        OptionalSingleAk1 old1 = null!;
+        OptionalSingleAk1Derived old1d = null!;
+        OptionalSingleAk1MoreDerived old1dd = null!;
+        OptionalSingleAk2 old2 = null!;
+        OptionalSingleComposite2 old2c = null!;
+        OptionalSingleAk2Derived old2d = null!;
+        OptionalSingleAk2MoreDerived old2dd = null!;
 
         return ExecuteWithStrategyInTransactionAsync(
             context =>
@@ -86,9 +84,9 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
                     context.Entry(root).Reference(e => e.OptionalSingleAkMoreDerived).Load();
                 }
 
-                old1 = root.OptionalSingleAk;
-                old1d = root.OptionalSingleAkDerived;
-                old1dd = root.OptionalSingleAkMoreDerived;
+                old1 = root.OptionalSingleAk!;
+                old1d = root.OptionalSingleAkDerived!;
+                old1dd = root.OptionalSingleAkMoreDerived!;
 
                 if (!DoesLazyLoading)
                 {
@@ -98,24 +96,24 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
                     context.Entry(old1dd).Reference(e => e.Single).Load();
                 }
 
-                old2 = root.OptionalSingleAk.Single;
-                old2c = root.OptionalSingleAk.SingleComposite;
-                old2d = (OptionalSingleAk2Derived)root.OptionalSingleAkDerived.Single;
-                old2dd = (OptionalSingleAk2MoreDerived)root.OptionalSingleAkMoreDerived.Single;
+                old2 = old1.Single!;
+                old2c = old1.SingleComposite!;
+                old2d = (OptionalSingleAk2Derived)old1d.Single!;
+                old2dd = (OptionalSingleAk2MoreDerived)old1dd.Single!;
 
                 if (useExistingEntities)
                 {
-                    new1 = context.Set<OptionalSingleAk1>().Single(e => e.Id == new1.Id);
-                    new1d = (OptionalSingleAk1Derived)context.Set<OptionalSingleAk1>().Single(e => e.Id == new1d.Id);
-                    new1dd = (OptionalSingleAk1MoreDerived)context.Set<OptionalSingleAk1>().Single(e => e.Id == new1dd.Id);
-                    new2 = context.Set<OptionalSingleAk2>().Single(e => e.Id == new2.Id);
-                    new2c = context.Set<OptionalSingleComposite2>().Single(e => e.Id == new2c.Id);
-                    new2d = (OptionalSingleAk2Derived)context.Set<OptionalSingleAk2>().Single(e => e.Id == new2d.Id);
-                    new2dd = (OptionalSingleAk2MoreDerived)context.Set<OptionalSingleAk2>().Single(e => e.Id == new2dd.Id);
+                    new1 = context.Set<OptionalSingleAk1>().Single(e => e.Id == new1!.Id);
+                    new1d = (OptionalSingleAk1Derived)context.Set<OptionalSingleAk1>().Single(e => e.Id == new1d!.Id);
+                    new1dd = (OptionalSingleAk1MoreDerived)context.Set<OptionalSingleAk1>().Single(e => e.Id == new1dd!.Id);
+                    new2 = context.Set<OptionalSingleAk2>().Single(e => e.Id == new2!.Id);
+                    new2c = context.Set<OptionalSingleComposite2>().Single(e => e.Id == new2c!.Id);
+                    new2d = (OptionalSingleAk2Derived)context.Set<OptionalSingleAk2>().Single(e => e.Id == new2d!.Id);
+                    new2dd = (OptionalSingleAk2MoreDerived)context.Set<OptionalSingleAk2>().Single(e => e.Id == new2dd!.Id);
                 }
                 else
                 {
-                    context.AddRange(new1, new1d, new1dd, new2, new2d, new2dd, new2c);
+                    context.AddRange(new1!, new1d!, new1dd!, new2!, new2d!, new2dd!, new2c!);
                 }
 
                 if ((changeMechanism & ChangeMechanism.Principal) != 0)
@@ -180,13 +178,13 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
             {
                 await LoadRootAsync(context);
 
-                var loaded1 = context.Set<OptionalSingleAk1>().Single(e => e.Id == old1.Id);
-                var loaded1d = context.Set<OptionalSingleAk1>().Single(e => e.Id == old1d.Id);
-                var loaded1dd = context.Set<OptionalSingleAk1>().Single(e => e.Id == old1dd.Id);
-                var loaded2 = context.Set<OptionalSingleAk2>().Single(e => e.Id == old2.Id);
-                var loaded2d = context.Set<OptionalSingleAk2>().Single(e => e.Id == old2d.Id);
-                var loaded2dd = context.Set<OptionalSingleAk2>().Single(e => e.Id == old2dd.Id);
-                var loaded2c = context.Set<OptionalSingleComposite2>().Single(e => e.Id == old2c.Id);
+                var loaded1 = context.Set<OptionalSingleAk1>().Single(e => e.Id == old1!.Id);
+                var loaded1d = context.Set<OptionalSingleAk1>().Single(e => e.Id == old1d!.Id);
+                var loaded1dd = context.Set<OptionalSingleAk1>().Single(e => e.Id == old1dd!.Id);
+                var loaded2 = context.Set<OptionalSingleAk2>().Single(e => e.Id == old2!.Id);
+                var loaded2d = context.Set<OptionalSingleAk2>().Single(e => e.Id == old2d!.Id);
+                var loaded2dd = context.Set<OptionalSingleAk2>().Single(e => e.Id == old2dd!.Id);
+                var loaded2c = context.Set<OptionalSingleComposite2>().Single(e => e.Id == old2c!.Id);
 
                 Assert.Null(loaded1.Root);
                 Assert.Null(loaded1d.Root);
@@ -216,13 +214,13 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
         OptionalSingleAk1 new1;
         OptionalSingleAk1Derived new1d;
         OptionalSingleAk1MoreDerived new1dd;
-        OptionalSingleAk1 old1 = null;
-        OptionalSingleAk1Derived old1d = null;
-        OptionalSingleAk1MoreDerived old1dd = null;
-        OptionalSingleAk2 old2 = null;
-        OptionalSingleComposite2 old2c = null;
-        OptionalSingleAk2Derived old2d = null;
-        OptionalSingleAk2MoreDerived old2dd = null;
+        OptionalSingleAk1 old1 = null!;
+        OptionalSingleAk1Derived old1d = null!;
+        OptionalSingleAk1MoreDerived old1dd = null!;
+        OptionalSingleAk2 old2 = null!;
+        OptionalSingleComposite2 old2c = null!;
+        OptionalSingleAk2Derived old2d = null!;
+        OptionalSingleAk2MoreDerived old2dd = null!;
 
         return ExecuteWithStrategyInTransactionAsync(
             async context =>
@@ -257,9 +255,9 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
                     context.Entry(root).Reference(e => e.OptionalSingleAkMoreDerived).Load();
                 }
 
-                old1 = root.OptionalSingleAk;
-                old1d = root.OptionalSingleAkDerived;
-                old1dd = root.OptionalSingleAkMoreDerived;
+                old1 = root.OptionalSingleAk!;
+                old1d = root.OptionalSingleAkDerived!;
+                old1dd = root.OptionalSingleAkMoreDerived!;
 
                 if (!DoesLazyLoading)
                 {
@@ -269,21 +267,21 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
                     context.Entry(old1dd).Reference(e => e.Single).Load();
                 }
 
-                old2 = root.OptionalSingleAk.Single;
-                old2c = root.OptionalSingleAk.SingleComposite;
-                old2d = (OptionalSingleAk2Derived)root.OptionalSingleAkDerived.Single;
-                old2dd = (OptionalSingleAk2MoreDerived)root.OptionalSingleAkMoreDerived.Single;
+                old2 = old1.Single!;
+                old2c = old1.SingleComposite!;
+                old2d = (OptionalSingleAk2Derived)old1d.Single!;
+                old2dd = (OptionalSingleAk2MoreDerived)old1dd.Single!;
 
                 using (var context2 = CreateContext())
                 {
-                    UseTransaction(context2.Database, context.Database.CurrentTransaction);
+                    UseTransaction(context2.Database, context.Database.CurrentTransaction!);
                     var root2 = context2.Set<Root>()
                         .Include(e => e.OptionalChildrenAk).ThenInclude(e => e.Children)
                         .Include(e => e.OptionalChildrenAk).ThenInclude(e => e.CompositeChildren)
-                        .Include(e => e.OptionalSingleAk).ThenInclude(e => e.Single)
-                        .Include(e => e.OptionalSingleAk).ThenInclude(e => e.SingleComposite)
-                        .Include(e => e.OptionalSingleAkDerived).ThenInclude(e => e.Single)
-                        .Include(e => e.OptionalSingleAkMoreDerived).ThenInclude(e => e.Single)
+                        .Include(e => e.OptionalSingleAk!).ThenInclude(e => e.Single)
+                        .Include(e => e.OptionalSingleAk!).ThenInclude(e => e.SingleComposite)
+                        .Include(e => e.OptionalSingleAkDerived!).ThenInclude(e => e.Single)
+                        .Include(e => e.OptionalSingleAkMoreDerived!).ThenInclude(e => e.Single)
                         .Single(IsTheRoot);
 
                     context2.AddRange(new1, new1d, new1dd, new2, new2d, new2dd, new2c);
@@ -371,13 +369,13 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
             {
                 await LoadRootAsync(context);
 
-                var loaded1 = context.Set<OptionalSingleAk1>().Single(e => e.Id == old1.Id);
-                var loaded1d = context.Set<OptionalSingleAk1>().Single(e => e.Id == old1d.Id);
-                var loaded1dd = context.Set<OptionalSingleAk1>().Single(e => e.Id == old1dd.Id);
-                var loaded2 = context.Set<OptionalSingleAk2>().Single(e => e.Id == old2.Id);
-                var loaded2d = context.Set<OptionalSingleAk2>().Single(e => e.Id == old2d.Id);
-                var loaded2dd = context.Set<OptionalSingleAk2>().Single(e => e.Id == old2dd.Id);
-                var loaded2c = context.Set<OptionalSingleComposite2>().Single(e => e.Id == old2c.Id);
+                var loaded1 = context.Set<OptionalSingleAk1>().Single(e => e.Id == old1!.Id);
+                var loaded1d = context.Set<OptionalSingleAk1>().Single(e => e.Id == old1d!.Id);
+                var loaded1dd = context.Set<OptionalSingleAk1>().Single(e => e.Id == old1dd!.Id);
+                var loaded2 = context.Set<OptionalSingleAk2>().Single(e => e.Id == old2!.Id);
+                var loaded2d = context.Set<OptionalSingleAk2>().Single(e => e.Id == old2d!.Id);
+                var loaded2dd = context.Set<OptionalSingleAk2>().Single(e => e.Id == old2dd!.Id);
+                var loaded2c = context.Set<OptionalSingleComposite2>().Single(e => e.Id == old2c!.Id);
 
                 Assert.Null(loaded1.Root);
                 Assert.Null(loaded1d.Root);
@@ -405,13 +403,13 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
         ChangeMechanism changeMechanism,
         bool useExistingEntities)
     {
-        RequiredSingleAk2 new2 = null;
-        RequiredSingleComposite2 new2c = null;
-        RequiredSingleAk1 new1 = null;
+        RequiredSingleAk2 new2 = null!;
+        RequiredSingleComposite2 new2c = null!;
+        RequiredSingleAk1 new1 = null!;
         Root newRoot;
-        RequiredSingleAk1 old1 = null;
-        RequiredSingleAk2 old2 = null;
-        RequiredSingleComposite2 old2c = null;
+        RequiredSingleAk1 old1 = null!;
+        RequiredSingleAk2 old2 = null!;
+        RequiredSingleComposite2 old2c = null!;
 
         return ExecuteWithStrategyInTransactionAsync(
             context =>
@@ -459,13 +457,13 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
 
                 if (useExistingEntities)
                 {
-                    new1 = context.Set<RequiredSingleAk1>().Single(e => e.Id == new1.Id);
-                    new2 = context.Set<RequiredSingleAk2>().Single(e => e.Id == new2.Id);
-                    new2c = context.Set<RequiredSingleComposite2>().Single(e => e.Id == new2c.Id);
+                    new1 = context.Set<RequiredSingleAk1>().Single(e => e.Id == new1!.Id);
+                    new2 = context.Set<RequiredSingleAk2>().Single(e => e.Id == new2!.Id);
+                    new2c = context.Set<RequiredSingleComposite2>().Single(e => e.Id == new2c!.Id);
                 }
                 else
                 {
-                    context.AddRange(new1, new2, new2c);
+                    context.AddRange(new1!, new2!, new2c!);
                 }
 
                 if ((changeMechanism & ChangeMechanism.Principal) != 0)
@@ -507,9 +505,9 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
             {
                 await LoadRootAsync(context);
 
-                Assert.False(context.Set<RequiredSingleAk1>().Any(e => e.Id == old1.Id));
-                Assert.False(context.Set<RequiredSingleAk2>().Any(e => e.Id == old2.Id));
-                Assert.False(context.Set<RequiredSingleComposite2>().Any(e => e.Id == old2c.Id));
+                Assert.False(context.Set<RequiredSingleAk1>().Any(e => e.Id == old1!.Id));
+                Assert.False(context.Set<RequiredSingleAk2>().Any(e => e.Id == old2!.Id));
+                Assert.False(context.Set<RequiredSingleComposite2>().Any(e => e.Id == old2c!.Id));
             });
     }
 
@@ -528,19 +526,19 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
         ChangeMechanism changeMechanism,
         bool useExistingEntities)
     {
-        RequiredNonPkSingleAk2 new2 = null;
-        RequiredNonPkSingleAk2Derived new2d = null;
-        RequiredNonPkSingleAk2MoreDerived new2dd = null;
-        RequiredNonPkSingleAk1 new1 = null;
-        RequiredNonPkSingleAk1Derived new1d = null;
-        RequiredNonPkSingleAk1MoreDerived new1dd = null;
+        RequiredNonPkSingleAk2 new2 = null!;
+        RequiredNonPkSingleAk2Derived new2d = null!;
+        RequiredNonPkSingleAk2MoreDerived new2dd = null!;
+        RequiredNonPkSingleAk1 new1 = null!;
+        RequiredNonPkSingleAk1Derived new1d = null!;
+        RequiredNonPkSingleAk1MoreDerived new1dd = null!;
         Root newRoot;
-        RequiredNonPkSingleAk1 old1 = null;
-        RequiredNonPkSingleAk1Derived old1d = null;
-        RequiredNonPkSingleAk1MoreDerived old1dd = null;
-        RequiredNonPkSingleAk2 old2 = null;
-        RequiredNonPkSingleAk2Derived old2d = null;
-        RequiredNonPkSingleAk2MoreDerived old2dd = null;
+        RequiredNonPkSingleAk1 old1 = null!;
+        RequiredNonPkSingleAk1Derived old1d = null!;
+        RequiredNonPkSingleAk1MoreDerived old1dd = null!;
+        RequiredNonPkSingleAk2 old2 = null!;
+        RequiredNonPkSingleAk2Derived old2d = null!;
+        RequiredNonPkSingleAk2MoreDerived old2dd = null!;
 
         return ExecuteWithStrategyInTransactionAsync(
             context =>
@@ -615,12 +613,12 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
 
                 if (useExistingEntities)
                 {
-                    new1 = context.Set<RequiredNonPkSingleAk1>().Single(e => e.Id == new1.Id);
-                    new1d = (RequiredNonPkSingleAk1Derived)context.Set<RequiredNonPkSingleAk1>().Single(e => e.Id == new1d.Id);
-                    new1dd = (RequiredNonPkSingleAk1MoreDerived)context.Set<RequiredNonPkSingleAk1>().Single(e => e.Id == new1dd.Id);
-                    new2 = context.Set<RequiredNonPkSingleAk2>().Single(e => e.Id == new2.Id);
-                    new2d = (RequiredNonPkSingleAk2Derived)context.Set<RequiredNonPkSingleAk2>().Single(e => e.Id == new2d.Id);
-                    new2dd = (RequiredNonPkSingleAk2MoreDerived)context.Set<RequiredNonPkSingleAk2>().Single(e => e.Id == new2dd.Id);
+                    new1 = context.Set<RequiredNonPkSingleAk1>().Single(e => e.Id == new1!.Id);
+                    new1d = (RequiredNonPkSingleAk1Derived)context.Set<RequiredNonPkSingleAk1>().Single(e => e.Id == new1d!.Id);
+                    new1dd = (RequiredNonPkSingleAk1MoreDerived)context.Set<RequiredNonPkSingleAk1>().Single(e => e.Id == new1dd!.Id);
+                    new2 = context.Set<RequiredNonPkSingleAk2>().Single(e => e.Id == new2!.Id);
+                    new2d = (RequiredNonPkSingleAk2Derived)context.Set<RequiredNonPkSingleAk2>().Single(e => e.Id == new2d!.Id);
+                    new2dd = (RequiredNonPkSingleAk2MoreDerived)context.Set<RequiredNonPkSingleAk2>().Single(e => e.Id == new2dd!.Id);
 
                     new1d.RootId = old1d.RootId;
                     new1dd.RootId = old1dd.RootId;
@@ -628,10 +626,10 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
                 }
                 else
                 {
-                    new1d.RootId = old1d.RootId;
-                    new1dd.RootId = old1dd.RootId;
+                    new1d!.RootId = old1d.RootId;
+                    new1dd!.RootId = old1dd.RootId;
                     new1dd.DerivedRootId = old1dd.DerivedRootId;
-                    context.AddRange(new1, new1d, new1dd, new2, new2d, new2dd);
+                    context.AddRange(new1!, new1d, new1dd, new2!, new2d!, new2dd!);
                 }
 
                 if ((changeMechanism & ChangeMechanism.Principal) != 0)
@@ -687,12 +685,12 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
             {
                 var loadedRoot = await LoadRootAsync(context);
 
-                Assert.False(context.Set<RequiredNonPkSingleAk1>().Any(e => e.Id == old1.Id));
-                Assert.False(context.Set<RequiredNonPkSingleAk1>().Any(e => e.Id == old1d.Id));
-                Assert.False(context.Set<RequiredNonPkSingleAk1>().Any(e => e.Id == old1dd.Id));
-                Assert.False(context.Set<RequiredNonPkSingleAk2>().Any(e => e.Id == old2.Id));
-                Assert.False(context.Set<RequiredNonPkSingleAk2>().Any(e => e.Id == old2d.Id));
-                Assert.False(context.Set<RequiredNonPkSingleAk2>().Any(e => e.Id == old2dd.Id));
+                Assert.False(context.Set<RequiredNonPkSingleAk1>().Any(e => e.Id == old1!.Id));
+                Assert.False(context.Set<RequiredNonPkSingleAk1>().Any(e => e.Id == old1d!.Id));
+                Assert.False(context.Set<RequiredNonPkSingleAk1>().Any(e => e.Id == old1dd!.Id));
+                Assert.False(context.Set<RequiredNonPkSingleAk2>().Any(e => e.Id == old2!.Id));
+                Assert.False(context.Set<RequiredNonPkSingleAk2>().Any(e => e.Id == old2d!.Id));
+                Assert.False(context.Set<RequiredNonPkSingleAk2>().Any(e => e.Id == old2dd!.Id));
             });
     }
 
@@ -702,10 +700,10 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
      InlineData((int)(ChangeMechanism.Principal | ChangeMechanism.Dependent | ChangeMechanism.Fk))]
     public virtual Task Sever_optional_one_to_one_with_alternate_key(ChangeMechanism changeMechanism)
     {
-        Root root = null;
-        OptionalSingleAk1 old1 = null;
-        OptionalSingleAk2 old2 = null;
-        OptionalSingleComposite2 old2c = null;
+        Root root = null!;
+        OptionalSingleAk1 old1 = null!;
+        OptionalSingleAk2 old2 = null!;
+        OptionalSingleComposite2 old2c = null!;
         return ExecuteWithStrategyInTransactionAsync(
             async context =>
             {
@@ -716,7 +714,7 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
                     context.Entry(root).Reference(e => e.OptionalSingleAk).Load();
                 }
 
-                old1 = root.OptionalSingleAk;
+                old1 = root.OptionalSingleAk!;
 
                 if (!DoesLazyLoading)
                 {
@@ -724,8 +722,8 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
                     context.Entry(old1).Reference(e => e.SingleComposite).Load();
                 }
 
-                old2 = root.OptionalSingleAk.Single;
-                old2c = root.OptionalSingleAk.SingleComposite;
+                old2 = old1.Single!;
+                old2c = old1.SingleComposite!;
 
                 if ((changeMechanism & ChangeMechanism.Principal) != 0)
                 {
@@ -763,9 +761,9 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
                 {
                     var loadedRoot = await LoadRootAsync(context);
 
-                    var loaded1 = context.Set<OptionalSingleAk1>().Single(e => e.Id == old1.Id);
-                    var loaded2 = context.Set<OptionalSingleAk2>().Single(e => e.Id == old2.Id);
-                    var loaded2c = context.Set<OptionalSingleComposite2>().Single(e => e.Id == old2c.Id);
+                    var loaded1 = context.Set<OptionalSingleAk1>().Single(e => e.Id == old1!.Id);
+                    var loaded2 = context.Set<OptionalSingleAk2>().Single(e => e.Id == old2!.Id);
+                    var loaded2c = context.Set<OptionalSingleComposite2>().Single(e => e.Id == old2c!.Id);
 
                     Assert.Null(loaded1.Root);
                     Assert.Same(loaded1, loaded2.Back);
@@ -782,10 +780,10 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
      InlineData((int)(ChangeMechanism.Principal | ChangeMechanism.Dependent))]
     public virtual Task Sever_required_one_to_one_with_alternate_key(ChangeMechanism changeMechanism)
     {
-        Root root = null;
-        RequiredSingleAk1 old1 = null;
-        RequiredSingleAk2 old2 = null;
-        RequiredSingleComposite2 old2c = null;
+        Root root = null!;
+        RequiredSingleAk1 old1 = null!;
+        RequiredSingleAk2 old2 = null!;
+        RequiredSingleComposite2 old2c = null!;
         return ExecuteWithStrategyInTransactionAsync(
             async context =>
             {
@@ -809,12 +807,12 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
 
                 if ((changeMechanism & ChangeMechanism.Principal) != 0)
                 {
-                    root.RequiredSingleAk = null;
+                    root.RequiredSingleAk = null!;
                 }
 
                 if ((changeMechanism & ChangeMechanism.Dependent) != 0)
                 {
-                    old1.Root = null;
+                    old1.Root = null!;
                 }
 
                 if ((changeMechanism & ChangeMechanism.Fk) != 0)
@@ -840,9 +838,9 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
             {
                 var loadedRoot = await LoadRootAsync(context);
 
-                Assert.False(context.Set<RequiredSingleAk1>().Any(e => e.Id == old1.Id));
-                Assert.False(context.Set<RequiredSingleAk2>().Any(e => e.Id == old2.Id));
-                Assert.False(context.Set<RequiredSingleComposite2>().Any(e => e.Id == old2c.Id));
+                Assert.False(context.Set<RequiredSingleAk1>().Any(e => e.Id == old1!.Id));
+                Assert.False(context.Set<RequiredSingleAk2>().Any(e => e.Id == old2!.Id));
+                Assert.False(context.Set<RequiredSingleComposite2>().Any(e => e.Id == old2c!.Id));
             });
     }
 
@@ -850,9 +848,9 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
      InlineData((int)(ChangeMechanism.Principal | ChangeMechanism.Dependent))]
     public virtual Task Sever_required_non_PK_one_to_one_with_alternate_key(ChangeMechanism changeMechanism)
     {
-        Root root = null;
-        RequiredNonPkSingleAk1 old1 = null;
-        RequiredNonPkSingleAk2 old2 = null;
+        Root root = null!;
+        RequiredNonPkSingleAk1 old1 = null!;
+        RequiredNonPkSingleAk2 old2 = null!;
         return ExecuteWithStrategyInTransactionAsync(
             async context =>
             {
@@ -874,12 +872,12 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
 
                 if ((changeMechanism & ChangeMechanism.Principal) != 0)
                 {
-                    root.RequiredNonPkSingleAk = null;
+                    root.RequiredNonPkSingleAk = null!;
                 }
 
                 if ((changeMechanism & ChangeMechanism.Dependent) != 0)
                 {
-                    old1.Root = null;
+                    old1.Root = null!;
                 }
 
                 if ((changeMechanism & ChangeMechanism.Fk) != 0)
@@ -908,8 +906,8 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
             {
                 var loadedRoot = await LoadRootAsync(context);
 
-                Assert.False(context.Set<RequiredNonPkSingleAk1>().Any(e => e.Id == old1.Id));
-                Assert.False(context.Set<RequiredNonPkSingleAk2>().Any(e => e.Id == old2.Id));
+                Assert.False(context.Set<RequiredNonPkSingleAk1>().Any(e => e.Id == old1!.Id));
+                Assert.False(context.Set<RequiredNonPkSingleAk2>().Any(e => e.Id == old2!.Id));
             });
     }
 
@@ -926,11 +924,11 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
      InlineData((int)(ChangeMechanism.Principal | ChangeMechanism.Dependent | ChangeMechanism.Fk), true)]
     public virtual Task Reparent_optional_one_to_one_with_alternate_key(ChangeMechanism changeMechanism, bool useExistingRoot)
     {
-        Root newRoot = null;
+        Root newRoot = null!;
         Root root;
-        OptionalSingleAk1 old1 = null;
-        OptionalSingleAk2 old2 = null;
-        OptionalSingleComposite2 old2c = null;
+        OptionalSingleAk1 old1 = null!;
+        OptionalSingleAk2 old2 = null!;
+        OptionalSingleComposite2 old2c = null!;
 
         return ExecuteWithStrategyInTransactionAsync(
             async context =>
@@ -946,14 +944,14 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
             {
                 root = await LoadRootAsync(context);
 
-                context.Entry(newRoot).State = useExistingRoot ? EntityState.Unchanged : EntityState.Added;
+                context.Entry(newRoot!).State = useExistingRoot ? EntityState.Unchanged : EntityState.Added;
 
                 if (!DoesLazyLoading)
                 {
                     context.Entry(root).Reference(e => e.OptionalSingleAk).Load();
                 }
 
-                old1 = root.OptionalSingleAk;
+                old1 = root.OptionalSingleAk!;
 
                 if (!DoesLazyLoading)
                 {
@@ -961,22 +959,22 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
                     context.Entry(old1).Reference(e => e.SingleComposite).Load();
                 }
 
-                old2 = root.OptionalSingleAk.Single;
-                old2c = root.OptionalSingleAk.SingleComposite;
+                old2 = old1.Single!;
+                old2c = old1.SingleComposite!;
 
                 if ((changeMechanism & ChangeMechanism.Principal) != 0)
                 {
-                    newRoot.OptionalSingleAk = old1;
+                    newRoot!.OptionalSingleAk = old1;
                 }
 
                 if ((changeMechanism & ChangeMechanism.Dependent) != 0)
                 {
-                    old1.Root = newRoot;
+                    old1.Root = newRoot!;
                 }
 
                 if ((changeMechanism & ChangeMechanism.Fk) != 0)
                 {
-                    old1.RootId = newRoot.AlternateId;
+                    old1.RootId = newRoot!.AlternateId;
                 }
 
                 Assert.True(context.ChangeTracker.HasChanges());
@@ -990,7 +988,7 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
                 Assert.Same(newRoot, old1.Root);
                 Assert.Same(old1, old2.Back);
                 Assert.Same(old1, old2c.Back);
-                Assert.Equal(newRoot.AlternateId, old1.RootId);
+                Assert.Equal(newRoot!.AlternateId, old1.RootId);
                 Assert.Equal(old1.AlternateId, old2.BackId);
                 Assert.Equal(old1.Id, old2c.BackId);
                 Assert.Equal(old1.AlternateId, old2c.ParentAlternateId);
@@ -998,10 +996,10 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
             {
                 await LoadRootAsync(context);
 
-                newRoot = context.Set<Root>().Single(e => e.Id == newRoot.Id);
-                var loaded1 = context.Set<OptionalSingleAk1>().Single(e => e.Id == old1.Id);
-                var loaded2 = context.Set<OptionalSingleAk2>().Single(e => e.Id == old2.Id);
-                var loaded2c = context.Set<OptionalSingleComposite2>().Single(e => e.Id == old2c.Id);
+                newRoot = context.Set<Root>().Single(e => e.Id == newRoot!.Id);
+                var loaded1 = context.Set<OptionalSingleAk1>().Single(e => e.Id == old1!.Id);
+                var loaded2 = context.Set<OptionalSingleAk2>().Single(e => e.Id == old2!.Id);
+                var loaded2c = context.Set<OptionalSingleComposite2>().Single(e => e.Id == old2c!.Id);
 
                 Assert.Same(newRoot, loaded1.Root);
                 Assert.Same(loaded1, loaded2.Back);
@@ -1026,11 +1024,11 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
      InlineData((int)(ChangeMechanism.Principal | ChangeMechanism.Dependent | ChangeMechanism.Fk), true)]
     public virtual Task Reparent_required_one_to_one_with_alternate_key(ChangeMechanism changeMechanism, bool useExistingRoot)
     {
-        Root newRoot = null;
+        Root newRoot = null!;
         Root root;
-        RequiredSingleAk1 old1 = null;
-        RequiredSingleAk2 old2 = null;
-        RequiredSingleComposite2 old2c = null;
+        RequiredSingleAk1 old1 = null!;
+        RequiredSingleAk2 old2 = null!;
+        RequiredSingleComposite2 old2c = null!;
 
         return ExecuteWithStrategyInTransactionAsync(
             context =>
@@ -1048,7 +1046,7 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
             {
                 root = await LoadRootAsync(context);
 
-                context.Entry(newRoot).State = useExistingRoot ? EntityState.Unchanged : EntityState.Added;
+                context.Entry(newRoot!).State = useExistingRoot ? EntityState.Unchanged : EntityState.Added;
 
                 if (!DoesLazyLoading)
                 {
@@ -1068,17 +1066,17 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
 
                 if ((changeMechanism & ChangeMechanism.Principal) != 0)
                 {
-                    newRoot.RequiredSingleAk = old1;
+                    newRoot!.RequiredSingleAk = old1;
                 }
 
                 if ((changeMechanism & ChangeMechanism.Dependent) != 0)
                 {
-                    old1.Root = newRoot;
+                    old1.Root = newRoot!;
                 }
 
                 if ((changeMechanism & ChangeMechanism.Fk) != 0)
                 {
-                    old1.RootId = newRoot.AlternateId;
+                    old1.RootId = newRoot!.AlternateId;
                 }
 
                 Assert.True(context.ChangeTracker.HasChanges());
@@ -1092,7 +1090,7 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
                 Assert.Same(newRoot, old1.Root);
                 Assert.Same(old1, old2.Back);
                 Assert.Same(old1, old2c.Back);
-                Assert.Equal(newRoot.AlternateId, old1.RootId);
+                Assert.Equal(newRoot!.AlternateId, old1.RootId);
                 Assert.Equal(old1.AlternateId, old2.BackId);
                 Assert.Equal(old1.Id, old2c.BackId);
                 Assert.Equal(old1.AlternateId, old2c.BackAlternateId);
@@ -1100,10 +1098,10 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
             {
                 var loadedRoot = await LoadRootAsync(context);
 
-                newRoot = context.Set<Root>().Single(e => e.Id == newRoot.Id);
-                var loaded1 = context.Set<RequiredSingleAk1>().Single(e => e.Id == old1.Id);
-                var loaded2 = context.Set<RequiredSingleAk2>().Single(e => e.Id == old2.Id);
-                var loaded2c = context.Set<RequiredSingleComposite2>().Single(e => e.Id == old2c.Id);
+                newRoot = context.Set<Root>().Single(e => e.Id == newRoot!.Id);
+                var loaded1 = context.Set<RequiredSingleAk1>().Single(e => e.Id == old1!.Id);
+                var loaded2 = context.Set<RequiredSingleAk2>().Single(e => e.Id == old2!.Id);
+                var loaded2c = context.Set<RequiredSingleComposite2>().Single(e => e.Id == old2c!.Id);
 
                 Assert.Same(newRoot, loaded1.Root);
                 Assert.Same(loaded1, loaded2.Back);
@@ -1128,10 +1126,10 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
      InlineData((int)(ChangeMechanism.Principal | ChangeMechanism.Dependent | ChangeMechanism.Fk), true)]
     public virtual Task Reparent_required_non_PK_one_to_one_with_alternate_key(ChangeMechanism changeMechanism, bool useExistingRoot)
     {
-        Root newRoot = null;
+        Root newRoot = null!;
         Root root;
-        RequiredNonPkSingleAk1 old1 = null;
-        RequiredNonPkSingleAk2 old2 = null;
+        RequiredNonPkSingleAk1 old1 = null!;
+        RequiredNonPkSingleAk2 old2 = null!;
 
         return ExecuteWithStrategyInTransactionAsync(
             context =>
@@ -1149,7 +1147,7 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
             {
                 root = await LoadRootAsync(context);
 
-                context.Entry(newRoot).State = useExistingRoot ? EntityState.Unchanged : EntityState.Added;
+                context.Entry(newRoot!).State = useExistingRoot ? EntityState.Unchanged : EntityState.Added;
 
                 if (!DoesLazyLoading)
                 {
@@ -1167,17 +1165,17 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
 
                 if ((changeMechanism & ChangeMechanism.Principal) != 0)
                 {
-                    newRoot.RequiredNonPkSingleAk = old1;
+                    newRoot!.RequiredNonPkSingleAk = old1;
                 }
 
                 if ((changeMechanism & ChangeMechanism.Dependent) != 0)
                 {
-                    old1.Root = newRoot;
+                    old1.Root = newRoot!;
                 }
 
                 if ((changeMechanism & ChangeMechanism.Fk) != 0)
                 {
-                    old1.RootId = newRoot.AlternateId;
+                    old1.RootId = newRoot!.AlternateId;
                 }
 
                 Assert.True(context.ChangeTracker.HasChanges());
@@ -1190,15 +1188,15 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
 
                 Assert.Same(newRoot, old1.Root);
                 Assert.Same(old1, old2.Back);
-                Assert.Equal(newRoot.AlternateId, old1.RootId);
+                Assert.Equal(newRoot!.AlternateId, old1.RootId);
                 Assert.Equal(old1.AlternateId, old2.BackId);
             }, async context =>
             {
                 var loadedRoot = await LoadRootAsync(context);
 
-                newRoot = context.Set<Root>().Single(e => e.Id == newRoot.Id);
-                var loaded1 = context.Set<RequiredNonPkSingleAk1>().Single(e => e.Id == old1.Id);
-                var loaded2 = context.Set<RequiredNonPkSingleAk2>().Single(e => e.Id == old2.Id);
+                newRoot = context.Set<Root>().Single(e => e.Id == newRoot!.Id);
+                var loaded1 = context.Set<RequiredNonPkSingleAk1>().Single(e => e.Id == old1!.Id);
+                var loaded2 = context.Set<RequiredNonPkSingleAk2>().Single(e => e.Id == old2!.Id);
 
                 Assert.Same(newRoot, loaded1.Root);
                 Assert.Same(loaded1, loaded2.Back);
@@ -1233,7 +1231,7 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
                     context.Entry(root).Reference(e => e.OptionalSingleAk).Load();
                 }
 
-                var removed = root.OptionalSingleAk;
+                var removed = root.OptionalSingleAk!;
 
                 if (!DoesLazyLoading)
                 {
@@ -1242,8 +1240,8 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
                 }
 
                 removedId = removed.Id;
-                var orphaned = removed.Single;
-                var orphanedC = removed.SingleComposite;
+                var orphaned = removed.Single!;
+                var orphanedC = removed.SingleComposite!;
                 orphanedId = orphaned.Id;
                 orphanedIdC = orphanedC.Id;
 
@@ -1662,7 +1660,7 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
                     context.Entry(root).Reference(e => e.OptionalSingleAk).Load();
                 }
 
-                var removed = root.OptionalSingleAk;
+                var removed = root.OptionalSingleAk!;
 
                 if (!DoesLazyLoading)
                 {
@@ -1671,8 +1669,8 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
                 }
 
                 removedId = removed.Id;
-                orphanedId = removed.Single.Id;
-                orphanedIdC = removed.SingleComposite.Id;
+                orphanedId = removed.Single!.Id;
+                orphanedIdC = removed.SingleComposite!.Id;
             },
             context =>
             {
@@ -1681,14 +1679,14 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
 
                 var root = context.Set<Root>().Include(e => e.OptionalSingleAk).Single(IsTheRoot);
 
-                var removed = root.OptionalSingleAk;
+                var removed = root.OptionalSingleAk!;
 
                 if (!DoesLazyLoading)
                 {
                     context.Entry(removed).Reference(e => e.Single).Load();
                 }
 
-                var orphaned = removed.Single;
+                var orphaned = removed.Single!;
 
                 context.Remove(removed);
 
@@ -1742,10 +1740,10 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
         var removedId = 0;
         var orphanedId = 0;
         var orphanedIdC = 0;
-        Root root = null;
-        OptionalSingleAk1 removed = null;
-        OptionalSingleAk2 orphaned = null;
-        OptionalSingleComposite2 orphanedC = null;
+        Root root = null!;
+        OptionalSingleAk1 removed = null!;
+        OptionalSingleAk2 orphaned = null!;
+        OptionalSingleComposite2 orphanedC = null!;
 
         return ExecuteWithStrategyInTransactionAsync(
             async context =>
@@ -1757,7 +1755,7 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
                     context.Entry(root).Reference(e => e.OptionalSingleAk).Load();
                 }
 
-                removed = root.OptionalSingleAk;
+                removed = root.OptionalSingleAk!;
 
                 if (!DoesLazyLoading)
                 {
@@ -1765,17 +1763,17 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
                     context.Entry(removed).Reference(e => e.SingleComposite).Load();
                 }
 
-                orphaned = removed.Single;
-                orphanedC = removed.SingleComposite;
+                orphaned = removed.Single!;
+                orphanedC = removed.SingleComposite!;
             },
             context =>
             {
                 context.ChangeTracker.CascadeDeleteTiming = cascadeDeleteTiming;
                 context.ChangeTracker.DeleteOrphansTiming = deleteOrphansTiming;
 
-                removedId = removed.Id;
-                orphanedId = orphaned.Id;
-                orphanedIdC = orphanedC.Id;
+                removedId = removed!.Id;
+                orphanedId = orphaned!.Id;
+                orphanedIdC = orphanedC!.Id;
 
                 context.Remove(removed);
 
@@ -1830,10 +1828,10 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
         var removedId = 0;
         var orphanedId = 0;
         var orphanedIdC = 0;
-        Root root = null;
-        RequiredSingleAk1 removed = null;
-        RequiredSingleAk2 orphaned = null;
-        RequiredSingleComposite2 orphanedC = null;
+        Root root = null!;
+        RequiredSingleAk1 removed = null!;
+        RequiredSingleAk2 orphaned = null!;
+        RequiredSingleComposite2 orphanedC = null!;
 
         return ExecuteWithStrategyInTransactionAsync(
             async context =>
@@ -1861,9 +1859,9 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
                 context.ChangeTracker.CascadeDeleteTiming = cascadeDeleteTiming;
                 context.ChangeTracker.DeleteOrphansTiming = deleteOrphansTiming;
 
-                removedId = removed.Id;
-                orphanedId = orphaned.Id;
-                orphanedIdC = orphanedC.Id;
+                removedId = removed!.Id;
+                orphanedId = orphaned!.Id;
+                orphanedIdC = orphanedC!.Id;
 
                 context.Remove(removed);
 
@@ -1928,9 +1926,9 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
     {
         var removedId = 0;
         var orphanedId = 0;
-        Root root = null;
-        RequiredNonPkSingleAk1 removed = null;
-        RequiredNonPkSingleAk2 orphaned = null;
+        Root root = null!;
+        RequiredNonPkSingleAk1 removed = null!;
+        RequiredNonPkSingleAk2 orphaned = null!;
 
         return ExecuteWithStrategyInTransactionAsync(
             async context =>
@@ -1956,8 +1954,8 @@ public abstract partial class ProxyGraphUpdatesTestBase<TFixture> : IClassFixtur
                 context.ChangeTracker.CascadeDeleteTiming = cascadeDeleteTiming;
                 context.ChangeTracker.DeleteOrphansTiming = deleteOrphansTiming;
 
-                removedId = removed.Id;
-                orphanedId = orphaned.Id;
+                removedId = removed!.Id;
+                orphanedId = orphaned!.Id;
 
                 context.Remove(removed);
 

--- a/test/EFCore.Specification.Tests/InterceptionTestBase.cs
+++ b/test/EFCore.Specification.Tests/InterceptionTestBase.cs
@@ -5,8 +5,6 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace Microsoft.EntityFrameworkCore;
 
-#nullable disable
-
 public abstract class InterceptionTestBase(InterceptionTestBase.InterceptionFixtureBase fixture)
 {
     protected InterceptionFixtureBase Fixture { get; } = fixture;
@@ -16,7 +14,7 @@ public abstract class InterceptionTestBase(InterceptionTestBase.InterceptionFixt
         [DatabaseGenerated(DatabaseGeneratedOption.None)]
         public int Id { get; set; }
 
-        public string Type { get; set; }
+        public string Type { get; set; } = null!;
     }
 
     protected class Brane
@@ -24,7 +22,7 @@ public abstract class InterceptionTestBase(InterceptionTestBase.InterceptionFixt
         [DatabaseGenerated(DatabaseGeneratedOption.None)]
         public int Id { get; set; }
 
-        public string Type { get; set; }
+        public string Type { get; set; } = null!;
     }
 
     public class UniverseContext(DbContextOptions options) : PoolableDbContext(options)
@@ -50,7 +48,7 @@ public abstract class InterceptionTestBase(InterceptionTestBase.InterceptionFixt
     {
         var interceptor = new TInterceptor();
 
-        var context = inject ? await CreateContextAsync(null, interceptor) : await CreateContextAsync(interceptor);
+        var context = inject ? await CreateContextAsync(null!, interceptor) : await CreateContextAsync(interceptor);
 
         return (context, interceptor);
     }
@@ -63,7 +61,7 @@ public abstract class InterceptionTestBase(InterceptionTestBase.InterceptionFixt
 
     public Task<UniverseContext> CreateContextAsync(
         IEnumerable<IInterceptor> appInterceptors,
-        IEnumerable<IInterceptor> injectedInterceptors = null)
+        IEnumerable<IInterceptor>? injectedInterceptors = null)
         => SeedAsync(new UniverseContext(Fixture.CreateOptions(appInterceptors, injectedInterceptors ?? [])));
 
     public virtual Task<UniverseContext> SeedAsync(UniverseContext context)
@@ -87,7 +85,7 @@ public abstract class InterceptionTestBase(InterceptionTestBase.InterceptionFixt
 
     public class TestDiagnosticListener : ITestDiagnosticListener,
         IObserver<DiagnosticListener>,
-        IObserver<KeyValuePair<string, object>>
+        IObserver<KeyValuePair<string, object?>>
     {
         private readonly DbContextId _contextId;
         private readonly IDisposable _subscription;
@@ -138,7 +136,7 @@ public abstract class InterceptionTestBase(InterceptionTestBase.InterceptionFixt
             }
         }
 
-        public void OnNext(KeyValuePair<string, object> value)
+        public void OnNext(KeyValuePair<string, object?> value)
         {
             var eventData = value.Value as DbContextEventData;
             if (eventData?.Context?.ContextId == _contextId)

--- a/test/EFCore.Specification.Tests/JsonTypesTestBase.cs
+++ b/test/EFCore.Specification.Tests/JsonTypesTestBase.cs
@@ -650,7 +650,7 @@ public abstract class JsonTypesTestBase(NonSharedFixture fixture) : NonSharedMod
 
     protected class NullablePhysicalAddressType
     {
-        public PhysicalAddress? PhysicalAddress { get; set; } = null!;
+        public PhysicalAddress? PhysicalAddress { get; set; }
     }
 
     [Theory, InlineData((sbyte)Enum8.Min, """{"Prop":-128}"""), InlineData((sbyte)Enum8.Max, """{"Prop":127}"""),

--- a/test/EFCore.Specification.Tests/KeysWithConvertersTestBase.cs
+++ b/test/EFCore.Specification.Tests/KeysWithConvertersTestBase.cs
@@ -6,8 +6,6 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace Microsoft.EntityFrameworkCore;
 
-#nullable disable
-
 public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : IClassFixture<TFixture>
     where TFixture : KeysWithConvertersTestBase<TFixture>.KeysWithConvertersFixtureBase, new()
 {
@@ -19,8 +17,8 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
     [Fact]
     public virtual async Task Can_insert_and_read_back_with_struct_key_and_optional_dependents()
     {
-        IntStructKeyPrincipal[] principals = null;
-        IntStructKeyOptionalDependent[] dependents = null;
+        IntStructKeyPrincipal[] principals = null!;
+        IntStructKeyOptionalDependent[] dependents = null!;
         await InsertOptionalGraph<IntStructKeyPrincipal, IntStructKeyOptionalDependent>();
 
         using (var context = CreateContext())
@@ -28,8 +26,8 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
             await RunQueries(context);
 
             Validate(
-                principals,
-                dependents,
+                principals!,
+                dependents!,
                 [(0, [0]), (1, [1]), (2, [2, 2, 2]), (3, [])],
                 [(0, 0), (1, 1), (2, 2), (3, 2), (4, 2), (5, null)]);
 
@@ -129,8 +127,8 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
     [Fact]
     public virtual async Task Can_insert_and_read_back_with_comparable_struct_key_and_optional_dependents()
     {
-        ComparableIntStructKeyPrincipal[] principals = null;
-        ComparableIntStructKeyOptionalDependent[] dependents = null;
+        ComparableIntStructKeyPrincipal[] principals = null!;
+        ComparableIntStructKeyOptionalDependent[] dependents = null!;
         await InsertOptionalGraph<ComparableIntStructKeyPrincipal, ComparableIntStructKeyOptionalDependent>();
 
         using (var context = CreateContext())
@@ -138,8 +136,8 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
             await RunQueries(context);
 
             Validate(
-                principals,
-                dependents,
+                principals!,
+                dependents!,
                 [(0, [0]), (1, [1]), (2, [2, 2, 2]), (3, [])],
                 [(0, 0), (1, 1), (2, 2), (3, 2), (4, 2), (5, null)]);
 
@@ -249,8 +247,8 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
     [Fact]
     public virtual async Task Can_insert_and_read_back_with_generic_comparable_struct_key_and_optional_dependents()
     {
-        GenericComparableIntStructKeyPrincipal[] principals = null;
-        GenericComparableIntStructKeyOptionalDependent[] dependents = null;
+        GenericComparableIntStructKeyPrincipal[] principals = null!;
+        GenericComparableIntStructKeyOptionalDependent[] dependents = null!;
         await InsertOptionalGraph<GenericComparableIntStructKeyPrincipal, GenericComparableIntStructKeyOptionalDependent>();
 
         using (var context = CreateContext())
@@ -258,8 +256,8 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
             await RunQueries(context);
 
             Validate(
-                principals,
-                dependents,
+                principals!,
+                dependents!,
                 [(0, [0]), (1, [1]), (2, [2, 2, 2]), (3, [])],
                 [(0, 0), (1, 1), (2, 2), (3, 2), (4, 2), (5, null)]);
 
@@ -373,8 +371,8 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
     [Fact]
     public virtual async Task Can_insert_and_read_back_with_struct_key_and_required_dependents()
     {
-        IntStructKeyPrincipal[] principals = null;
-        IntStructKeyRequiredDependent[] dependents = null;
+        IntStructKeyPrincipal[] principals = null!;
+        IntStructKeyRequiredDependent[] dependents = null!;
         await InsertRequiredGraph<IntStructKeyPrincipal, IntStructKeyRequiredDependent>();
 
         using (var context = CreateContext())
@@ -382,8 +380,8 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
             await RunQueries(context);
 
             Validate(
-                principals,
-                dependents,
+                principals!,
+                dependents!,
                 [(0, [0]), (1, [1]), (2, [2, 2, 2, 2]), (3, [])],
                 [(0, 0), (1, 1), (2, 2), (3, 2), (4, 2), (5, 2)]);
 
@@ -450,14 +448,14 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
 
             dependents =
             [
-                await context.Set<IntStructKeyRequiredDependent>().FirstOrDefaultAsync(e => e.Id.Equals(new IntStructKey { Id = 111 })),
-                await context.Set<IntStructKeyRequiredDependent>()
-                    .FirstOrDefaultAsync(e => e.Id.Equals(new IntStructKey { Id = oneTwelve })),
-                await context.Set<IntStructKeyRequiredDependent>().FirstOrDefaultAsync(e => e.Id.Equals(oneThirteen)),
-                await context.Set<IntStructKeyRequiredDependent>().FirstOrDefaultAsync(e => e.Id.Equals(new IntStructKey { Id = 114 })),
-                await context.Set<IntStructKeyRequiredDependent>()
-                    .FirstOrDefaultAsync(e => e.Id.Equals(new IntStructKey { Id = oneFifteeen })),
-                await context.Set<IntStructKeyRequiredDependent>().FirstOrDefaultAsync(e => e.Id.Equals(oneSixteen))
+                (await context.Set<IntStructKeyRequiredDependent>().FirstOrDefaultAsync(e => e.Id.Equals(new IntStructKey { Id = 111 })))!,
+                (await context.Set<IntStructKeyRequiredDependent>()
+                    .FirstOrDefaultAsync(e => e.Id.Equals(new IntStructKey { Id = oneTwelve })))!,
+                (await context.Set<IntStructKeyRequiredDependent>().FirstOrDefaultAsync(e => e.Id.Equals(oneThirteen)))!,
+                (await context.Set<IntStructKeyRequiredDependent>().FirstOrDefaultAsync(e => e.Id.Equals(new IntStructKey { Id = 114 })))!,
+                (await context.Set<IntStructKeyRequiredDependent>()
+                    .FirstOrDefaultAsync(e => e.Id.Equals(new IntStructKey { Id = oneFifteeen })))!,
+                (await context.Set<IntStructKeyRequiredDependent>().FirstOrDefaultAsync(e => e.Id.Equals(oneSixteen)))!
             ];
 
             Assert.Same(dependents[0], await context.Set<IntStructKeyRequiredDependent>().FindAsync(new IntStructKey { Id = 111 }));
@@ -486,8 +484,8 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
     [Fact]
     public virtual async Task Can_insert_and_read_back_with_comparable_struct_key_and_required_dependents()
     {
-        ComparableIntStructKeyPrincipal[] principals = null;
-        ComparableIntStructKeyRequiredDependent[] dependents = null;
+        ComparableIntStructKeyPrincipal[] principals = null!;
+        ComparableIntStructKeyRequiredDependent[] dependents = null!;
         await InsertRequiredGraph<ComparableIntStructKeyPrincipal, ComparableIntStructKeyRequiredDependent>();
 
         using (var context = CreateContext())
@@ -495,8 +493,8 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
             await RunQueries(context);
 
             Validate(
-                principals,
-                dependents,
+                principals!,
+                dependents!,
                 [(0, [0]), (1, [1]), (2, [2, 2, 2, 2]), (3, [])],
                 [(0, 0), (1, 1), (2, 2), (3, 2), (4, 2), (5, 2)]);
 
@@ -563,16 +561,16 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
 
             dependents =
             [
-                await context.Set<ComparableIntStructKeyRequiredDependent>()
-                    .FirstOrDefaultAsync(e => e.Id.Equals(new ComparableIntStructKey { Id = 111 })),
-                await context.Set<ComparableIntStructKeyRequiredDependent>()
-                    .FirstOrDefaultAsync(e => e.Id.Equals(new ComparableIntStructKey { Id = oneTwelve })),
-                await context.Set<ComparableIntStructKeyRequiredDependent>().FirstOrDefaultAsync(e => e.Id.Equals(oneThirteen)),
-                await context.Set<ComparableIntStructKeyRequiredDependent>()
-                    .FirstOrDefaultAsync(e => e.Id.Equals(new ComparableIntStructKey { Id = 114 })),
-                await context.Set<ComparableIntStructKeyRequiredDependent>()
-                    .FirstOrDefaultAsync(e => e.Id.Equals(new ComparableIntStructKey { Id = oneFifteeen })),
-                await context.Set<ComparableIntStructKeyRequiredDependent>().FirstOrDefaultAsync(e => e.Id.Equals(oneSixteen))
+                (await context.Set<ComparableIntStructKeyRequiredDependent>()
+                    .FirstOrDefaultAsync(e => e.Id.Equals(new ComparableIntStructKey { Id = 111 })))!,
+                (await context.Set<ComparableIntStructKeyRequiredDependent>()
+                    .FirstOrDefaultAsync(e => e.Id.Equals(new ComparableIntStructKey { Id = oneTwelve })))!,
+                (await context.Set<ComparableIntStructKeyRequiredDependent>().FirstOrDefaultAsync(e => e.Id.Equals(oneThirteen)))!,
+                (await context.Set<ComparableIntStructKeyRequiredDependent>()
+                    .FirstOrDefaultAsync(e => e.Id.Equals(new ComparableIntStructKey { Id = 114 })))!,
+                (await context.Set<ComparableIntStructKeyRequiredDependent>()
+                    .FirstOrDefaultAsync(e => e.Id.Equals(new ComparableIntStructKey { Id = oneFifteeen })))!,
+                (await context.Set<ComparableIntStructKeyRequiredDependent>().FirstOrDefaultAsync(e => e.Id.Equals(oneSixteen)))!
             ];
 
             Assert.Same(
@@ -608,8 +606,8 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
     [Fact]
     public virtual async Task Can_insert_and_read_back_with_generic_comparable_struct_key_and_required_dependents()
     {
-        GenericComparableIntStructKeyPrincipal[] principals = null;
-        GenericComparableIntStructKeyRequiredDependent[] dependents = null;
+        GenericComparableIntStructKeyPrincipal[] principals = null!;
+        GenericComparableIntStructKeyRequiredDependent[] dependents = null!;
         await InsertRequiredGraph<GenericComparableIntStructKeyPrincipal, GenericComparableIntStructKeyRequiredDependent>();
 
         using (var context = CreateContext())
@@ -617,8 +615,8 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
             await RunQueries(context);
 
             Validate(
-                principals,
-                dependents,
+                principals!,
+                dependents!,
                 [(0, [0]), (1, [1]), (2, [2, 2, 2, 2]), (3, [])],
                 [(0, 0), (1, 1), (2, 2), (3, 2), (4, 2), (5, 2)]);
 
@@ -685,16 +683,16 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
 
             dependents =
             [
-                await context.Set<GenericComparableIntStructKeyRequiredDependent>()
-                    .FirstOrDefaultAsync(e => e.Id.Equals(new GenericComparableIntStructKey { Id = 111 })),
-                await context.Set<GenericComparableIntStructKeyRequiredDependent>()
-                    .FirstOrDefaultAsync(e => e.Id.Equals(new GenericComparableIntStructKey { Id = oneTwelve })),
-                await context.Set<GenericComparableIntStructKeyRequiredDependent>().FirstOrDefaultAsync(e => e.Id.Equals(oneThirteen)),
-                await context.Set<GenericComparableIntStructKeyRequiredDependent>()
-                    .FirstOrDefaultAsync(e => e.Id.Equals(new GenericComparableIntStructKey { Id = 114 })),
-                await context.Set<GenericComparableIntStructKeyRequiredDependent>()
-                    .FirstOrDefaultAsync(e => e.Id.Equals(new GenericComparableIntStructKey { Id = oneFifteeen })),
-                await context.Set<GenericComparableIntStructKeyRequiredDependent>().FirstOrDefaultAsync(e => e.Id.Equals(oneSixteen))
+                (await context.Set<GenericComparableIntStructKeyRequiredDependent>()
+                    .FirstOrDefaultAsync(e => e.Id.Equals(new GenericComparableIntStructKey { Id = 111 })))!,
+                (await context.Set<GenericComparableIntStructKeyRequiredDependent>()
+                    .FirstOrDefaultAsync(e => e.Id.Equals(new GenericComparableIntStructKey { Id = oneTwelve })))!,
+                (await context.Set<GenericComparableIntStructKeyRequiredDependent>().FirstOrDefaultAsync(e => e.Id.Equals(oneThirteen)))!,
+                (await context.Set<GenericComparableIntStructKeyRequiredDependent>()
+                    .FirstOrDefaultAsync(e => e.Id.Equals(new GenericComparableIntStructKey { Id = 114 })))!,
+                (await context.Set<GenericComparableIntStructKeyRequiredDependent>()
+                    .FirstOrDefaultAsync(e => e.Id.Equals(new GenericComparableIntStructKey { Id = oneFifteeen })))!,
+                (await context.Set<GenericComparableIntStructKeyRequiredDependent>().FirstOrDefaultAsync(e => e.Id.Equals(oneSixteen)))!
             ];
 
             Assert.Same(
@@ -734,8 +732,8 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
     [Fact]
     public virtual async Task Can_insert_and_read_back_with_class_key_and_optional_dependents()
     {
-        IntClassKeyPrincipal[] principals = null;
-        IntClassKeyOptionalDependent[] dependents = null;
+        IntClassKeyPrincipal[] principals = null!;
+        IntClassKeyOptionalDependent[] dependents = null!;
         await InsertOptionalGraph<IntClassKeyPrincipal, IntClassKeyOptionalDependent>();
 
         using (var context = CreateContext())
@@ -743,8 +741,8 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
             await RunQueries(context);
 
             Validate(
-                principals,
-                dependents,
+                principals!,
+                dependents!,
                 [(0, [0]), (1, [1]), (2, [2, 2, 2]), (3, [])],
                 [(0, 0), (1, 1), (2, 2), (3, 2), (4, 2), (5, null)]);
 
@@ -844,8 +842,8 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
     [Fact]
     public virtual async Task Can_insert_and_read_back_with_enumerable_class_key_and_optional_dependents()
     {
-        EnumerableClassKeyPrincipal[] principals = null;
-        EnumerableClassKeyOptionalDependent[] dependents = null;
+        EnumerableClassKeyPrincipal[] principals = null!;
+        EnumerableClassKeyOptionalDependent[] dependents = null!;
         await InsertOptionalGraph<EnumerableClassKeyPrincipal, EnumerableClassKeyOptionalDependent>();
 
         using (var context = CreateContext())
@@ -853,8 +851,8 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
             await RunQueries(context);
 
             Validate(
-                principals,
-                dependents,
+                principals!,
+                dependents!,
                 [(0, [0]), (1, [1]), (2, [2, 2, 2]), (3, [])],
                 [(0, 0), (1, 1), (2, 2), (3, 2), (4, 2), (5, null)]);
 
@@ -955,8 +953,8 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
     [Fact]
     public virtual async Task Can_insert_and_read_back_with_bare_class_key_and_optional_dependents()
     {
-        BareIntClassKeyPrincipal[] principals = null;
-        BareIntClassKeyOptionalDependent[] dependents = null;
+        BareIntClassKeyPrincipal[] principals = null!;
+        BareIntClassKeyOptionalDependent[] dependents = null!;
         await InsertOptionalGraph<BareIntClassKeyPrincipal, BareIntClassKeyOptionalDependent>();
 
         using (var context = CreateContext())
@@ -964,8 +962,8 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
             await RunQueries(context);
 
             Validate(
-                principals,
-                dependents,
+                principals!,
+                dependents!,
                 [(0, [0]), (1, [1]), (2, [2, 2, 2]), (3, [])],
                 [(0, 0), (1, 1), (2, 2), (3, 2), (4, 2), (5, null)]);
 
@@ -1065,8 +1063,8 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
     [Fact]
     public virtual async Task Can_insert_and_read_back_with_comparable_class_key_and_optional_dependents()
     {
-        ComparableIntClassKeyPrincipal[] principals = null;
-        ComparableIntClassKeyOptionalDependent[] dependents = null;
+        ComparableIntClassKeyPrincipal[] principals = null!;
+        ComparableIntClassKeyOptionalDependent[] dependents = null!;
         await InsertOptionalGraph<ComparableIntClassKeyPrincipal, ComparableIntClassKeyOptionalDependent>();
 
         using (var context = CreateContext())
@@ -1074,8 +1072,8 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
             await RunQueries(context);
 
             Validate(
-                principals,
-                dependents,
+                principals!,
+                dependents!,
                 [(0, [0]), (1, [1]), (2, [2, 2, 2]), (3, [])],
                 [(0, 0), (1, 1), (2, 2), (3, 2), (4, 2), (5, null)]);
 
@@ -1181,8 +1179,8 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
     [Fact]
     public virtual async Task Can_insert_and_read_back_with_struct_binary_key_and_optional_dependents()
     {
-        BytesStructKeyPrincipal[] principals = null;
-        BytesStructKeyOptionalDependent[] dependents = null;
+        BytesStructKeyPrincipal[] principals = null!;
+        BytesStructKeyOptionalDependent[] dependents = null!;
         await InsertOptionalBytesGraph<BytesStructKeyPrincipal, BytesStructKeyOptionalDependent>();
 
         using (var context = CreateContext())
@@ -1190,8 +1188,8 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
             await RunQueries(context);
 
             Validate(
-                principals,
-                dependents,
+                principals!,
+                dependents!,
                 [(0, [0]), (1, [1]), (2, [2, 2, 2]), (3, [])],
                 [(0, 0), (1, 1), (2, 2), (3, 2), (4, 2), (5, null)]);
 
@@ -1295,8 +1293,8 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
     [Fact]
     public virtual async Task Can_insert_and_read_back_with_structural_struct_binary_key_and_optional_dependents()
     {
-        StructuralComparableBytesStructKeyPrincipal[] principals = null;
-        StructuralComparableBytesStructKeyOptionalDependent[] dependents = null;
+        StructuralComparableBytesStructKeyPrincipal[] principals = null!;
+        StructuralComparableBytesStructKeyOptionalDependent[] dependents = null!;
         await InsertOptionalBytesGraph<StructuralComparableBytesStructKeyPrincipal, StructuralComparableBytesStructKeyOptionalDependent>();
 
         using (var context = CreateContext())
@@ -1304,8 +1302,8 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
             await RunQueries(context);
 
             Validate(
-                principals,
-                dependents,
+                principals!,
+                dependents!,
                 [(0, [0]), (1, [1]), (2, [2, 2, 2]), (3, [])],
                 [(0, 0), (1, 1), (2, 2), (3, 2), (4, 2), (5, null)]);
 
@@ -1429,8 +1427,8 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
     [Fact]
     public virtual async Task Can_insert_and_read_back_with_comparable_struct_binary_key_and_optional_dependents()
     {
-        ComparableBytesStructKeyPrincipal[] principals = null;
-        ComparableBytesStructKeyOptionalDependent[] dependents = null;
+        ComparableBytesStructKeyPrincipal[] principals = null!;
+        ComparableBytesStructKeyOptionalDependent[] dependents = null!;
         await InsertOptionalBytesGraph<ComparableBytesStructKeyPrincipal, ComparableBytesStructKeyOptionalDependent>();
 
         using (var context = CreateContext())
@@ -1438,8 +1436,8 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
             await RunQueries(context);
 
             Validate(
-                principals,
-                dependents,
+                principals!,
+                dependents!,
                 [(0, [0]), (1, [1]), (2, [2, 2, 2]), (3, [])],
                 [(0, 0), (1, 1), (2, 2), (3, 2), (4, 2), (5, null)]);
 
@@ -1553,8 +1551,8 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
     [Fact]
     public virtual async Task Can_insert_and_read_back_with_generic_comparable_struct_binary_key_and_optional_dependents()
     {
-        GenericComparableBytesStructKeyPrincipal[] principals = null;
-        GenericComparableBytesStructKeyOptionalDependent[] dependents = null;
+        GenericComparableBytesStructKeyPrincipal[] principals = null!;
+        GenericComparableBytesStructKeyOptionalDependent[] dependents = null!;
         await InsertOptionalBytesGraph<GenericComparableBytesStructKeyPrincipal, GenericComparableBytesStructKeyOptionalDependent>();
 
         using (var context = CreateContext())
@@ -1562,8 +1560,8 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
             await RunQueries(context);
 
             Validate(
-                principals,
-                dependents,
+                principals!,
+                dependents!,
                 [(0, [0]), (1, [1]), (2, [2, 2, 2]), (3, [])],
                 [(0, 0), (1, 1), (2, 2), (3, 2), (4, 2), (5, null)]);
 
@@ -1680,8 +1678,8 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
     [Fact]
     public virtual async Task Can_insert_and_read_back_with_struct_binary_key_and_required_dependents()
     {
-        BytesStructKeyPrincipal[] principals = null;
-        BytesStructKeyRequiredDependent[] dependents = null;
+        BytesStructKeyPrincipal[] principals = null!;
+        BytesStructKeyRequiredDependent[] dependents = null!;
         await InsertRequiredBytesGraph<BytesStructKeyPrincipal, BytesStructKeyRequiredDependent>();
 
         using (var context = CreateContext())
@@ -1689,8 +1687,8 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
             await RunQueries(context);
 
             Validate(
-                principals,
-                dependents,
+                principals!,
+                dependents!,
                 [(0, [0]), (1, [1]), (2, [2, 2, 2, 2]), (3, [])],
                 [(0, 0), (1, 1), (2, 2), (3, 2), (4, 2), (5, 2)]);
 
@@ -1757,16 +1755,16 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
 
             dependents =
             [
-                await context.Set<BytesStructKeyRequiredDependent>()
-                    .FirstOrDefaultAsync(e => e.Id.Equals(new BytesStructKey { Id = new byte[] { 111 } })),
-                await context.Set<BytesStructKeyRequiredDependent>()
-                    .FirstOrDefaultAsync(e => e.Id.Equals(new BytesStructKey { Id = oneTwelve })),
-                await context.Set<BytesStructKeyRequiredDependent>().FirstOrDefaultAsync(e => e.Id.Equals(oneThirteen)),
-                await context.Set<BytesStructKeyRequiredDependent>()
-                    .FirstOrDefaultAsync(e => e.Id.Equals(new BytesStructKey { Id = new byte[] { 114 } })),
-                await context.Set<BytesStructKeyRequiredDependent>()
-                    .FirstOrDefaultAsync(e => e.Id.Equals(new BytesStructKey { Id = oneFifteeen })),
-                await context.Set<BytesStructKeyRequiredDependent>().FirstOrDefaultAsync(e => e.Id.Equals(oneSixteen))
+                (await context.Set<BytesStructKeyRequiredDependent>()
+                    .FirstOrDefaultAsync(e => e.Id.Equals(new BytesStructKey { Id = new byte[] { 111 } })))!,
+                (await context.Set<BytesStructKeyRequiredDependent>()
+                    .FirstOrDefaultAsync(e => e.Id.Equals(new BytesStructKey { Id = oneTwelve })))!,
+                (await context.Set<BytesStructKeyRequiredDependent>().FirstOrDefaultAsync(e => e.Id.Equals(oneThirteen)))!,
+                (await context.Set<BytesStructKeyRequiredDependent>()
+                    .FirstOrDefaultAsync(e => e.Id.Equals(new BytesStructKey { Id = new byte[] { 114 } })))!,
+                (await context.Set<BytesStructKeyRequiredDependent>()
+                    .FirstOrDefaultAsync(e => e.Id.Equals(new BytesStructKey { Id = oneFifteeen })))!,
+                (await context.Set<BytesStructKeyRequiredDependent>().FirstOrDefaultAsync(e => e.Id.Equals(oneSixteen)))!
             ];
 
             Assert.Same(
@@ -1798,8 +1796,8 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
     [Fact]
     public virtual async Task Can_insert_and_read_back_with_comparable_struct_binary_key_and_required_dependents()
     {
-        ComparableBytesStructKeyPrincipal[] principals = null;
-        ComparableBytesStructKeyRequiredDependent[] dependents = null;
+        ComparableBytesStructKeyPrincipal[] principals = null!;
+        ComparableBytesStructKeyRequiredDependent[] dependents = null!;
         await InsertRequiredBytesGraph<ComparableBytesStructKeyPrincipal, ComparableBytesStructKeyRequiredDependent>();
 
         using (var context = CreateContext())
@@ -1807,8 +1805,8 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
             await RunQueries(context);
 
             Validate(
-                principals,
-                dependents,
+                principals!,
+                dependents!,
                 [(0, [0]), (1, [1]), (2, [2, 2, 2, 2]), (3, [])],
                 [(0, 0), (1, 1), (2, 2), (3, 2), (4, 2), (5, 2)]);
 
@@ -1875,16 +1873,16 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
 
             dependents =
             [
-                await context.Set<ComparableBytesStructKeyRequiredDependent>()
-                    .FirstOrDefaultAsync(e => e.Id.Equals(new ComparableBytesStructKey { Id = new byte[] { 111 } })),
-                await context.Set<ComparableBytesStructKeyRequiredDependent>()
-                    .FirstOrDefaultAsync(e => e.Id.Equals(new ComparableBytesStructKey { Id = oneTwelve })),
-                await context.Set<ComparableBytesStructKeyRequiredDependent>().FirstOrDefaultAsync(e => e.Id.Equals(oneThirteen)),
-                await context.Set<ComparableBytesStructKeyRequiredDependent>()
-                    .FirstOrDefaultAsync(e => e.Id.Equals(new ComparableBytesStructKey { Id = new byte[] { 114 } })),
-                await context.Set<ComparableBytesStructKeyRequiredDependent>()
-                    .FirstOrDefaultAsync(e => e.Id.Equals(new ComparableBytesStructKey { Id = oneFifteeen })),
-                await context.Set<ComparableBytesStructKeyRequiredDependent>().FirstOrDefaultAsync(e => e.Id.Equals(oneSixteen))
+                (await context.Set<ComparableBytesStructKeyRequiredDependent>()
+                    .FirstOrDefaultAsync(e => e.Id.Equals(new ComparableBytesStructKey { Id = new byte[] { 111 } })))!,
+                (await context.Set<ComparableBytesStructKeyRequiredDependent>()
+                    .FirstOrDefaultAsync(e => e.Id.Equals(new ComparableBytesStructKey { Id = oneTwelve })))!,
+                (await context.Set<ComparableBytesStructKeyRequiredDependent>().FirstOrDefaultAsync(e => e.Id.Equals(oneThirteen)))!,
+                (await context.Set<ComparableBytesStructKeyRequiredDependent>()
+                    .FirstOrDefaultAsync(e => e.Id.Equals(new ComparableBytesStructKey { Id = new byte[] { 114 } })))!,
+                (await context.Set<ComparableBytesStructKeyRequiredDependent>()
+                    .FirstOrDefaultAsync(e => e.Id.Equals(new ComparableBytesStructKey { Id = oneFifteeen })))!,
+                (await context.Set<ComparableBytesStructKeyRequiredDependent>().FirstOrDefaultAsync(e => e.Id.Equals(oneSixteen)))!
             ];
 
             Assert.Same(
@@ -1923,8 +1921,8 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
     [Fact]
     public virtual async Task Can_insert_and_read_back_with_structural_struct_binary_key_and_required_dependents()
     {
-        StructuralComparableBytesStructKeyPrincipal[] principals = null;
-        StructuralComparableBytesStructKeyRequiredDependent[] dependents = null;
+        StructuralComparableBytesStructKeyPrincipal[] principals = null!;
+        StructuralComparableBytesStructKeyRequiredDependent[] dependents = null!;
         await InsertRequiredBytesGraph<StructuralComparableBytesStructKeyPrincipal, StructuralComparableBytesStructKeyRequiredDependent>();
 
         using (var context = CreateContext())
@@ -1932,8 +1930,8 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
             await RunQueries(context);
 
             Validate(
-                principals,
-                dependents,
+                principals!,
+                dependents!,
                 [(0, [0]), (1, [1]), (2, [2, 2, 2, 2]), (3, [])],
                 [(0, 0), (1, 1), (2, 2), (3, 2), (4, 2), (5, 2)]);
 
@@ -2005,16 +2003,16 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
 
             dependents =
             [
-                await context.Set<StructuralComparableBytesStructKeyRequiredDependent>().FirstOrDefaultAsync(e
-                    => e.Id.Equals(new StructuralComparableBytesStructKey { Id = new byte[] { 111 } })),
-                await context.Set<StructuralComparableBytesStructKeyRequiredDependent>()
-                    .FirstOrDefaultAsync(e => e.Id.Equals(new StructuralComparableBytesStructKey { Id = oneTwelve })),
-                await context.Set<StructuralComparableBytesStructKeyRequiredDependent>().FirstOrDefaultAsync(e => e.Id.Equals(oneThirteen)),
-                await context.Set<StructuralComparableBytesStructKeyRequiredDependent>().FirstOrDefaultAsync(e
-                    => e.Id.Equals(new StructuralComparableBytesStructKey { Id = new byte[] { 114 } })),
-                await context.Set<StructuralComparableBytesStructKeyRequiredDependent>()
-                    .FirstOrDefaultAsync(e => e.Id.Equals(new StructuralComparableBytesStructKey { Id = oneFifteeen })),
-                await context.Set<StructuralComparableBytesStructKeyRequiredDependent>().FirstOrDefaultAsync(e => e.Id.Equals(oneSixteen))
+                (await context.Set<StructuralComparableBytesStructKeyRequiredDependent>().FirstOrDefaultAsync(e
+                    => e.Id.Equals(new StructuralComparableBytesStructKey { Id = new byte[] { 111 } })))!,
+                (await context.Set<StructuralComparableBytesStructKeyRequiredDependent>()
+                    .FirstOrDefaultAsync(e => e.Id.Equals(new StructuralComparableBytesStructKey { Id = oneTwelve })))!,
+                (await context.Set<StructuralComparableBytesStructKeyRequiredDependent>().FirstOrDefaultAsync(e => e.Id.Equals(oneThirteen)))!,
+                (await context.Set<StructuralComparableBytesStructKeyRequiredDependent>().FirstOrDefaultAsync(e
+                    => e.Id.Equals(new StructuralComparableBytesStructKey { Id = new byte[] { 114 } })))!,
+                (await context.Set<StructuralComparableBytesStructKeyRequiredDependent>()
+                    .FirstOrDefaultAsync(e => e.Id.Equals(new StructuralComparableBytesStructKey { Id = oneFifteeen })))!,
+                (await context.Set<StructuralComparableBytesStructKeyRequiredDependent>().FirstOrDefaultAsync(e => e.Id.Equals(oneSixteen)))!
             ];
 
             Assert.Same(
@@ -2057,8 +2055,8 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
     [Fact]
     public virtual async Task Can_insert_and_read_back_with_generic_comparable_struct_binary_key_and_required_dependents()
     {
-        GenericComparableBytesStructKeyPrincipal[] principals = null;
-        GenericComparableBytesStructKeyRequiredDependent[] dependents = null;
+        GenericComparableBytesStructKeyPrincipal[] principals = null!;
+        GenericComparableBytesStructKeyRequiredDependent[] dependents = null!;
         await InsertRequiredBytesGraph<GenericComparableBytesStructKeyPrincipal, GenericComparableBytesStructKeyRequiredDependent>();
 
         using (var context = CreateContext())
@@ -2066,8 +2064,8 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
             await RunQueries(context);
 
             Validate(
-                principals,
-                dependents,
+                principals!,
+                dependents!,
                 [(0, [0]), (1, [1]), (2, [2, 2, 2, 2]), (3, [])],
                 [(0, 0), (1, 1), (2, 2), (3, 2), (4, 2), (5, 2)]);
 
@@ -2135,16 +2133,16 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
 
             dependents =
             [
-                await context.Set<GenericComparableBytesStructKeyRequiredDependent>().FirstOrDefaultAsync(e
-                    => e.Id.Equals(new GenericComparableBytesStructKey { Id = new byte[] { 111 } })),
-                await context.Set<GenericComparableBytesStructKeyRequiredDependent>()
-                    .FirstOrDefaultAsync(e => e.Id.Equals(new GenericComparableBytesStructKey { Id = oneTwelve })),
-                await context.Set<GenericComparableBytesStructKeyRequiredDependent>().FirstOrDefaultAsync(e => e.Id.Equals(oneThirteen)),
-                await context.Set<GenericComparableBytesStructKeyRequiredDependent>().FirstOrDefaultAsync(e
-                    => e.Id.Equals(new GenericComparableBytesStructKey { Id = new byte[] { 114 } })),
-                await context.Set<GenericComparableBytesStructKeyRequiredDependent>()
-                    .FirstOrDefaultAsync(e => e.Id.Equals(new GenericComparableBytesStructKey { Id = oneFifteeen })),
-                await context.Set<GenericComparableBytesStructKeyRequiredDependent>().FirstOrDefaultAsync(e => e.Id.Equals(oneSixteen))
+                (await context.Set<GenericComparableBytesStructKeyRequiredDependent>().FirstOrDefaultAsync(e
+                    => e.Id.Equals(new GenericComparableBytesStructKey { Id = new byte[] { 111 } })))!,
+                (await context.Set<GenericComparableBytesStructKeyRequiredDependent>()
+                    .FirstOrDefaultAsync(e => e.Id.Equals(new GenericComparableBytesStructKey { Id = oneTwelve })))!,
+                (await context.Set<GenericComparableBytesStructKeyRequiredDependent>().FirstOrDefaultAsync(e => e.Id.Equals(oneThirteen)))!,
+                (await context.Set<GenericComparableBytesStructKeyRequiredDependent>().FirstOrDefaultAsync(e
+                    => e.Id.Equals(new GenericComparableBytesStructKey { Id = new byte[] { 114 } })))!,
+                (await context.Set<GenericComparableBytesStructKeyRequiredDependent>()
+                    .FirstOrDefaultAsync(e => e.Id.Equals(new GenericComparableBytesStructKey { Id = oneFifteeen })))!,
+                (await context.Set<GenericComparableBytesStructKeyRequiredDependent>().FirstOrDefaultAsync(e => e.Id.Equals(oneSixteen)))!
             ];
 
             Assert.Same(
@@ -2217,7 +2215,7 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
             var key = new Key("1-1-1");
             var ownedEntity = await context.Set<BaseEntity>().FindAsync(key);
 
-            Assert.Equal(0, ownedEntity.Text.Position);
+            Assert.Equal(0, ownedEntity!.Text.Position);
         }
     }
 
@@ -2245,7 +2243,7 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
         {
             var owner = await context.Set<OwnerIntStructKey>().FindAsync(new IntStructKey(1));
 
-            Assert.Equal(88, owner.Owned.Position);
+            Assert.Equal(88, owner!.Owned.Position);
         }
     }
 
@@ -2271,7 +2269,7 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
         using (var context = CreateContext())
         {
             var owner = await context.Set<OwnerBytesStructKey>().FindAsync(new BytesStructKey([1, 5, 7, 1]));
-            Assert.Equal(88, owner.Owned.Position);
+            Assert.Equal(88, owner!.Owned.Position);
         }
     }
 
@@ -2296,7 +2294,7 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
         using (var context = CreateContext())
         {
             var owner = await context.Set<OwnerComparableIntStructKey>().FindAsync(new ComparableIntStructKey(1));
-            Assert.Equal(88, owner.Owned.Position);
+            Assert.Equal(88, owner!.Owned.Position);
         }
     }
 
@@ -2324,7 +2322,7 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
         using (var context = CreateContext())
         {
             var owner = await context.Set<OwnerComparableBytesStructKey>().FindAsync(new ComparableBytesStructKey([1, 5, 7, 1]));
-            Assert.Equal(88, owner.Owned.Position);
+            Assert.Equal(88, owner!.Owned.Position);
         }
     }
 
@@ -2352,7 +2350,7 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
         using (var context = CreateContext())
         {
             var owner = await context.Set<OwnerGenericComparableIntStructKey>().FindAsync(new GenericComparableIntStructKey(1));
-            Assert.Equal(88, owner.Owned.Position);
+            Assert.Equal(88, owner!.Owned.Position);
         }
     }
 
@@ -2381,7 +2379,7 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
         {
             var owner = await context.Set<OwnerGenericComparableBytesStructKey>()
                 .FindAsync(new GenericComparableBytesStructKey([1, 5, 7, 1]));
-            Assert.Equal(88, owner.Owned.Position);
+            Assert.Equal(88, owner!.Owned.Position);
         }
     }
 
@@ -2411,7 +2409,7 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
         {
             var owner = await context.Set<OwnerStructuralComparableBytesStructKey>()
                 .FindAsync(new StructuralComparableBytesStructKey([1, 5, 7, 1]));
-            Assert.Equal(88, owner.Owned.Position);
+            Assert.Equal(88, owner!.Owned.Position);
         }
     }
 
@@ -2436,7 +2434,7 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
         using (var context = CreateContext())
         {
             var owner = await context.Set<OwnerIntClassKey>().FindAsync(new IntClassKey(1));
-            Assert.Equal(88, owner.Owned.Position);
+            Assert.Equal(88, owner!.Owned.Position);
         }
     }
 
@@ -2461,7 +2459,7 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
         using (var context = CreateContext())
         {
             var owner = await context.Set<OwnerBareIntClassKey>().FindAsync(new BareIntClassKey(1));
-            Assert.Equal(88, owner.Owned.Position);
+            Assert.Equal(88, owner!.Owned.Position);
         }
     }
 
@@ -2486,7 +2484,7 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
         using (var context = CreateContext())
         {
             var owner = await context.Set<OwnerComparableIntClassKey>().FindAsync(new ComparableIntClassKey(1));
-            Assert.Equal(88, owner.Owned.Position);
+            Assert.Equal(88, owner!.Owned.Position);
         }
     }
 
@@ -2513,15 +2511,15 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
         using (var context = CreateContext())
         {
             var owner = await context.Set<OwnerGenericComparableIntClassKey>().FindAsync(new GenericComparableIntClassKey(1));
-            Assert.Equal(88, owner.Owned.Position);
+            Assert.Equal(88, owner!.Owned.Position);
         }
     }
 
     [Fact]
     public virtual async Task Can_insert_and_read_back_with_struct_key_and_optional_dependents_with_shadow_FK()
     {
-        IntStructKeyPrincipalShadow[] principals = null;
-        IntStructKeyOptionalDependentShadow[] dependents = null;
+        IntStructKeyPrincipalShadow[] principals = null!;
+        IntStructKeyOptionalDependentShadow[] dependents = null!;
         using (var context = CreateContext())
         {
             var principals0 = new IntStructKeyPrincipalShadow[]
@@ -2550,8 +2548,8 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
             await RunQueries(context);
 
             Validate(
-                principals,
-                dependents,
+                principals!,
+                dependents!,
                 [(0, [0]), (1, [1]), (2, [2, 2, 2]), (3, [])],
                 [(0, 0), (1, 1), (2, 2), (3, 2), (4, 2), (5, null)]);
 
@@ -2679,8 +2677,8 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
     [Fact]
     public virtual async Task Can_insert_and_read_back_with_comparable_struct_key_and_optional_dependents_with_shadow_FK()
     {
-        ComparableIntStructKeyPrincipalShadow[] principals = null;
-        ComparableIntStructKeyOptionalDependentShadow[] dependents = null;
+        ComparableIntStructKeyPrincipalShadow[] principals = null!;
+        ComparableIntStructKeyOptionalDependentShadow[] dependents = null!;
         using (var context = CreateContext())
         {
             var principals0 = new ComparableIntStructKeyPrincipalShadow[]
@@ -2709,8 +2707,8 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
             await RunQueries(context);
 
             Validate(
-                principals,
-                dependents,
+                principals!,
+                dependents!,
                 [(0, [0]), (1, [1]), (2, [2, 2, 2]), (3, [])],
                 [(0, 0), (1, 1), (2, 2), (3, 2), (4, 2), (5, null)]);
 
@@ -2850,8 +2848,8 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
     [Fact]
     public virtual async Task Can_insert_and_read_back_with_generic_comparable_struct_key_and_optional_dependents_with_shadow_FK()
     {
-        GenericComparableIntStructKeyPrincipalShadow[] principals = null;
-        GenericComparableIntStructKeyOptionalDependentShadow[] dependents = null;
+        GenericComparableIntStructKeyPrincipalShadow[] principals = null!;
+        GenericComparableIntStructKeyOptionalDependentShadow[] dependents = null!;
         using (var context = CreateContext())
         {
             var principals0 = new GenericComparableIntStructKeyPrincipalShadow[]
@@ -2900,8 +2898,8 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
             await RunQueries(context);
 
             Validate(
-                principals,
-                dependents,
+                principals!,
+                dependents!,
                 [(0, [0]), (1, [1]), (2, [2, 2, 2]), (3, [])],
                 [(0, 0), (1, 1), (2, 2), (3, 2), (4, 2), (5, null)]);
 
@@ -3045,8 +3043,8 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
     [Fact]
     public virtual async Task Can_insert_and_read_back_with_struct_key_and_required_dependents_with_shadow_FK()
     {
-        IntStructKeyPrincipalShadow[] principals = null;
-        IntStructKeyRequiredDependentShadow[] dependents = null;
+        IntStructKeyPrincipalShadow[] principals = null!;
+        IntStructKeyRequiredDependentShadow[] dependents = null!;
         using (var context = CreateContext())
         {
             var principals0 = new IntStructKeyPrincipalShadow[]
@@ -3075,8 +3073,8 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
             await RunQueries(context);
 
             Validate(
-                principals,
-                dependents,
+                principals!,
+                dependents!,
                 [(0, [0]), (1, [1]), (2, [2, 2, 2, 2]), (3, [])],
                 [(0, 0), (1, 1), (2, 2), (3, 2), (4, 2), (5, 2)]);
 
@@ -3143,16 +3141,16 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
 
             dependents =
             [
-                await context.Set<IntStructKeyRequiredDependentShadow>()
-                    .FirstOrDefaultAsync(e => e.Id.Equals(new IntStructKey { Id = 111 })),
-                await context.Set<IntStructKeyRequiredDependentShadow>()
-                    .FirstOrDefaultAsync(e => e.Id.Equals(new IntStructKey { Id = oneTwelve })),
-                await context.Set<IntStructKeyRequiredDependentShadow>().FirstOrDefaultAsync(e => e.Id.Equals(oneThirteen)),
-                await context.Set<IntStructKeyRequiredDependentShadow>()
-                    .FirstOrDefaultAsync(e => e.Id.Equals(new IntStructKey { Id = 114 })),
-                await context.Set<IntStructKeyRequiredDependentShadow>()
-                    .FirstOrDefaultAsync(e => e.Id.Equals(new IntStructKey { Id = oneFifteeen })),
-                await context.Set<IntStructKeyRequiredDependentShadow>().FirstOrDefaultAsync(e => e.Id.Equals(oneSixteen))
+                (await context.Set<IntStructKeyRequiredDependentShadow>()
+                    .FirstOrDefaultAsync(e => e.Id.Equals(new IntStructKey { Id = 111 })))!,
+                (await context.Set<IntStructKeyRequiredDependentShadow>()
+                    .FirstOrDefaultAsync(e => e.Id.Equals(new IntStructKey { Id = oneTwelve })))!,
+                (await context.Set<IntStructKeyRequiredDependentShadow>().FirstOrDefaultAsync(e => e.Id.Equals(oneThirteen)))!,
+                (await context.Set<IntStructKeyRequiredDependentShadow>()
+                    .FirstOrDefaultAsync(e => e.Id.Equals(new IntStructKey { Id = 114 })))!,
+                (await context.Set<IntStructKeyRequiredDependentShadow>()
+                    .FirstOrDefaultAsync(e => e.Id.Equals(new IntStructKey { Id = oneFifteeen })))!,
+                (await context.Set<IntStructKeyRequiredDependentShadow>().FirstOrDefaultAsync(e => e.Id.Equals(oneSixteen)))!
             ];
 
             Assert.Same(dependents[0], await context.Set<IntStructKeyRequiredDependentShadow>().FindAsync(new IntStructKey { Id = 111 }));
@@ -3205,8 +3203,8 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
     [Fact]
     public virtual async Task Can_insert_and_read_back_with_comparable_struct_key_and_required_dependents_with_shadow_FK()
     {
-        ComparableIntStructKeyPrincipalShadow[] principals = null;
-        ComparableIntStructKeyRequiredDependentShadow[] dependents = null;
+        ComparableIntStructKeyPrincipalShadow[] principals = null!;
+        ComparableIntStructKeyRequiredDependentShadow[] dependents = null!;
         using (var context = CreateContext())
         {
             var principals0 = new ComparableIntStructKeyPrincipalShadow[]
@@ -3235,8 +3233,8 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
             await RunQueries(context);
 
             Validate(
-                principals,
-                dependents,
+                principals!,
+                dependents!,
                 [(0, [0]), (1, [1]), (2, [2, 2, 2, 2]), (3, [])],
                 [(0, 0), (1, 1), (2, 2), (3, 2), (4, 2), (5, 2)]);
 
@@ -3303,16 +3301,16 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
 
             dependents =
             [
-                await context.Set<ComparableIntStructKeyRequiredDependentShadow>()
-                    .FirstOrDefaultAsync(e => e.Id.Equals(new ComparableIntStructKey { Id = 111 })),
-                await context.Set<ComparableIntStructKeyRequiredDependentShadow>()
-                    .FirstOrDefaultAsync(e => e.Id.Equals(new ComparableIntStructKey { Id = oneTwelve })),
-                await context.Set<ComparableIntStructKeyRequiredDependentShadow>().FirstOrDefaultAsync(e => e.Id.Equals(oneThirteen)),
-                await context.Set<ComparableIntStructKeyRequiredDependentShadow>()
-                    .FirstOrDefaultAsync(e => e.Id.Equals(new ComparableIntStructKey { Id = 114 })),
-                await context.Set<ComparableIntStructKeyRequiredDependentShadow>()
-                    .FirstOrDefaultAsync(e => e.Id.Equals(new ComparableIntStructKey { Id = oneFifteeen })),
-                await context.Set<ComparableIntStructKeyRequiredDependentShadow>().FirstOrDefaultAsync(e => e.Id.Equals(oneSixteen))
+                (await context.Set<ComparableIntStructKeyRequiredDependentShadow>()
+                    .FirstOrDefaultAsync(e => e.Id.Equals(new ComparableIntStructKey { Id = 111 })))!,
+                (await context.Set<ComparableIntStructKeyRequiredDependentShadow>()
+                    .FirstOrDefaultAsync(e => e.Id.Equals(new ComparableIntStructKey { Id = oneTwelve })))!,
+                (await context.Set<ComparableIntStructKeyRequiredDependentShadow>().FirstOrDefaultAsync(e => e.Id.Equals(oneThirteen)))!,
+                (await context.Set<ComparableIntStructKeyRequiredDependentShadow>()
+                    .FirstOrDefaultAsync(e => e.Id.Equals(new ComparableIntStructKey { Id = 114 })))!,
+                (await context.Set<ComparableIntStructKeyRequiredDependentShadow>()
+                    .FirstOrDefaultAsync(e => e.Id.Equals(new ComparableIntStructKey { Id = oneFifteeen })))!,
+                (await context.Set<ComparableIntStructKeyRequiredDependentShadow>().FirstOrDefaultAsync(e => e.Id.Equals(oneSixteen)))!
             ];
 
             Assert.Same(
@@ -3373,8 +3371,8 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
     [Fact]
     public virtual async Task Can_insert_and_read_back_with_generic_comparable_struct_key_and_required_dependents_with_shadow_FK()
     {
-        GenericComparableIntStructKeyPrincipalShadow[] principals = null;
-        GenericComparableIntStructKeyRequiredDependentShadow[] dependents = null;
+        GenericComparableIntStructKeyPrincipalShadow[] principals = null!;
+        GenericComparableIntStructKeyRequiredDependentShadow[] dependents = null!;
         using (var context = CreateContext())
         {
             var principals0 = new GenericComparableIntStructKeyPrincipalShadow[]
@@ -3427,8 +3425,8 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
             await RunQueries(context);
 
             Validate(
-                principals,
-                dependents,
+                principals!,
+                dependents!,
                 [(0, [0]), (1, [1]), (2, [2, 2, 2, 2]), (3, [])],
                 [(0, 0), (1, 1), (2, 2), (3, 2), (4, 2), (5, 2)]);
 
@@ -3496,17 +3494,17 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
 
             dependents =
             [
-                await context.Set<GenericComparableIntStructKeyRequiredDependentShadow>()
-                    .FirstOrDefaultAsync(e => e.Id.Equals(new GenericComparableIntStructKey { Id = 111 })),
-                await context.Set<GenericComparableIntStructKeyRequiredDependentShadow>()
-                    .FirstOrDefaultAsync(e => e.Id.Equals(new GenericComparableIntStructKey { Id = oneTwelve })),
-                await context.Set<GenericComparableIntStructKeyRequiredDependentShadow>()
-                    .FirstOrDefaultAsync(e => e.Id.Equals(oneThirteen)),
-                await context.Set<GenericComparableIntStructKeyRequiredDependentShadow>()
-                    .FirstOrDefaultAsync(e => e.Id.Equals(new GenericComparableIntStructKey { Id = 114 })),
-                await context.Set<GenericComparableIntStructKeyRequiredDependentShadow>()
-                    .FirstOrDefaultAsync(e => e.Id.Equals(new GenericComparableIntStructKey { Id = oneFifteeen })),
-                await context.Set<GenericComparableIntStructKeyRequiredDependentShadow>().FirstOrDefaultAsync(e => e.Id.Equals(oneSixteen))
+                (await context.Set<GenericComparableIntStructKeyRequiredDependentShadow>()
+                    .FirstOrDefaultAsync(e => e.Id.Equals(new GenericComparableIntStructKey { Id = 111 })))!,
+                (await context.Set<GenericComparableIntStructKeyRequiredDependentShadow>()
+                    .FirstOrDefaultAsync(e => e.Id.Equals(new GenericComparableIntStructKey { Id = oneTwelve })))!,
+                (await context.Set<GenericComparableIntStructKeyRequiredDependentShadow>()
+                    .FirstOrDefaultAsync(e => e.Id.Equals(oneThirteen)))!,
+                (await context.Set<GenericComparableIntStructKeyRequiredDependentShadow>()
+                    .FirstOrDefaultAsync(e => e.Id.Equals(new GenericComparableIntStructKey { Id = 114 })))!,
+                (await context.Set<GenericComparableIntStructKeyRequiredDependentShadow>()
+                    .FirstOrDefaultAsync(e => e.Id.Equals(new GenericComparableIntStructKey { Id = oneFifteeen })))!,
+                (await context.Set<GenericComparableIntStructKeyRequiredDependentShadow>().FirstOrDefaultAsync(e => e.Id.Equals(oneSixteen)))!
             ];
 
             Assert.Same(
@@ -3570,8 +3568,8 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
     [Fact]
     public virtual async Task Can_insert_and_read_back_with_class_key_and_optional_dependents_with_shadow_FK()
     {
-        IntClassKeyPrincipalShadow[] principals = null;
-        IntClassKeyOptionalDependentShadow[] dependents = null;
+        IntClassKeyPrincipalShadow[] principals = null!;
+        IntClassKeyOptionalDependentShadow[] dependents = null!;
         using (var context = CreateContext())
         {
             var principals0 = new IntClassKeyPrincipalShadow[]
@@ -3600,8 +3598,8 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
             await RunQueries(context);
 
             Validate(
-                principals,
-                dependents,
+                principals!,
+                dependents!,
                 [(0, [0]), (1, [1]), (2, [2, 2, 2]), (3, [])],
                 [(0, 0), (1, 1), (2, 2), (3, 2), (4, 2), (5, null)]);
 
@@ -3728,8 +3726,8 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
     [Fact]
     public virtual async Task Can_insert_and_read_back_with_bare_class_key_and_optional_dependents_with_shadow_FK()
     {
-        BareIntClassKeyPrincipalShadow[] principals = null;
-        BareIntClassKeyOptionalDependentShadow[] dependents = null;
+        BareIntClassKeyPrincipalShadow[] principals = null!;
+        BareIntClassKeyOptionalDependentShadow[] dependents = null!;
         using (var context = CreateContext())
         {
             var principals0 = new BareIntClassKeyPrincipalShadow[]
@@ -3758,8 +3756,8 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
             await RunQueries(context);
 
             Validate(
-                principals,
-                dependents,
+                principals!,
+                dependents!,
                 [(0, [0]), (1, [1]), (2, [2, 2, 2]), (3, [])],
                 [(0, 0), (1, 1), (2, 2), (3, 2), (4, 2), (5, null)]);
 
@@ -3887,8 +3885,8 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
     [Fact]
     public virtual async Task Can_insert_and_read_back_with_comparable_class_key_and_optional_dependents_with_shadow_FK()
     {
-        ComparableIntClassKeyPrincipalShadow[] principals = null;
-        ComparableIntClassKeyOptionalDependentShadow[] dependents = null;
+        ComparableIntClassKeyPrincipalShadow[] principals = null!;
+        ComparableIntClassKeyOptionalDependentShadow[] dependents = null!;
         using (var context = CreateContext())
         {
             var principals0 = new ComparableIntClassKeyPrincipalShadow[]
@@ -3917,8 +3915,8 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
             await RunQueries(context);
 
             Validate(
-                principals,
-                dependents,
+                principals!,
+                dependents!,
                 [(0, [0]), (1, [1]), (2, [2, 2, 2]), (3, [])],
                 [(0, 0), (1, 1), (2, 2), (3, 2), (4, 2), (5, null)]);
 
@@ -4053,8 +4051,8 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
     [Fact]
     public virtual async Task Can_insert_and_read_back_with_struct_binary_key_and_optional_dependents_with_shadow_FK()
     {
-        BytesStructKeyPrincipalShadow[] principals = null;
-        BytesStructKeyOptionalDependentShadow[] dependents = null;
+        BytesStructKeyPrincipalShadow[] principals = null!;
+        BytesStructKeyOptionalDependentShadow[] dependents = null!;
         using (var context = CreateContext())
         {
             var principals0 = new BytesStructKeyPrincipalShadow[]
@@ -4083,8 +4081,8 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
             await RunQueries(context);
 
             Validate(
-                principals,
-                dependents,
+                principals!,
+                dependents!,
                 [(0, [0]), (1, [1]), (2, [2, 2, 2]), (3, [])],
                 [(0, 0), (1, 1), (2, 2), (3, 2), (4, 2), (5, null)]);
 
@@ -4220,8 +4218,8 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
     [Fact]
     public virtual async Task Can_insert_and_read_back_with_structural_struct_binary_key_and_optional_dependents_with_shadow_FK()
     {
-        StructuralComparableBytesStructKeyPrincipalShadow[] principals = null;
-        StructuralComparableBytesStructKeyOptionalDependentShadow[] dependents = null;
+        StructuralComparableBytesStructKeyPrincipalShadow[] principals = null!;
+        StructuralComparableBytesStructKeyOptionalDependentShadow[] dependents = null!;
         using (var context = CreateContext())
         {
             var principals0 = new StructuralComparableBytesStructKeyPrincipalShadow[]
@@ -4270,8 +4268,8 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
             await RunQueries(context);
 
             Validate(
-                principals,
-                dependents,
+                principals!,
+                dependents!,
                 [(0, [0]), (1, [1]), (2, [2, 2, 2]), (3, [])],
                 [(0, 0), (1, 1), (2, 2), (3, 2), (4, 2), (5, null)]);
 
@@ -4425,8 +4423,8 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
     [Fact]
     public virtual async Task Can_insert_and_read_back_with_comparable_struct_binary_key_and_optional_dependents_with_shadow_FK()
     {
-        ComparableBytesStructKeyPrincipalShadow[] principals = null;
-        ComparableBytesStructKeyOptionalDependentShadow[] dependents = null;
+        ComparableBytesStructKeyPrincipalShadow[] principals = null!;
+        ComparableBytesStructKeyOptionalDependentShadow[] dependents = null!;
         using (var context = CreateContext())
         {
             var principals0 = new ComparableBytesStructKeyPrincipalShadow[]
@@ -4475,8 +4473,8 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
             await RunQueries(context);
 
             Validate(
-                principals,
-                dependents,
+                principals!,
+                dependents!,
                 [(0, [0]), (1, [1]), (2, [2, 2, 2]), (3, [])],
                 [(0, 0), (1, 1), (2, 2), (3, 2), (4, 2), (5, null)]);
 
@@ -4619,8 +4617,8 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
     [Fact]
     public virtual async Task Can_insert_and_read_back_with_generic_comparable_struct_binary_key_and_optional_dependents_with_shadow_FK()
     {
-        GenericComparableBytesStructKeyPrincipalShadow[] principals = null;
-        GenericComparableBytesStructKeyOptionalDependentShadow[] dependents = null;
+        GenericComparableBytesStructKeyPrincipalShadow[] principals = null!;
+        GenericComparableBytesStructKeyOptionalDependentShadow[] dependents = null!;
         using (var context = CreateContext())
         {
             var principals0 = new GenericComparableBytesStructKeyPrincipalShadow[]
@@ -4669,8 +4667,8 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
             await RunQueries(context);
 
             Validate(
-                principals,
-                dependents,
+                principals!,
+                dependents!,
                 [(0, [0]), (1, [1]), (2, [2, 2, 2]), (3, [])],
                 [(0, 0), (1, 1), (2, 2), (3, 2), (4, 2), (5, null)]);
 
@@ -4820,8 +4818,8 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
     [Fact]
     public virtual async Task Can_insert_and_read_back_with_struct_binary_key_and_required_dependents_with_shadow_FK()
     {
-        BytesStructKeyPrincipalShadow[] principals = null;
-        BytesStructKeyRequiredDependentShadow[] dependents = null;
+        BytesStructKeyPrincipalShadow[] principals = null!;
+        BytesStructKeyRequiredDependentShadow[] dependents = null!;
         using (var context = CreateContext())
         {
             var principals0 = new BytesStructKeyPrincipalShadow[]
@@ -4850,8 +4848,8 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
             await RunQueries(context);
 
             Validate(
-                principals,
-                dependents,
+                principals!,
+                dependents!,
                 [(0, [0]), (1, [1]), (2, [2, 2, 2, 2]), (3, [])],
                 [(0, 0), (1, 1), (2, 2), (3, 2), (4, 2), (5, 2)]);
 
@@ -4918,16 +4916,16 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
 
             dependents =
             [
-                await context.Set<BytesStructKeyRequiredDependentShadow>()
-                    .FirstOrDefaultAsync(e => e.Id.Equals(new BytesStructKey { Id = new byte[] { 111 } })),
-                await context.Set<BytesStructKeyRequiredDependentShadow>()
-                    .FirstOrDefaultAsync(e => e.Id.Equals(new BytesStructKey { Id = oneTwelve })),
-                await context.Set<BytesStructKeyRequiredDependentShadow>().FirstOrDefaultAsync(e => e.Id.Equals(oneThirteen)),
-                await context.Set<BytesStructKeyRequiredDependentShadow>()
-                    .FirstOrDefaultAsync(e => e.Id.Equals(new BytesStructKey { Id = new byte[] { 114 } })),
-                await context.Set<BytesStructKeyRequiredDependentShadow>()
-                    .FirstOrDefaultAsync(e => e.Id.Equals(new BytesStructKey { Id = oneFifteeen })),
-                await context.Set<BytesStructKeyRequiredDependentShadow>().FirstOrDefaultAsync(e => e.Id.Equals(oneSixteen))
+                (await context.Set<BytesStructKeyRequiredDependentShadow>()
+                    .FirstOrDefaultAsync(e => e.Id.Equals(new BytesStructKey { Id = new byte[] { 111 } })))!,
+                (await context.Set<BytesStructKeyRequiredDependentShadow>()
+                    .FirstOrDefaultAsync(e => e.Id.Equals(new BytesStructKey { Id = oneTwelve })))!,
+                (await context.Set<BytesStructKeyRequiredDependentShadow>().FirstOrDefaultAsync(e => e.Id.Equals(oneThirteen)))!,
+                (await context.Set<BytesStructKeyRequiredDependentShadow>()
+                    .FirstOrDefaultAsync(e => e.Id.Equals(new BytesStructKey { Id = new byte[] { 114 } })))!,
+                (await context.Set<BytesStructKeyRequiredDependentShadow>()
+                    .FirstOrDefaultAsync(e => e.Id.Equals(new BytesStructKey { Id = oneFifteeen })))!,
+                (await context.Set<BytesStructKeyRequiredDependentShadow>().FirstOrDefaultAsync(e => e.Id.Equals(oneSixteen)))!
             ];
 
             Assert.Same(
@@ -4992,8 +4990,8 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
     [Fact]
     public virtual async Task Can_insert_and_read_back_with_comparable_struct_binary_key_and_required_dependents_with_shadow_FK()
     {
-        ComparableBytesStructKeyPrincipalShadow[] principals = null;
-        ComparableBytesStructKeyRequiredDependentShadow[] dependents = null;
+        ComparableBytesStructKeyPrincipalShadow[] principals = null!;
+        ComparableBytesStructKeyRequiredDependentShadow[] dependents = null!;
         using (var context = CreateContext())
         {
             var principals0 = new ComparableBytesStructKeyPrincipalShadow[]
@@ -5046,8 +5044,8 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
             await RunQueries(context);
 
             Validate(
-                principals,
-                dependents,
+                principals!,
+                dependents!,
                 [(0, [0]), (1, [1]), (2, [2, 2, 2, 2]), (3, [])],
                 [(0, 0), (1, 1), (2, 2), (3, 2), (4, 2), (5, 2)]);
 
@@ -5114,16 +5112,16 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
 
             dependents =
             [
-                await context.Set<ComparableBytesStructKeyRequiredDependentShadow>()
-                    .FirstOrDefaultAsync(e => e.Id.Equals(new ComparableBytesStructKey { Id = new byte[] { 111 } })),
-                await context.Set<ComparableBytesStructKeyRequiredDependentShadow>()
-                    .FirstOrDefaultAsync(e => e.Id.Equals(new ComparableBytesStructKey { Id = oneTwelve })),
-                await context.Set<ComparableBytesStructKeyRequiredDependentShadow>().FirstOrDefaultAsync(e => e.Id.Equals(oneThirteen)),
-                await context.Set<ComparableBytesStructKeyRequiredDependentShadow>()
-                    .FirstOrDefaultAsync(e => e.Id.Equals(new ComparableBytesStructKey { Id = new byte[] { 114 } })),
-                await context.Set<ComparableBytesStructKeyRequiredDependentShadow>()
-                    .FirstOrDefaultAsync(e => e.Id.Equals(new ComparableBytesStructKey { Id = oneFifteeen })),
-                await context.Set<ComparableBytesStructKeyRequiredDependentShadow>().FirstOrDefaultAsync(e => e.Id.Equals(oneSixteen))
+                (await context.Set<ComparableBytesStructKeyRequiredDependentShadow>()
+                    .FirstOrDefaultAsync(e => e.Id.Equals(new ComparableBytesStructKey { Id = new byte[] { 111 } })))!,
+                (await context.Set<ComparableBytesStructKeyRequiredDependentShadow>()
+                    .FirstOrDefaultAsync(e => e.Id.Equals(new ComparableBytesStructKey { Id = oneTwelve })))!,
+                (await context.Set<ComparableBytesStructKeyRequiredDependentShadow>().FirstOrDefaultAsync(e => e.Id.Equals(oneThirteen)))!,
+                (await context.Set<ComparableBytesStructKeyRequiredDependentShadow>()
+                    .FirstOrDefaultAsync(e => e.Id.Equals(new ComparableBytesStructKey { Id = new byte[] { 114 } })))!,
+                (await context.Set<ComparableBytesStructKeyRequiredDependentShadow>()
+                    .FirstOrDefaultAsync(e => e.Id.Equals(new ComparableBytesStructKey { Id = oneFifteeen })))!,
+                (await context.Set<ComparableBytesStructKeyRequiredDependentShadow>().FirstOrDefaultAsync(e => e.Id.Equals(oneSixteen)))!
             ];
 
             Assert.Same(
@@ -5193,8 +5191,8 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
     [Fact]
     public virtual async Task Can_insert_and_read_back_with_structural_struct_binary_key_and_required_dependents_with_shadow_FK()
     {
-        StructuralComparableBytesStructKeyPrincipalShadow[] principals = null;
-        StructuralComparableBytesStructKeyRequiredDependentShadow[] dependents = null;
+        StructuralComparableBytesStructKeyPrincipalShadow[] principals = null!;
+        StructuralComparableBytesStructKeyRequiredDependentShadow[] dependents = null!;
         using (var context = CreateContext())
         {
             var principals0 = new StructuralComparableBytesStructKeyPrincipalShadow[]
@@ -5247,8 +5245,8 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
             await RunQueries(context);
 
             Validate(
-                principals,
-                dependents,
+                principals!,
+                dependents!,
                 [(0, [0]), (1, [1]), (2, [2, 2, 2, 2]), (3, [])],
                 [(0, 0), (1, 1), (2, 2), (3, 2), (4, 2), (5, 2)]);
 
@@ -5320,18 +5318,18 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
 
             dependents =
             [
-                await context.Set<StructuralComparableBytesStructKeyRequiredDependentShadow>()
-                    .FirstOrDefaultAsync(e => e.Id.Equals(new StructuralComparableBytesStructKey { Id = new byte[] { 111 } })),
-                await context.Set<StructuralComparableBytesStructKeyRequiredDependentShadow>()
-                    .FirstOrDefaultAsync(e => e.Id.Equals(new StructuralComparableBytesStructKey { Id = oneTwelve })),
-                await context.Set<StructuralComparableBytesStructKeyRequiredDependentShadow>()
-                    .FirstOrDefaultAsync(e => e.Id.Equals(oneThirteen)),
-                await context.Set<StructuralComparableBytesStructKeyRequiredDependentShadow>()
-                    .FirstOrDefaultAsync(e => e.Id.Equals(new StructuralComparableBytesStructKey { Id = new byte[] { 114 } })),
-                await context.Set<StructuralComparableBytesStructKeyRequiredDependentShadow>()
-                    .FirstOrDefaultAsync(e => e.Id.Equals(new StructuralComparableBytesStructKey { Id = oneFifteeen })),
-                await context.Set<StructuralComparableBytesStructKeyRequiredDependentShadow>()
-                    .FirstOrDefaultAsync(e => e.Id.Equals(oneSixteen))
+                (await context.Set<StructuralComparableBytesStructKeyRequiredDependentShadow>()
+                    .FirstOrDefaultAsync(e => e.Id.Equals(new StructuralComparableBytesStructKey { Id = new byte[] { 111 } })))!,
+                (await context.Set<StructuralComparableBytesStructKeyRequiredDependentShadow>()
+                    .FirstOrDefaultAsync(e => e.Id.Equals(new StructuralComparableBytesStructKey { Id = oneTwelve })))!,
+                (await context.Set<StructuralComparableBytesStructKeyRequiredDependentShadow>()
+                    .FirstOrDefaultAsync(e => e.Id.Equals(oneThirteen)))!,
+                (await context.Set<StructuralComparableBytesStructKeyRequiredDependentShadow>()
+                    .FirstOrDefaultAsync(e => e.Id.Equals(new StructuralComparableBytesStructKey { Id = new byte[] { 114 } })))!,
+                (await context.Set<StructuralComparableBytesStructKeyRequiredDependentShadow>()
+                    .FirstOrDefaultAsync(e => e.Id.Equals(new StructuralComparableBytesStructKey { Id = oneFifteeen })))!,
+                (await context.Set<StructuralComparableBytesStructKeyRequiredDependentShadow>()
+                    .FirstOrDefaultAsync(e => e.Id.Equals(oneSixteen)))!
             ];
 
             Assert.Same(
@@ -5405,8 +5403,8 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
     [Fact]
     public virtual async Task Can_insert_and_read_back_with_generic_comparable_struct_binary_key_and_required_dependents_with_shadow_FK()
     {
-        GenericComparableBytesStructKeyPrincipalShadow[] principals = null;
-        GenericComparableBytesStructKeyRequiredDependentShadow[] dependents = null;
+        GenericComparableBytesStructKeyPrincipalShadow[] principals = null!;
+        GenericComparableBytesStructKeyRequiredDependentShadow[] dependents = null!;
         using (var context = CreateContext())
         {
             var principals0 = new GenericComparableBytesStructKeyPrincipalShadow[]
@@ -5459,8 +5457,8 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
             await RunQueries(context);
 
             Validate(
-                principals,
-                dependents,
+                principals!,
+                dependents!,
                 [(0, [0]), (1, [1]), (2, [2, 2, 2, 2]), (3, [])],
                 [(0, 0), (1, 1), (2, 2), (3, 2), (4, 2), (5, 2)]);
 
@@ -5532,18 +5530,18 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
 
             dependents =
             [
-                await context.Set<GenericComparableBytesStructKeyRequiredDependentShadow>()
-                    .FirstOrDefaultAsync(e => e.Id.Equals(new GenericComparableBytesStructKey { Id = new byte[] { 111 } })),
-                await context.Set<GenericComparableBytesStructKeyRequiredDependentShadow>()
-                    .FirstOrDefaultAsync(e => e.Id.Equals(new GenericComparableBytesStructKey { Id = oneTwelve })),
-                await context.Set<GenericComparableBytesStructKeyRequiredDependentShadow>()
-                    .FirstOrDefaultAsync(e => e.Id.Equals(oneThirteen)),
-                await context.Set<GenericComparableBytesStructKeyRequiredDependentShadow>()
-                    .FirstOrDefaultAsync(e => e.Id.Equals(new GenericComparableBytesStructKey { Id = new byte[] { 114 } })),
-                await context.Set<GenericComparableBytesStructKeyRequiredDependentShadow>()
-                    .FirstOrDefaultAsync(e => e.Id.Equals(new GenericComparableBytesStructKey { Id = oneFifteeen })),
-                await context.Set<GenericComparableBytesStructKeyRequiredDependentShadow>()
-                    .FirstOrDefaultAsync(e => e.Id.Equals(oneSixteen))
+                (await context.Set<GenericComparableBytesStructKeyRequiredDependentShadow>()
+                    .FirstOrDefaultAsync(e => e.Id.Equals(new GenericComparableBytesStructKey { Id = new byte[] { 111 } })))!,
+                (await context.Set<GenericComparableBytesStructKeyRequiredDependentShadow>()
+                    .FirstOrDefaultAsync(e => e.Id.Equals(new GenericComparableBytesStructKey { Id = oneTwelve })))!,
+                (await context.Set<GenericComparableBytesStructKeyRequiredDependentShadow>()
+                    .FirstOrDefaultAsync(e => e.Id.Equals(oneThirteen)))!,
+                (await context.Set<GenericComparableBytesStructKeyRequiredDependentShadow>()
+                    .FirstOrDefaultAsync(e => e.Id.Equals(new GenericComparableBytesStructKey { Id = new byte[] { 114 } })))!,
+                (await context.Set<GenericComparableBytesStructKeyRequiredDependentShadow>()
+                    .FirstOrDefaultAsync(e => e.Id.Equals(new GenericComparableBytesStructKey { Id = oneFifteeen })))!,
+                (await context.Set<GenericComparableBytesStructKeyRequiredDependentShadow>()
+                    .FirstOrDefaultAsync(e => e.Id.Equals(oneSixteen)))!
             ];
 
             Assert.Same(
@@ -5664,7 +5662,7 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
         IList<(int, int[])> expectedPrincipalToDependents,
         IList<(int, int?)> expectedDependentToPrincipals,
         Func<IIntPrincipal, IList<IIntOptionalDependent>> getDependents,
-        Func<IIntOptionalDependent, IIntPrincipal> getPrincipal)
+        Func<IIntOptionalDependent, IIntPrincipal?> getPrincipal)
     {
         Assert.Equal(4, principals.Count);
         for (var i = 0; i < 4; i++)
@@ -5793,7 +5791,7 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
         IList<(int, int[])> expectedPrincipalToDependents,
         IList<(int, int?)> expectedDependentToPrincipals,
         Func<IBytesPrincipal, IList<IBytesOptionalDependent>> getDependents,
-        Func<IBytesOptionalDependent, IBytesPrincipal> getPrincipal)
+        Func<IBytesOptionalDependent, IBytesPrincipal?> getPrincipal)
     {
         Assert.Equal(4, principals.Count);
         Assert.Equal(new byte[] { 1 }, principals[0].BackingId);
@@ -5896,7 +5894,7 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
 
         public byte[] Id { get; set; } = id;
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => obj is BytesStructKey other && Equals(other);
 
         public bool Equals(BytesStructKey other)
@@ -5926,8 +5924,8 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
 
         public int Id { get; set; } = id;
 
-        public int CompareTo(object other)
-            => Id - ((ComparableIntStructKey)other).Id;
+        public int CompareTo(object? other)
+            => Id - ((ComparableIntStructKey)other!).Id;
     }
 
     protected struct ComparableBytesStructKey(byte[] id) : IComparable
@@ -5937,7 +5935,7 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
 
         public byte[] Id { get; set; } = id;
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => obj is ComparableBytesStructKey other && Equals(other);
 
         public bool Equals(ComparableBytesStructKey other)
@@ -5960,9 +5958,9 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
             return code.ToHashCode();
         }
 
-        public int CompareTo(object other)
+        public int CompareTo(object? other)
         {
-            var result = Id.Length - ((ComparableBytesStructKey)other).Id.Length;
+            var result = Id.Length - ((ComparableBytesStructKey)other!).Id.Length;
 
             return result != 0
                 ? result
@@ -5989,7 +5987,7 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
 
         public byte[] Id { get; set; } = id;
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => obj is GenericComparableBytesStructKey other && Equals(other);
 
         public bool Equals(GenericComparableBytesStructKey other)
@@ -6030,7 +6028,7 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
 
         public byte[] Id { get; set; } = id;
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => obj is StructuralComparableBytesStructKey other && Equals(other);
 
         public bool Equals(StructuralComparableBytesStructKey other)
@@ -6053,9 +6051,9 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
             return code.ToHashCode();
         }
 
-        public int CompareTo(object other, IComparer comparer)
+        public int CompareTo(object? other, IComparer comparer)
         {
-            var typedOther = (StructuralComparableBytesStructKey)other;
+            var typedOther = (StructuralComparableBytesStructKey)other!;
 
             var i = -1;
             var result = Id.Length - typedOther.Id.Length;
@@ -6078,7 +6076,7 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
         protected bool Equals(IntClassKey other)
             => other != null && Id == other.Id;
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => obj == this
                 || (obj?.GetType() == GetType()
                     && Equals((IntClassKey)obj));
@@ -6103,7 +6101,7 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
         protected bool Equals(EnumerableClassKey other)
             => other != null && Id == other.Id;
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => obj == this
                 || (obj?.GetType() == GetType()
                     && Equals((IntClassKey)obj));
@@ -6123,7 +6121,7 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
             = new(
                 (l, r) => (l == null && r == null) || (l != null && r != null && l.Id == r.Id),
                 v => v == null ? 0 : v.Id.GetHashCode(),
-                v => v == null ? null : new BareIntClassKey(v.Id));
+                v => v == null ? null! : new BareIntClassKey(v.Id));
 
         public int Id { get; set; } = id;
     }
@@ -6138,7 +6136,7 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
         protected bool Equals(ComparableIntClassKey other)
             => other != null && Id == other.Id;
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => obj == this
                 || (obj?.GetType() == GetType()
                     && Equals((ComparableIntClassKey)obj));
@@ -6146,8 +6144,8 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
         public override int GetHashCode()
             => Id;
 
-        public int CompareTo(object other)
-            => Id - ((ComparableIntClassKey)other).Id;
+        public int CompareTo(object? other)
+            => Id - ((ComparableIntClassKey)other!).Id;
     }
 
     protected class GenericComparableIntClassKey(int id) : IComparable<GenericComparableIntClassKey>
@@ -6160,7 +6158,7 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
         protected bool Equals(GenericComparableIntClassKey other)
             => other != null && Id == other.Id;
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => obj == this
                 || (obj?.GetType() == GetType()
                     && Equals((GenericComparableIntClassKey)obj));
@@ -6168,8 +6166,8 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
         public override int GetHashCode()
             => Id;
 
-        public int CompareTo(GenericComparableIntClassKey other)
-            => Id - other.Id;
+        public int CompareTo(GenericComparableIntClassKey? other)
+            => Id - other!.Id;
     }
 
     protected interface IBytesPrincipal
@@ -6181,7 +6179,7 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
     protected interface IBytesOptionalDependent
     {
         byte[] BackingId { get; set; }
-        byte[] BackingPrincipalId { get; set; }
+        byte[]? BackingPrincipalId { get; set; }
     }
 
     protected interface IBytesRequiredDependent
@@ -6211,9 +6209,9 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
     protected class IntStructKeyPrincipal : IIntPrincipal
     {
         public IntStructKey Id { get; set; }
-        public string Foo { get; set; }
-        public ICollection<IntStructKeyRequiredDependent> RequiredDependents { get; set; }
-        public ICollection<IntStructKeyOptionalDependent> OptionalDependents { get; set; }
+        public string Foo { get; set; } = null!;
+        public ICollection<IntStructKeyRequiredDependent> RequiredDependents { get; set; } = null!;
+        public ICollection<IntStructKeyOptionalDependent> OptionalDependents { get; set; } = null!;
 
         [NotMapped]
         public int BackingId
@@ -6227,7 +6225,7 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
     {
         public IntStructKey Id { get; set; }
         public IntStructKey PrincipalId { get; set; }
-        public IntStructKeyPrincipal Principal { get; set; }
+        public IntStructKeyPrincipal Principal { get; set; } = null!;
 
         [NotMapped]
         public int BackingId
@@ -6248,7 +6246,7 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
     {
         public IntStructKey Id { get; set; }
         public IntStructKey? PrincipalId { get; set; }
-        public IntStructKeyPrincipal Principal { get; set; }
+        public IntStructKeyPrincipal? Principal { get; set; }
 
         [NotMapped]
         public int BackingId
@@ -6268,9 +6266,9 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
     protected class BytesStructKeyPrincipal : IBytesPrincipal
     {
         public BytesStructKey Id { get; set; }
-        public string Foo { get; set; }
-        public ICollection<BytesStructKeyOptionalDependent> OptionalDependents { get; set; }
-        public ICollection<BytesStructKeyRequiredDependent> RequiredDependents { get; set; }
+        public string Foo { get; set; } = null!;
+        public ICollection<BytesStructKeyOptionalDependent> OptionalDependents { get; set; } = null!;
+        public ICollection<BytesStructKeyRequiredDependent> RequiredDependents { get; set; } = null!;
 
         [NotMapped]
         public byte[] BackingId
@@ -6284,7 +6282,7 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
     {
         public BytesStructKey Id { get; set; }
         public BytesStructKey? PrincipalId { get; set; }
-        public BytesStructKeyPrincipal Principal { get; set; }
+        public BytesStructKeyPrincipal? Principal { get; set; }
 
         [NotMapped]
         public byte[] BackingId
@@ -6294,7 +6292,7 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
         }
 
         [NotMapped]
-        public byte[] BackingPrincipalId
+        public byte[]? BackingPrincipalId
         {
             get => PrincipalId?.Id;
             set => PrincipalId = value != null ? new BytesStructKey(value) : null;
@@ -6305,7 +6303,7 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
     {
         public BytesStructKey Id { get; set; }
         public BytesStructKey PrincipalId { get; set; }
-        public BytesStructKeyPrincipal Principal { get; set; }
+        public BytesStructKeyPrincipal Principal { get; set; } = null!;
 
         [NotMapped]
         public byte[] BackingId
@@ -6325,9 +6323,9 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
     protected class ComparableIntStructKeyPrincipal : IIntPrincipal
     {
         public ComparableIntStructKey Id { get; set; }
-        public string Foo { get; set; }
-        public ICollection<ComparableIntStructKeyOptionalDependent> OptionalDependents { get; set; }
-        public ICollection<ComparableIntStructKeyRequiredDependent> RequiredDependents { get; set; }
+        public string Foo { get; set; } = null!;
+        public ICollection<ComparableIntStructKeyOptionalDependent> OptionalDependents { get; set; } = null!;
+        public ICollection<ComparableIntStructKeyRequiredDependent> RequiredDependents { get; set; } = null!;
 
         [NotMapped]
         public int BackingId
@@ -6341,7 +6339,7 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
     {
         public ComparableIntStructKey Id { get; set; }
         public ComparableIntStructKey? PrincipalId { get; set; }
-        public ComparableIntStructKeyPrincipal Principal { get; set; }
+        public ComparableIntStructKeyPrincipal? Principal { get; set; }
 
         [NotMapped]
         public int BackingId
@@ -6362,7 +6360,7 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
     {
         public ComparableIntStructKey Id { get; set; }
         public ComparableIntStructKey PrincipalId { get; set; }
-        public ComparableIntStructKeyPrincipal Principal { get; set; }
+        public ComparableIntStructKeyPrincipal Principal { get; set; } = null!;
 
         [NotMapped]
         public int BackingId
@@ -6382,9 +6380,9 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
     protected class ComparableBytesStructKeyPrincipal : IBytesPrincipal
     {
         public ComparableBytesStructKey Id { get; set; }
-        public string Foo { get; set; }
-        public ICollection<ComparableBytesStructKeyOptionalDependent> OptionalDependents { get; set; }
-        public ICollection<ComparableBytesStructKeyRequiredDependent> RequiredDependents { get; set; }
+        public string Foo { get; set; } = null!;
+        public ICollection<ComparableBytesStructKeyOptionalDependent> OptionalDependents { get; set; } = null!;
+        public ICollection<ComparableBytesStructKeyRequiredDependent> RequiredDependents { get; set; } = null!;
 
         [NotMapped]
         public byte[] BackingId
@@ -6398,7 +6396,7 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
     {
         public ComparableBytesStructKey Id { get; set; }
         public ComparableBytesStructKey? PrincipalId { get; set; }
-        public ComparableBytesStructKeyPrincipal Principal { get; set; }
+        public ComparableBytesStructKeyPrincipal? Principal { get; set; }
 
         [NotMapped]
         public byte[] BackingId
@@ -6408,7 +6406,7 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
         }
 
         [NotMapped]
-        public byte[] BackingPrincipalId
+        public byte[]? BackingPrincipalId
         {
             get => PrincipalId?.Id;
             set => PrincipalId = value != null ? new ComparableBytesStructKey(value) : null;
@@ -6419,7 +6417,7 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
     {
         public ComparableBytesStructKey Id { get; set; }
         public ComparableBytesStructKey PrincipalId { get; set; }
-        public ComparableBytesStructKeyPrincipal Principal { get; set; }
+        public ComparableBytesStructKeyPrincipal Principal { get; set; } = null!;
 
         [NotMapped]
         public byte[] BackingId
@@ -6439,9 +6437,9 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
     protected class GenericComparableIntStructKeyPrincipal : IIntPrincipal
     {
         public GenericComparableIntStructKey Id { get; set; }
-        public string Foo { get; set; }
-        public ICollection<GenericComparableIntStructKeyOptionalDependent> OptionalDependents { get; set; }
-        public ICollection<GenericComparableIntStructKeyRequiredDependent> RequiredDependents { get; set; }
+        public string Foo { get; set; } = null!;
+        public ICollection<GenericComparableIntStructKeyOptionalDependent> OptionalDependents { get; set; } = null!;
+        public ICollection<GenericComparableIntStructKeyRequiredDependent> RequiredDependents { get; set; } = null!;
 
         [NotMapped]
         public int BackingId
@@ -6455,7 +6453,7 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
     {
         public GenericComparableIntStructKey Id { get; set; }
         public GenericComparableIntStructKey? PrincipalId { get; set; }
-        public GenericComparableIntStructKeyPrincipal Principal { get; set; }
+        public GenericComparableIntStructKeyPrincipal? Principal { get; set; }
 
         [NotMapped]
         public int BackingId
@@ -6478,7 +6476,7 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
     {
         public GenericComparableIntStructKey Id { get; set; }
         public GenericComparableIntStructKey PrincipalId { get; set; }
-        public GenericComparableIntStructKeyPrincipal Principal { get; set; }
+        public GenericComparableIntStructKeyPrincipal Principal { get; set; } = null!;
 
         [NotMapped]
         public int BackingId
@@ -6498,9 +6496,9 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
     protected class GenericComparableBytesStructKeyPrincipal : IBytesPrincipal
     {
         public GenericComparableBytesStructKey Id { get; set; }
-        public string Foo { get; set; }
-        public ICollection<GenericComparableBytesStructKeyOptionalDependent> OptionalDependents { get; set; }
-        public ICollection<GenericComparableBytesStructKeyRequiredDependent> RequiredDependents { get; set; }
+        public string Foo { get; set; } = null!;
+        public ICollection<GenericComparableBytesStructKeyOptionalDependent> OptionalDependents { get; set; } = null!;
+        public ICollection<GenericComparableBytesStructKeyRequiredDependent> RequiredDependents { get; set; } = null!;
 
         [NotMapped]
         public byte[] BackingId
@@ -6514,7 +6512,7 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
     {
         public GenericComparableBytesStructKey Id { get; set; }
         public GenericComparableBytesStructKey? PrincipalId { get; set; }
-        public GenericComparableBytesStructKeyPrincipal Principal { get; set; }
+        public GenericComparableBytesStructKeyPrincipal? Principal { get; set; }
 
         [NotMapped]
         public byte[] BackingId
@@ -6524,7 +6522,7 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
         }
 
         [NotMapped]
-        public byte[] BackingPrincipalId
+        public byte[]? BackingPrincipalId
         {
             get => PrincipalId?.Id;
             set => PrincipalId = value != null
@@ -6537,7 +6535,7 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
     {
         public GenericComparableBytesStructKey Id { get; set; }
         public GenericComparableBytesStructKey PrincipalId { get; set; }
-        public GenericComparableBytesStructKeyPrincipal Principal { get; set; }
+        public GenericComparableBytesStructKeyPrincipal Principal { get; set; } = null!;
 
         [NotMapped]
         public byte[] BackingId
@@ -6557,9 +6555,9 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
     protected class StructuralComparableBytesStructKeyPrincipal : IBytesPrincipal
     {
         public StructuralComparableBytesStructKey Id { get; set; }
-        public string Foo { get; set; }
-        public ICollection<StructuralComparableBytesStructKeyOptionalDependent> OptionalDependents { get; set; }
-        public ICollection<StructuralComparableBytesStructKeyRequiredDependent> RequiredDependents { get; set; }
+        public string Foo { get; set; } = null!;
+        public ICollection<StructuralComparableBytesStructKeyOptionalDependent> OptionalDependents { get; set; } = null!;
+        public ICollection<StructuralComparableBytesStructKeyRequiredDependent> RequiredDependents { get; set; } = null!;
 
         [NotMapped]
         public byte[] BackingId
@@ -6573,7 +6571,7 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
     {
         public StructuralComparableBytesStructKey Id { get; set; }
         public StructuralComparableBytesStructKey? PrincipalId { get; set; }
-        public StructuralComparableBytesStructKeyPrincipal Principal { get; set; }
+        public StructuralComparableBytesStructKeyPrincipal? Principal { get; set; }
 
         [NotMapped]
         public byte[] BackingId
@@ -6583,7 +6581,7 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
         }
 
         [NotMapped]
-        public byte[] BackingPrincipalId
+        public byte[]? BackingPrincipalId
         {
             get => PrincipalId?.Id;
             set => PrincipalId = value != null
@@ -6596,7 +6594,7 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
     {
         public StructuralComparableBytesStructKey Id { get; set; }
         public StructuralComparableBytesStructKey PrincipalId { get; set; }
-        public StructuralComparableBytesStructKeyPrincipal Principal { get; set; }
+        public StructuralComparableBytesStructKeyPrincipal Principal { get; set; } = null!;
 
         [NotMapped]
         public byte[] BackingId
@@ -6615,10 +6613,10 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
 
     protected class IntClassKeyPrincipal : IIntPrincipal
     {
-        public IntClassKey Id { get; set; }
-        public string Foo { get; set; }
-        public ICollection<IntClassKeyOptionalDependent> OptionalDependents { get; set; }
-        public ICollection<IntClassKeyRequiredDependent> RequiredDependents { get; set; }
+        public IntClassKey Id { get; set; } = null!;
+        public string Foo { get; set; } = null!;
+        public ICollection<IntClassKeyOptionalDependent> OptionalDependents { get; set; } = null!;
+        public ICollection<IntClassKeyRequiredDependent> RequiredDependents { get; set; } = null!;
 
         [NotMapped]
         public int BackingId
@@ -6630,9 +6628,9 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
 
     protected class IntClassKeyOptionalDependent : IIntOptionalDependent
     {
-        public IntClassKey Id { get; set; }
-        public IntClassKey PrincipalId { get; set; }
-        public IntClassKeyPrincipal Principal { get; set; }
+        public IntClassKey Id { get; set; } = null!;
+        public IntClassKey? PrincipalId { get; set; }
+        public IntClassKeyPrincipal? Principal { get; set; }
 
         [NotMapped]
         public int BackingId
@@ -6651,9 +6649,9 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
 
     protected class IntClassKeyRequiredDependent : IIntRequiredDependent
     {
-        public IntClassKey Id { get; set; }
-        public IntClassKey PrincipalId { get; set; }
-        public IntClassKeyPrincipal Principal { get; set; }
+        public IntClassKey Id { get; set; } = null!;
+        public IntClassKey PrincipalId { get; set; } = null!;
+        public IntClassKeyPrincipal Principal { get; set; } = null!;
 
         [NotMapped]
         public int BackingId
@@ -6672,10 +6670,10 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
 
     protected class EnumerableClassKeyPrincipal : IIntPrincipal
     {
-        public EnumerableClassKey Id { get; set; }
-        public string Foo { get; set; }
-        public ICollection<EnumerableClassKeyOptionalDependent> OptionalDependents { get; set; }
-        public ICollection<EnumerableClassKeyRequiredDependent> RequiredDependents { get; set; }
+        public EnumerableClassKey Id { get; set; } = null!;
+        public string Foo { get; set; } = null!;
+        public ICollection<EnumerableClassKeyOptionalDependent> OptionalDependents { get; set; } = null!;
+        public ICollection<EnumerableClassKeyRequiredDependent> RequiredDependents { get; set; } = null!;
 
         [NotMapped]
         public int BackingId
@@ -6687,9 +6685,9 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
 
     protected class EnumerableClassKeyOptionalDependent : IIntOptionalDependent
     {
-        public EnumerableClassKey Id { get; set; }
-        public EnumerableClassKey PrincipalId { get; set; }
-        public EnumerableClassKeyPrincipal Principal { get; set; }
+        public EnumerableClassKey Id { get; set; } = null!;
+        public EnumerableClassKey? PrincipalId { get; set; }
+        public EnumerableClassKeyPrincipal? Principal { get; set; }
 
         [NotMapped]
         public int BackingId
@@ -6708,9 +6706,9 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
 
     protected class EnumerableClassKeyRequiredDependent : IIntRequiredDependent
     {
-        public EnumerableClassKey Id { get; set; }
-        public EnumerableClassKey PrincipalId { get; set; }
-        public EnumerableClassKeyPrincipal Principal { get; set; }
+        public EnumerableClassKey Id { get; set; } = null!;
+        public EnumerableClassKey PrincipalId { get; set; } = null!;
+        public EnumerableClassKeyPrincipal Principal { get; set; } = null!;
 
         [NotMapped]
         public int BackingId
@@ -6729,10 +6727,10 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
 
     protected class BareIntClassKeyPrincipal : IIntPrincipal
     {
-        public BareIntClassKey Id { get; set; }
-        public string Foo { get; set; }
-        public ICollection<BareIntClassKeyOptionalDependent> OptionalDependents { get; set; }
-        public ICollection<BareIntClassKeyRequiredDependent> RequiredDependents { get; set; }
+        public BareIntClassKey Id { get; set; } = null!;
+        public string Foo { get; set; } = null!;
+        public ICollection<BareIntClassKeyOptionalDependent> OptionalDependents { get; set; } = null!;
+        public ICollection<BareIntClassKeyRequiredDependent> RequiredDependents { get; set; } = null!;
 
         [NotMapped]
         public int BackingId
@@ -6744,9 +6742,9 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
 
     protected class BareIntClassKeyOptionalDependent : IIntOptionalDependent
     {
-        public BareIntClassKey Id { get; set; }
-        public BareIntClassKey PrincipalId { get; set; }
-        public BareIntClassKeyPrincipal Principal { get; set; }
+        public BareIntClassKey Id { get; set; } = null!;
+        public BareIntClassKey? PrincipalId { get; set; }
+        public BareIntClassKeyPrincipal? Principal { get; set; }
 
         [NotMapped]
         public int BackingId
@@ -6765,9 +6763,9 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
 
     protected class BareIntClassKeyRequiredDependent : IIntRequiredDependent
     {
-        public BareIntClassKey Id { get; set; }
-        public BareIntClassKey PrincipalId { get; set; }
-        public BareIntClassKeyPrincipal Principal { get; set; }
+        public BareIntClassKey Id { get; set; } = null!;
+        public BareIntClassKey PrincipalId { get; set; } = null!;
+        public BareIntClassKeyPrincipal Principal { get; set; } = null!;
 
         [NotMapped]
         public int BackingId
@@ -6786,10 +6784,10 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
 
     protected class ComparableIntClassKeyPrincipal : IIntPrincipal
     {
-        public ComparableIntClassKey Id { get; set; }
-        public string Foo { get; set; }
-        public ICollection<ComparableIntClassKeyOptionalDependent> OptionalDependents { get; set; }
-        public ICollection<ComparableIntClassKeyRequiredDependent> RequiredDependents { get; set; }
+        public ComparableIntClassKey Id { get; set; } = null!;
+        public string Foo { get; set; } = null!;
+        public ICollection<ComparableIntClassKeyOptionalDependent> OptionalDependents { get; set; } = null!;
+        public ICollection<ComparableIntClassKeyRequiredDependent> RequiredDependents { get; set; } = null!;
 
         [NotMapped]
         public int BackingId
@@ -6801,9 +6799,9 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
 
     protected class ComparableIntClassKeyOptionalDependent : IIntOptionalDependent
     {
-        public ComparableIntClassKey Id { get; set; }
-        public ComparableIntClassKey PrincipalId { get; set; }
-        public ComparableIntClassKeyPrincipal Principal { get; set; }
+        public ComparableIntClassKey Id { get; set; } = null!;
+        public ComparableIntClassKey? PrincipalId { get; set; }
+        public ComparableIntClassKeyPrincipal? Principal { get; set; }
 
         [NotMapped]
         public int BackingId
@@ -6822,9 +6820,9 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
 
     protected class ComparableIntClassKeyRequiredDependent : IIntRequiredDependent
     {
-        public ComparableIntClassKey Id { get; set; }
-        public ComparableIntClassKey PrincipalId { get; set; }
-        public ComparableIntClassKeyPrincipal Principal { get; set; }
+        public ComparableIntClassKey Id { get; set; } = null!;
+        public ComparableIntClassKey PrincipalId { get; set; } = null!;
+        public ComparableIntClassKeyPrincipal Principal { get; set; } = null!;
 
         [NotMapped]
         public int BackingId
@@ -6843,10 +6841,10 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
 
     protected class GenericComparableIntClassKeyPrincipal : IIntPrincipal
     {
-        public GenericComparableIntClassKey Id { get; set; }
-        public string Foo { get; set; }
-        public ICollection<GenericComparableIntClassKeyOptionalDependent> OptionalDependents { get; set; }
-        public ICollection<GenericComparableIntClassKeyRequiredDependent> RequiredDependents { get; set; }
+        public GenericComparableIntClassKey Id { get; set; } = null!;
+        public string Foo { get; set; } = null!;
+        public ICollection<GenericComparableIntClassKeyOptionalDependent> OptionalDependents { get; set; } = null!;
+        public ICollection<GenericComparableIntClassKeyRequiredDependent> RequiredDependents { get; set; } = null!;
 
         [NotMapped]
         public int BackingId
@@ -6858,9 +6856,9 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
 
     protected class GenericComparableIntClassKeyOptionalDependent : IIntOptionalDependent
     {
-        public GenericComparableIntClassKey Id { get; set; }
-        public GenericComparableIntClassKey PrincipalId { get; set; }
-        public GenericComparableIntClassKeyPrincipal Principal { get; set; }
+        public GenericComparableIntClassKey Id { get; set; } = null!;
+        public GenericComparableIntClassKey? PrincipalId { get; set; }
+        public GenericComparableIntClassKeyPrincipal? Principal { get; set; }
 
         [NotMapped]
         public int BackingId
@@ -6879,9 +6877,9 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
 
     protected class GenericComparableIntClassKeyRequiredDependent : IIntRequiredDependent
     {
-        public GenericComparableIntClassKey Id { get; set; }
-        public GenericComparableIntClassKey PrincipalId { get; set; }
-        public GenericComparableIntClassKeyPrincipal Principal { get; set; }
+        public GenericComparableIntClassKey Id { get; set; } = null!;
+        public GenericComparableIntClassKey PrincipalId { get; set; } = null!;
+        public GenericComparableIntClassKeyPrincipal Principal { get; set; } = null!;
 
         [NotMapped]
         public int BackingId
@@ -6901,221 +6899,221 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
     protected class IntStructKeyPrincipalShadow
     {
         public IntStructKey Id { get; set; }
-        public string Foo { get; set; }
-        public ICollection<IntStructKeyRequiredDependentShadow> RequiredDependents { get; set; }
-        public ICollection<IntStructKeyOptionalDependentShadow> OptionalDependents { get; set; }
+        public string Foo { get; set; } = null!;
+        public ICollection<IntStructKeyRequiredDependentShadow> RequiredDependents { get; set; } = null!;
+        public ICollection<IntStructKeyOptionalDependentShadow> OptionalDependents { get; set; } = null!;
     }
 
     protected class IntStructKeyRequiredDependentShadow
     {
         public IntStructKey Id { get; set; }
-        public IntStructKeyPrincipalShadow Principal { get; set; }
+        public IntStructKeyPrincipalShadow Principal { get; set; } = null!;
     }
 
     protected class IntStructKeyOptionalDependentShadow
     {
         public IntStructKey Id { get; set; }
-        public IntStructKeyPrincipalShadow Principal { get; set; }
+        public IntStructKeyPrincipalShadow? Principal { get; set; }
     }
 
     protected class BytesStructKeyPrincipalShadow
     {
         public BytesStructKey Id { get; set; }
-        public string Foo { get; set; }
-        public ICollection<BytesStructKeyOptionalDependentShadow> OptionalDependents { get; set; }
-        public ICollection<BytesStructKeyRequiredDependentShadow> RequiredDependents { get; set; }
+        public string Foo { get; set; } = null!;
+        public ICollection<BytesStructKeyOptionalDependentShadow> OptionalDependents { get; set; } = null!;
+        public ICollection<BytesStructKeyRequiredDependentShadow> RequiredDependents { get; set; } = null!;
     }
 
     protected class BytesStructKeyOptionalDependentShadow
     {
         public BytesStructKey Id { get; set; }
-        public BytesStructKeyPrincipalShadow Principal { get; set; }
+        public BytesStructKeyPrincipalShadow? Principal { get; set; }
     }
 
     protected class BytesStructKeyRequiredDependentShadow
     {
         public BytesStructKey Id { get; set; }
-        public BytesStructKeyPrincipalShadow Principal { get; set; }
+        public BytesStructKeyPrincipalShadow Principal { get; set; } = null!;
     }
 
     protected class ComparableIntStructKeyPrincipalShadow
     {
         public ComparableIntStructKey Id { get; set; }
-        public string Foo { get; set; }
-        public ICollection<ComparableIntStructKeyOptionalDependentShadow> OptionalDependents { get; set; }
-        public ICollection<ComparableIntStructKeyRequiredDependentShadow> RequiredDependents { get; set; }
+        public string Foo { get; set; } = null!;
+        public ICollection<ComparableIntStructKeyOptionalDependentShadow> OptionalDependents { get; set; } = null!;
+        public ICollection<ComparableIntStructKeyRequiredDependentShadow> RequiredDependents { get; set; } = null!;
     }
 
     protected class ComparableIntStructKeyOptionalDependentShadow
     {
         public ComparableIntStructKey Id { get; set; }
-        public ComparableIntStructKeyPrincipalShadow Principal { get; set; }
+        public ComparableIntStructKeyPrincipalShadow? Principal { get; set; }
     }
 
     protected class ComparableIntStructKeyRequiredDependentShadow
     {
         public ComparableIntStructKey Id { get; set; }
-        public ComparableIntStructKeyPrincipalShadow Principal { get; set; }
+        public ComparableIntStructKeyPrincipalShadow Principal { get; set; } = null!;
     }
 
     protected class ComparableBytesStructKeyPrincipalShadow
     {
         public ComparableBytesStructKey Id { get; set; }
-        public string Foo { get; set; }
-        public ICollection<ComparableBytesStructKeyOptionalDependentShadow> OptionalDependents { get; set; }
-        public ICollection<ComparableBytesStructKeyRequiredDependentShadow> RequiredDependents { get; set; }
+        public string Foo { get; set; } = null!;
+        public ICollection<ComparableBytesStructKeyOptionalDependentShadow> OptionalDependents { get; set; } = null!;
+        public ICollection<ComparableBytesStructKeyRequiredDependentShadow> RequiredDependents { get; set; } = null!;
     }
 
     protected class ComparableBytesStructKeyOptionalDependentShadow
     {
         public ComparableBytesStructKey Id { get; set; }
-        public ComparableBytesStructKeyPrincipalShadow Principal { get; set; }
+        public ComparableBytesStructKeyPrincipalShadow? Principal { get; set; }
     }
 
     protected class ComparableBytesStructKeyRequiredDependentShadow
     {
         public ComparableBytesStructKey Id { get; set; }
-        public ComparableBytesStructKeyPrincipalShadow Principal { get; set; }
+        public ComparableBytesStructKeyPrincipalShadow Principal { get; set; } = null!;
     }
 
     protected class GenericComparableIntStructKeyPrincipalShadow
     {
         public GenericComparableIntStructKey Id { get; set; }
-        public string Foo { get; set; }
-        public ICollection<GenericComparableIntStructKeyOptionalDependentShadow> OptionalDependents { get; set; }
-        public ICollection<GenericComparableIntStructKeyRequiredDependentShadow> RequiredDependents { get; set; }
+        public string Foo { get; set; } = null!;
+        public ICollection<GenericComparableIntStructKeyOptionalDependentShadow> OptionalDependents { get; set; } = null!;
+        public ICollection<GenericComparableIntStructKeyRequiredDependentShadow> RequiredDependents { get; set; } = null!;
     }
 
     protected class GenericComparableIntStructKeyOptionalDependentShadow
     {
         public GenericComparableIntStructKey Id { get; set; }
-        public GenericComparableIntStructKeyPrincipalShadow Principal { get; set; }
+        public GenericComparableIntStructKeyPrincipalShadow? Principal { get; set; }
     }
 
     protected class GenericComparableIntStructKeyRequiredDependentShadow
     {
         public GenericComparableIntStructKey Id { get; set; }
-        public GenericComparableIntStructKeyPrincipalShadow Principal { get; set; }
+        public GenericComparableIntStructKeyPrincipalShadow Principal { get; set; } = null!;
     }
 
     protected class GenericComparableBytesStructKeyPrincipalShadow
     {
         public GenericComparableBytesStructKey Id { get; set; }
-        public string Foo { get; set; }
-        public ICollection<GenericComparableBytesStructKeyOptionalDependentShadow> OptionalDependents { get; set; }
-        public ICollection<GenericComparableBytesStructKeyRequiredDependentShadow> RequiredDependents { get; set; }
+        public string Foo { get; set; } = null!;
+        public ICollection<GenericComparableBytesStructKeyOptionalDependentShadow> OptionalDependents { get; set; } = null!;
+        public ICollection<GenericComparableBytesStructKeyRequiredDependentShadow> RequiredDependents { get; set; } = null!;
     }
 
     protected class GenericComparableBytesStructKeyOptionalDependentShadow
     {
         public GenericComparableBytesStructKey Id { get; set; }
-        public GenericComparableBytesStructKeyPrincipalShadow Principal { get; set; }
+        public GenericComparableBytesStructKeyPrincipalShadow? Principal { get; set; }
     }
 
     protected class GenericComparableBytesStructKeyRequiredDependentShadow
     {
         public GenericComparableBytesStructKey Id { get; set; }
-        public GenericComparableBytesStructKeyPrincipalShadow Principal { get; set; }
+        public GenericComparableBytesStructKeyPrincipalShadow Principal { get; set; } = null!;
     }
 
     protected class StructuralComparableBytesStructKeyPrincipalShadow
     {
         public StructuralComparableBytesStructKey Id { get; set; }
-        public string Foo { get; set; }
-        public ICollection<StructuralComparableBytesStructKeyOptionalDependentShadow> OptionalDependents { get; set; }
-        public ICollection<StructuralComparableBytesStructKeyRequiredDependentShadow> RequiredDependents { get; set; }
+        public string Foo { get; set; } = null!;
+        public ICollection<StructuralComparableBytesStructKeyOptionalDependentShadow> OptionalDependents { get; set; } = null!;
+        public ICollection<StructuralComparableBytesStructKeyRequiredDependentShadow> RequiredDependents { get; set; } = null!;
     }
 
     protected class StructuralComparableBytesStructKeyOptionalDependentShadow
     {
         public StructuralComparableBytesStructKey Id { get; set; }
-        public StructuralComparableBytesStructKeyPrincipalShadow Principal { get; set; }
+        public StructuralComparableBytesStructKeyPrincipalShadow? Principal { get; set; }
     }
 
     protected class StructuralComparableBytesStructKeyRequiredDependentShadow
     {
         public StructuralComparableBytesStructKey Id { get; set; }
-        public StructuralComparableBytesStructKeyPrincipalShadow Principal { get; set; }
+        public StructuralComparableBytesStructKeyPrincipalShadow Principal { get; set; } = null!;
     }
 
     protected class IntClassKeyPrincipalShadow
     {
-        public IntClassKey Id { get; set; }
-        public string Foo { get; set; }
-        public ICollection<IntClassKeyOptionalDependentShadow> OptionalDependents { get; set; }
-        public ICollection<IntClassKeyRequiredDependentShadow> RequiredDependents { get; set; }
+        public IntClassKey Id { get; set; } = null!;
+        public string Foo { get; set; } = null!;
+        public ICollection<IntClassKeyOptionalDependentShadow> OptionalDependents { get; set; } = null!;
+        public ICollection<IntClassKeyRequiredDependentShadow> RequiredDependents { get; set; } = null!;
     }
 
     protected class IntClassKeyOptionalDependentShadow
     {
-        public IntClassKey Id { get; set; }
-        public IntClassKeyPrincipalShadow Principal { get; set; }
+        public IntClassKey Id { get; set; } = null!;
+        public IntClassKeyPrincipalShadow? Principal { get; set; }
     }
 
     protected class IntClassKeyRequiredDependentShadow
     {
-        public IntClassKey Id { get; set; }
-        public IntClassKeyPrincipalShadow Principal { get; set; }
+        public IntClassKey Id { get; set; } = null!;
+        public IntClassKeyPrincipalShadow Principal { get; set; } = null!;
     }
 
     protected class BareIntClassKeyPrincipalShadow
     {
-        public BareIntClassKey Id { get; set; }
-        public string Foo { get; set; }
-        public ICollection<BareIntClassKeyOptionalDependentShadow> OptionalDependents { get; set; }
-        public ICollection<BareIntClassKeyRequiredDependentShadow> RequiredDependents { get; set; }
+        public BareIntClassKey Id { get; set; } = null!;
+        public string Foo { get; set; } = null!;
+        public ICollection<BareIntClassKeyOptionalDependentShadow> OptionalDependents { get; set; } = null!;
+        public ICollection<BareIntClassKeyRequiredDependentShadow> RequiredDependents { get; set; } = null!;
     }
 
     protected class BareIntClassKeyOptionalDependentShadow
     {
-        public BareIntClassKey Id { get; set; }
-        public BareIntClassKeyPrincipalShadow Principal { get; set; }
+        public BareIntClassKey Id { get; set; } = null!;
+        public BareIntClassKeyPrincipalShadow? Principal { get; set; }
     }
 
     protected class BareIntClassKeyRequiredDependentShadow
     {
-        public BareIntClassKey Id { get; set; }
-        public BareIntClassKeyPrincipalShadow Principal { get; set; }
+        public BareIntClassKey Id { get; set; } = null!;
+        public BareIntClassKeyPrincipalShadow Principal { get; set; } = null!;
     }
 
     protected class ComparableIntClassKeyPrincipalShadow
     {
-        public ComparableIntClassKey Id { get; set; }
-        public string Foo { get; set; }
-        public ICollection<ComparableIntClassKeyOptionalDependentShadow> OptionalDependents { get; set; }
-        public ICollection<ComparableIntClassKeyRequiredDependentShadow> RequiredDependents { get; set; }
+        public ComparableIntClassKey Id { get; set; } = null!;
+        public string Foo { get; set; } = null!;
+        public ICollection<ComparableIntClassKeyOptionalDependentShadow> OptionalDependents { get; set; } = null!;
+        public ICollection<ComparableIntClassKeyRequiredDependentShadow> RequiredDependents { get; set; } = null!;
     }
 
     protected class ComparableIntClassKeyOptionalDependentShadow
     {
-        public ComparableIntClassKey Id { get; set; }
-        public ComparableIntClassKeyPrincipalShadow Principal { get; set; }
+        public ComparableIntClassKey Id { get; set; } = null!;
+        public ComparableIntClassKeyPrincipalShadow? Principal { get; set; }
     }
 
     protected class ComparableIntClassKeyRequiredDependentShadow
     {
-        public ComparableIntClassKey Id { get; set; }
-        public ComparableIntClassKeyPrincipalShadow Principal { get; set; }
+        public ComparableIntClassKey Id { get; set; } = null!;
+        public ComparableIntClassKeyPrincipalShadow Principal { get; set; } = null!;
     }
 
     protected class GenericComparableIntClassKeyPrincipalShadow
     {
-        public GenericComparableIntClassKey Id { get; set; }
-        public string Foo { get; set; }
-        public ICollection<GenericComparableIntClassKeyOptionalDependentShadow> OptionalDependents { get; set; }
-        public ICollection<GenericComparableIntClassKeyRequiredDependentShadow> RequiredDependents { get; set; }
+        public GenericComparableIntClassKey Id { get; set; } = null!;
+        public string Foo { get; set; } = null!;
+        public ICollection<GenericComparableIntClassKeyOptionalDependentShadow> OptionalDependents { get; set; } = null!;
+        public ICollection<GenericComparableIntClassKeyRequiredDependentShadow> RequiredDependents { get; set; } = null!;
     }
 
     protected class GenericComparableIntClassKeyOptionalDependentShadow
     {
-        public GenericComparableIntClassKey Id { get; set; }
-        public GenericComparableIntClassKeyPrincipalShadow Principal { get; set; }
+        public GenericComparableIntClassKey Id { get; set; } = null!;
+        public GenericComparableIntClassKeyPrincipalShadow? Principal { get; set; }
     }
 
     protected class GenericComparableIntClassKeyRequiredDependentShadow
     {
-        public GenericComparableIntClassKey Id { get; set; }
-        public GenericComparableIntClassKeyPrincipalShadow Principal { get; set; }
+        public GenericComparableIntClassKey Id { get; set; } = null!;
+        public GenericComparableIntClassKeyPrincipalShadow Principal { get; set; } = null!;
     }
 
     protected class Key(string id)
@@ -7135,8 +7133,8 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
             Text = text;
         }
 
-        public Key Name { get; set; }
-        public TextEntity Text { get; set; }
+        public Key Name { get; set; } = null!;
+        public TextEntity Text { get; set; } = null!;
     }
 
     protected class TextEntity
@@ -7147,7 +7145,7 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
     protected class OwnerIntStructKey(IntStructKey id, OwnedIntStructKey owned)
     {
         public OwnerIntStructKey(IntStructKey id)
-            : this(id, null)
+            : this(id, null!)
         {
         }
 
@@ -7163,7 +7161,7 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
     protected class OwnerBytesStructKey(BytesStructKey id, OwnedBytesStructKey owned)
     {
         public OwnerBytesStructKey(BytesStructKey id)
-            : this(id, null)
+            : this(id, null!)
         {
         }
 
@@ -7179,7 +7177,7 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
     protected class OwnerComparableIntStructKey(ComparableIntStructKey id, OwnedComparableIntStructKey owned)
     {
         public OwnerComparableIntStructKey(ComparableIntStructKey id)
-            : this(id, null)
+            : this(id, null!)
         {
         }
 
@@ -7195,7 +7193,7 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
     protected class OwnerComparableBytesStructKey(ComparableBytesStructKey id, OwnedComparableBytesStructKey owned)
     {
         public OwnerComparableBytesStructKey(ComparableBytesStructKey id)
-            : this(id, null)
+            : this(id, null!)
         {
         }
 
@@ -7211,7 +7209,7 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
     protected class OwnerGenericComparableIntStructKey(GenericComparableIntStructKey id, OwnedGenericComparableIntStructKey owned)
     {
         public OwnerGenericComparableIntStructKey(GenericComparableIntStructKey id)
-            : this(id, null)
+            : this(id, null!)
         {
         }
 
@@ -7227,7 +7225,7 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
     protected class OwnerGenericComparableBytesStructKey(GenericComparableBytesStructKey id, OwnedGenericComparableBytesStructKey owned)
     {
         public OwnerGenericComparableBytesStructKey(GenericComparableBytesStructKey id)
-            : this(id, null)
+            : this(id, null!)
         {
         }
 
@@ -7245,7 +7243,7 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
         OwnedStructuralComparableBytesStructKey owned)
     {
         public OwnerStructuralComparableBytesStructKey(StructuralComparableBytesStructKey id)
-            : this(id, null)
+            : this(id, null!)
         {
         }
 
@@ -7261,7 +7259,7 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
     protected class OwnerIntClassKey(IntClassKey id, OwnedIntClassKey owned)
     {
         public OwnerIntClassKey(IntClassKey id)
-            : this(id, null)
+            : this(id, null!)
         {
         }
 
@@ -7277,7 +7275,7 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
     protected class OwnerBareIntClassKey(BareIntClassKey id, OwnedBareIntClassKey owned)
     {
         public OwnerBareIntClassKey(BareIntClassKey id)
-            : this(id, null)
+            : this(id, null!)
         {
         }
 
@@ -7293,7 +7291,7 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
     protected class OwnerComparableIntClassKey(ComparableIntClassKey id, OwnedComparableIntClassKey owned)
     {
         public OwnerComparableIntClassKey(ComparableIntClassKey id)
-            : this(id, null)
+            : this(id, null!)
         {
         }
 
@@ -7309,7 +7307,7 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
     protected class OwnerGenericComparableIntClassKey(GenericComparableIntClassKey id, OwnedGenericComparableIntClassKey owned)
     {
         public OwnerGenericComparableIntClassKey(GenericComparableIntClassKey id)
-            : this(id, null)
+            : this(id, null!)
         {
         }
 
@@ -7351,7 +7349,7 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
             modelBuilder.Entity<IntClassKeyOptionalDependent>(b =>
             {
                 b.Property(e => e.Id).HasConversion(IntClassKey.Converter);
-                b.Property(e => e.PrincipalId).HasConversion(IntClassKey.Converter);
+                b.Property(e => e.PrincipalId).HasConversion((ValueConverter)IntClassKey.Converter);
             });
 
             modelBuilder.Entity<IntClassKeyRequiredDependent>(b =>
@@ -7380,7 +7378,7 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
             modelBuilder.Entity<BareIntClassKeyOptionalDependent>(b =>
             {
                 b.Property(e => e.Id).HasConversion(BareIntClassKey.Converter, BareIntClassKey.Comparer);
-                b.Property(e => e.PrincipalId).HasConversion(BareIntClassKey.Converter, BareIntClassKey.Comparer);
+                b.Property(e => e.PrincipalId).HasConversion((ValueConverter)BareIntClassKey.Converter, BareIntClassKey.Comparer);
             });
 
             modelBuilder.Entity<BareIntClassKeyRequiredDependent>(b =>
@@ -7498,7 +7496,7 @@ public abstract class KeysWithConvertersTestBase<TFixture>(TFixture fixture) : I
             modelBuilder.Entity<GenericComparableIntClassKeyOptionalDependent>(b =>
             {
                 b.Property(e => e.Id).HasConversion(GenericComparableIntClassKey.Converter);
-                b.Property(e => e.PrincipalId).HasConversion(GenericComparableIntClassKey.Converter);
+                b.Property(e => e.PrincipalId).HasConversion((ValueConverter)GenericComparableIntClassKey.Converter);
             });
 
             modelBuilder.Entity<GenericComparableIntClassKeyRequiredDependent>(b =>

--- a/test/EFCore.Specification.Tests/LazyLoadTestBase.cs
+++ b/test/EFCore.Specification.Tests/LazyLoadTestBase.cs
@@ -8,8 +8,6 @@ using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 
 namespace Microsoft.EntityFrameworkCore;
 
-#nullable disable
-
 public abstract partial class LoadTestBase<TFixture>
 {
     [Theory, InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll, false),
@@ -1787,7 +1785,7 @@ public abstract partial class LoadTestBase<TFixture>
     {
         using var context = CreateContext(lazyLoadingEnabled: true);
         context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
-        var child = context.Attach(new ChildAk { Id = 767, ParentId = null }).Entity;
+        var child = context.Attach(new ChildAk { Id = 767, ParentId = null! }).Entity;
 
         ClearLog();
 
@@ -1833,7 +1831,7 @@ public abstract partial class LoadTestBase<TFixture>
     {
         using var context = CreateContext(lazyLoadingEnabled: true);
         context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
-        var single = context.Attach(new SingleAk { Id = 767, ParentId = null }).Entity;
+        var single = context.Attach(new SingleAk { Id = 767, ParentId = null! }).Entity;
 
         ClearLog();
 

--- a/test/EFCore.Specification.Tests/LoadTestBase.cs
+++ b/test/EFCore.Specification.Tests/LoadTestBase.cs
@@ -8,8 +8,6 @@ using Microsoft.EntityFrameworkCore.Metadata.Internal;
 // ReSharper disable InconsistentNaming
 namespace Microsoft.EntityFrameworkCore;
 
-#nullable disable
-
 public abstract partial class LoadTestBase<TFixture>(TFixture fixture) : IClassFixture<TFixture>
     where TFixture : LoadTestBase<TFixture>.LoadFixtureBase
 {
@@ -3059,7 +3057,7 @@ public abstract partial class LoadTestBase<TFixture>(TFixture fixture) : IClassF
     public virtual async Task Load_many_to_one_reference_to_principal_null_FK_alternate_key(EntityState state, bool async)
     {
         using var context = CreateContext();
-        var child = context.Attach(new ChildAk { Id = 767, ParentId = null }).Entity;
+        var child = context.Attach(new ChildAk { Id = 767, ParentId = null! }).Entity;
 
         ClearLog();
 
@@ -3093,7 +3091,7 @@ public abstract partial class LoadTestBase<TFixture>(TFixture fixture) : IClassF
     public virtual async Task Load_one_to_one_reference_to_principal_null_FK_alternate_key(EntityState state, bool async)
     {
         using var context = CreateContext();
-        var single = context.Attach(new SingleAk { Id = 767, ParentId = null }).Entity;
+        var single = context.Attach(new SingleAk { Id = 767, ParentId = null! }).Entity;
 
         ClearLog();
 
@@ -3128,7 +3126,7 @@ public abstract partial class LoadTestBase<TFixture>(TFixture fixture) : IClassF
     public virtual async Task Load_many_to_one_reference_to_principal_using_Query_null_FK_alternate_key(EntityState state, bool async)
     {
         using var context = CreateContext();
-        var child = context.Attach(new ChildAk { Id = 767, ParentId = null }).Entity;
+        var child = context.Attach(new ChildAk { Id = 767, ParentId = null! }).Entity;
 
         ClearLog();
 
@@ -3159,7 +3157,7 @@ public abstract partial class LoadTestBase<TFixture>(TFixture fixture) : IClassF
     public virtual async Task Load_one_to_one_reference_to_principal_using_Query_null_FK_alternate_key(EntityState state, bool async)
     {
         using var context = CreateContext();
-        var single = context.Attach(new SingleAk { Id = 767, ParentId = null }).Entity;
+        var single = context.Attach(new SingleAk { Id = 767, ParentId = null! }).Entity;
 
         ClearLog();
 
@@ -4367,7 +4365,7 @@ public abstract partial class LoadTestBase<TFixture>(TFixture fixture) : IClassF
         Assert.Equal(newParent.Id, child.ParentId);
         Assert.Equal(EntityState.Modified, childEntry.State);
 
-        child.Parent = null;
+        child.Parent = null!;
         childEntry.DetectChanges();
 
         Assert.Null(child.Parent);
@@ -4499,27 +4497,27 @@ public abstract partial class LoadTestBase<TFixture>(TFixture fixture) : IClassF
 
     protected class Parent
     {
-        private IEnumerable<Child> _children;
-        private SinglePkToPk _singlePkToPk;
-        private Single _single;
-        private RequiredSingle _requiredSingle;
-        private IEnumerable<ChildAk> _childrenAk;
-        private SingleAk _singleAk;
-        private IEnumerable<ChildShadowFk> _childrenShadowFk;
-        private SingleShadowFk _singleShadowFk;
-        private IEnumerable<ChildCompositeKey> _childrenCompositeKey;
-        private SingleCompositeKey _singleCompositeKey;
+        private IEnumerable<Child> _children = null!;
+        private SinglePkToPk _singlePkToPk = null!;
+        private Single _single = null!;
+        private RequiredSingle _requiredSingle = null!;
+        private IEnumerable<ChildAk> _childrenAk = null!;
+        private SingleAk _singleAk = null!;
+        private IEnumerable<ChildShadowFk> _childrenShadowFk = null!;
+        private SingleShadowFk? _singleShadowFk;
+        private IEnumerable<ChildCompositeKey> _childrenCompositeKey = null!;
+        private SingleCompositeKey _singleCompositeKey = null!;
 
-        public ILazyLoader Loader { get; set; }
+        public ILazyLoader Loader { get; set; } = null!;
 
         [DatabaseGenerated(DatabaseGeneratedOption.None)]
         public int Id { get; set; }
 
-        public string AlternateId { get; set; }
+        public string AlternateId { get; set; } = null!;
 
         public IEnumerable<Child> Children
         {
-            get => Loader.Load(this, ref _children);
+            get => Loader.Load(this, ref _children!)!;
             set => _children = value;
         }
 
@@ -4536,7 +4534,7 @@ public abstract partial class LoadTestBase<TFixture>(TFixture fixture) : IClassF
 
         public SinglePkToPk SinglePkToPk
         {
-            get => Loader.Load(this, ref _singlePkToPk);
+            get => Loader.Load(this, ref _singlePkToPk!)!;
             set => _singlePkToPk = value;
         }
 
@@ -4553,7 +4551,7 @@ public abstract partial class LoadTestBase<TFixture>(TFixture fixture) : IClassF
 
         public Single Single
         {
-            get => Loader.Load(this, ref _single);
+            get => Loader.Load(this, ref _single!)!;
             set => _single = value;
         }
 
@@ -4570,13 +4568,13 @@ public abstract partial class LoadTestBase<TFixture>(TFixture fixture) : IClassF
 
         public RequiredSingle RequiredSingle
         {
-            get => Loader.Load(this, ref _requiredSingle);
+            get => Loader.Load(this, ref _requiredSingle!)!;
             set => _requiredSingle = value;
         }
 
         public IEnumerable<ChildAk> ChildrenAk
         {
-            get => Loader.Load(this, ref _childrenAk);
+            get => Loader.Load(this, ref _childrenAk!)!;
             set => _childrenAk = value;
         }
 
@@ -4593,7 +4591,7 @@ public abstract partial class LoadTestBase<TFixture>(TFixture fixture) : IClassF
 
         public SingleAk SingleAk
         {
-            get => Loader.Load(this, ref _singleAk);
+            get => Loader.Load(this, ref _singleAk!)!;
             set => _singleAk = value;
         }
 
@@ -4610,7 +4608,7 @@ public abstract partial class LoadTestBase<TFixture>(TFixture fixture) : IClassF
 
         public IEnumerable<ChildShadowFk> ChildrenShadowFk
         {
-            get => Loader.Load(this, ref _childrenShadowFk);
+            get => Loader.Load(this, ref _childrenShadowFk!)!;
             set => _childrenShadowFk = value;
         }
 
@@ -4625,13 +4623,13 @@ public abstract partial class LoadTestBase<TFixture>(TFixture fixture) : IClassF
             return ChildrenShadowFk;
         }
 
-        public SingleShadowFk SingleShadowFk
+        public SingleShadowFk? SingleShadowFk
         {
             get => Loader.Load(this, ref _singleShadowFk);
             set => _singleShadowFk = value;
         }
 
-        public async Task<SingleShadowFk> LazyLoadSingleShadowFk(bool async)
+        public async Task<SingleShadowFk?> LazyLoadSingleShadowFk(bool async)
         {
             if (async)
             {
@@ -4644,7 +4642,7 @@ public abstract partial class LoadTestBase<TFixture>(TFixture fixture) : IClassF
 
         public IEnumerable<ChildCompositeKey> ChildrenCompositeKey
         {
-            get => Loader.Load(this, ref _childrenCompositeKey);
+            get => Loader.Load(this, ref _childrenCompositeKey!)!;
             set => _childrenCompositeKey = value;
         }
 
@@ -4661,7 +4659,7 @@ public abstract partial class LoadTestBase<TFixture>(TFixture fixture) : IClassF
 
         public SingleCompositeKey SingleCompositeKey
         {
-            get => Loader.Load(this, ref _singleCompositeKey);
+            get => Loader.Load(this, ref _singleCompositeKey!)!;
             set => _singleCompositeKey = value;
         }
 
@@ -4679,9 +4677,9 @@ public abstract partial class LoadTestBase<TFixture>(TFixture fixture) : IClassF
 
     protected class Child
     {
-        private Parent _parent;
+        private Parent _parent = null!;
 
-        private ILazyLoader Loader { get; set; }
+        private ILazyLoader Loader { get; set; } = null!;
 
         [DatabaseGenerated(DatabaseGeneratedOption.None)]
         public int Id { get; set; }
@@ -4690,7 +4688,7 @@ public abstract partial class LoadTestBase<TFixture>(TFixture fixture) : IClassF
 
         public Parent Parent
         {
-            get => Loader.Load(this, ref _parent);
+            get => Loader.Load(this, ref _parent!)!;
             set => _parent = value;
         }
 
@@ -4708,25 +4706,25 @@ public abstract partial class LoadTestBase<TFixture>(TFixture fixture) : IClassF
 
     protected class SinglePkToPk
     {
-        private Parent _parent;
+        private Parent _parent = null!;
 
-        private ILazyLoader Loader { get; set; }
+        private ILazyLoader Loader { get; set; } = null!;
 
         [DatabaseGenerated(DatabaseGeneratedOption.None)]
         public int Id { get; set; }
 
         public Parent Parent
         {
-            get => Loader.Load(this, ref _parent);
+            get => Loader.Load(this, ref _parent!)!;
             set => _parent = value;
         }
     }
 
     protected class Single
     {
-        private Parent _parent;
+        private Parent _parent = null!;
 
-        private ILazyLoader Loader { get; set; }
+        private ILazyLoader Loader { get; set; } = null!;
 
         [DatabaseGenerated(DatabaseGeneratedOption.None)]
         public int Id { get; set; }
@@ -4735,7 +4733,7 @@ public abstract partial class LoadTestBase<TFixture>(TFixture fixture) : IClassF
 
         public Parent Parent
         {
-            get => Loader.Load(this, ref _parent);
+            get => Loader.Load(this, ref _parent!)!;
             set => _parent = value;
         }
 
@@ -4753,9 +4751,9 @@ public abstract partial class LoadTestBase<TFixture>(TFixture fixture) : IClassF
 
     protected class RequiredSingle
     {
-        private Parent _parent;
+        private Parent _parent = null!;
 
-        private ILazyLoader Loader { get; set; }
+        private ILazyLoader Loader { get; set; } = null!;
 
         [DatabaseGenerated(DatabaseGeneratedOption.None)]
         public int Id { get; set; }
@@ -4764,57 +4762,57 @@ public abstract partial class LoadTestBase<TFixture>(TFixture fixture) : IClassF
 
         public Parent Parent
         {
-            get => Loader.Load(this, ref _parent);
+            get => Loader.Load(this, ref _parent!)!;
             set => _parent = value;
         }
     }
 
     protected class ChildAk
     {
-        private Parent _parent;
+        private Parent _parent = null!;
 
-        private ILazyLoader Loader { get; set; }
+        private ILazyLoader Loader { get; set; } = null!;
 
         [DatabaseGenerated(DatabaseGeneratedOption.None)]
         public int Id { get; set; }
 
-        public string ParentId { get; set; }
+        public string ParentId { get; set; } = null!;
 
         public Parent Parent
         {
-            get => Loader.Load(this, ref _parent);
+            get => Loader.Load(this, ref _parent!)!;
             set => _parent = value;
         }
     }
 
     protected class SingleAk
     {
-        private Parent _parent;
+        private Parent _parent = null!;
 
-        private ILazyLoader Loader { get; set; }
+        private ILazyLoader Loader { get; set; } = null!;
 
         [DatabaseGenerated(DatabaseGeneratedOption.None)]
         public int Id { get; set; }
 
-        public string ParentId { get; set; }
+        public string ParentId { get; set; } = null!;
 
         public Parent Parent
         {
-            get => Loader.Load(this, ref _parent);
+            get => Loader.Load(this, ref _parent!)!;
             set => _parent = value;
         }
     }
 
     protected class ChildShadowFk
     {
-        private Parent _parent;
+        private Parent? _parent;
 
-        private ILazyLoader Loader { get; set; }
+        private ILazyLoader Loader { get; set; } = null!;
 
         [DatabaseGenerated(DatabaseGeneratedOption.None)]
         public int Id { get; set; }
 
-        public Parent Parent
+        public Parent? Parent
         {
             get => Loader.Load(this, ref _parent);
             set => _parent = value;
@@ -4823,14 +4821,14 @@ public abstract partial class LoadTestBase<TFixture>(TFixture fixture) : IClassF
 
     protected class SingleShadowFk
     {
-        private Parent _parent;
+        private Parent? _parent;
 
-        private ILazyLoader Loader { get; set; }
+        private ILazyLoader Loader { get; set; } = null!;
 
         [DatabaseGenerated(DatabaseGeneratedOption.None)]
         public int Id { get; set; }
 
-        public Parent Parent
+        public Parent? Parent
         {
             get => Loader.Load(this, ref _parent);
             set => _parent = value;
@@ -4839,38 +4837,38 @@ public abstract partial class LoadTestBase<TFixture>(TFixture fixture) : IClassF
 
     protected class ChildCompositeKey
     {
-        private Parent _parent;
+        private Parent _parent = null!;
 
-        private ILazyLoader Loader { get; set; }
+        private ILazyLoader Loader { get; set; } = null!;
 
         [DatabaseGenerated(DatabaseGeneratedOption.None)]
         public int Id { get; set; }
 
         public int? ParentId { get; set; }
-        public string ParentAlternateId { get; set; }
+        public string ParentAlternateId { get; set; } = null!;
 
         public Parent Parent
         {
-            get => Loader.Load(this, ref _parent);
+            get => Loader.Load(this, ref _parent!)!;
             set => _parent = value;
         }
     }
 
     protected class SingleCompositeKey
     {
-        private Parent _parent;
+        private Parent _parent = null!;
 
-        private ILazyLoader Loader { get; set; }
+        private ILazyLoader Loader { get; set; } = null!;
 
         [DatabaseGenerated(DatabaseGeneratedOption.None)]
         public int Id { get; set; }
 
         public int? ParentId { get; set; }
-        public string ParentAlternateId { get; set; }
+        public string ParentAlternateId { get; set; } = null!;
 
         public Parent Parent
         {
-            get => Loader.Load(this, ref _parent);
+            get => Loader.Load(this, ref _parent!)!;
             set => _parent = value;
         }
     }
@@ -4886,7 +4884,7 @@ public abstract partial class LoadTestBase<TFixture>(TFixture fixture) : IClassF
 
         public int Id { get; set; }
 
-        protected Action<object, string> LazyLoader { get; }
+        protected Action<object, string> LazyLoader { get; } = null!;
     }
 
     protected class Deposit : RootClass
@@ -4914,7 +4912,7 @@ public abstract partial class LoadTestBase<TFixture>(TFixture fixture) : IClassF
 
         public int? DepositID { get; set; }
 
-        private Deposit _deposit;
+        private Deposit _deposit = null!;
 
         public Deposit Deposit
         {
@@ -4937,8 +4935,8 @@ public abstract partial class LoadTestBase<TFixture>(TFixture fixture) : IClassF
 
     protected class OptionalChildView
     {
-        private readonly Action<object, string> _loader;
-        private RootClass _root;
+        private readonly Action<object, string> _loader = null!;
+        private RootClass _root = null!;
 
         public OptionalChildView()
         {
@@ -4958,8 +4956,8 @@ public abstract partial class LoadTestBase<TFixture>(TFixture fixture) : IClassF
 
     protected class RequiredChildView
     {
-        private readonly Action<object, string> _loader;
-        private RootClass _root;
+        private readonly Action<object, string> _loader = null!;
+        private RootClass _root = null!;
 
         public RequiredChildView()
         {
@@ -4979,9 +4977,9 @@ public abstract partial class LoadTestBase<TFixture>(TFixture fixture) : IClassF
 
     protected class ParentFullLoaderByConstructor
     {
-        private readonly ILazyLoader _loader;
-        private IEnumerable<ChildFullLoaderByConstructor> _children;
-        private SingleFullLoaderByConstructor _single;
+        private readonly ILazyLoader _loader = null!;
+        private IEnumerable<ChildFullLoaderByConstructor> _children = null!;
+        private SingleFullLoaderByConstructor _single = null!;
 
         public ParentFullLoaderByConstructor()
         {
@@ -4995,7 +4993,7 @@ public abstract partial class LoadTestBase<TFixture>(TFixture fixture) : IClassF
 
         public IEnumerable<ChildFullLoaderByConstructor> Children
         {
-            get => _loader.Load(this, ref _children);
+            get => _loader.Load(this, ref _children!)!;
             set => _children = value;
         }
 
@@ -5012,7 +5010,7 @@ public abstract partial class LoadTestBase<TFixture>(TFixture fixture) : IClassF
 
         public SingleFullLoaderByConstructor Single
         {
-            get => _loader.Load(this, ref _single);
+            get => _loader.Load(this, ref _single!)!;
             set => _single = value;
         }
 
@@ -5030,8 +5028,8 @@ public abstract partial class LoadTestBase<TFixture>(TFixture fixture) : IClassF
 
     protected class ChildFullLoaderByConstructor
     {
-        private readonly ILazyLoader _loader;
-        private ParentFullLoaderByConstructor _parent;
+        private readonly ILazyLoader _loader = null!;
+        private ParentFullLoaderByConstructor _parent = null!;
 
         public ChildFullLoaderByConstructor()
         {
@@ -5047,7 +5045,7 @@ public abstract partial class LoadTestBase<TFixture>(TFixture fixture) : IClassF
 
         public ParentFullLoaderByConstructor Parent
         {
-            get => _loader.Load(this, ref _parent);
+            get => _loader.Load(this, ref _parent!)!;
             set => _parent = value;
         }
 
@@ -5065,8 +5063,8 @@ public abstract partial class LoadTestBase<TFixture>(TFixture fixture) : IClassF
 
     protected class SingleFullLoaderByConstructor
     {
-        private readonly ILazyLoader _loader;
-        private ParentFullLoaderByConstructor _parent;
+        private readonly ILazyLoader _loader = null!;
+        private ParentFullLoaderByConstructor _parent = null!;
 
         public SingleFullLoaderByConstructor()
         {
@@ -5082,7 +5080,7 @@ public abstract partial class LoadTestBase<TFixture>(TFixture fixture) : IClassF
 
         public ParentFullLoaderByConstructor Parent
         {
-            get => _loader.Load(this, ref _parent);
+            get => _loader.Load(this, ref _parent!)!;
             set => _parent = value;
         }
 
@@ -5100,9 +5098,9 @@ public abstract partial class LoadTestBase<TFixture>(TFixture fixture) : IClassF
 
     protected class ParentDelegateLoaderByConstructor
     {
-        private readonly Action<object, string> _loader;
-        private IEnumerable<ChildDelegateLoaderByConstructor> _children;
-        private SingleDelegateLoaderByConstructor _single;
+        private readonly Action<object, string> _loader = null!;
+        private IEnumerable<ChildDelegateLoaderByConstructor> _children = null!;
+        private SingleDelegateLoaderByConstructor _single = null!;
 
         public ParentDelegateLoaderByConstructor()
         {
@@ -5122,15 +5120,15 @@ public abstract partial class LoadTestBase<TFixture>(TFixture fixture) : IClassF
 
         public SingleDelegateLoaderByConstructor Single
         {
-            get => _single ?? _loader.Load(this, ref _single);
+            get => _single ?? _loader.Load<SingleDelegateLoaderByConstructor>(this, ref _single!)!;
             set => _single = value;
         }
     }
 
     protected class ChildDelegateLoaderByConstructor
     {
-        private readonly Action<object, string> _loader;
-        private ParentDelegateLoaderByConstructor _parent;
+        private readonly Action<object, string> _loader = null!;
+        private ParentDelegateLoaderByConstructor _parent = null!;
         private int? _parentId;
 
         public ChildDelegateLoaderByConstructor()
@@ -5151,22 +5149,22 @@ public abstract partial class LoadTestBase<TFixture>(TFixture fixture) : IClassF
                 if (_parentId != value)
                 {
                     _parentId = value;
-                    _parent = null;
+                    _parent = null!;
                 }
             }
         }
 
         public ParentDelegateLoaderByConstructor Parent
         {
-            get => _parent ?? _loader.Load(this, ref _parent);
+            get => _parent ?? _loader.Load<ParentDelegateLoaderByConstructor>(this, ref _parent!)!;
             set => _parent = value;
         }
     }
 
     protected class SingleDelegateLoaderByConstructor
     {
-        private readonly Action<object, string> _loader;
-        private ParentDelegateLoaderByConstructor _parent;
+        private readonly Action<object, string> _loader = null!;
+        private ParentDelegateLoaderByConstructor _parent = null!;
         private int? _parentId;
 
         public SingleDelegateLoaderByConstructor()
@@ -5187,24 +5185,24 @@ public abstract partial class LoadTestBase<TFixture>(TFixture fixture) : IClassF
                 if (_parentId != value)
                 {
                     _parentId = value;
-                    _parent = null;
+                    _parent = null!;
                 }
             }
         }
 
         public ParentDelegateLoaderByConstructor Parent
         {
-            get => _parent ?? _loader.Load(this, ref _parent);
+            get => _parent ?? _loader.Load<ParentDelegateLoaderByConstructor>(this, ref _parent!)!;
             set => _parent = value;
         }
     }
 
     protected class ParentDelegateLoaderByProperty
     {
-        private IEnumerable<ChildDelegateLoaderByProperty> _children;
-        private SingleDelegateLoaderByProperty _single;
+        private IEnumerable<ChildDelegateLoaderByProperty> _children = null!;
+        private SingleDelegateLoaderByProperty _single = null!;
 
-        private Action<object, string> LazyLoader { get; set; }
+        private Action<object, string> LazyLoader { get; set; } = null!;
 
         [DatabaseGenerated(DatabaseGeneratedOption.None)]
         public int Id { get; set; }
@@ -5217,17 +5215,17 @@ public abstract partial class LoadTestBase<TFixture>(TFixture fixture) : IClassF
 
         public SingleDelegateLoaderByProperty Single
         {
-            get => _single ?? LazyLoader.Load(this, ref _single);
+            get => _single ?? LazyLoader.Load<SingleDelegateLoaderByProperty>(this, ref _single!)!;
             set => _single = value;
         }
     }
 
     protected class ChildDelegateLoaderByProperty
     {
-        private ParentDelegateLoaderByProperty _parent;
+        private ParentDelegateLoaderByProperty _parent = null!;
         private int? _parentId;
 
-        private Action<object, string> LazyLoader { get; set; }
+        private Action<object, string> LazyLoader { get; set; } = null!;
 
         [DatabaseGenerated(DatabaseGeneratedOption.None)]
         public int Id { get; set; }
@@ -5240,24 +5238,24 @@ public abstract partial class LoadTestBase<TFixture>(TFixture fixture) : IClassF
                 if (_parentId != value)
                 {
                     _parentId = value;
-                    _parent = null;
+                    _parent = null!;
                 }
             }
         }
 
         public ParentDelegateLoaderByProperty Parent
         {
-            get => _parent ?? LazyLoader.Load(this, ref _parent);
+            get => _parent ?? LazyLoader.Load<ParentDelegateLoaderByProperty>(this, ref _parent!)!;
             set => _parent = value;
         }
     }
 
     protected class SingleDelegateLoaderByProperty
     {
-        private ParentDelegateLoaderByProperty _parent;
+        private ParentDelegateLoaderByProperty _parent = null!;
         private int? _parentId;
 
-        private Action<object, string> LazyLoader { get; set; }
+        private Action<object, string> LazyLoader { get; set; } = null!;
 
         [DatabaseGenerated(DatabaseGeneratedOption.None)]
         public int Id { get; set; }
@@ -5270,25 +5268,25 @@ public abstract partial class LoadTestBase<TFixture>(TFixture fixture) : IClassF
                 if (_parentId != value)
                 {
                     _parentId = value;
-                    _parent = null;
+                    _parent = null!;
                 }
             }
         }
 
         public ParentDelegateLoaderByProperty Parent
         {
-            get => _parent ?? LazyLoader.Load(this, ref _parent);
+            get => _parent ?? LazyLoader.Load<ParentDelegateLoaderByProperty>(this, ref _parent!)!;
             set => _parent = value;
         }
     }
 
     protected class ParentDelegateLoaderWithStateByProperty
     {
-        private IEnumerable<ChildDelegateLoaderWithStateByProperty> _children;
-        private SingleDelegateLoaderWithStateByProperty _single;
+        private IEnumerable<ChildDelegateLoaderWithStateByProperty> _children = null!;
+        private SingleDelegateLoaderWithStateByProperty _single = null!;
 
-        private object LazyLoaderState { get; set; }
-        private Action<object, string> LazyLoader { get; set; }
+        private object LazyLoaderState { get; set; } = null!;
+        private Action<object, string> LazyLoader { get; set; } = null!;
 
         [DatabaseGenerated(DatabaseGeneratedOption.None)]
         public int Id { get; set; }
@@ -5301,18 +5299,18 @@ public abstract partial class LoadTestBase<TFixture>(TFixture fixture) : IClassF
 
         public SingleDelegateLoaderWithStateByProperty Single
         {
-            get => _single ?? LazyLoader.Load(this, ref _single);
+            get => _single ?? LazyLoader.Load<SingleDelegateLoaderWithStateByProperty>(this, ref _single!)!;
             set => _single = value;
         }
     }
 
     protected class ChildDelegateLoaderWithStateByProperty
     {
-        private ParentDelegateLoaderWithStateByProperty _parent;
+        private ParentDelegateLoaderWithStateByProperty _parent = null!;
         private int? _parentId;
 
-        private object LazyLoaderState { get; set; }
-        private Action<object, string> LazyLoader { get; set; }
+        private object LazyLoaderState { get; set; } = null!;
+        private Action<object, string> LazyLoader { get; set; } = null!;
 
         [DatabaseGenerated(DatabaseGeneratedOption.None)]
         public int Id { get; set; }
@@ -5325,25 +5323,25 @@ public abstract partial class LoadTestBase<TFixture>(TFixture fixture) : IClassF
                 if (_parentId != value)
                 {
                     _parentId = value;
-                    _parent = null;
+                    _parent = null!;
                 }
             }
         }
 
         public ParentDelegateLoaderWithStateByProperty Parent
         {
-            get => _parent ?? LazyLoader.Load(this, ref _parent);
+            get => _parent ?? LazyLoader.Load<ParentDelegateLoaderWithStateByProperty>(this, ref _parent!)!;
             set => _parent = value;
         }
     }
 
     protected class SingleDelegateLoaderWithStateByProperty
     {
-        private ParentDelegateLoaderWithStateByProperty _parent;
+        private ParentDelegateLoaderWithStateByProperty _parent = null!;
         private int? _parentId;
 
-        private object LazyLoaderState { get; set; }
-        private Action<object, string> LazyLoader { get; set; }
+        private object LazyLoaderState { get; set; } = null!;
+        private Action<object, string> LazyLoader { get; set; } = null!;
 
         [DatabaseGenerated(DatabaseGeneratedOption.None)]
         public int Id { get; set; }
@@ -5356,14 +5354,14 @@ public abstract partial class LoadTestBase<TFixture>(TFixture fixture) : IClassF
                 if (_parentId != value)
                 {
                     _parentId = value;
-                    _parent = null;
+                    _parent = null!;
                 }
             }
         }
 
         public ParentDelegateLoaderWithStateByProperty Parent
         {
-            get => _parent ?? LazyLoader.Load(this, ref _parent);
+            get => _parent ?? LazyLoader.Load<ParentDelegateLoaderWithStateByProperty>(this, ref _parent!)!;
             set => _parent = value;
         }
     }

--- a/test/EFCore.Specification.Tests/LoggingTestBase.cs
+++ b/test/EFCore.Specification.Tests/LoggingTestBase.cs
@@ -6,13 +6,11 @@ using Microsoft.EntityFrameworkCore.Diagnostics.Internal;
 // ReSharper disable InconsistentNaming
 namespace Microsoft.EntityFrameworkCore;
 
-#nullable disable
-
 public abstract class LoggingTestBase
 {
     [Fact]
     public void Logs_context_initialization_default_options()
-        => Assert.Equal(ExpectedMessage(DefaultOptions), ActualMessage(CreateOptionsBuilder));
+        => Assert.Equal(ExpectedMessage(DefaultOptions!), ActualMessage(CreateOptionsBuilder));
 
     [Fact]
     public void Logs_context_initialization_no_tracking()
@@ -57,22 +55,22 @@ public abstract class LoggingTestBase
     protected class Animal
     {
         public int Id { get; set; }
-        public string Name { get; set; }
-        public Person FavoritePerson { get; set; }
+        public string Name { get; set; } = null!;
+        public Person FavoritePerson { get; set; } = null!;
     }
 
     protected class Cat : Animal
     {
-        public string Breed { get; set; }
-        public string Type { get; set; }
+        public string Breed { get; set; } = null!;
+        public string Type { get; set; } = null!;
         public int Identity { get; set; }
     }
 
     protected class Person
     {
         public int Id { get; set; }
-        public string Name { get; set; }
-        public string FavoriteBreed { get; set; }
+        public string Name { get; set; } = null!;
+        public string FavoriteBreed { get; set; } = null!;
     }
 
     protected abstract TestLogger CreateTestLogger();
@@ -83,7 +81,7 @@ public abstract class LoggingTestBase
 
     protected abstract string ProviderVersion { get; }
 
-    protected virtual string DefaultOptions
+    protected virtual string? DefaultOptions
         => null;
 
     protected virtual string ActualMessage(Func<IServiceCollection, DbContextOptionsBuilder> optionsActions)
@@ -96,7 +94,7 @@ public abstract class LoggingTestBase
             var _ = context.Model;
         }
 
-        return loggerFactory.Log.Single(t => t.Id.Id == CoreEventId.ContextInitialized.Id).Message;
+        return loggerFactory.Log.Single(t => t.Id.Id == CoreEventId.ContextInitialized.Id).Message!;
     }
 
     protected class LoggingContext(DbContextOptionsBuilder optionsBuilder) : DbContext(optionsBuilder.Options);

--- a/test/EFCore.Specification.Tests/ManyToManyFieldsLoadTestBase.cs
+++ b/test/EFCore.Specification.Tests/ManyToManyFieldsLoadTestBase.cs
@@ -5,8 +5,6 @@ using Microsoft.EntityFrameworkCore.TestModels.ManyToManyFieldsModel;
 
 namespace Microsoft.EntityFrameworkCore;
 
-#nullable disable
-
 public abstract class ManyToManyFieldsLoadTestBase<TFixture>(TFixture fixture) : IClassFixture<TFixture>
     where TFixture : ManyToManyFieldsLoadTestBase<TFixture>.ManyToManyFieldsLoadFixtureBase
 {
@@ -38,9 +36,9 @@ public abstract class ManyToManyFieldsLoadTestBase<TFixture>(TFixture fixture) :
 
         ClearLog();
 
-        var collectionEntry = context.Entry(left).Collection(e => e.TwoSkip);
+        var collectionEntry = context.Entry(left!).Collection(e => e.TwoSkip);
 
-        context.Entry(left).State = state;
+        context.Entry(left!).State = state;
 
         Assert.False(collectionEntry.IsLoaded);
 
@@ -54,7 +52,7 @@ public abstract class ManyToManyFieldsLoadTestBase<TFixture>(TFixture fixture) :
         }
 
         Assert.True(collectionEntry.IsLoaded);
-        foreach (var entityTwo in left.TwoSkip)
+        foreach (var entityTwo in left!.TwoSkip)
         {
             Assert.False(context.Entry(entityTwo).Collection(e => e.OneSkip).IsLoaded);
         }
@@ -81,9 +79,9 @@ public abstract class ManyToManyFieldsLoadTestBase<TFixture>(TFixture fixture) :
 
         ClearLog();
 
-        var collectionEntry = context.Entry(left).Collection(e => e.TwoSkipShared);
+        var collectionEntry = context.Entry(left!).Collection(e => e.TwoSkipShared);
 
-        context.Entry(left).State = state;
+        context.Entry(left!).State = state;
 
         Assert.False(collectionEntry.IsLoaded);
 
@@ -92,7 +90,7 @@ public abstract class ManyToManyFieldsLoadTestBase<TFixture>(TFixture fixture) :
             : collectionEntry.Query().ToList();
 
         Assert.False(collectionEntry.IsLoaded);
-        foreach (var entityTwo in left.TwoSkipShared)
+        foreach (var entityTwo in left!.TwoSkipShared)
         {
             Assert.False(context.Entry(entityTwo).Collection(e => e.OneSkipShared).IsLoaded);
         }
@@ -249,9 +247,9 @@ public abstract class ManyToManyFieldsLoadTestBase<TFixture>(TFixture fixture) :
 
         ClearLog();
 
-        var navigationEntry = context.Entry(left).Navigation("TwoSkip");
+        var navigationEntry = context.Entry(left!).Navigation("TwoSkip");
 
-        context.Entry(left).State = state;
+        context.Entry(left!).State = state;
 
         Assert.False(navigationEntry.IsLoaded);
 
@@ -265,7 +263,7 @@ public abstract class ManyToManyFieldsLoadTestBase<TFixture>(TFixture fixture) :
         }
 
         Assert.True(navigationEntry.IsLoaded);
-        foreach (var entityTwo in left.TwoSkip)
+        foreach (var entityTwo in left!.TwoSkip)
         {
             Assert.False(context.Entry((object)entityTwo).Collection("OneSkip").IsLoaded);
         }
@@ -292,9 +290,9 @@ public abstract class ManyToManyFieldsLoadTestBase<TFixture>(TFixture fixture) :
 
         ClearLog();
 
-        var collectionEntry = context.Entry(left).Navigation("TwoSkipShared");
+        var collectionEntry = context.Entry(left!).Navigation("TwoSkipShared");
 
-        context.Entry(left).State = state;
+        context.Entry(left!).State = state;
 
         Assert.False(collectionEntry.IsLoaded);
 
@@ -303,7 +301,7 @@ public abstract class ManyToManyFieldsLoadTestBase<TFixture>(TFixture fixture) :
             : collectionEntry.Query().ToList<object>();
 
         Assert.False(collectionEntry.IsLoaded);
-        foreach (var entityTwo in left.TwoSkipShared)
+        foreach (var entityTwo in left!.TwoSkipShared)
         {
             Assert.False(context.Entry((object)entityTwo).Collection("OneSkipShared").IsLoaded);
         }
@@ -500,9 +498,9 @@ public abstract class ManyToManyFieldsLoadTestBase<TFixture>(TFixture fixture) :
 
         ClearLog();
 
-        var collectionEntry = context.Entry(left).Collection(e => e.ThreeSkipFull);
+        var collectionEntry = context.Entry(left!).Collection(e => e.ThreeSkipFull);
 
-        context.Entry(left).State = state;
+        context.Entry(left!).State = state;
 
         Assert.False(collectionEntry.IsLoaded);
 
@@ -516,7 +514,7 @@ public abstract class ManyToManyFieldsLoadTestBase<TFixture>(TFixture fixture) :
         }
 
         Assert.True(collectionEntry.IsLoaded);
-        foreach (var entityTwo in left.ThreeSkipFull)
+        foreach (var entityTwo in left!.ThreeSkipFull)
         {
             Assert.False(context.Entry(entityTwo).Collection(e => e.CompositeKeySkipFull).IsLoaded);
         }
@@ -543,9 +541,9 @@ public abstract class ManyToManyFieldsLoadTestBase<TFixture>(TFixture fixture) :
 
         ClearLog();
 
-        var collectionEntry = context.Entry(left).Collection(e => e.ThreeSkipFull);
+        var collectionEntry = context.Entry(left!).Collection(e => e.ThreeSkipFull);
 
-        context.Entry(left).State = state;
+        context.Entry(left!).State = state;
 
         Assert.False(collectionEntry.IsLoaded);
 
@@ -554,7 +552,7 @@ public abstract class ManyToManyFieldsLoadTestBase<TFixture>(TFixture fixture) :
             : collectionEntry.Query().ToList();
 
         Assert.False(collectionEntry.IsLoaded);
-        foreach (var entityTwo in left.ThreeSkipFull)
+        foreach (var entityTwo in left!.ThreeSkipFull)
         {
             Assert.False(context.Entry(entityTwo).Collection(e => e.CompositeKeySkipFull).IsLoaded);
         }
@@ -625,7 +623,7 @@ public abstract class ManyToManyFieldsLoadTestBase<TFixture>(TFixture fixture) :
 
         ClearLog();
 
-        var collectionEntry = context.Entry(left).Collection(e => e.TwoSkipShared);
+        var collectionEntry = context.Entry(left!).Collection(e => e.TwoSkipShared);
 
         Assert.False(collectionEntry.IsLoaded);
 
@@ -634,7 +632,7 @@ public abstract class ManyToManyFieldsLoadTestBase<TFixture>(TFixture fixture) :
             : collectionEntry.Query().Include(e => e.ThreeSkipFull).ToList();
 
         Assert.False(collectionEntry.IsLoaded);
-        foreach (var entityTwo in left.TwoSkipShared)
+        foreach (var entityTwo in left!.TwoSkipShared)
         {
             Assert.False(context.Entry(entityTwo).Collection(e => e.OneSkipShared).IsLoaded);
             Assert.True(context.Entry(entityTwo).Collection(e => e.ThreeSkipFull).IsLoaded);
@@ -671,7 +669,7 @@ public abstract class ManyToManyFieldsLoadTestBase<TFixture>(TFixture fixture) :
 
         ClearLog();
 
-        var collectionEntry = context.Entry(left).Collection(e => e.TwoSkipShared);
+        var collectionEntry = context.Entry(left!).Collection(e => e.TwoSkipShared);
 
         Assert.False(collectionEntry.IsLoaded);
 
@@ -681,7 +679,7 @@ public abstract class ManyToManyFieldsLoadTestBase<TFixture>(TFixture fixture) :
             : queryable.ToList();
 
         Assert.False(collectionEntry.IsLoaded);
-        foreach (var entityTwo in left.TwoSkipShared)
+        foreach (var entityTwo in left!.TwoSkipShared)
         {
             Assert.True(context.Entry(entityTwo).Collection(e => e.OneSkipShared).IsLoaded);
         }
@@ -707,7 +705,7 @@ public abstract class ManyToManyFieldsLoadTestBase<TFixture>(TFixture fixture) :
 
         ClearLog();
 
-        var collectionEntry = context.Entry(left).Collection(e => e.TwoSkipShared);
+        var collectionEntry = context.Entry(left!).Collection(e => e.TwoSkipShared);
 
         Assert.False(collectionEntry.IsLoaded);
 
@@ -717,7 +715,7 @@ public abstract class ManyToManyFieldsLoadTestBase<TFixture>(TFixture fixture) :
             : queryable.ToList();
 
         Assert.True(collectionEntry.IsLoaded);
-        foreach (var entityTwo in left.TwoSkipShared)
+        foreach (var entityTwo in left!.TwoSkipShared)
         {
             Assert.True(context.Entry(entityTwo).Collection(e => e.OneSkipShared).IsLoaded);
         }
@@ -743,7 +741,7 @@ public abstract class ManyToManyFieldsLoadTestBase<TFixture>(TFixture fixture) :
 
         ClearLog();
 
-        var collectionEntry = context.Entry(left).Collection(e => e.TwoSkipShared);
+        var collectionEntry = context.Entry(left!).Collection(e => e.TwoSkipShared);
 
         Assert.False(collectionEntry.IsLoaded);
 
@@ -752,7 +750,7 @@ public abstract class ManyToManyFieldsLoadTestBase<TFixture>(TFixture fixture) :
             : collectionEntry.Query().Include(e => e.ThreeSkipFull.Where(e => e.Id == 13 || e.Id == 11)).ToList();
 
         Assert.False(collectionEntry.IsLoaded);
-        foreach (var entityTwo in left.TwoSkipShared)
+        foreach (var entityTwo in left!.TwoSkipShared)
         {
             Assert.False(context.Entry(entityTwo).Collection(e => e.OneSkipShared).IsLoaded);
             Assert.True(context.Entry(entityTwo).Collection(e => e.ThreeSkipFull).IsLoaded);
@@ -790,7 +788,7 @@ public abstract class ManyToManyFieldsLoadTestBase<TFixture>(TFixture fixture) :
 
         ClearLog();
 
-        var collectionEntry = context.Entry(left).Collection(e => e.TwoSkipShared);
+        var collectionEntry = context.Entry(left!).Collection(e => e.TwoSkipShared);
 
         Assert.False(collectionEntry.IsLoaded);
 
@@ -812,7 +810,7 @@ public abstract class ManyToManyFieldsLoadTestBase<TFixture>(TFixture fixture) :
 
         RecordLog();
         Assert.False(collectionEntry.IsLoaded);
-        Assert.Empty(left.TwoSkipShared);
+        Assert.Empty(left!.TwoSkipShared);
         Assert.Single(context.ChangeTracker.Entries());
 
         Assert.Equal(3, projected.Count);
@@ -842,7 +840,7 @@ public abstract class ManyToManyFieldsLoadTestBase<TFixture>(TFixture fixture) :
 
         ClearLog();
 
-        var collectionEntry = context.Entry(left).Collection(e => e.TwoSkipShared);
+        var collectionEntry = context.Entry(left!).Collection(e => e.TwoSkipShared);
 
         Assert.False(collectionEntry.IsLoaded);
 

--- a/test/EFCore.Specification.Tests/ManyToManyTrackingTestBase.cs
+++ b/test/EFCore.Specification.Tests/ManyToManyTrackingTestBase.cs
@@ -7,15 +7,13 @@ using Microsoft.EntityFrameworkCore.TestModels.ManyToManyModel;
 
 namespace Microsoft.EntityFrameworkCore;
 
-#nullable disable
-
 public abstract partial class ManyToManyTrackingTestBase<TFixture>(TFixture fixture) : IClassFixture<TFixture>
     where TFixture : ManyToManyTrackingTestBase<TFixture>.ManyToManyTrackingFixtureBase
 {
     [Theory, InlineData(false), InlineData(true)]
     public virtual async Task Can_insert_many_to_many_composite_with_navs(bool async)
     {
-        List<int> keys = null;
+        List<int> keys = null!;
 
         await ExecuteWithStrategyInTransactionAsync(
             async context =>
@@ -88,7 +86,7 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>(TFixture fixt
             },
             async context =>
             {
-                var queryable = context.Set<EntityCompositeKey>().Where(e => keys.Contains(e.Key1)).Include(e => e.LeafSkipFull);
+                var queryable = context.Set<EntityCompositeKey>().Where(e => keys!.Contains(e.Key1)).Include(e => e.LeafSkipFull);
                 var results = async ? await queryable.ToListAsync() : queryable.ToList();
                 Assert.Equal(3, results.Count);
 
@@ -284,13 +282,13 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>(TFixture fixt
                 {
                     if (left.LeafSkipFull?.Contains(right) == true)
                     {
-                        Assert.Contains(left, right.CompositeKeySkipFull);
+                        Assert.Contains(left, right.CompositeKeySkipFull!);
                         count++;
                     }
 
                     if (right.CompositeKeySkipFull?.Contains(left) == true)
                     {
-                        Assert.Contains(right, left.LeafSkipFull);
+                        Assert.Contains(right, left.LeafSkipFull!);
                         count++;
                     }
                 }
@@ -462,7 +460,7 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>(TFixture fixt
     [Theory, InlineData(false), InlineData(true)]
     public virtual async Task Can_insert_many_to_many_composite_shared_with_navs(bool async)
     {
-        List<int> keys = null;
+        List<int> keys = null!;
 
         await ExecuteWithStrategyInTransactionAsync(
             async context =>
@@ -535,7 +533,7 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>(TFixture fixt
             },
             async context =>
             {
-                var queryable = context.Set<EntityCompositeKey>().Where(e => keys.Contains(e.Key1)).Include(e => e.RootSkipShared);
+                var queryable = context.Set<EntityCompositeKey>().Where(e => keys!.Contains(e.Key1)).Include(e => e.RootSkipShared);
                 var results = async ? await queryable.ToListAsync() : queryable.ToList();
                 Assert.Equal(3, results.Count);
 
@@ -571,7 +569,7 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>(TFixture fixt
     [Fact]
     public virtual Task Can_update_many_to_many_composite_shared_with_navs()
     {
-        List<int> rootKeys = null;
+        List<int> rootKeys = null!;
 
         return ExecuteWithStrategyInTransactionAsync(
             async context =>
@@ -684,9 +682,9 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>(TFixture fixt
             Assert.Equal(joinCount, context.ChangeTracker.Entries<Dictionary<string, object>>().Count());
             Assert.Equal(leftCount + rightCount + joinCount, context.ChangeTracker.Entries().Count());
 
-            Assert.Contains(leftEntities[0].RootSkipShared, e => context.Entry(e).Property(e => e.Id).CurrentValue == rootKeys[0]);
-            Assert.Contains(leftEntities[0].RootSkipShared, e => context.Entry(e).Property(e => e.Id).CurrentValue == rootKeys[1]);
-            Assert.Contains(leftEntities[0].RootSkipShared, e => context.Entry(e).Property(e => e.Id).CurrentValue == rootKeys[2]);
+            Assert.Contains(leftEntities[0].RootSkipShared, e => context.Entry(e).Property(e => e.Id).CurrentValue == rootKeys![0]);
+            Assert.Contains(leftEntities[0].RootSkipShared, e => context.Entry(e).Property(e => e.Id).CurrentValue == rootKeys![1]);
+            Assert.Contains(leftEntities[0].RootSkipShared, e => context.Entry(e).Property(e => e.Id).CurrentValue == rootKeys![2]);
 
             Assert.Contains(rightEntities[0].CompositeKeySkipShared, e => e.Key2 == "Z7711");
             Assert.Contains(rightEntities[0].CompositeKeySkipShared, e => e.Key2 == "Z7712");
@@ -696,7 +694,7 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>(TFixture fixt
             Assert.DoesNotContain(rightEntities[1].CompositeKeySkipShared, e => e.Key2 == "8_2");
 
             Assert.DoesNotContain(leftEntities[2].RootSkipShared, e => e.Name == "Branch 6");
-            Assert.Contains(leftEntities[2].RootSkipShared, e => context.Entry(e).Property(e => e.Id).CurrentValue == rootKeys[3]);
+            Assert.Contains(leftEntities[2].RootSkipShared, e => context.Entry(e).Property(e => e.Id).CurrentValue == rootKeys![3]);
 
             Assert.DoesNotContain(rightEntities[3].CompositeKeySkipShared, e => e.Key2 == "8_5");
             Assert.Contains(rightEntities[3].CompositeKeySkipShared, e => e.Key2 == "Z7714");
@@ -714,13 +712,13 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>(TFixture fixt
                 {
                     if (left.RootSkipShared?.Contains(right) == true)
                     {
-                        Assert.Contains(left, right.CompositeKeySkipShared);
+                        Assert.Contains(left, right.CompositeKeySkipShared!);
                         count++;
                     }
 
                     if (right.CompositeKeySkipShared?.Contains(left) == true)
                     {
-                        Assert.Contains(right, left.RootSkipShared);
+                        Assert.Contains(right, left.RootSkipShared!);
                         count++;
                     }
                 }
@@ -842,7 +840,7 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>(TFixture fixt
     [Theory, InlineData(false), InlineData(true)]
     public virtual async Task Can_insert_many_to_many_composite_additional_pk_with_navs(bool async)
     {
-        List<string> keys = null;
+        List<string> keys = null!;
 
         await ExecuteWithStrategyInTransactionAsync(
             async context =>
@@ -927,7 +925,7 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>(TFixture fixt
             },
             async context =>
             {
-                var queryable = context.Set<EntityCompositeKey>().Where(e => keys.Contains(e.Key2)).Include(e => e.ThreeSkipFull);
+                var queryable = context.Set<EntityCompositeKey>().Where(e => keys!.Contains(e.Key2)).Include(e => e.ThreeSkipFull);
                 var results = async ? await queryable.ToListAsync() : queryable.ToList();
                 Assert.Equal(3, results.Count);
 
@@ -986,7 +984,7 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>(TFixture fixt
     [Fact]
     public virtual Task Can_update_many_to_many_composite_additional_pk_with_navs()
     {
-        List<int> threeIds = null;
+        List<int> threeIds = null!;
 
         return ExecuteWithStrategyInTransactionAsync(
             async context =>
@@ -1102,9 +1100,9 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>(TFixture fixt
             Assert.Equal(joinCount, context.ChangeTracker.Entries<JoinThreeToCompositeKeyFull>().Count());
             Assert.Equal(leftCount + rightCount + joinCount, context.ChangeTracker.Entries().Count());
 
-            Assert.Contains(leftEntities[0].ThreeSkipFull, e => context.Entry(e).Property(e => e.Id).CurrentValue == threeIds[0]);
-            Assert.Contains(leftEntities[0].ThreeSkipFull, e => context.Entry(e).Property(e => e.Id).CurrentValue == threeIds[1]);
-            Assert.Contains(leftEntities[0].ThreeSkipFull, e => context.Entry(e).Property(e => e.Id).CurrentValue == threeIds[2]);
+            Assert.Contains(leftEntities[0].ThreeSkipFull, e => context.Entry(e).Property(e => e.Id).CurrentValue == threeIds![0]);
+            Assert.Contains(leftEntities[0].ThreeSkipFull, e => context.Entry(e).Property(e => e.Id).CurrentValue == threeIds![1]);
+            Assert.Contains(leftEntities[0].ThreeSkipFull, e => context.Entry(e).Property(e => e.Id).CurrentValue == threeIds![2]);
 
             Assert.Contains(rightEntities[0].CompositeKeySkipFull, e => e.Key2 == "Z7711");
             Assert.Contains(rightEntities[0].CompositeKeySkipFull, e => e.Key2 == "Z7712");
@@ -1114,7 +1112,7 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>(TFixture fixt
             Assert.DoesNotContain(rightEntities[1].CompositeKeySkipFull, e => e.Key2 == "9_2");
 
             Assert.DoesNotContain(leftEntities[3].ThreeSkipFull, e => e.Name == "EntityThree 23");
-            Assert.Contains(leftEntities[3].ThreeSkipFull, e => context.Entry(e).Property(e => e.Id).CurrentValue == threeIds[3]);
+            Assert.Contains(leftEntities[3].ThreeSkipFull, e => context.Entry(e).Property(e => e.Id).CurrentValue == threeIds![3]);
 
             Assert.DoesNotContain(rightEntities[2].CompositeKeySkipFull, e => e.Key2 == "6_1");
             Assert.Contains(rightEntities[2].CompositeKeySkipFull, e => e.Key2 == "Z7714");
@@ -1147,13 +1145,13 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>(TFixture fixt
                 {
                     if (left.ThreeSkipFull?.Contains(right) == true)
                     {
-                        Assert.Contains(left, right.CompositeKeySkipFull);
+                        Assert.Contains(left, right.CompositeKeySkipFull!);
                         count++;
                     }
 
                     if (right.CompositeKeySkipFull?.Contains(left) == true)
                     {
-                        Assert.Contains(right, left.ThreeSkipFull);
+                        Assert.Contains(right, left.ThreeSkipFull!);
                         count++;
                     }
                 }
@@ -1313,8 +1311,8 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>(TFixture fixt
     [Theory, InlineData(false), InlineData(true)]
     public virtual async Task Can_insert_many_to_many_self_shared(bool async)
     {
-        List<int> leftKeys = null;
-        List<int> rightKeys = null;
+        List<int> leftKeys = null!;
+        List<int> rightKeys = null!;
 
         await ExecuteWithStrategyInTransactionAsync(
             async context =>
@@ -1374,7 +1372,7 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>(TFixture fixt
             async context =>
             {
                 var queryable = context.Set<EntityTwo>()
-                    .Where(e => leftKeys.Contains(e.Id) || rightKeys.Contains(e.Id))
+                    .Where(e => leftKeys!.Contains(e.Id) || rightKeys!.Contains(e.Id))
                     .Include(e => e.SelfSkipSharedLeft);
 
                 var results = async ? await queryable.ToListAsync() : queryable.ToList();
@@ -1382,13 +1380,13 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>(TFixture fixt
 
                 var leftEntities = context.ChangeTracker.Entries<EntityTwo>()
                     .Select(e => e.Entity)
-                    .Where(e => leftKeys.Contains(e.Id))
+                    .Where(e => leftKeys!.Contains(e.Id))
                     .OrderBy(e => e.Name)
                     .ToList();
 
                 var rightEntities = context.ChangeTracker.Entries<EntityTwo>()
                     .Select(e => e.Entity)
-                    .Where(e => rightKeys.Contains(e.Id))
+                    .Where(e => rightKeys!.Contains(e.Id))
                     .OrderBy(e => e.Name)
                     .ToList();
 
@@ -1417,7 +1415,7 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>(TFixture fixt
     [Fact]
     public virtual Task Can_update_many_to_many_self()
     {
-        List<int> ids = null;
+        List<int> ids = null!;
 
         return ExecuteWithStrategyInTransactionAsync(
             async context =>
@@ -1519,22 +1517,22 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>(TFixture fixt
             Assert.Equal(joinCount, context.ChangeTracker.Entries<Dictionary<string, object>>().Count());
             Assert.Equal(count + joinCount, context.ChangeTracker.Entries().Count());
 
-            Assert.Contains(leftEntities[0].SelfSkipSharedRight, e => context.Entry(e).Property(e => e.Id).CurrentValue == ids[0]);
-            Assert.Contains(leftEntities[0].SelfSkipSharedRight, e => context.Entry(e).Property(e => e.Id).CurrentValue == ids[1]);
-            Assert.Contains(leftEntities[0].SelfSkipSharedRight, e => context.Entry(e).Property(e => e.Id).CurrentValue == ids[2]);
+            Assert.Contains(leftEntities[0].SelfSkipSharedRight, e => context.Entry(e).Property(e => e.Id).CurrentValue == ids![0]);
+            Assert.Contains(leftEntities[0].SelfSkipSharedRight, e => context.Entry(e).Property(e => e.Id).CurrentValue == ids![1]);
+            Assert.Contains(leftEntities[0].SelfSkipSharedRight, e => context.Entry(e).Property(e => e.Id).CurrentValue == ids![2]);
 
-            Assert.Contains(rightEntities[0].SelfSkipSharedLeft, e => context.Entry(e).Property(e => e.Id).CurrentValue == ids[4]);
-            Assert.Contains(rightEntities[0].SelfSkipSharedLeft, e => context.Entry(e).Property(e => e.Id).CurrentValue == ids[5]);
-            Assert.Contains(rightEntities[0].SelfSkipSharedLeft, e => context.Entry(e).Property(e => e.Id).CurrentValue == ids[6]);
+            Assert.Contains(rightEntities[0].SelfSkipSharedLeft, e => context.Entry(e).Property(e => e.Id).CurrentValue == ids![4]);
+            Assert.Contains(rightEntities[0].SelfSkipSharedLeft, e => context.Entry(e).Property(e => e.Id).CurrentValue == ids![5]);
+            Assert.Contains(rightEntities[0].SelfSkipSharedLeft, e => context.Entry(e).Property(e => e.Id).CurrentValue == ids![6]);
 
             Assert.DoesNotContain(leftEntities[0].SelfSkipSharedRight, e => e.Name == "EntityTwo 9");
             Assert.DoesNotContain(rightEntities[1].SelfSkipSharedLeft, e => e.Name == "EntityTwo 1");
 
             Assert.DoesNotContain(leftEntities[4].SelfSkipSharedRight, e => e.Name == "EntityTwo 18");
-            Assert.Contains(leftEntities[4].SelfSkipSharedRight, e => context.Entry(e).Property(e => e.Id).CurrentValue == ids[3]);
+            Assert.Contains(leftEntities[4].SelfSkipSharedRight, e => context.Entry(e).Property(e => e.Id).CurrentValue == ids![3]);
 
             Assert.DoesNotContain(rightEntities[5].SelfSkipSharedLeft, e => e.Name == "EntityTwo 12");
-            Assert.Contains(rightEntities[5].SelfSkipSharedLeft, e => context.Entry(e).Property(e => e.Id).CurrentValue == ids[7]);
+            Assert.Contains(rightEntities[5].SelfSkipSharedLeft, e => context.Entry(e).Property(e => e.Id).CurrentValue == ids![7]);
 
             var allLeft = context.ChangeTracker.Entries<EntityTwo>().Select(e => e.Entity).OrderBy(e => e.Name).ToList();
             var allRight = context.ChangeTracker.Entries<EntityTwo>().Select(e => e.Entity).OrderBy(e => e.Name).ToList();
@@ -1549,13 +1547,13 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>(TFixture fixt
                 {
                     if (left.SelfSkipSharedRight?.Contains(right) == true)
                     {
-                        Assert.Contains(left, right.SelfSkipSharedLeft);
+                        Assert.Contains(left, right.SelfSkipSharedLeft!);
                         joins++;
                     }
 
                     if (right.SelfSkipSharedLeft?.Contains(left) == true)
                     {
-                        Assert.Contains(right, left.SelfSkipSharedRight);
+                        Assert.Contains(right, left.SelfSkipSharedRight!);
                         joins++;
                     }
                 }
@@ -1569,7 +1567,7 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>(TFixture fixt
     [Theory, InlineData(false), InlineData(true)]
     public virtual async Task Can_insert_many_to_many_with_navs(bool async)
     {
-        List<int> keys = null;
+        List<int> keys = null!;
 
         await ExecuteWithStrategyInTransactionAsync(
             async context =>
@@ -1627,7 +1625,7 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>(TFixture fixt
             },
             async context =>
             {
-                var queryable = context.Set<EntityTwo>().Where(e => keys.Contains(e.Id)).Include(e => e.ThreeSkipFull);
+                var queryable = context.Set<EntityTwo>().Where(e => keys!.Contains(e.Id)).Include(e => e.ThreeSkipFull);
                 var results = async ? await queryable.ToListAsync() : queryable.ToList();
                 Assert.Equal(3, results.Count);
 
@@ -1805,13 +1803,13 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>(TFixture fixt
                 {
                     if (left.ThreeSkipFull?.Contains(right) == true)
                     {
-                        Assert.Contains(left, right.TwoSkipFull);
+                        Assert.Contains(left, right.TwoSkipFull!);
                         count++;
                     }
 
                     if (right.TwoSkipFull?.Contains(left) == true)
                     {
-                        Assert.Contains(right, left.ThreeSkipFull);
+                        Assert.Contains(right, left.ThreeSkipFull!);
                         count++;
                     }
                 }
@@ -1825,7 +1823,7 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>(TFixture fixt
     [Theory, InlineData(false), InlineData(true)]
     public virtual async Task Can_insert_many_to_many_with_inheritance(bool async)
     {
-        List<int> keys = null;
+        List<int> keys = null!;
 
         await ExecuteWithStrategyInTransactionAsync(
             async context =>
@@ -1883,7 +1881,7 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>(TFixture fixt
             },
             async context =>
             {
-                var queryable = context.Set<EntityOne>().Where(e => keys.Contains(e.Id)).Include(e => e.BranchSkip);
+                var queryable = context.Set<EntityOne>().Where(e => keys!.Contains(e.Id)).Include(e => e.BranchSkip);
                 var results = async ? await queryable.ToListAsync() : queryable.ToList();
                 Assert.Equal(3, results.Count);
 
@@ -2040,13 +2038,13 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>(TFixture fixt
                 {
                     if (left.BranchSkip?.Contains(right) == true)
                     {
-                        Assert.Contains(left, right.OneSkip);
+                        Assert.Contains(left, right.OneSkip!);
                         count++;
                     }
 
                     if (right.OneSkip?.Contains(left) == true)
                     {
-                        Assert.Contains(right, left.BranchSkip);
+                        Assert.Contains(right, left.BranchSkip!);
                         count++;
                     }
                 }
@@ -2060,8 +2058,8 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>(TFixture fixt
     [Theory, InlineData(false), InlineData(true)]
     public virtual async Task Can_insert_many_to_many_self_with_payload(bool async)
     {
-        List<int> leftKeys = null;
-        List<int> rightKeys = null;
+        List<int> leftKeys = null!;
+        List<int> rightKeys = null!;
 
         await ExecuteWithStrategyInTransactionAsync(
             async context =>
@@ -2121,7 +2119,7 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>(TFixture fixt
             async context =>
             {
                 var queryable = context.Set<EntityOne>()
-                    .Where(e => leftKeys.Contains(e.Id) || rightKeys.Contains(e.Id))
+                    .Where(e => leftKeys!.Contains(e.Id) || rightKeys!.Contains(e.Id))
                     .Include(e => e.SelfSkipPayloadLeft);
 
                 var results = async ? await queryable.ToListAsync() : queryable.ToList();
@@ -2129,13 +2127,13 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>(TFixture fixt
 
                 var leftEntities = context.ChangeTracker.Entries<EntityOne>()
                     .Select(e => e.Entity)
-                    .Where(e => leftKeys.Contains(e.Id))
+                    .Where(e => leftKeys!.Contains(e.Id))
                     .OrderBy(e => e.Name)
                     .ToList();
 
                 var rightEntities = context.ChangeTracker.Entries<EntityOne>()
                     .Select(e => e.Entity)
-                    .Where(e => rightKeys.Contains(e.Id))
+                    .Where(e => rightKeys!.Contains(e.Id))
                     .OrderBy(e => e.Name)
                     .ToList();
 
@@ -2184,7 +2182,7 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>(TFixture fixt
     [Fact]
     public virtual Task Can_update_many_to_many_self_with_payload()
     {
-        List<int> keys = null;
+        List<int> keys = null!;
 
         return ExecuteWithStrategyInTransactionAsync(
             async context =>
@@ -2298,22 +2296,22 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>(TFixture fixt
             Assert.Equal(joinCount, context.ChangeTracker.Entries<JoinOneSelfPayload>().Count());
             Assert.Equal(count + joinCount, context.ChangeTracker.Entries().Count());
 
-            Assert.Contains(leftEntities[0].SelfSkipPayloadRight, e => context.Entry(e).Property(e => e.Id).CurrentValue == keys[0]);
-            Assert.Contains(leftEntities[0].SelfSkipPayloadRight, e => context.Entry(e).Property(e => e.Id).CurrentValue == keys[1]);
-            Assert.Contains(leftEntities[0].SelfSkipPayloadRight, e => context.Entry(e).Property(e => e.Id).CurrentValue == keys[2]);
+            Assert.Contains(leftEntities[0].SelfSkipPayloadRight, e => context.Entry(e).Property(e => e.Id).CurrentValue == keys![0]);
+            Assert.Contains(leftEntities[0].SelfSkipPayloadRight, e => context.Entry(e).Property(e => e.Id).CurrentValue == keys![1]);
+            Assert.Contains(leftEntities[0].SelfSkipPayloadRight, e => context.Entry(e).Property(e => e.Id).CurrentValue == keys![2]);
 
-            Assert.Contains(rightEntities[0].SelfSkipPayloadLeft, e => context.Entry(e).Property(e => e.Id).CurrentValue == keys[4]);
-            Assert.Contains(rightEntities[0].SelfSkipPayloadLeft, e => context.Entry(e).Property(e => e.Id).CurrentValue == keys[5]);
-            Assert.Contains(rightEntities[0].SelfSkipPayloadLeft, e => context.Entry(e).Property(e => e.Id).CurrentValue == keys[6]);
+            Assert.Contains(rightEntities[0].SelfSkipPayloadLeft, e => context.Entry(e).Property(e => e.Id).CurrentValue == keys![4]);
+            Assert.Contains(rightEntities[0].SelfSkipPayloadLeft, e => context.Entry(e).Property(e => e.Id).CurrentValue == keys![5]);
+            Assert.Contains(rightEntities[0].SelfSkipPayloadLeft, e => context.Entry(e).Property(e => e.Id).CurrentValue == keys![6]);
 
             Assert.DoesNotContain(leftEntities[7].SelfSkipPayloadRight, e => e.Name == "EntityOne 6");
             Assert.DoesNotContain(rightEntities[11].SelfSkipPayloadLeft, e => e.Name == "EntityOne 13");
 
             Assert.DoesNotContain(leftEntities[4].SelfSkipPayloadRight, e => e.Name == "EntityOne 2");
-            Assert.Contains(leftEntities[4].SelfSkipPayloadRight, e => context.Entry(e).Property(e => e.Id).CurrentValue == keys[3]);
+            Assert.Contains(leftEntities[4].SelfSkipPayloadRight, e => context.Entry(e).Property(e => e.Id).CurrentValue == keys![3]);
 
             Assert.DoesNotContain(rightEntities[4].SelfSkipPayloadLeft, e => e.Name == "EntityOne 6");
-            Assert.Contains(rightEntities[4].SelfSkipPayloadLeft, e => context.Entry(e).Property(e => e.Id).CurrentValue == keys[7]);
+            Assert.Contains(rightEntities[4].SelfSkipPayloadLeft, e => context.Entry(e).Property(e => e.Id).CurrentValue == keys![7]);
 
             var joinEntries = context.ChangeTracker.Entries<JoinOneSelfPayload>().ToList();
             foreach (var joinEntry in joinEntries)
@@ -2324,7 +2322,7 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>(TFixture fixt
                 Assert.Contains(joinEntity, joinEntity.Left.JoinSelfPayloadLeft);
                 Assert.Contains(joinEntity, joinEntity.Right.JoinSelfPayloadRight);
 
-                if (joinEntity.LeftId == keys[5]
+                if (joinEntity.LeftId == keys![5]
                     && joinEntity.RightId == 1)
                 {
                     Assert.Equal(postSave ? EntityState.Unchanged : EntityState.Added, joinEntry.State);
@@ -2353,13 +2351,13 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>(TFixture fixt
                 {
                     if (left.SelfSkipPayloadRight?.Contains(right) == true)
                     {
-                        Assert.Contains(left, right.SelfSkipPayloadLeft);
+                        Assert.Contains(left, right.SelfSkipPayloadLeft!);
                         joins++;
                     }
 
                     if (right.SelfSkipPayloadLeft?.Contains(left) == true)
                     {
-                        Assert.Contains(right, left.SelfSkipPayloadRight);
+                        Assert.Contains(right, left.SelfSkipPayloadRight!);
                         joins++;
                     }
                 }
@@ -2373,7 +2371,7 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>(TFixture fixt
     [Theory, InlineData(false), InlineData(true)]
     public virtual async Task Can_insert_many_to_many_shared_with_payload(bool async)
     {
-        List<int> keys = null;
+        List<int> keys = null!;
 
         await ExecuteWithStrategyInTransactionAsync(
             async context =>
@@ -2431,7 +2429,7 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>(TFixture fixt
             },
             async context =>
             {
-                var queryable = context.Set<EntityOne>().Where(e => keys.Contains(e.Id)).Include(e => e.ThreeSkipPayloadFullShared);
+                var queryable = context.Set<EntityOne>().Where(e => keys!.Contains(e.Id)).Include(e => e.ThreeSkipPayloadFullShared);
                 var results = async ? await queryable.ToListAsync() : queryable.ToList();
                 Assert.Equal(3, results.Count);
 
@@ -2647,13 +2645,13 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>(TFixture fixt
                 {
                     if (left.ThreeSkipPayloadFullShared?.Contains(right) == true)
                     {
-                        Assert.Contains(left, right.OneSkipPayloadFullShared);
+                        Assert.Contains(left, right.OneSkipPayloadFullShared!);
                         count++;
                     }
 
                     if (right.OneSkipPayloadFullShared?.Contains(left) == true)
                     {
-                        Assert.Contains(right, left.ThreeSkipPayloadFullShared);
+                        Assert.Contains(right, left.ThreeSkipPayloadFullShared!);
                         count++;
                     }
                 }
@@ -2667,7 +2665,7 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>(TFixture fixt
     [Theory, InlineData(false), InlineData(true)]
     public virtual async Task Can_insert_many_to_many_shared(bool async)
     {
-        List<int> keys = null;
+        List<int> keys = null!;
 
         await ExecuteWithStrategyInTransactionAsync(
             async context =>
@@ -2725,7 +2723,7 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>(TFixture fixt
             },
             async context =>
             {
-                var queryable = context.Set<EntityOne>().Where(e => keys.Contains(e.Id)).Include(e => e.TwoSkipShared);
+                var queryable = context.Set<EntityOne>().Where(e => keys!.Contains(e.Id)).Include(e => e.TwoSkipShared);
                 var results = async ? await queryable.ToListAsync() : queryable.ToList();
                 Assert.Equal(3, results.Count);
 
@@ -2890,13 +2888,13 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>(TFixture fixt
                 {
                     if (left.TwoSkipShared?.Contains(right) == true)
                     {
-                        Assert.Contains(left, right.OneSkipShared);
+                        Assert.Contains(left, right.OneSkipShared!);
                         count++;
                     }
 
                     if (right.OneSkipShared?.Contains(left) == true)
                     {
-                        Assert.Contains(right, left.TwoSkipShared);
+                        Assert.Contains(right, left.TwoSkipShared!);
                         count++;
                     }
                 }
@@ -2910,7 +2908,7 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>(TFixture fixt
     [Theory, InlineData(false), InlineData(true)]
     public virtual async Task Can_insert_many_to_many_with_payload(bool async)
     {
-        List<int> keys = null;
+        List<int> keys = null!;
 
         await ExecuteWithStrategyInTransactionAsync(
             async context =>
@@ -2968,7 +2966,7 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>(TFixture fixt
             },
             async context =>
             {
-                var queryable = context.Set<EntityOne>().Where(e => keys.Contains(e.Id)).Include(e => e.ThreeSkipPayloadFull);
+                var queryable = context.Set<EntityOne>().Where(e => keys!.Contains(e.Id)).Include(e => e.ThreeSkipPayloadFull);
                 var results = async ? await queryable.ToListAsync() : queryable.ToList();
                 Assert.Equal(3, results.Count);
 
@@ -3192,13 +3190,13 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>(TFixture fixt
                 {
                     if (left.ThreeSkipPayloadFull?.Contains(right) == true)
                     {
-                        Assert.Contains(left, right.OneSkipPayloadFull);
+                        Assert.Contains(left, right.OneSkipPayloadFull!);
                         count++;
                     }
 
                     if (right.OneSkipPayloadFull?.Contains(left) == true)
                     {
-                        Assert.Contains(right, left.ThreeSkipPayloadFull);
+                        Assert.Contains(right, left.ThreeSkipPayloadFull!);
                         count++;
                     }
                 }
@@ -3336,7 +3334,7 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>(TFixture fixt
     [Theory, InlineData(false), InlineData(true)]
     public virtual async Task Can_insert_many_to_many(bool async)
     {
-        List<int> keys = null;
+        List<int> keys = null!;
 
         await ExecuteWithStrategyInTransactionAsync(
             async context =>
@@ -3394,7 +3392,7 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>(TFixture fixt
             },
             async context =>
             {
-                var queryable = context.Set<EntityOne>().Where(e => keys.Contains(e.Id)).Include(e => e.TwoSkip);
+                var queryable = context.Set<EntityOne>().Where(e => keys!.Contains(e.Id)).Include(e => e.TwoSkip);
                 var results = async ? await queryable.ToListAsync() : queryable.ToList();
                 Assert.Equal(3, results.Count);
 
@@ -3432,7 +3430,7 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>(TFixture fixt
         bool useTrackGraph,
         bool useDetectChanges)
     {
-        List<int> keys = null;
+        List<int> keys = null!;
 
         await ExecuteWithStrategyInTransactionAsync(
             async context =>
@@ -3553,7 +3551,7 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>(TFixture fixt
             async context =>
             {
                 var queryable = context.Set<EntityOne>()
-                    .Where(e => keys.Contains(e.Id))
+                    .Where(e => keys!.Contains(e.Id))
                     .Include(e => e.TwoSkip)
                     .ThenInclude(e => e.Extra);
 
@@ -3601,7 +3599,7 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>(TFixture fixt
      InlineData(true, true, true)]
     public virtual async Task Can_insert_many_to_many_with_dangling_join(bool async, bool useTrackGraph, bool useDetectChanges)
     {
-        List<int> keys = null;
+        List<int> keys = null!;
 
         await ExecuteWithStrategyInTransactionAsync(
             async context =>
@@ -3683,7 +3681,7 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>(TFixture fixt
             async context =>
             {
                 var queryable = context.Set<EntityOne>()
-                    .Where(e => keys.Contains(e.Id))
+                    .Where(e => keys!.Contains(e.Id))
                     .Include(e => e.TwoSkip)
                     .ThenInclude(e => e.Extra);
 
@@ -3728,8 +3726,8 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>(TFixture fixt
     [Fact]
     public virtual Task Can_update_many_to_many()
     {
-        List<int> oneIds = null;
-        List<int> twoIds = null;
+        List<int> oneIds = null!;
+        List<int> twoIds = null!;
 
         return ExecuteWithStrategyInTransactionAsync(
             async context =>
@@ -3839,22 +3837,22 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>(TFixture fixt
             Assert.Equal(joinCount, context.ChangeTracker.Entries<JoinOneToTwo>().Count());
             Assert.Equal(leftCount + rightCount + joinCount, context.ChangeTracker.Entries().Count());
 
-            Assert.Contains(leftEntities[0].TwoSkip, e => context.Entry(e).Property(e => e.Id).CurrentValue == twoIds[0]);
-            Assert.Contains(leftEntities[0].TwoSkip, e => context.Entry(e).Property(e => e.Id).CurrentValue == twoIds[1]);
-            Assert.Contains(leftEntities[0].TwoSkip, e => context.Entry(e).Property(e => e.Id).CurrentValue == twoIds[2]);
+            Assert.Contains(leftEntities[0].TwoSkip, e => context.Entry(e).Property(e => e.Id).CurrentValue == twoIds![0]);
+            Assert.Contains(leftEntities[0].TwoSkip, e => context.Entry(e).Property(e => e.Id).CurrentValue == twoIds![1]);
+            Assert.Contains(leftEntities[0].TwoSkip, e => context.Entry(e).Property(e => e.Id).CurrentValue == twoIds![2]);
 
-            Assert.Contains(rightEntities[0].OneSkip, e => context.Entry(e).Property(e => e.Id).CurrentValue == oneIds[0]);
-            Assert.Contains(rightEntities[0].OneSkip, e => context.Entry(e).Property(e => e.Id).CurrentValue == oneIds[1]);
-            Assert.Contains(rightEntities[0].OneSkip, e => context.Entry(e).Property(e => e.Id).CurrentValue == oneIds[2]);
+            Assert.Contains(rightEntities[0].OneSkip, e => context.Entry(e).Property(e => e.Id).CurrentValue == oneIds![0]);
+            Assert.Contains(rightEntities[0].OneSkip, e => context.Entry(e).Property(e => e.Id).CurrentValue == oneIds![1]);
+            Assert.Contains(rightEntities[0].OneSkip, e => context.Entry(e).Property(e => e.Id).CurrentValue == oneIds![2]);
 
             Assert.DoesNotContain(leftEntities[1].TwoSkip, e => e.Name == "EntityTwo 1");
             Assert.DoesNotContain(rightEntities[1].OneSkip, e => e.Name == "EntityOne 1");
 
             Assert.DoesNotContain(leftEntities[2].TwoSkip, e => e.Name == "EntityTwo 1");
-            Assert.Contains(leftEntities[2].TwoSkip, e => context.Entry(e).Property(e => e.Id).CurrentValue == twoIds[3]);
+            Assert.Contains(leftEntities[2].TwoSkip, e => context.Entry(e).Property(e => e.Id).CurrentValue == twoIds![3]);
 
             Assert.DoesNotContain(rightEntities[2].OneSkip, e => e.Name == "EntityOne 1");
-            Assert.Contains(rightEntities[2].OneSkip, e => context.Entry(e).Property(e => e.Id).CurrentValue == oneIds[3]);
+            Assert.Contains(rightEntities[2].OneSkip, e => context.Entry(e).Property(e => e.Id).CurrentValue == oneIds![3]);
 
             var allLeft = context.ChangeTracker.Entries<EntityOne>().Select(e => e.Entity).OrderBy(e => e.Name).ToList();
             var allRight = context.ChangeTracker.Entries<EntityTwo>().Select(e => e.Entity).OrderBy(e => e.Name).ToList();
@@ -3869,13 +3867,13 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>(TFixture fixt
                 {
                     if (left.TwoSkip?.Contains(right) == true)
                     {
-                        Assert.Contains(left, right.OneSkip);
+                        Assert.Contains(left, right.OneSkip!);
                         count++;
                     }
 
                     if (right.OneSkip?.Contains(left) == true)
                     {
-                        Assert.Contains(right, left.TwoSkip);
+                        Assert.Contains(right, left.TwoSkip!);
                         count++;
                     }
                 }
@@ -3980,7 +3978,7 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>(TFixture fixt
     [Theory, InlineData(false), InlineData(true)]
     public virtual async Task Can_insert_many_to_many_fully_by_convention(bool async)
     {
-        List<int> keys = null;
+        List<int> keys = null!;
 
         await ExecuteWithStrategyInTransactionAsync(
             async context =>
@@ -4034,7 +4032,7 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>(TFixture fixt
             },
             async context =>
             {
-                var queryable = context.Set<ImplicitManyToManyA>().Where(e => keys.Contains(e.Id)).Include(e => e.Bs);
+                var queryable = context.Set<ImplicitManyToManyA>().Where(e => keys!.Contains(e.Id)).Include(e => e.Bs);
                 var results = async ? await queryable.ToListAsync() : queryable.ToList();
                 Assert.Equal(3, results.Count);
 
@@ -4327,7 +4325,7 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>(TFixture fixt
     [Theory, InlineData(false), InlineData(true)]
     public virtual async Task Initial_tracking_uses_skip_navigations(bool async)
     {
-        List<int> keys = null;
+        List<int> keys = null!;
 
         await ExecuteWithStrategyInTransactionAsync(
             async context =>
@@ -4375,7 +4373,7 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>(TFixture fixt
             },
             async context =>
             {
-                var queryable = context.Set<ImplicitManyToManyA>().Where(e => keys.Contains(e.Id)).Include(e => e.Bs);
+                var queryable = context.Set<ImplicitManyToManyA>().Where(e => keys!.Contains(e.Id)).Include(e => e.Bs);
                 var results = async ? await queryable.ToListAsync() : queryable.ToList();
                 Assert.Equal(3, results.Count);
 
@@ -4440,13 +4438,13 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>(TFixture fixt
             {
                 if (left.TwoSkip?.Contains(right) == true)
                 {
-                    Assert.Contains(left, right.OneSkip);
+                    Assert.Contains(left, right.OneSkip!);
                     joinCount++;
                 }
 
                 if (right.OneSkip?.Contains(left) == true)
                 {
-                    Assert.Contains(right, left.TwoSkip);
+                    Assert.Contains(right, left.TwoSkip!);
                     joinCount++;
                 }
             }
@@ -4516,12 +4514,12 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>(TFixture fixt
 
                 await context.SaveChangesAsync();
 
-                id = (int)entity["Id"];
+                id = (int)entity["Id"]!;
             }, async context =>
             {
-                var entity = await context.Set<ProxyableSharedType>("PST").SingleAsync(e => (int)e["Id"] == id);
+                var entity = await context.Set<ProxyableSharedType>("PST").SingleAsync(e => (int)e["Id"]! == id);
 
-                Assert.Equal("NewlyAdded", (string)entity["Payload"]);
+                Assert.Equal("NewlyAdded", (string)entity["Payload"]!);
 
                 entity["Payload"] = "AlreadyUpdated";
 
@@ -4533,15 +4531,15 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>(TFixture fixt
                 await context.SaveChangesAsync();
             }, async context =>
             {
-                var entity = await context.Set<ProxyableSharedType>("PST").SingleAsync(e => (int)e["Id"] == id);
+                var entity = await context.Set<ProxyableSharedType>("PST").SingleAsync(e => (int)e["Id"]! == id);
 
-                Assert.Equal("AlreadyUpdated", (string)entity["Payload"]);
+                Assert.Equal("AlreadyUpdated", (string)entity["Payload"]!);
 
                 context.Set<ProxyableSharedType>("PST").Remove(entity);
 
                 await context.SaveChangesAsync();
 
-                Assert.False(await context.Set<ProxyableSharedType>("PST").AnyAsync(e => (int)e["Id"] == id));
+                Assert.False(await context.Set<ProxyableSharedType>("PST").AnyAsync(e => (int)e["Id"]! == id));
             });
     }
 
@@ -4642,7 +4640,7 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>(TFixture fixt
             async context =>
             {
                 var queryable = context.Set<EntityTwo>()
-                    .Where(e => e.Name.StartsWith("Z"))
+                    .Where(e => e.Name!.StartsWith("Z"))
                     .OrderBy(e => e.Name)
                     .Include(e => e.ThreeSkipFull);
 
@@ -5656,20 +5654,20 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>(TFixture fixt
 
                             if (navigation.IsCollection)
                             {
-                                var currentCollection = ((IEnumerable<object>)current)?.ToList();
-                                var snapshotCollection = ((IEnumerable<object>)snapshot)?.ToList();
+                                var currentCollection = ((IEnumerable<object>)current!)?.ToList();
+                                var snapshotCollection = ((IEnumerable<object>)snapshot!)?.ToList();
 
                                 if (snapshot == null)
                                 {
-                                    Assert.True(current == null || !currentCollection.Any());
+                                    Assert.True(current == null || !currentCollection!.Any());
                                 }
                                 else if (current == null)
                                 {
-                                    Assert.True(snapshot == null || !snapshotCollection.Any());
+                                    Assert.True(snapshot == null || !snapshotCollection!.Any());
                                 }
                                 else
                                 {
-                                    Assert.Equal(snapshotCollection.Count, currentCollection.Count);
+                                    Assert.Equal(snapshotCollection!.Count, currentCollection!.Count);
 
                                     foreach (var related in snapshotCollection)
                                     {
@@ -5699,9 +5697,9 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>(TFixture fixt
 
     protected virtual Task ExecuteWithStrategyInTransactionAsync(
         Func<ManyToManyContext, Task> testOperation,
-        Func<ManyToManyContext, Task> nestedTestOperation1 = null,
-        Func<ManyToManyContext, Task> nestedTestOperation2 = null,
-        Func<ManyToManyContext, Task> nestedTestOperation3 = null)
+        Func<ManyToManyContext, Task>? nestedTestOperation1 = null,
+        Func<ManyToManyContext, Task>? nestedTestOperation2 = null,
+        Func<ManyToManyContext, Task>? nestedTestOperation3 = null)
         => TestHelpers.ExecuteWithStrategyInTransactionAsync(
             CreateContext, UseTransaction,
             testOperation, nestedTestOperation1, nestedTestOperation2, nestedTestOperation3);

--- a/test/EFCore.Specification.Tests/ModelBuilding/ModelBuilderTest.ComplexCollections.cs
+++ b/test/EFCore.Specification.Tests/ModelBuilding/ModelBuilderTest.ComplexCollections.cs
@@ -7,8 +7,6 @@ using Microsoft.EntityFrameworkCore.Metadata.Internal;
 // ReSharper disable InconsistentNaming
 namespace Microsoft.EntityFrameworkCore.ModelBuilding;
 
-#nullable disable
-
 public abstract partial class ModelBuilderTest
 {
     public abstract class ComplexCollectionTestBase(ModelBuilderFixtureBase fixture) : ModelBuilderTestBase(fixture)
@@ -37,7 +35,7 @@ public abstract partial class ModelBuilderTest
                 .Ignore(c => c.Orders);
 
             var model = modelBuilder.FinalizeModel();
-            var complexCollection = model.FindEntityType(typeof(ComplexProperties)).GetComplexProperties().Single();
+            var complexCollection = model.FindEntityType(typeof(ComplexProperties))!.GetComplexProperties().Single();
 
             Assert.Equal("bar", complexCollection.ComplexType["foo"]);
             Assert.Equal("bar2", complexCollection["foo2"]);
@@ -70,10 +68,10 @@ public abstract partial class ModelBuilderTest
                 .Property(c => c.Name).HasAnnotation("foo", "bar");
 
             var model = modelBuilder.FinalizeModel();
-            var complexCollection = model.FindEntityType(typeof(ComplexProperties)).GetComplexProperties().Single();
+            var complexCollection = model.FindEntityType(typeof(ComplexProperties))!.GetComplexProperties().Single();
             var property = complexCollection.ComplexType.FindProperty(nameof(Customer.Name));
 
-            Assert.Equal("bar", property["foo"]);
+            Assert.Equal("bar", property!["foo"]);
         }
 
         [Fact]
@@ -93,10 +91,10 @@ public abstract partial class ModelBuilderTest
                 .Property<string>(Customer.NameProperty.Name).HasAnnotation("foo", "bar");
 
             var model = modelBuilder.FinalizeModel();
-            var complexCollection = model.FindEntityType(typeof(ComplexProperties)).GetComplexProperties().Single();
+            var complexCollection = model.FindEntityType(typeof(ComplexProperties))!.GetComplexProperties().Single();
             var property = complexCollection.ComplexType.FindProperty(nameof(Customer.Name));
 
-            Assert.Equal("bar", property["foo"]);
+            Assert.Equal("bar", property!["foo"]);
         }
 
         [Fact]
@@ -116,10 +114,10 @@ public abstract partial class ModelBuilderTest
                 .Property(c => c.Name);
 
             var model = modelBuilder.FinalizeModel();
-            var complexCollection = model.FindEntityType(typeof(ComplexProperties)).GetComplexProperties().Single();
+            var complexCollection = model.FindEntityType(typeof(ComplexProperties))!.GetComplexProperties().Single();
             var property = complexCollection.ComplexType.FindProperty(nameof(Customer.Name));
 
-            Assert.Equal("bar", property["foo"]);
+            Assert.Equal("bar", property!["foo"]);
         }
 
         [Fact(Skip = "Issue #35613")]
@@ -145,14 +143,14 @@ public abstract partial class ModelBuilderTest
                     });
 
             var model = modelBuilder.FinalizeModel();
-            var complexType = model.FindEntityType(typeof(ComplexProperties)).GetComplexProperties().Single().ComplexType;
+            var complexType = model.FindEntityType(typeof(ComplexProperties))!.GetComplexProperties().Single().ComplexType;
 
-            Assert.False(complexType.FindProperty("Up").IsNullable);
-            Assert.True(complexType.FindProperty("Down").IsNullable);
-            Assert.False(complexType.FindProperty("Charm").IsNullable);
-            Assert.True(complexType.FindProperty("Strange").IsNullable);
-            Assert.False(complexType.FindProperty("Top").IsNullable);
-            Assert.True(complexType.FindProperty("Bottom").IsNullable);
+            Assert.False(complexType.FindProperty("Up")!.IsNullable);
+            Assert.True(complexType.FindProperty("Down")!.IsNullable);
+            Assert.False(complexType.FindProperty("Charm")!.IsNullable);
+            Assert.True(complexType.FindProperty("Strange")!.IsNullable);
+            Assert.False(complexType.FindProperty("Top")!.IsNullable);
+            Assert.True(complexType.FindProperty("Bottom")!.IsNullable);
         }
 
         [Fact]
@@ -179,7 +177,7 @@ public abstract partial class ModelBuilderTest
                     });
 
             var model = modelBuilder.FinalizeModel();
-            var complexType = model.FindEntityType(typeof(ComplexProperties)).GetComplexProperties().Single().ComplexType;
+            var complexType = model.FindEntityType(typeof(ComplexProperties))!.GetComplexProperties().Single().ComplexType;
 
             Assert.Contains(nameof(Quarks.Id), complexType.GetProperties().Select(p => p.Name));
             Assert.DoesNotContain(nameof(Quarks.Up), complexType.GetProperties().Select(p => p.Name));
@@ -199,7 +197,7 @@ public abstract partial class ModelBuilderTest
                 .ComplexCollection(e => e.Customers, b => ConfigureComplexCollection(b).Ignore(c => c.Details).Ignore(c => c.Orders));
 
             var model = modelBuilder.FinalizeModel();
-            var complexType = model.FindEntityType(typeof(ComplexProperties)).GetComplexProperties().Single().ComplexType;
+            var complexType = model.FindEntityType(typeof(ComplexProperties))!.GetComplexProperties().Single().ComplexType;
             Assert.Null(complexType.FindProperty(nameof(Customer.AlternateKey)));
         }
 
@@ -220,7 +218,7 @@ public abstract partial class ModelBuilderTest
 
             var model = modelBuilder.FinalizeModel();
 
-            var complexType = model.FindEntityType(typeof(ComplexProperties)).GetComplexProperties().Single().ComplexType;
+            var complexType = model.FindEntityType(typeof(ComplexProperties))!.GetComplexProperties().Single().ComplexType;
             Assert.Null(complexType.FindProperty("Shadow"));
         }
 
@@ -247,7 +245,7 @@ public abstract partial class ModelBuilderTest
 
             var model = modelBuilder.FinalizeModel();
 
-            var complexType = model.FindEntityType(typeof(ComplexProperties)).GetComplexProperties().Single().ComplexType;
+            var complexType = model.FindEntityType(typeof(ComplexProperties))!.GetComplexProperties().Single().ComplexType;
             Assert.NotNull(complexType.FindProperty("Shadow"));
         }
 
@@ -274,14 +272,14 @@ public abstract partial class ModelBuilderTest
                     });
 
             var model = modelBuilder.FinalizeModel();
-            var complexType = model.FindEntityType(typeof(ComplexProperties)).GetComplexProperties().Single().ComplexType;
+            var complexType = model.FindEntityType(typeof(ComplexProperties))!.GetComplexProperties().Single().ComplexType;
 
-            Assert.False(complexType.FindProperty("Up").IsNullable);
-            Assert.False(complexType.FindProperty("Down").IsNullable);
-            Assert.False(complexType.FindProperty("Charm").IsNullable);
-            Assert.False(complexType.FindProperty("Strange").IsNullable);
-            Assert.False(complexType.FindProperty("Top").IsNullable);
-            Assert.False(complexType.FindProperty("Bottom").IsNullable);
+            Assert.False(complexType.FindProperty("Up")!.IsNullable);
+            Assert.False(complexType.FindProperty("Down")!.IsNullable);
+            Assert.False(complexType.FindProperty("Charm")!.IsNullable);
+            Assert.False(complexType.FindProperty("Strange")!.IsNullable);
+            Assert.False(complexType.FindProperty("Top")!.IsNullable);
+            Assert.False(complexType.FindProperty("Bottom")!.IsNullable);
         }
 
         [Fact(Skip = "Issue #35613")]
@@ -305,13 +303,13 @@ public abstract partial class ModelBuilderTest
                     });
 
             var model = modelBuilder.FinalizeModel();
-            var complexProperty = model.FindEntityType(typeof(ComplexProperties)).GetComplexProperties().Single();
+            var complexProperty = model.FindEntityType(typeof(ComplexProperties))!.GetComplexProperties().Single();
             Assert.True(complexProperty.IsNullable);
 
             var complexType = complexProperty.ComplexType;
-            Assert.True(complexType.FindProperty("Down").IsNullable);
-            Assert.True(complexType.FindProperty("Strange").IsNullable);
-            Assert.True(complexType.FindProperty("Bottom").IsNullable);
+            Assert.True(complexType.FindProperty("Down")!.IsNullable);
+            Assert.True(complexType.FindProperty("Strange")!.IsNullable);
+            Assert.True(complexType.FindProperty("Bottom")!.IsNullable);
         }
 
         [Fact(Skip = "Issue #35613")]
@@ -342,11 +340,11 @@ public abstract partial class ModelBuilderTest
                     });
 
             var model = modelBuilder.FinalizeModel();
-            var complexType = model.FindEntityType(typeof(ComplexProperties)).GetComplexProperties().Single().ComplexType;
+            var complexType = model.FindEntityType(typeof(ComplexProperties))!.GetComplexProperties().Single().ComplexType;
 
-            Assert.False(complexType.FindProperty("Up").IsNullable);
-            Assert.False(complexType.FindProperty("Charm").IsNullable);
-            Assert.False(complexType.FindProperty("Top").IsNullable);
+            Assert.False(complexType.FindProperty("Up")!.IsNullable);
+            Assert.False(complexType.FindProperty("Charm")!.IsNullable);
+            Assert.False(complexType.FindProperty("Top")!.IsNullable);
         }
 
         [Fact(Skip = "Issue #35613")]
@@ -370,18 +368,18 @@ public abstract partial class ModelBuilderTest
                     });
 
             var model = modelBuilder.FinalizeModel();
-            var complexType = model.FindEntityType(typeof(ComplexProperties)).GetComplexProperties().Single().ComplexType;
+            var complexType = model.FindEntityType(typeof(ComplexProperties))!.GetComplexProperties().Single().ComplexType;
 
-            Assert.False(complexType.FindProperty("Up").IsShadowProperty());
-            Assert.False(complexType.FindProperty("Down").IsShadowProperty());
-            Assert.True(complexType.FindProperty("Gluon").IsShadowProperty());
-            Assert.True(complexType.FindProperty("Photon").IsShadowProperty());
+            Assert.False(complexType.FindProperty("Up")!.IsShadowProperty());
+            Assert.False(complexType.FindProperty("Down")!.IsShadowProperty());
+            Assert.True(complexType.FindProperty("Gluon")!.IsShadowProperty());
+            Assert.True(complexType.FindProperty("Photon")!.IsShadowProperty());
 
-            Assert.Equal(-1, complexType.FindProperty("Up").GetShadowIndex());
-            Assert.Equal(-1, complexType.FindProperty("Down").GetShadowIndex());
-            Assert.NotEqual(-1, complexType.FindProperty("Gluon").GetShadowIndex());
-            Assert.NotEqual(-1, complexType.FindProperty("Photon").GetShadowIndex());
-            Assert.NotEqual(complexType.FindProperty("Gluon").GetShadowIndex(), complexType.FindProperty("Photon").GetShadowIndex());
+            Assert.Equal(-1, complexType.FindProperty("Up")!.GetShadowIndex());
+            Assert.Equal(-1, complexType.FindProperty("Down")!.GetShadowIndex());
+            Assert.NotEqual(-1, complexType.FindProperty("Gluon")!.GetShadowIndex());
+            Assert.NotEqual(-1, complexType.FindProperty("Photon")!.GetShadowIndex());
+            Assert.NotEqual(complexType.FindProperty("Gluon")!.GetShadowIndex(), complexType.FindProperty("Photon")!.GetShadowIndex());
         }
 
         [Fact(Skip = "Issue #35613")]
@@ -489,29 +487,29 @@ public abstract partial class ModelBuilderTest
                     });
 
             var model = modelBuilder.FinalizeModel();
-            var complexType = model.FindEntityType(typeof(ComplexProperties)).GetComplexProperties().Single().ComplexType;
+            var complexType = model.FindEntityType(typeof(ComplexProperties))!.GetComplexProperties().Single().ComplexType;
 
             var up = complexType.FindProperty("Up");
-            Assert.Null(up.GetProviderClrType());
+            Assert.Null(up!.GetProviderClrType());
             Assert.True(up.GetValueComparer().IsDefault());
 
             var down = complexType.FindProperty("Down");
-            Assert.Same(typeof(byte[]), down.GetProviderClrType());
+            Assert.Same(typeof(byte[]), down!.GetProviderClrType());
             Assert.True(down.GetValueComparer().IsDefault());
             Assert.True(down.GetProviderValueComparer() is ValueComparer<TBytes>);
 
             var charm = complexType.FindProperty("Charm");
-            Assert.Same(typeof(long), charm.GetProviderClrType());
+            Assert.Same(typeof(long), charm!.GetProviderClrType());
             Assert.IsType<CustomValueComparer<int>>(charm.GetValueComparer());
             Assert.True(charm.GetProviderValueComparer().IsDefault());
 
             var strange = complexType.FindProperty("Strange");
-            Assert.Null(strange.GetProviderClrType());
+            Assert.Null(strange!.GetProviderClrType());
             Assert.True(strange.GetValueComparer().IsDefault());
             Assert.True(strange.GetProviderValueComparer().IsDefault());
 
             var top = complexType.FindProperty("Top");
-            Assert.Same(typeof(string), top.GetProviderClrType());
+            Assert.Same(typeof(string), top!.GetProviderClrType());
             Assert.IsType<CustomValueComparer<string>>(top.GetValueComparer());
             Assert.True(top.GetProviderValueComparer() is ValueComparer<string>);
         }
@@ -537,7 +535,7 @@ public abstract partial class ModelBuilderTest
                     });
 
             var model = modelBuilder.FinalizeModel();
-            var complexType = model.FindEntityType(typeof(ComplexProperties)).GetComplexProperties().Single().ComplexType;
+            var complexType = model.FindEntityType(typeof(ComplexProperties))!.GetComplexProperties().Single().ComplexType;
 
             Assert.Null(complexType.FindProperty("Up")!.GetProviderClrType());
             Assert.Same(typeof(byte[]), complexType.FindProperty("Down")!.GetProviderClrType());
@@ -573,21 +571,21 @@ public abstract partial class ModelBuilderTest
                     });
 
             var model = modelBuilder.FinalizeModel();
-            var complexType = model.FindEntityType(typeof(ComplexProperties)).GetComplexProperties().Single().ComplexType;
+            var complexType = model.FindEntityType(typeof(ComplexProperties))!.GetComplexProperties().Single().ComplexType;
 
-            Assert.Null(complexType.FindProperty("Up").GetValueConverter());
+            Assert.Null(complexType.FindProperty("Up")!.GetValueConverter());
 
             var down = complexType.FindProperty("Down");
-            Assert.Same(stringConverter, down.GetValueConverter());
+            Assert.Same(stringConverter, down!.GetValueConverter());
             Assert.True(down.GetValueComparer().IsDefault());
             Assert.True(down.GetProviderValueComparer() is ValueComparer<TBytes>);
 
             var charm = complexType.FindProperty("Charm");
-            Assert.Same(intConverter, charm.GetValueConverter());
+            Assert.Same(intConverter, charm!.GetValueConverter());
             Assert.True(charm.GetValueComparer().IsDefault());
             Assert.IsType<CustomValueComparer<long>>(charm.GetProviderValueComparer());
 
-            Assert.Null(complexType.FindProperty("Strange").GetValueConverter());
+            Assert.Null(complexType.FindProperty("Strange")!.GetValueConverter());
         }
 
         [Fact(Skip = "Issue #35613")]
@@ -616,26 +614,26 @@ public abstract partial class ModelBuilderTest
                     });
 
             var model = modelBuilder.FinalizeModel();
-            var complexType = model.FindEntityType(typeof(ComplexProperties)).GetComplexProperties().Single().ComplexType;
+            var complexType = model.FindEntityType(typeof(ComplexProperties))!.GetComplexProperties().Single().ComplexType;
 
             var up = complexType.FindProperty("Up");
-            Assert.Equal(typeof(int), up.GetProviderClrType());
+            Assert.Equal(typeof(int), up!.GetProviderClrType());
             Assert.Null(up.GetValueConverter());
             Assert.IsType<CustomValueComparer<int>>(up.GetValueComparer());
             Assert.IsType<CustomValueComparer<int>>(up.GetProviderValueComparer());
 
             var down = complexType.FindProperty("Down");
-            Assert.IsType<UTF8StringToBytesConverter>(down.GetValueConverter());
+            Assert.IsType<UTF8StringToBytesConverter>(down!.GetValueConverter());
             Assert.IsType<CustomValueComparer<string>>(down.GetValueComparer());
             Assert.True(down.GetProviderValueComparer() is ValueComparer<TBytes>);
 
             var charm = complexType.FindProperty("Charm");
-            Assert.IsType<CastingConverter<int, long>>(charm.GetValueConverter());
+            Assert.IsType<CastingConverter<int, long>>(charm!.GetValueConverter());
             Assert.IsType<CustomValueComparer<int>>(charm.GetValueComparer());
             Assert.True(charm.GetProviderValueComparer().IsDefault());
 
             var strange = complexType.FindProperty("Strange");
-            Assert.Null(strange.GetValueConverter());
+            Assert.Null(strange!.GetValueConverter());
             Assert.True(strange.GetValueComparer().IsDefault());
             Assert.True(strange.GetProviderValueComparer().IsDefault());
         }
@@ -659,33 +657,33 @@ public abstract partial class ModelBuilderTest
                     {
                         ConfigureComplexCollection(b);
                         b.Property(e => e.Up);
-                        b.Property(e => e.Down).HasConversion(v => int.Parse(v), v => v.ToString());
+                        b.Property(e => e.Down).HasConversion(v => int.Parse(v!), v => v.ToString());
                         b.Property<int>("Charm").HasConversion(v => (long)v, v => (int)v, new CustomValueComparer<int>());
                         b.Property<float>("Strange").HasConversion(
                             v => (double)v, v => (float)v, new CustomValueComparer<float>(), new CustomValueComparer<double>());
                     });
 
             var model = modelBuilder.FinalizeModel();
-            var complexType = model.FindEntityType(typeof(ComplexProperties)).GetComplexProperties().Single().ComplexType;
+            var complexType = model.FindEntityType(typeof(ComplexProperties))!.GetComplexProperties().Single().ComplexType;
 
             var up = complexType.FindProperty("Up");
-            Assert.Null(up.GetProviderClrType());
+            Assert.Null(up!.GetProviderClrType());
             Assert.Null(up.GetValueConverter());
             Assert.True(up.GetValueComparer().IsDefault());
             Assert.True(up.GetProviderValueComparer().IsDefault());
 
             var down = complexType.FindProperty("Down");
-            Assert.IsType<ValueConverter<string, int>>(down.GetValueConverter());
+            Assert.IsType<ValueConverter<string, int>>(down!.GetValueConverter());
             Assert.True(down.GetValueComparer().IsDefault());
             Assert.True(down.GetProviderValueComparer().IsDefault());
 
             var charm = complexType.FindProperty("Charm");
-            Assert.IsType<ValueConverter<int, long>>(charm.GetValueConverter());
+            Assert.IsType<ValueConverter<int, long>>(charm!.GetValueConverter());
             Assert.IsType<CustomValueComparer<int>>(charm.GetValueComparer());
             Assert.True(charm.GetProviderValueComparer().IsDefault());
 
             var strange = complexType.FindProperty("Strange");
-            Assert.IsType<ValueConverter<float, double>>(strange.GetValueConverter());
+            Assert.IsType<ValueConverter<float, double>>(strange!.GetValueConverter());
             Assert.IsType<CustomValueComparer<float>>(strange.GetValueComparer());
             Assert.IsType<CustomValueComparer<double>>(strange.GetProviderValueComparer());
         }
@@ -706,7 +704,7 @@ public abstract partial class ModelBuilderTest
                         ConfigureComplexCollection(b);
                         b.Property(e => e.Up);
                         b.Property(e => e.Down).HasConversion(
-                            new ValueConverter<string, int>(v => int.Parse(v), v => v.ToString()));
+                            new ValueConverter<string?, int>(v => int.Parse(v!), v => v.ToString()));
                         b.Property<int>("Charm").HasConversion(
                             new ValueConverter<int, long>(v => v, v => (int)v), new CustomValueComparer<int>());
                         b.Property<float>("Strange").HasConversion(
@@ -715,26 +713,26 @@ public abstract partial class ModelBuilderTest
                     });
 
             var model = modelBuilder.FinalizeModel();
-            var complexType = model.FindEntityType(typeof(ComplexProperties)).GetComplexProperties().Single().ComplexType;
+            var complexType = model.FindEntityType(typeof(ComplexProperties))!.GetComplexProperties().Single().ComplexType;
 
             var up = complexType.FindProperty("Up");
-            Assert.Null(up.GetProviderClrType());
+            Assert.Null(up!.GetProviderClrType());
             Assert.Null(up.GetValueConverter());
             Assert.True(up.GetValueComparer().IsDefault());
             Assert.True(up.GetProviderValueComparer().IsDefault());
 
             var down = complexType.FindProperty("Down");
-            Assert.IsType<ValueConverter<string, int>>(down.GetValueConverter());
+            Assert.IsType<ValueConverter<string, int>>(down!.GetValueConverter());
             Assert.True(down.GetValueComparer().IsDefault());
             Assert.True(down.GetProviderValueComparer().IsDefault());
 
             var charm = complexType.FindProperty("Charm");
-            Assert.IsType<ValueConverter<int, long>>(charm.GetValueConverter());
+            Assert.IsType<ValueConverter<int, long>>(charm!.GetValueConverter());
             Assert.IsType<CustomValueComparer<int>>(charm.GetValueComparer());
             Assert.True(charm.GetProviderValueComparer().IsDefault());
 
             var strange = complexType.FindProperty("Strange");
-            Assert.IsType<ValueConverter<float, double>>(strange.GetValueConverter());
+            Assert.IsType<ValueConverter<float, double>>(strange!.GetValueConverter());
             Assert.IsType<CustomValueComparer<float>>(strange.GetValueComparer());
             Assert.IsType<CustomValueComparer<double>>(strange.GetProviderValueComparer());
         }
@@ -758,14 +756,14 @@ public abstract partial class ModelBuilderTest
                     });
 
             var model = modelBuilder.FinalizeModel();
-            var complexType = model.FindEntityType(typeof(ComplexProperties)).GetComplexProperties().Single().ComplexType;
+            var complexType = model.FindEntityType(typeof(ComplexProperties))!.GetComplexProperties().Single().ComplexType;
 
             var id = complexType.FindProperty("Id");
-            Assert.IsType<NumberToStringConverter<int>>(id.GetValueConverter());
+            Assert.IsType<NumberToStringConverter<int>>(id!.GetValueConverter());
             Assert.IsType<CustomValueComparer<int>>(id.GetValueComparer());
 
             var wierd = complexType.FindProperty("Wierd");
-            Assert.IsType<NumberToStringConverter<int>>(wierd.GetValueConverter());
+            Assert.IsType<NumberToStringConverter<int>>(wierd!.GetValueConverter());
             Assert.IsType<NullableValueComparer<int>>(wierd.GetValueComparer());
         }
 
@@ -792,15 +790,15 @@ public abstract partial class ModelBuilderTest
                     });
 
             var model = modelBuilder.FinalizeModel();
-            var complexType = model.FindEntityType(typeof(ComplexProperties)).GetComplexProperties().Single().ComplexType;
+            var complexType = model.FindEntityType(typeof(ComplexProperties))!.GetComplexProperties().Single().ComplexType;
 
             var id = complexType.FindProperty("Id");
-            Assert.IsType<NumberToStringConverter<int>>(id.GetValueConverter());
+            Assert.IsType<NumberToStringConverter<int>>(id!.GetValueConverter());
             Assert.IsType<CustomValueComparer<int>>(id.GetValueComparer());
             Assert.IsType<CustomValueComparer<string>>(id.GetProviderValueComparer());
 
             var wierd = complexType.FindProperty("Wierd");
-            Assert.IsType<NumberToStringConverter<int?>>(wierd.GetValueConverter());
+            Assert.IsType<NumberToStringConverter<int?>>(wierd!.GetValueConverter());
             Assert.IsType<CustomValueComparer<int?>>(wierd.GetValueComparer());
             Assert.IsType<CustomValueComparer<string>>(wierd.GetProviderValueComparer());
         }
@@ -826,8 +824,8 @@ public abstract partial class ModelBuilderTest
                     });
 
             var model = modelBuilder.FinalizeModel();
-            var complexType = model.FindEntityType(typeof(ComplexProperties)).GetComplexProperties().Single().ComplexType;
-            Assert.Null(complexType.FindProperty("Up").GetValueConverter());
+            var complexType = model.FindEntityType(typeof(ComplexProperties))!.GetComplexProperties().Single().ComplexType;
+            Assert.Null(complexType.FindProperty("Up")!.GetValueConverter());
         }
 
         [Fact]
@@ -850,11 +848,11 @@ public abstract partial class ModelBuilderTest
                     });
 
             var model = modelBuilder.FinalizeModel();
-            var complexType = model.FindEntityType(typeof(ComplexProperties)).GetComplexProperties().Single().ComplexType;
+            var complexType = model.FindEntityType(typeof(ComplexProperties))!.GetComplexProperties().Single().ComplexType;
 
-            Assert.Equal("_forUp", complexType.FindProperty("Up").GetFieldName());
-            Assert.Equal("_forDown", complexType.FindProperty("Down").GetFieldName());
-            Assert.Equal("_forWierd", complexType.FindProperty("_forWierd").GetFieldName());
+            Assert.Equal("_forUp", complexType.FindProperty("Up")!.GetFieldName());
+            Assert.Equal("_forDown", complexType.FindProperty("Down")!.GetFieldName());
+            Assert.Equal("_forWierd", complexType.FindProperty("_forWierd")!.GetFieldName());
         }
 
         [Fact]
@@ -922,15 +920,15 @@ public abstract partial class ModelBuilderTest
                     });
 
             var model = modelBuilder.FinalizeModel();
-            var complexType = model.FindEntityType(typeof(ComplexProperties)).GetComplexProperties().Single().ComplexType;
+            var complexType = model.FindEntityType(typeof(ComplexProperties))!.GetComplexProperties().Single().ComplexType;
 
-            Assert.Equal(0, complexType.FindProperty(Customer.IdProperty.Name).GetMaxLength());
-            Assert.Equal(0, complexType.FindProperty("Up").GetMaxLength());
-            Assert.Equal(100, complexType.FindProperty("Down").GetMaxLength());
-            Assert.Equal(0, complexType.FindProperty("Charm").GetMaxLength());
-            Assert.Equal(100, complexType.FindProperty("Strange").GetMaxLength());
-            Assert.Equal(0, complexType.FindProperty("Top").GetMaxLength());
-            Assert.Equal(100, complexType.FindProperty("Bottom").GetMaxLength());
+            Assert.Equal(0, complexType.FindProperty(Customer.IdProperty.Name)!.GetMaxLength());
+            Assert.Equal(0, complexType.FindProperty("Up")!.GetMaxLength());
+            Assert.Equal(100, complexType.FindProperty("Down")!.GetMaxLength());
+            Assert.Equal(0, complexType.FindProperty("Charm")!.GetMaxLength());
+            Assert.Equal(100, complexType.FindProperty("Strange")!.GetMaxLength());
+            Assert.Equal(0, complexType.FindProperty("Top")!.GetMaxLength());
+            Assert.Equal(100, complexType.FindProperty("Bottom")!.GetMaxLength());
         }
 
         [Fact(Skip = "Issue #35613")]
@@ -956,7 +954,7 @@ public abstract partial class ModelBuilderTest
                     });
 
             var model = modelBuilder.FinalizeModel();
-            var complexType = model.FindEntityType(typeof(ComplexProperties)).GetComplexProperties().Single().ComplexType;
+            var complexType = model.FindEntityType(typeof(ComplexProperties))!.GetComplexProperties().Single().ComplexType;
 
             Assert.Equal(0, complexType.FindProperty(Customer.IdProperty.Name)!.Sentinel);
             Assert.Equal(1, complexType.FindProperty("Up")!.Sentinel);
@@ -992,7 +990,7 @@ public abstract partial class ModelBuilderTest
                     });
 
             var model = modelBuilder.FinalizeModel();
-            var complexType = model.FindEntityType(typeof(ComplexProperties)).GetComplexProperties().Single().ComplexType;
+            var complexType = model.FindEntityType(typeof(ComplexProperties))!.GetComplexProperties().Single().ComplexType;
 
             Assert.Equal(-1, complexType.FindProperty(Customer.IdProperty.Name)!.Sentinel);
             Assert.Equal(-1, complexType.FindProperty("Up")!.Sentinel);
@@ -1028,15 +1026,15 @@ public abstract partial class ModelBuilderTest
                     });
 
             var model = modelBuilder.FinalizeModel();
-            var complexType = model.FindEntityType(typeof(ComplexProperties)).GetComplexProperties().Single().ComplexType;
+            var complexType = model.FindEntityType(typeof(ComplexProperties))!.GetComplexProperties().Single().ComplexType;
 
-            Assert.Equal(0, complexType.FindProperty(Customer.IdProperty.Name).GetMaxLength());
-            Assert.Equal(0, complexType.FindProperty("Up").GetMaxLength());
-            Assert.Equal(-1, complexType.FindProperty("Down").GetMaxLength());
-            Assert.Equal(0, complexType.FindProperty("Charm").GetMaxLength());
-            Assert.Equal(-1, complexType.FindProperty("Strange").GetMaxLength());
-            Assert.Equal(0, complexType.FindProperty("Top").GetMaxLength());
-            Assert.Equal(-1, complexType.FindProperty("Bottom").GetMaxLength());
+            Assert.Equal(0, complexType.FindProperty(Customer.IdProperty.Name)!.GetMaxLength());
+            Assert.Equal(0, complexType.FindProperty("Up")!.GetMaxLength());
+            Assert.Equal(-1, complexType.FindProperty("Down")!.GetMaxLength());
+            Assert.Equal(0, complexType.FindProperty("Charm")!.GetMaxLength());
+            Assert.Equal(-1, complexType.FindProperty("Strange")!.GetMaxLength());
+            Assert.Equal(0, complexType.FindProperty("Top")!.GetMaxLength());
+            Assert.Equal(-1, complexType.FindProperty("Bottom")!.GetMaxLength());
         }
 
         [Fact(Skip = "Issue #35613")]
@@ -1064,22 +1062,22 @@ public abstract partial class ModelBuilderTest
                     });
 
             var model = modelBuilder.FinalizeModel();
-            var complexType = model.FindEntityType(typeof(ComplexProperties)).GetComplexProperties().Single().ComplexType;
+            var complexType = model.FindEntityType(typeof(ComplexProperties))!.GetComplexProperties().Single().ComplexType;
 
-            Assert.Equal(1, complexType.FindProperty(Customer.IdProperty.Name).GetPrecision());
-            Assert.Equal(0, complexType.FindProperty(Customer.IdProperty.Name).GetScale());
-            Assert.Equal(1, complexType.FindProperty("Up").GetPrecision());
-            Assert.Equal(0, complexType.FindProperty("Up").GetScale());
-            Assert.Equal(100, complexType.FindProperty("Down").GetPrecision());
-            Assert.Equal(10, complexType.FindProperty("Down").GetScale());
-            Assert.Equal(1, complexType.FindProperty("Charm").GetPrecision());
-            Assert.Equal(0, complexType.FindProperty("Charm").GetScale());
-            Assert.Equal(100, complexType.FindProperty("Strange").GetPrecision());
-            Assert.Equal(10, complexType.FindProperty("Strange").GetScale());
-            Assert.Equal(1, complexType.FindProperty("Top").GetPrecision());
-            Assert.Equal(0, complexType.FindProperty("Top").GetScale());
-            Assert.Equal(100, complexType.FindProperty("Bottom").GetPrecision());
-            Assert.Equal(10, complexType.FindProperty("Bottom").GetScale());
+            Assert.Equal(1, complexType.FindProperty(Customer.IdProperty.Name)!.GetPrecision());
+            Assert.Equal(0, complexType.FindProperty(Customer.IdProperty.Name)!.GetScale());
+            Assert.Equal(1, complexType.FindProperty("Up")!.GetPrecision());
+            Assert.Equal(0, complexType.FindProperty("Up")!.GetScale());
+            Assert.Equal(100, complexType.FindProperty("Down")!.GetPrecision());
+            Assert.Equal(10, complexType.FindProperty("Down")!.GetScale());
+            Assert.Equal(1, complexType.FindProperty("Charm")!.GetPrecision());
+            Assert.Equal(0, complexType.FindProperty("Charm")!.GetScale());
+            Assert.Equal(100, complexType.FindProperty("Strange")!.GetPrecision());
+            Assert.Equal(10, complexType.FindProperty("Strange")!.GetScale());
+            Assert.Equal(1, complexType.FindProperty("Top")!.GetPrecision());
+            Assert.Equal(0, complexType.FindProperty("Top")!.GetScale());
+            Assert.Equal(100, complexType.FindProperty("Bottom")!.GetPrecision());
+            Assert.Equal(10, complexType.FindProperty("Bottom")!.GetScale());
         }
 
         [Fact(Skip = "Issue #35613")]
@@ -1105,14 +1103,14 @@ public abstract partial class ModelBuilderTest
 
             var model = modelBuilder.FinalizeModel();
 
-            var complexType = model.FindEntityType(typeof(ComplexProperties)).GetComplexProperties().Single().ComplexType;
+            var complexType = model.FindEntityType(typeof(ComplexProperties))!.GetComplexProperties().Single().ComplexType;
 
-            Assert.Null(complexType.FindProperty(Customer.IdProperty.Name).GetValueGeneratorFactory());
-            Assert.IsType<CustomValueGenerator>(complexType.FindProperty("Up").GetValueGeneratorFactory()(null, null));
-            Assert.IsType<CustomValueGenerator>(complexType.FindProperty("Down").GetValueGeneratorFactory()(null, null));
-            Assert.IsType<CustomValueGenerator>(complexType.FindProperty("Strange").GetValueGeneratorFactory()(null, null));
-            Assert.IsType<CustomValueGenerator>(complexType.FindProperty("Top").GetValueGeneratorFactory()(null, null));
-            Assert.IsType<CustomValueGenerator>(complexType.FindProperty("Bottom").GetValueGeneratorFactory()(null, null));
+            Assert.Null(complexType.FindProperty(Customer.IdProperty.Name)!.GetValueGeneratorFactory());
+            Assert.IsType<CustomValueGenerator>(complexType.FindProperty("Up")!.GetValueGeneratorFactory()!(null!, null!));
+            Assert.IsType<CustomValueGenerator>(complexType.FindProperty("Down")!.GetValueGeneratorFactory()!(null!, null!));
+            Assert.IsType<CustomValueGenerator>(complexType.FindProperty("Strange")!.GetValueGeneratorFactory()!(null!, null!));
+            Assert.IsType<CustomValueGenerator>(complexType.FindProperty("Top")!.GetValueGeneratorFactory()!(null!, null!));
+            Assert.IsType<CustomValueGenerator>(complexType.FindProperty("Bottom")!.GetValueGeneratorFactory()!(null!, null!));
         }
 
         private class CustomValueGenerator : ValueGenerator<int>
@@ -1160,17 +1158,17 @@ public abstract partial class ModelBuilderTest
                         b.Property(e => e.Down).HasValueGenerator<BadCustomValueGenerator2>();
                     });
 
-            var complexType = model.FindEntityType(typeof(ComplexProperties))
+            var complexType = model.FindEntityType(typeof(ComplexProperties))!
                 .FindComplexProperty(nameof(ComplexProperties.QuarksCollection))!.ComplexType;
 
             Assert.Equal(
                 CoreStrings.CannotCreateValueGenerator(nameof(BadCustomValueGenerator1), "HasValueGenerator"),
-                Assert.Throws<InvalidOperationException>(() => complexType.FindProperty("Up").GetValueGeneratorFactory()(null, null))
+                Assert.Throws<InvalidOperationException>(() => complexType.FindProperty("Up")!.GetValueGeneratorFactory()!(null!, null!))
                     .Message);
 
             Assert.Equal(
                 CoreStrings.CannotCreateValueGenerator(nameof(BadCustomValueGenerator2), "HasValueGenerator"),
-                Assert.Throws<InvalidOperationException>(() => complexType.FindProperty("Down").GetValueGeneratorFactory()(null, null))
+                Assert.Throws<InvalidOperationException>(() => complexType.FindProperty("Down")!.GetValueGeneratorFactory()!(null!, null!))
                     .Message);
         }
 
@@ -1184,7 +1182,7 @@ public abstract partial class ModelBuilderTest
 
         protected class StringCollectionEntity
         {
-            public ICollection<string> Property { get; set; }
+            public ICollection<string> Property { get; set; } = null!;
         }
 
         [Fact(Skip = "Issue #35613")]
@@ -1210,15 +1208,15 @@ public abstract partial class ModelBuilderTest
                     });
 
             var model = modelBuilder.FinalizeModel();
-            var complexType = model.FindEntityType(typeof(ComplexProperties)).GetComplexProperties().Single().ComplexType;
+            var complexType = model.FindEntityType(typeof(ComplexProperties))!.GetComplexProperties().Single().ComplexType;
 
-            Assert.Null(complexType.FindProperty(Customer.IdProperty.Name).IsUnicode());
-            Assert.True(complexType.FindProperty("Up").IsUnicode());
-            Assert.False(complexType.FindProperty("Down").IsUnicode());
-            Assert.True(complexType.FindProperty("Charm").IsUnicode());
-            Assert.False(complexType.FindProperty("Strange").IsUnicode());
-            Assert.True(complexType.FindProperty("Top").IsUnicode());
-            Assert.False(complexType.FindProperty("Bottom").IsUnicode());
+            Assert.Null(complexType.FindProperty(Customer.IdProperty.Name)!.IsUnicode());
+            Assert.True(complexType.FindProperty("Up")!.IsUnicode());
+            Assert.False(complexType.FindProperty("Down")!.IsUnicode());
+            Assert.True(complexType.FindProperty("Charm")!.IsUnicode());
+            Assert.False(complexType.FindProperty("Strange")!.IsUnicode());
+            Assert.True(complexType.FindProperty("Top")!.IsUnicode());
+            Assert.False(complexType.FindProperty("Bottom")!.IsUnicode());
         }
 
         [Fact(Skip = "Issue #35613")]
@@ -1246,15 +1244,15 @@ public abstract partial class ModelBuilderTest
                     });
 
             var model = modelBuilder.FinalizeModel();
-            var complexType = model.FindEntityType(typeof(ComplexProperties)).GetComplexProperties().Single().ComplexType;
+            var complexType = model.FindEntityType(typeof(ComplexProperties))!.GetComplexProperties().Single().ComplexType;
 
-            Assert.True(complexType.FindProperty(Customer.IdProperty.Name).IsUnicode());
-            Assert.True(complexType.FindProperty("Up").IsUnicode());
-            Assert.False(complexType.FindProperty("Down").IsUnicode());
-            Assert.True(complexType.FindProperty("Charm").IsUnicode());
-            Assert.False(complexType.FindProperty("Strange").IsUnicode());
-            Assert.True(complexType.FindProperty("Top").IsUnicode());
-            Assert.False(complexType.FindProperty("Bottom").IsUnicode());
+            Assert.True(complexType.FindProperty(Customer.IdProperty.Name)!.IsUnicode());
+            Assert.True(complexType.FindProperty("Up")!.IsUnicode());
+            Assert.False(complexType.FindProperty("Down")!.IsUnicode());
+            Assert.True(complexType.FindProperty("Charm")!.IsUnicode());
+            Assert.False(complexType.FindProperty("Strange")!.IsUnicode());
+            Assert.True(complexType.FindProperty("Top")!.IsUnicode());
+            Assert.False(complexType.FindProperty("Bottom")!.IsUnicode());
         }
 
         [Fact]

--- a/test/EFCore.Specification.Tests/ModelBuilding/ModelBuilderTest.ComplexType.cs
+++ b/test/EFCore.Specification.Tests/ModelBuilding/ModelBuilderTest.ComplexType.cs
@@ -10,8 +10,6 @@ using Microsoft.EntityFrameworkCore.TestModels.BasicTypesModel;
 // ReSharper disable InconsistentNaming
 namespace Microsoft.EntityFrameworkCore.ModelBuilding;
 
-#nullable disable
-
 public abstract partial class ModelBuilderTest
 {
     public abstract class ComplexTypeTestBase(ModelBuilderFixtureBase fixture) : ModelBuilderTestBase(fixture)
@@ -33,7 +31,7 @@ public abstract partial class ModelBuilderTest
                 .Ignore(c => c.Orders);
 
             var model = modelBuilder.FinalizeModel();
-            var complexProperty = model.FindEntityType(typeof(ComplexProperties)).GetComplexProperties().Single();
+            var complexProperty = model.FindEntityType(typeof(ComplexProperties))!.GetComplexProperties().Single();
 
             Assert.Equal("bar", complexProperty.ComplexType["foo"]);
             Assert.Equal("bar2", complexProperty["foo2"]);
@@ -65,10 +63,10 @@ public abstract partial class ModelBuilderTest
                 .Property(c => c.Name).HasAnnotation("foo", "bar");
 
             var model = modelBuilder.FinalizeModel();
-            var complexProperty = model.FindEntityType(typeof(ComplexProperties)).GetComplexProperties().Single();
+            var complexProperty = model.FindEntityType(typeof(ComplexProperties))!.GetComplexProperties().Single();
             var property = complexProperty.ComplexType.FindProperty(nameof(Customer.Name));
 
-            Assert.Equal("bar", property["foo"]);
+            Assert.Equal("bar", property!["foo"]);
         }
 
         [Fact]
@@ -87,10 +85,10 @@ public abstract partial class ModelBuilderTest
                 .Property<string>(Customer.NameProperty.Name).HasAnnotation("foo", "bar");
 
             var model = modelBuilder.FinalizeModel();
-            var complexProperty = model.FindEntityType(typeof(ComplexProperties)).GetComplexProperties().Single();
+            var complexProperty = model.FindEntityType(typeof(ComplexProperties))!.GetComplexProperties().Single();
             var property = complexProperty.ComplexType.FindProperty(nameof(Customer.Name));
 
-            Assert.Equal("bar", property["foo"]);
+            Assert.Equal("bar", property!["foo"]);
         }
 
         [Fact]
@@ -109,10 +107,10 @@ public abstract partial class ModelBuilderTest
                 .Property(c => c.Name);
 
             var model = modelBuilder.FinalizeModel();
-            var complexProperty = model.FindEntityType(typeof(ComplexProperties)).GetComplexProperties().Single();
+            var complexProperty = model.FindEntityType(typeof(ComplexProperties))!.GetComplexProperties().Single();
             var property = complexProperty.ComplexType.FindProperty(nameof(Customer.Name));
 
-            Assert.Equal("bar", property["foo"]);
+            Assert.Equal("bar", property!["foo"]);
         }
 
         [Fact(Skip = "Issue #35613")]
@@ -137,14 +135,14 @@ public abstract partial class ModelBuilderTest
                     });
 
             var model = modelBuilder.FinalizeModel();
-            var complexType = model.FindEntityType(typeof(ComplexProperties)).GetComplexProperties().Single().ComplexType;
+            var complexType = model.FindEntityType(typeof(ComplexProperties))!.GetComplexProperties().Single().ComplexType;
 
-            Assert.False(complexType.FindProperty("Up").IsNullable);
-            Assert.True(complexType.FindProperty("Down").IsNullable);
-            Assert.False(complexType.FindProperty("Charm").IsNullable);
-            Assert.True(complexType.FindProperty("Strange").IsNullable);
-            Assert.False(complexType.FindProperty("Top").IsNullable);
-            Assert.True(complexType.FindProperty("Bottom").IsNullable);
+            Assert.False(complexType.FindProperty("Up")!.IsNullable);
+            Assert.True(complexType.FindProperty("Down")!.IsNullable);
+            Assert.False(complexType.FindProperty("Charm")!.IsNullable);
+            Assert.True(complexType.FindProperty("Strange")!.IsNullable);
+            Assert.False(complexType.FindProperty("Top")!.IsNullable);
+            Assert.True(complexType.FindProperty("Bottom")!.IsNullable);
         }
 
         [Fact]
@@ -170,7 +168,7 @@ public abstract partial class ModelBuilderTest
                     });
 
             var model = modelBuilder.FinalizeModel();
-            var complexType = model.FindEntityType(typeof(ComplexProperties)).GetComplexProperties().Single().ComplexType;
+            var complexType = model.FindEntityType(typeof(ComplexProperties))!.GetComplexProperties().Single().ComplexType;
 
             Assert.Contains(nameof(Quarks.Id), complexType.GetProperties().Select(p => p.Name));
             Assert.DoesNotContain(nameof(Quarks.Up), complexType.GetProperties().Select(p => p.Name));
@@ -190,7 +188,7 @@ public abstract partial class ModelBuilderTest
                 .ComplexProperty(e => e.Customer, b => b.Ignore(c => c.Details).Ignore(c => c.Orders));
 
             var model = modelBuilder.FinalizeModel();
-            var complexType = model.FindEntityType(typeof(ComplexProperties)).GetComplexProperties().Single().ComplexType;
+            var complexType = model.FindEntityType(typeof(ComplexProperties))!.GetComplexProperties().Single().ComplexType;
             Assert.Null(complexType.FindProperty(nameof(Customer.AlternateKey)));
         }
 
@@ -209,7 +207,7 @@ public abstract partial class ModelBuilderTest
 
             var model = modelBuilder.FinalizeModel();
 
-            var complexType = model.FindEntityType(typeof(ComplexProperties)).GetComplexProperties().Single().ComplexType;
+            var complexType = model.FindEntityType(typeof(ComplexProperties))!.GetComplexProperties().Single().ComplexType;
             Assert.Null(complexType.FindProperty("Shadow"));
         }
 
@@ -235,7 +233,7 @@ public abstract partial class ModelBuilderTest
 
             var model = modelBuilder.FinalizeModel();
 
-            var complexType = model.FindEntityType(typeof(ComplexProperties)).GetComplexProperties().Single().ComplexType;
+            var complexType = model.FindEntityType(typeof(ComplexProperties))!.GetComplexProperties().Single().ComplexType;
             Assert.NotNull(complexType.FindProperty("Shadow"));
         }
 
@@ -261,14 +259,14 @@ public abstract partial class ModelBuilderTest
                     });
 
             var model = modelBuilder.FinalizeModel();
-            var complexType = model.FindEntityType(typeof(ComplexProperties)).GetComplexProperties().Single().ComplexType;
+            var complexType = model.FindEntityType(typeof(ComplexProperties))!.GetComplexProperties().Single().ComplexType;
 
-            Assert.False(complexType.FindProperty("Up").IsNullable);
-            Assert.False(complexType.FindProperty("Down").IsNullable);
-            Assert.False(complexType.FindProperty("Charm").IsNullable);
-            Assert.False(complexType.FindProperty("Strange").IsNullable);
-            Assert.False(complexType.FindProperty("Top").IsNullable);
-            Assert.False(complexType.FindProperty("Bottom").IsNullable);
+            Assert.False(complexType.FindProperty("Up")!.IsNullable);
+            Assert.False(complexType.FindProperty("Down")!.IsNullable);
+            Assert.False(complexType.FindProperty("Charm")!.IsNullable);
+            Assert.False(complexType.FindProperty("Strange")!.IsNullable);
+            Assert.False(complexType.FindProperty("Top")!.IsNullable);
+            Assert.False(complexType.FindProperty("Bottom")!.IsNullable);
         }
 
         [Fact(Skip = "Issue #35613")]
@@ -290,11 +288,11 @@ public abstract partial class ModelBuilderTest
                     });
 
             var model = modelBuilder.FinalizeModel();
-            var complexType = model.FindEntityType(typeof(ComplexProperties)).GetComplexProperties().Single().ComplexType;
+            var complexType = model.FindEntityType(typeof(ComplexProperties))!.GetComplexProperties().Single().ComplexType;
 
-            Assert.True(complexType.FindProperty("Down").IsNullable);
-            Assert.True(complexType.FindProperty("Strange").IsNullable);
-            Assert.True(complexType.FindProperty("Bottom").IsNullable);
+            Assert.True(complexType.FindProperty("Down")!.IsNullable);
+            Assert.True(complexType.FindProperty("Strange")!.IsNullable);
+            Assert.True(complexType.FindProperty("Bottom")!.IsNullable);
         }
 
         [Fact(Skip = "Issue #35613")]
@@ -324,11 +322,11 @@ public abstract partial class ModelBuilderTest
                     });
 
             var model = modelBuilder.FinalizeModel();
-            var complexType = model.FindEntityType(typeof(ComplexProperties)).GetComplexProperties().Single().ComplexType;
+            var complexType = model.FindEntityType(typeof(ComplexProperties))!.GetComplexProperties().Single().ComplexType;
 
-            Assert.False(complexType.FindProperty("Up").IsNullable);
-            Assert.False(complexType.FindProperty("Charm").IsNullable);
-            Assert.False(complexType.FindProperty("Top").IsNullable);
+            Assert.False(complexType.FindProperty("Up")!.IsNullable);
+            Assert.False(complexType.FindProperty("Charm")!.IsNullable);
+            Assert.False(complexType.FindProperty("Top")!.IsNullable);
         }
 
         [Fact(Skip = "Issue #35613")]
@@ -351,18 +349,18 @@ public abstract partial class ModelBuilderTest
                     });
 
             var model = modelBuilder.FinalizeModel();
-            var complexType = model.FindEntityType(typeof(ComplexProperties)).GetComplexProperties().Single().ComplexType;
+            var complexType = model.FindEntityType(typeof(ComplexProperties))!.GetComplexProperties().Single().ComplexType;
 
-            Assert.False(complexType.FindProperty("Up").IsShadowProperty());
-            Assert.False(complexType.FindProperty("Down").IsShadowProperty());
-            Assert.True(complexType.FindProperty("Gluon").IsShadowProperty());
-            Assert.True(complexType.FindProperty("Photon").IsShadowProperty());
+            Assert.False(complexType.FindProperty("Up")!.IsShadowProperty());
+            Assert.False(complexType.FindProperty("Down")!.IsShadowProperty());
+            Assert.True(complexType.FindProperty("Gluon")!.IsShadowProperty());
+            Assert.True(complexType.FindProperty("Photon")!.IsShadowProperty());
 
-            Assert.Equal(-1, complexType.FindProperty("Up").GetShadowIndex());
-            Assert.Equal(-1, complexType.FindProperty("Down").GetShadowIndex());
-            Assert.NotEqual(-1, complexType.FindProperty("Gluon").GetShadowIndex());
-            Assert.NotEqual(-1, complexType.FindProperty("Photon").GetShadowIndex());
-            Assert.NotEqual(complexType.FindProperty("Gluon").GetShadowIndex(), complexType.FindProperty("Photon").GetShadowIndex());
+            Assert.Equal(-1, complexType.FindProperty("Up")!.GetShadowIndex());
+            Assert.Equal(-1, complexType.FindProperty("Down")!.GetShadowIndex());
+            Assert.NotEqual(-1, complexType.FindProperty("Gluon")!.GetShadowIndex());
+            Assert.NotEqual(-1, complexType.FindProperty("Photon")!.GetShadowIndex());
+            Assert.NotEqual(complexType.FindProperty("Gluon")!.GetShadowIndex(), complexType.FindProperty("Photon")!.GetShadowIndex());
         }
 
         [Fact(Skip = "Issue #35613")]
@@ -389,23 +387,23 @@ public abstract partial class ModelBuilderTest
                     });
 
             var model = modelBuilder.FinalizeModel();
-            var complexType = model.FindEntityType(typeof(ComplexProperties)).GetComplexProperties().Single().ComplexType;
+            var complexType = model.FindEntityType(typeof(ComplexProperties))!.GetComplexProperties().Single().ComplexType;
 
-            Assert.False(complexType.FindProperty(Customer.IdProperty.Name).IsConcurrencyToken);
-            Assert.True(complexType.FindProperty("Up").IsConcurrencyToken);
-            Assert.False(complexType.FindProperty("Down").IsConcurrencyToken);
-            Assert.True(complexType.FindProperty("Charm").IsConcurrencyToken);
-            Assert.False(complexType.FindProperty("Strange").IsConcurrencyToken);
-            Assert.True(complexType.FindProperty("Top").IsConcurrencyToken);
-            Assert.False(complexType.FindProperty("Bottom").IsConcurrencyToken);
+            Assert.False(complexType.FindProperty(Customer.IdProperty.Name)!.IsConcurrencyToken);
+            Assert.True(complexType.FindProperty("Up")!.IsConcurrencyToken);
+            Assert.False(complexType.FindProperty("Down")!.IsConcurrencyToken);
+            Assert.True(complexType.FindProperty("Charm")!.IsConcurrencyToken);
+            Assert.False(complexType.FindProperty("Strange")!.IsConcurrencyToken);
+            Assert.True(complexType.FindProperty("Top")!.IsConcurrencyToken);
+            Assert.False(complexType.FindProperty("Bottom")!.IsConcurrencyToken);
 
-            Assert.Equal(-1, complexType.FindProperty(Customer.IdProperty.Name).GetOriginalValueIndex());
-            Assert.Equal(6, complexType.FindProperty("Up").GetOriginalValueIndex());
-            Assert.Equal(-1, complexType.FindProperty("Down").GetOriginalValueIndex());
-            Assert.Equal(4, complexType.FindProperty("Charm").GetOriginalValueIndex());
-            Assert.Equal(-1, complexType.FindProperty("Strange").GetOriginalValueIndex());
-            Assert.Equal(5, complexType.FindProperty("Top").GetOriginalValueIndex());
-            Assert.Equal(-1, complexType.FindProperty("Bottom").GetOriginalValueIndex());
+            Assert.Equal(-1, complexType.FindProperty(Customer.IdProperty.Name)!.GetOriginalValueIndex());
+            Assert.Equal(6, complexType.FindProperty("Up")!.GetOriginalValueIndex());
+            Assert.Equal(-1, complexType.FindProperty("Down")!.GetOriginalValueIndex());
+            Assert.Equal(4, complexType.FindProperty("Charm")!.GetOriginalValueIndex());
+            Assert.Equal(-1, complexType.FindProperty("Strange")!.GetOriginalValueIndex());
+            Assert.Equal(5, complexType.FindProperty("Top")!.GetOriginalValueIndex());
+            Assert.Equal(-1, complexType.FindProperty("Bottom")!.GetOriginalValueIndex());
 
             Assert.Equal(ChangeTrackingStrategy.ChangingAndChangedNotifications, complexType.GetChangeTrackingStrategy());
         }
@@ -533,29 +531,29 @@ public abstract partial class ModelBuilderTest
                     });
 
             var model = modelBuilder.FinalizeModel();
-            var complexType = model.FindEntityType(typeof(ComplexProperties)).GetComplexProperties().Single().ComplexType;
+            var complexType = model.FindEntityType(typeof(ComplexProperties))!.GetComplexProperties().Single().ComplexType;
 
             var up = complexType.FindProperty("Up");
-            Assert.Null(up.GetProviderClrType());
+            Assert.Null(up!.GetProviderClrType());
             Assert.True(up.GetValueComparer().IsDefault());
 
             var down = complexType.FindProperty("Down");
-            Assert.Same(typeof(byte[]), down.GetProviderClrType());
+            Assert.Same(typeof(byte[]), down!.GetProviderClrType());
             Assert.True(down.GetValueComparer().IsDefault());
             Assert.True(down.GetProviderValueComparer() is ValueComparer<TBytes>);
 
             var charm = complexType.FindProperty("Charm");
-            Assert.Same(typeof(long), charm.GetProviderClrType());
+            Assert.Same(typeof(long), charm!.GetProviderClrType());
             Assert.IsType<CustomValueComparer<int>>(charm.GetValueComparer());
             Assert.True(charm.GetProviderValueComparer().IsDefault());
 
             var strange = complexType.FindProperty("Strange");
-            Assert.Null(strange.GetProviderClrType());
+            Assert.Null(strange!.GetProviderClrType());
             Assert.True(strange.GetValueComparer().IsDefault());
             Assert.True(strange.GetProviderValueComparer().IsDefault());
 
             var top = complexType.FindProperty("Top");
-            Assert.Same(typeof(string), top.GetProviderClrType());
+            Assert.Same(typeof(string), top!.GetProviderClrType());
             Assert.IsType<CustomValueComparer<string>>(top.GetValueComparer());
             Assert.True(top.GetProviderValueComparer() is ValueComparer<string>);
         }
@@ -580,7 +578,7 @@ public abstract partial class ModelBuilderTest
                     });
 
             var model = modelBuilder.FinalizeModel();
-            var complexType = model.FindEntityType(typeof(ComplexProperties)).GetComplexProperties().Single().ComplexType;
+            var complexType = model.FindEntityType(typeof(ComplexProperties))!.GetComplexProperties().Single().ComplexType;
 
             Assert.Null(complexType.FindProperty("Up")!.GetProviderClrType());
             Assert.Same(typeof(byte[]), complexType.FindProperty("Down")!.GetProviderClrType());
@@ -615,21 +613,21 @@ public abstract partial class ModelBuilderTest
                     });
 
             var model = modelBuilder.FinalizeModel();
-            var complexType = model.FindEntityType(typeof(ComplexProperties)).GetComplexProperties().Single().ComplexType;
+            var complexType = model.FindEntityType(typeof(ComplexProperties))!.GetComplexProperties().Single().ComplexType;
 
-            Assert.Null(complexType.FindProperty("Up").GetValueConverter());
+            Assert.Null(complexType.FindProperty("Up")!.GetValueConverter());
 
             var down = complexType.FindProperty("Down");
-            Assert.Same(stringConverter, down.GetValueConverter());
+            Assert.Same(stringConverter, down!.GetValueConverter());
             Assert.True(down.GetValueComparer().IsDefault());
             Assert.True(down.GetProviderValueComparer() is ValueComparer<TBytes>);
 
             var charm = complexType.FindProperty("Charm");
-            Assert.Same(intConverter, charm.GetValueConverter());
+            Assert.Same(intConverter, charm!.GetValueConverter());
             Assert.True(charm.GetValueComparer().IsDefault());
             Assert.IsType<CustomValueComparer<long>>(charm.GetProviderValueComparer());
 
-            Assert.Null(complexType.FindProperty("Strange").GetValueConverter());
+            Assert.Null(complexType.FindProperty("Strange")!.GetValueConverter());
         }
 
         [Fact(Skip = "Issue #35613")]
@@ -657,26 +655,26 @@ public abstract partial class ModelBuilderTest
                     });
 
             var model = modelBuilder.FinalizeModel();
-            var complexType = model.FindEntityType(typeof(ComplexProperties)).GetComplexProperties().Single().ComplexType;
+            var complexType = model.FindEntityType(typeof(ComplexProperties))!.GetComplexProperties().Single().ComplexType;
 
             var up = complexType.FindProperty("Up");
-            Assert.Equal(typeof(int), up.GetProviderClrType());
+            Assert.Equal(typeof(int), up!.GetProviderClrType());
             Assert.Null(up.GetValueConverter());
             Assert.IsType<CustomValueComparer<int>>(up.GetValueComparer());
             Assert.IsType<CustomValueComparer<int>>(up.GetProviderValueComparer());
 
             var down = complexType.FindProperty("Down");
-            Assert.IsType<UTF8StringToBytesConverter>(down.GetValueConverter());
+            Assert.IsType<UTF8StringToBytesConverter>(down!.GetValueConverter());
             Assert.IsType<CustomValueComparer<string>>(down.GetValueComparer());
             Assert.True(down.GetProviderValueComparer() is ValueComparer<TBytes>);
 
             var charm = complexType.FindProperty("Charm");
-            Assert.IsType<CastingConverter<int, long>>(charm.GetValueConverter());
+            Assert.IsType<CastingConverter<int, long>>(charm!.GetValueConverter());
             Assert.IsType<CustomValueComparer<int>>(charm.GetValueComparer());
             Assert.True(charm.GetProviderValueComparer().IsDefault());
 
             var strange = complexType.FindProperty("Strange");
-            Assert.Null(strange.GetValueConverter());
+            Assert.Null(strange!.GetValueConverter());
             Assert.True(strange.GetValueComparer().IsDefault());
             Assert.True(strange.GetProviderValueComparer().IsDefault());
         }
@@ -699,33 +697,33 @@ public abstract partial class ModelBuilderTest
                     b =>
                     {
                         b.Property(e => e.Up);
-                        b.Property(e => e.Down).HasConversion(v => int.Parse(v), v => v.ToString());
+                        b.Property(e => e.Down).HasConversion(v => int.Parse(v!), v => v.ToString());
                         b.Property<int>("Charm").HasConversion(v => (long)v, v => (int)v, new CustomValueComparer<int>());
                         b.Property<float>("Strange").HasConversion(
                             v => (double)v, v => (float)v, new CustomValueComparer<float>(), new CustomValueComparer<double>());
                     });
 
             var model = modelBuilder.FinalizeModel();
-            var complexType = model.FindEntityType(typeof(ComplexProperties)).GetComplexProperties().Single().ComplexType;
+            var complexType = model.FindEntityType(typeof(ComplexProperties))!.GetComplexProperties().Single().ComplexType;
 
             var up = complexType.FindProperty("Up");
-            Assert.Null(up.GetProviderClrType());
+            Assert.Null(up!.GetProviderClrType());
             Assert.Null(up.GetValueConverter());
             Assert.True(up.GetValueComparer().IsDefault());
             Assert.True(up.GetProviderValueComparer().IsDefault());
 
             var down = complexType.FindProperty("Down");
-            Assert.IsType<ValueConverter<string, int>>(down.GetValueConverter());
+            Assert.IsType<ValueConverter<string, int>>(down!.GetValueConverter());
             Assert.True(down.GetValueComparer().IsDefault());
             Assert.True(down.GetProviderValueComparer().IsDefault());
 
             var charm = complexType.FindProperty("Charm");
-            Assert.IsType<ValueConverter<int, long>>(charm.GetValueConverter());
+            Assert.IsType<ValueConverter<int, long>>(charm!.GetValueConverter());
             Assert.IsType<CustomValueComparer<int>>(charm.GetValueComparer());
             Assert.True(charm.GetProviderValueComparer().IsDefault());
 
             var strange = complexType.FindProperty("Strange");
-            Assert.IsType<ValueConverter<float, double>>(strange.GetValueConverter());
+            Assert.IsType<ValueConverter<float, double>>(strange!.GetValueConverter());
             Assert.IsType<CustomValueComparer<float>>(strange.GetValueComparer());
             Assert.IsType<CustomValueComparer<double>>(strange.GetProviderValueComparer());
         }
@@ -745,7 +743,7 @@ public abstract partial class ModelBuilderTest
                     {
                         b.Property(e => e.Up);
                         b.Property(e => e.Down).HasConversion(
-                            new ValueConverter<string, int>(v => int.Parse(v), v => v.ToString()));
+                            new ValueConverter<string?, int>(v => int.Parse(v!), v => v.ToString()));
                         b.Property<int>("Charm").HasConversion(
                             new ValueConverter<int, long>(v => v, v => (int)v), new CustomValueComparer<int>());
                         b.Property<float>("Strange").HasConversion(
@@ -754,26 +752,26 @@ public abstract partial class ModelBuilderTest
                     });
 
             var model = modelBuilder.FinalizeModel();
-            var complexType = model.FindEntityType(typeof(ComplexProperties)).GetComplexProperties().Single().ComplexType;
+            var complexType = model.FindEntityType(typeof(ComplexProperties))!.GetComplexProperties().Single().ComplexType;
 
             var up = complexType.FindProperty("Up");
-            Assert.Null(up.GetProviderClrType());
+            Assert.Null(up!.GetProviderClrType());
             Assert.Null(up.GetValueConverter());
             Assert.True(up.GetValueComparer().IsDefault());
             Assert.True(up.GetProviderValueComparer().IsDefault());
 
             var down = complexType.FindProperty("Down");
-            Assert.IsType<ValueConverter<string, int>>(down.GetValueConverter());
+            Assert.IsType<ValueConverter<string, int>>(down!.GetValueConverter());
             Assert.True(down.GetValueComparer().IsDefault());
             Assert.True(down.GetProviderValueComparer().IsDefault());
 
             var charm = complexType.FindProperty("Charm");
-            Assert.IsType<ValueConverter<int, long>>(charm.GetValueConverter());
+            Assert.IsType<ValueConverter<int, long>>(charm!.GetValueConverter());
             Assert.IsType<CustomValueComparer<int>>(charm.GetValueComparer());
             Assert.True(charm.GetProviderValueComparer().IsDefault());
 
             var strange = complexType.FindProperty("Strange");
-            Assert.IsType<ValueConverter<float, double>>(strange.GetValueConverter());
+            Assert.IsType<ValueConverter<float, double>>(strange!.GetValueConverter());
             Assert.IsType<CustomValueComparer<float>>(strange.GetValueComparer());
             Assert.IsType<CustomValueComparer<double>>(strange.GetProviderValueComparer());
         }
@@ -792,21 +790,21 @@ public abstract partial class ModelBuilderTest
                     b =>
                     {
                         b.Property(e => e.ExpandoObject).HasConversion(
-                            v => (string)((IDictionary<string, object>)v)["Value"], v => DeserializeExpandoObject(v));
+                            v => (string)((IDictionary<string, object?>)v!)["Value"]!, v => DeserializeExpandoObject(v));
 
                         var comparer = new ValueComparer<ExpandoObject>(
-                            (v1, v2) => v1.SequenceEqual(v2),
-                            v => v.GetHashCode());
+                            (v1, v2) => v1!.SequenceEqual(v2!),
+                            v => v!.GetHashCode());
 
                         b.Property(e => e.ExpandoObject).Metadata.SetValueComparer(comparer);
                     });
 
             var model = modelBuilder.FinalizeModel();
 
-            var complexType = model.FindEntityType(typeof(ComplexProperties)).GetComplexProperties().Single().ComplexType;
+            var complexType = model.FindEntityType(typeof(ComplexProperties))!.GetComplexProperties().Single().ComplexType;
 
-            Assert.NotNull(complexType.FindProperty(nameof(DynamicProperty.ExpandoObject)).GetValueConverter());
-            Assert.NotNull(complexType.FindProperty(nameof(DynamicProperty.ExpandoObject)).GetValueComparer());
+            Assert.NotNull(complexType.FindProperty(nameof(DynamicProperty.ExpandoObject))!.GetValueConverter());
+            Assert.NotNull(complexType.FindProperty(nameof(DynamicProperty.ExpandoObject))!.GetValueComparer());
         }
 
         private static ExpandoObject DeserializeExpandoObject(string value)
@@ -818,9 +816,10 @@ public abstract partial class ModelBuilderTest
         }
 
         private class ExpandoObjectConverter() : ValueConverter<ExpandoObject, string>(
-            v => (string)((IDictionary<string, object>)v)["Value"], v => DeserializeExpandoObject(v));
+            v => (string)((IDictionary<string, object?>)v!)["Value"]!, v => DeserializeExpandoObject(v));
 
-        private class ExpandoObjectComparer() : ValueComparer<ExpandoObject>((v1, v2) => v1.SequenceEqual(v2), v => v.GetHashCode());
+        private class ExpandoObjectComparer() : ValueComparer<ExpandoObject>(
+            (v1, v2) => v1!.SequenceEqual(v2!), v => v!.GetHashCode());
 
         [Fact]
         public virtual void Properties_can_have_value_converter_configured_by_type()
@@ -840,9 +839,9 @@ public abstract partial class ModelBuilderTest
 
             var model = modelBuilder.FinalizeModel();
 
-            var complexType = model.FindEntityType(typeof(ComplexProperties)).GetComplexProperties().Single().ComplexType;
+            var complexType = model.FindEntityType(typeof(ComplexProperties))!.GetComplexProperties().Single().ComplexType;
             var wrappedProperty = complexType.FindProperty(nameof(WrappedStringEntity.WrappedString));
-            Assert.False(wrappedProperty.IsUnicode());
+            Assert.False(wrappedProperty!.IsUnicode());
             Assert.Equal(20, wrappedProperty.GetMaxLength());
             Assert.IsType<WrappedStringToStringConverter>(wrappedProperty.GetValueConverter());
             Assert.IsType<ValueComparer<WrappedString>>(wrappedProperty.GetValueComparer());
@@ -863,14 +862,14 @@ public abstract partial class ModelBuilderTest
                     b => b.Property<int?>("Wierd"));
 
             var model = modelBuilder.FinalizeModel();
-            var complexType = model.FindEntityType(typeof(ComplexProperties)).GetComplexProperties().Single().ComplexType;
+            var complexType = model.FindEntityType(typeof(ComplexProperties))!.GetComplexProperties().Single().ComplexType;
 
             var id = complexType.FindProperty("Id");
-            Assert.IsType<NumberToStringConverter<int>>(id.GetValueConverter());
+            Assert.IsType<NumberToStringConverter<int>>(id!.GetValueConverter());
             Assert.IsType<CustomValueComparer<int>>(id.GetValueComparer());
 
             var wierd = complexType.FindProperty("Wierd");
-            Assert.IsType<NumberToStringConverter<int>>(wierd.GetValueConverter());
+            Assert.IsType<NumberToStringConverter<int>>(wierd!.GetValueConverter());
             Assert.IsType<NullableValueComparer<int>>(wierd.GetValueComparer());
         }
 
@@ -893,21 +892,21 @@ public abstract partial class ModelBuilderTest
                     b => b.Property<int?>("Wierd"));
 
             var model = modelBuilder.FinalizeModel();
-            var complexType = model.FindEntityType(typeof(ComplexProperties)).GetComplexProperties().Single().ComplexType;
+            var complexType = model.FindEntityType(typeof(ComplexProperties))!.GetComplexProperties().Single().ComplexType;
 
             var id = complexType.FindProperty("Id");
-            Assert.IsType<NumberToStringConverter<int>>(id.GetValueConverter());
+            Assert.IsType<NumberToStringConverter<int>>(id!.GetValueConverter());
             Assert.IsType<CustomValueComparer<int>>(id.GetValueComparer());
             Assert.IsType<CustomValueComparer<string>>(id.GetProviderValueComparer());
 
             var wierd = complexType.FindProperty("Wierd");
-            Assert.IsType<NumberToStringConverter<int?>>(wierd.GetValueConverter());
+            Assert.IsType<NumberToStringConverter<int?>>(wierd!.GetValueConverter());
             Assert.IsType<CustomValueComparer<int?>>(wierd.GetValueComparer());
             Assert.IsType<CustomValueComparer<string>>(wierd.GetProviderValueComparer());
         }
 
         private class WrappedStringToStringConverter()
-            : ValueConverter<WrappedString, string>(v => v.Value, v => new WrappedString { Value = v });
+            : ValueConverter<WrappedString, string>(v => v.Value!, v => new WrappedString { Value = v });
 
         [Fact]
         public virtual void Value_converter_type_is_checked()
@@ -926,8 +925,8 @@ public abstract partial class ModelBuilderTest
                             new StringToBytesConverter(Encoding.UTF8))).Message));
 
             var model = modelBuilder.FinalizeModel();
-            var complexType = model.FindEntityType(typeof(ComplexProperties)).GetComplexProperties().Single().ComplexType;
-            Assert.Null(complexType.FindProperty("Up").GetValueConverter());
+            var complexType = model.FindEntityType(typeof(ComplexProperties))!.GetComplexProperties().Single().ComplexType;
+            Assert.Null(complexType.FindProperty("Up")!.GetValueConverter());
         }
 
         [Fact]
@@ -949,11 +948,11 @@ public abstract partial class ModelBuilderTest
                     });
 
             var model = modelBuilder.FinalizeModel();
-            var complexType = model.FindEntityType(typeof(ComplexProperties)).GetComplexProperties().Single().ComplexType;
+            var complexType = model.FindEntityType(typeof(ComplexProperties))!.GetComplexProperties().Single().ComplexType;
 
-            Assert.Equal("_forUp", complexType.FindProperty("Up").GetFieldName());
-            Assert.Equal("_forDown", complexType.FindProperty("Down").GetFieldName());
-            Assert.Equal("_forWierd", complexType.FindProperty("_forWierd").GetFieldName());
+            Assert.Equal("_forUp", complexType.FindProperty("Up")!.GetFieldName());
+            Assert.Equal("_forDown", complexType.FindProperty("Down")!.GetFieldName());
+            Assert.Equal("_forWierd", complexType.FindProperty("_forWierd")!.GetFieldName());
         }
 
         [Fact]
@@ -1019,14 +1018,14 @@ public abstract partial class ModelBuilderTest
 
             var model = modelBuilder.FinalizeModel();
 
-            var complexType = model.FindEntityType(typeof(ComplexProperties)).GetComplexProperties().Single().ComplexType;
-            Assert.Equal(ValueGenerated.Never, complexType.FindProperty(Customer.IdProperty.Name).ValueGenerated);
-            Assert.Equal(ValueGenerated.OnAddOrUpdate, complexType.FindProperty("Up").ValueGenerated);
-            Assert.Equal(ValueGenerated.Never, complexType.FindProperty("Down").ValueGenerated);
-            Assert.Equal(ValueGenerated.OnUpdateSometimes, complexType.FindProperty("Charm").ValueGenerated);
-            Assert.Equal(ValueGenerated.Never, complexType.FindProperty("Strange").ValueGenerated);
-            Assert.Equal(ValueGenerated.OnAddOrUpdate, complexType.FindProperty("Top").ValueGenerated);
-            Assert.Equal(ValueGenerated.OnUpdate, complexType.FindProperty("Bottom").ValueGenerated);
+            var complexType = model.FindEntityType(typeof(ComplexProperties))!.GetComplexProperties().Single().ComplexType;
+            Assert.Equal(ValueGenerated.Never, complexType.FindProperty(Customer.IdProperty.Name)!.ValueGenerated);
+            Assert.Equal(ValueGenerated.OnAddOrUpdate, complexType.FindProperty("Up")!.ValueGenerated);
+            Assert.Equal(ValueGenerated.Never, complexType.FindProperty("Down")!.ValueGenerated);
+            Assert.Equal(ValueGenerated.OnUpdateSometimes, complexType.FindProperty("Charm")!.ValueGenerated);
+            Assert.Equal(ValueGenerated.Never, complexType.FindProperty("Strange")!.ValueGenerated);
+            Assert.Equal(ValueGenerated.OnAddOrUpdate, complexType.FindProperty("Top")!.ValueGenerated);
+            Assert.Equal(ValueGenerated.OnUpdate, complexType.FindProperty("Bottom")!.ValueGenerated);
         }
 
         [Fact(Skip = "Issue #35613")]
@@ -1049,15 +1048,15 @@ public abstract partial class ModelBuilderTest
 
             var model = modelBuilder.FinalizeModel();
 
-            var complexType = model.FindEntityType(typeof(ComplexProperties)).GetComplexProperties().Single().ComplexType;
+            var complexType = model.FindEntityType(typeof(ComplexProperties))!.GetComplexProperties().Single().ComplexType;
 
-            Assert.Equal(ValueGenerated.OnAddOrUpdate, complexType.FindProperty("Up").ValueGenerated);
-            Assert.Equal(ValueGenerated.Never, complexType.FindProperty("Down").ValueGenerated);
-            Assert.Equal(ValueGenerated.OnAddOrUpdate, complexType.FindProperty("Charm").ValueGenerated);
+            Assert.Equal(ValueGenerated.OnAddOrUpdate, complexType.FindProperty("Up")!.ValueGenerated);
+            Assert.Equal(ValueGenerated.Never, complexType.FindProperty("Down")!.ValueGenerated);
+            Assert.Equal(ValueGenerated.OnAddOrUpdate, complexType.FindProperty("Charm")!.ValueGenerated);
 
-            Assert.True(complexType.FindProperty("Up").IsConcurrencyToken);
-            Assert.False(complexType.FindProperty("Down").IsConcurrencyToken);
-            Assert.True(complexType.FindProperty("Charm").IsConcurrencyToken);
+            Assert.True(complexType.FindProperty("Up")!.IsConcurrencyToken);
+            Assert.False(complexType.FindProperty("Down")!.IsConcurrencyToken);
+            Assert.True(complexType.FindProperty("Charm")!.IsConcurrencyToken);
         }
 
         [Fact(Skip = "Issue #35613")]
@@ -1082,15 +1081,15 @@ public abstract partial class ModelBuilderTest
                     });
 
             var model = modelBuilder.FinalizeModel();
-            var complexType = model.FindEntityType(typeof(ComplexProperties)).GetComplexProperties().Single().ComplexType;
+            var complexType = model.FindEntityType(typeof(ComplexProperties))!.GetComplexProperties().Single().ComplexType;
 
-            Assert.Null(complexType.FindProperty(Customer.IdProperty.Name).GetMaxLength());
-            Assert.Equal(0, complexType.FindProperty("Up").GetMaxLength());
-            Assert.Equal(100, complexType.FindProperty("Down").GetMaxLength());
-            Assert.Equal(0, complexType.FindProperty("Charm").GetMaxLength());
-            Assert.Equal(-1, complexType.FindProperty("Strange").GetMaxLength());
-            Assert.Equal(0, complexType.FindProperty("Top").GetMaxLength());
-            Assert.Equal(100, complexType.FindProperty("Bottom").GetMaxLength());
+            Assert.Null(complexType.FindProperty(Customer.IdProperty.Name)!.GetMaxLength());
+            Assert.Equal(0, complexType.FindProperty("Up")!.GetMaxLength());
+            Assert.Equal(100, complexType.FindProperty("Down")!.GetMaxLength());
+            Assert.Equal(0, complexType.FindProperty("Charm")!.GetMaxLength());
+            Assert.Equal(-1, complexType.FindProperty("Strange")!.GetMaxLength());
+            Assert.Equal(0, complexType.FindProperty("Top")!.GetMaxLength());
+            Assert.Equal(100, complexType.FindProperty("Bottom")!.GetMaxLength());
         }
 
         [Fact(Skip = "Issue #35613")]
@@ -1117,15 +1116,15 @@ public abstract partial class ModelBuilderTest
                     });
 
             var model = modelBuilder.FinalizeModel();
-            var complexType = model.FindEntityType(typeof(ComplexProperties)).GetComplexProperties().Single().ComplexType;
+            var complexType = model.FindEntityType(typeof(ComplexProperties))!.GetComplexProperties().Single().ComplexType;
 
-            Assert.Equal(0, complexType.FindProperty(Customer.IdProperty.Name).GetMaxLength());
-            Assert.Equal(0, complexType.FindProperty("Up").GetMaxLength());
-            Assert.Equal(100, complexType.FindProperty("Down").GetMaxLength());
-            Assert.Equal(0, complexType.FindProperty("Charm").GetMaxLength());
-            Assert.Equal(100, complexType.FindProperty("Strange").GetMaxLength());
-            Assert.Equal(0, complexType.FindProperty("Top").GetMaxLength());
-            Assert.Equal(100, complexType.FindProperty("Bottom").GetMaxLength());
+            Assert.Equal(0, complexType.FindProperty(Customer.IdProperty.Name)!.GetMaxLength());
+            Assert.Equal(0, complexType.FindProperty("Up")!.GetMaxLength());
+            Assert.Equal(100, complexType.FindProperty("Down")!.GetMaxLength());
+            Assert.Equal(0, complexType.FindProperty("Charm")!.GetMaxLength());
+            Assert.Equal(100, complexType.FindProperty("Strange")!.GetMaxLength());
+            Assert.Equal(0, complexType.FindProperty("Top")!.GetMaxLength());
+            Assert.Equal(100, complexType.FindProperty("Bottom")!.GetMaxLength());
         }
 
         [Fact(Skip = "Issue #35613")]
@@ -1150,7 +1149,7 @@ public abstract partial class ModelBuilderTest
                     });
 
             var model = modelBuilder.FinalizeModel();
-            var complexType = model.FindEntityType(typeof(ComplexProperties)).GetComplexProperties().Single().ComplexType;
+            var complexType = model.FindEntityType(typeof(ComplexProperties))!.GetComplexProperties().Single().ComplexType;
 
             Assert.Equal(0, complexType.FindProperty(Customer.IdProperty.Name)!.Sentinel);
             Assert.Equal(1, complexType.FindProperty("Up")!.Sentinel);
@@ -1185,7 +1184,7 @@ public abstract partial class ModelBuilderTest
                     });
 
             var model = modelBuilder.FinalizeModel();
-            var complexType = model.FindEntityType(typeof(ComplexProperties)).GetComplexProperties().Single().ComplexType;
+            var complexType = model.FindEntityType(typeof(ComplexProperties))!.GetComplexProperties().Single().ComplexType;
 
             Assert.Equal(-1, complexType.FindProperty(Customer.IdProperty.Name)!.Sentinel);
             Assert.Equal(-1, complexType.FindProperty("Up")!.Sentinel);
@@ -1220,15 +1219,15 @@ public abstract partial class ModelBuilderTest
                     });
 
             var model = modelBuilder.FinalizeModel();
-            var complexType = model.FindEntityType(typeof(ComplexProperties)).GetComplexProperties().Single().ComplexType;
+            var complexType = model.FindEntityType(typeof(ComplexProperties))!.GetComplexProperties().Single().ComplexType;
 
-            Assert.Equal(0, complexType.FindProperty(Customer.IdProperty.Name).GetMaxLength());
-            Assert.Equal(0, complexType.FindProperty("Up").GetMaxLength());
-            Assert.Equal(-1, complexType.FindProperty("Down").GetMaxLength());
-            Assert.Equal(0, complexType.FindProperty("Charm").GetMaxLength());
-            Assert.Equal(-1, complexType.FindProperty("Strange").GetMaxLength());
-            Assert.Equal(0, complexType.FindProperty("Top").GetMaxLength());
-            Assert.Equal(-1, complexType.FindProperty("Bottom").GetMaxLength());
+            Assert.Equal(0, complexType.FindProperty(Customer.IdProperty.Name)!.GetMaxLength());
+            Assert.Equal(0, complexType.FindProperty("Up")!.GetMaxLength());
+            Assert.Equal(-1, complexType.FindProperty("Down")!.GetMaxLength());
+            Assert.Equal(0, complexType.FindProperty("Charm")!.GetMaxLength());
+            Assert.Equal(-1, complexType.FindProperty("Strange")!.GetMaxLength());
+            Assert.Equal(0, complexType.FindProperty("Top")!.GetMaxLength());
+            Assert.Equal(-1, complexType.FindProperty("Bottom")!.GetMaxLength());
         }
 
         [Fact(Skip = "Issue #35613")]
@@ -1253,22 +1252,22 @@ public abstract partial class ModelBuilderTest
                     });
 
             var model = modelBuilder.FinalizeModel();
-            var complexType = model.FindEntityType(typeof(ComplexProperties)).GetComplexProperties().Single().ComplexType;
+            var complexType = model.FindEntityType(typeof(ComplexProperties))!.GetComplexProperties().Single().ComplexType;
 
-            Assert.Null(complexType.FindProperty(Customer.IdProperty.Name).GetPrecision());
-            Assert.Null(complexType.FindProperty(Customer.IdProperty.Name).GetScale());
-            Assert.Equal(1, complexType.FindProperty("Up").GetPrecision());
-            Assert.Equal(0, complexType.FindProperty("Up").GetScale());
-            Assert.Equal(100, complexType.FindProperty("Down").GetPrecision());
-            Assert.Equal(10, complexType.FindProperty("Down").GetScale());
-            Assert.Equal(1, complexType.FindProperty("Charm").GetPrecision());
-            Assert.Equal(0, complexType.FindProperty("Charm").GetScale());
-            Assert.Equal(100, complexType.FindProperty("Strange").GetPrecision());
-            Assert.Equal(10, complexType.FindProperty("Strange").GetScale());
-            Assert.Equal(1, complexType.FindProperty("Top").GetPrecision());
-            Assert.Equal(0, complexType.FindProperty("Top").GetScale());
-            Assert.Equal(100, complexType.FindProperty("Bottom").GetPrecision());
-            Assert.Equal(10, complexType.FindProperty("Bottom").GetScale());
+            Assert.Null(complexType.FindProperty(Customer.IdProperty.Name)!.GetPrecision());
+            Assert.Null(complexType.FindProperty(Customer.IdProperty.Name)!.GetScale());
+            Assert.Equal(1, complexType.FindProperty("Up")!.GetPrecision());
+            Assert.Equal(0, complexType.FindProperty("Up")!.GetScale());
+            Assert.Equal(100, complexType.FindProperty("Down")!.GetPrecision());
+            Assert.Equal(10, complexType.FindProperty("Down")!.GetScale());
+            Assert.Equal(1, complexType.FindProperty("Charm")!.GetPrecision());
+            Assert.Equal(0, complexType.FindProperty("Charm")!.GetScale());
+            Assert.Equal(100, complexType.FindProperty("Strange")!.GetPrecision());
+            Assert.Equal(10, complexType.FindProperty("Strange")!.GetScale());
+            Assert.Equal(1, complexType.FindProperty("Top")!.GetPrecision());
+            Assert.Equal(0, complexType.FindProperty("Top")!.GetScale());
+            Assert.Equal(100, complexType.FindProperty("Bottom")!.GetPrecision());
+            Assert.Equal(10, complexType.FindProperty("Bottom")!.GetScale());
         }
 
         [Fact(Skip = "Issue #35613")]
@@ -1295,22 +1294,22 @@ public abstract partial class ModelBuilderTest
                     });
 
             var model = modelBuilder.FinalizeModel();
-            var complexType = model.FindEntityType(typeof(ComplexProperties)).GetComplexProperties().Single().ComplexType;
+            var complexType = model.FindEntityType(typeof(ComplexProperties))!.GetComplexProperties().Single().ComplexType;
 
-            Assert.Equal(1, complexType.FindProperty(Customer.IdProperty.Name).GetPrecision());
-            Assert.Equal(0, complexType.FindProperty(Customer.IdProperty.Name).GetScale());
-            Assert.Equal(1, complexType.FindProperty("Up").GetPrecision());
-            Assert.Equal(0, complexType.FindProperty("Up").GetScale());
-            Assert.Equal(100, complexType.FindProperty("Down").GetPrecision());
-            Assert.Equal(10, complexType.FindProperty("Down").GetScale());
-            Assert.Equal(1, complexType.FindProperty("Charm").GetPrecision());
-            Assert.Equal(0, complexType.FindProperty("Charm").GetScale());
-            Assert.Equal(100, complexType.FindProperty("Strange").GetPrecision());
-            Assert.Equal(10, complexType.FindProperty("Strange").GetScale());
-            Assert.Equal(1, complexType.FindProperty("Top").GetPrecision());
-            Assert.Equal(0, complexType.FindProperty("Top").GetScale());
-            Assert.Equal(100, complexType.FindProperty("Bottom").GetPrecision());
-            Assert.Equal(10, complexType.FindProperty("Bottom").GetScale());
+            Assert.Equal(1, complexType.FindProperty(Customer.IdProperty.Name)!.GetPrecision());
+            Assert.Equal(0, complexType.FindProperty(Customer.IdProperty.Name)!.GetScale());
+            Assert.Equal(1, complexType.FindProperty("Up")!.GetPrecision());
+            Assert.Equal(0, complexType.FindProperty("Up")!.GetScale());
+            Assert.Equal(100, complexType.FindProperty("Down")!.GetPrecision());
+            Assert.Equal(10, complexType.FindProperty("Down")!.GetScale());
+            Assert.Equal(1, complexType.FindProperty("Charm")!.GetPrecision());
+            Assert.Equal(0, complexType.FindProperty("Charm")!.GetScale());
+            Assert.Equal(100, complexType.FindProperty("Strange")!.GetPrecision());
+            Assert.Equal(10, complexType.FindProperty("Strange")!.GetScale());
+            Assert.Equal(1, complexType.FindProperty("Top")!.GetPrecision());
+            Assert.Equal(0, complexType.FindProperty("Top")!.GetScale());
+            Assert.Equal(100, complexType.FindProperty("Bottom")!.GetPrecision());
+            Assert.Equal(10, complexType.FindProperty("Bottom")!.GetScale());
         }
 
         [Fact(Skip = "Issue #35613")]
@@ -1335,14 +1334,14 @@ public abstract partial class ModelBuilderTest
 
             var model = modelBuilder.FinalizeModel();
 
-            var complexType = model.FindEntityType(typeof(ComplexProperties)).GetComplexProperties().Single().ComplexType;
+            var complexType = model.FindEntityType(typeof(ComplexProperties))!.GetComplexProperties().Single().ComplexType;
 
-            Assert.Null(complexType.FindProperty(Customer.IdProperty.Name).GetValueGeneratorFactory());
-            Assert.IsType<CustomValueGenerator>(complexType.FindProperty("Up").GetValueGeneratorFactory()(null, null));
-            Assert.IsType<CustomValueGenerator>(complexType.FindProperty("Down").GetValueGeneratorFactory()(null, null));
-            Assert.IsType<CustomValueGenerator>(complexType.FindProperty("Strange").GetValueGeneratorFactory()(null, null));
-            Assert.IsType<CustomValueGenerator>(complexType.FindProperty("Top").GetValueGeneratorFactory()(null, null));
-            Assert.IsType<CustomValueGenerator>(complexType.FindProperty("Bottom").GetValueGeneratorFactory()(null, null));
+            Assert.Null(complexType.FindProperty(Customer.IdProperty.Name)!.GetValueGeneratorFactory());
+            Assert.IsType<CustomValueGenerator>(complexType.FindProperty("Up")!.GetValueGeneratorFactory()!(null!, null!));
+            Assert.IsType<CustomValueGenerator>(complexType.FindProperty("Down")!.GetValueGeneratorFactory()!(null!, null!));
+            Assert.IsType<CustomValueGenerator>(complexType.FindProperty("Strange")!.GetValueGeneratorFactory()!(null!, null!));
+            Assert.IsType<CustomValueGenerator>(complexType.FindProperty("Top")!.GetValueGeneratorFactory()!(null!, null!));
+            Assert.IsType<CustomValueGenerator>(complexType.FindProperty("Bottom")!.GetValueGeneratorFactory()!(null!, null!));
         }
 
         private class CustomValueGenerator : ValueGenerator<int>
@@ -1390,17 +1389,17 @@ public abstract partial class ModelBuilderTest
                         b.Property(e => e.Down).HasValueGenerator<BadCustomValueGenerator2>();
                     });
 
-            var complexType = model.FindEntityType(typeof(ComplexProperties))
+            var complexType = model.FindEntityType(typeof(ComplexProperties))!
                 .FindComplexProperty(nameof(ComplexProperties.Quarks))!.ComplexType;
 
             Assert.Equal(
                 CoreStrings.CannotCreateValueGenerator(nameof(BadCustomValueGenerator1), "HasValueGenerator"),
-                Assert.Throws<InvalidOperationException>(() => complexType.FindProperty("Up").GetValueGeneratorFactory()(null, null))
+                Assert.Throws<InvalidOperationException>(() => complexType.FindProperty("Up")!.GetValueGeneratorFactory()!(null!, null!))
                     .Message);
 
             Assert.Equal(
                 CoreStrings.CannotCreateValueGenerator(nameof(BadCustomValueGenerator2), "HasValueGenerator"),
-                Assert.Throws<InvalidOperationException>(() => complexType.FindProperty("Down").GetValueGeneratorFactory()(null, null))
+                Assert.Throws<InvalidOperationException>(() => complexType.FindProperty("Down")!.GetValueGeneratorFactory()!(null!, null!))
                     .Message);
         }
 
@@ -1414,7 +1413,7 @@ public abstract partial class ModelBuilderTest
 
         protected class StringCollectionEntity
         {
-            public ICollection<string> Property { get; set; }
+            public ICollection<string> Property { get; set; } = null!;
         }
 
         [Fact(Skip = "Issue #35613")]
@@ -1439,15 +1438,15 @@ public abstract partial class ModelBuilderTest
                     });
 
             var model = modelBuilder.FinalizeModel();
-            var complexType = model.FindEntityType(typeof(ComplexProperties)).GetComplexProperties().Single().ComplexType;
+            var complexType = model.FindEntityType(typeof(ComplexProperties))!.GetComplexProperties().Single().ComplexType;
 
-            Assert.Null(complexType.FindProperty(Customer.IdProperty.Name).IsUnicode());
-            Assert.True(complexType.FindProperty("Up").IsUnicode());
-            Assert.False(complexType.FindProperty("Down").IsUnicode());
-            Assert.True(complexType.FindProperty("Charm").IsUnicode());
-            Assert.False(complexType.FindProperty("Strange").IsUnicode());
-            Assert.True(complexType.FindProperty("Top").IsUnicode());
-            Assert.False(complexType.FindProperty("Bottom").IsUnicode());
+            Assert.Null(complexType.FindProperty(Customer.IdProperty.Name)!.IsUnicode());
+            Assert.True(complexType.FindProperty("Up")!.IsUnicode());
+            Assert.False(complexType.FindProperty("Down")!.IsUnicode());
+            Assert.True(complexType.FindProperty("Charm")!.IsUnicode());
+            Assert.False(complexType.FindProperty("Strange")!.IsUnicode());
+            Assert.True(complexType.FindProperty("Top")!.IsUnicode());
+            Assert.False(complexType.FindProperty("Bottom")!.IsUnicode());
         }
 
         [Fact(Skip = "Issue #35613")]
@@ -1474,15 +1473,15 @@ public abstract partial class ModelBuilderTest
                     });
 
             var model = modelBuilder.FinalizeModel();
-            var complexType = model.FindEntityType(typeof(ComplexProperties)).GetComplexProperties().Single().ComplexType;
+            var complexType = model.FindEntityType(typeof(ComplexProperties))!.GetComplexProperties().Single().ComplexType;
 
-            Assert.True(complexType.FindProperty(Customer.IdProperty.Name).IsUnicode());
-            Assert.True(complexType.FindProperty("Up").IsUnicode());
-            Assert.False(complexType.FindProperty("Down").IsUnicode());
-            Assert.True(complexType.FindProperty("Charm").IsUnicode());
-            Assert.False(complexType.FindProperty("Strange").IsUnicode());
-            Assert.True(complexType.FindProperty("Top").IsUnicode());
-            Assert.False(complexType.FindProperty("Bottom").IsUnicode());
+            Assert.True(complexType.FindProperty(Customer.IdProperty.Name)!.IsUnicode());
+            Assert.True(complexType.FindProperty("Up")!.IsUnicode());
+            Assert.False(complexType.FindProperty("Down")!.IsUnicode());
+            Assert.True(complexType.FindProperty("Charm")!.IsUnicode());
+            Assert.False(complexType.FindProperty("Strange")!.IsUnicode());
+            Assert.True(complexType.FindProperty("Top")!.IsUnicode());
+            Assert.False(complexType.FindProperty("Bottom")!.IsUnicode());
         }
 
         [Fact]
@@ -1520,10 +1519,10 @@ public abstract partial class ModelBuilderTest
                 .ComplexProperty(e => e.EntityWithFields).Property(e => e.Id);
 
             var model = modelBuilder.FinalizeModel();
-            var complexType = model.FindEntityType(typeof(ComplexProperties)).GetComplexProperties().Single().ComplexType;
+            var complexType = model.FindEntityType(typeof(ComplexProperties))!.GetComplexProperties().Single().ComplexType;
             Assert.Equal(6, complexType.GetProperties().Count());
             var property = complexType.FindProperty(nameof(EntityWithFields.Id));
-            Assert.Null(property.PropertyInfo);
+            Assert.Null(property!.PropertyInfo);
             Assert.NotNull(property.FieldInfo);
         }
 
@@ -1541,7 +1540,7 @@ public abstract partial class ModelBuilderTest
                     b => b.Ignore(e => e.CompanyId));
 
             var model = modelBuilder.FinalizeModel();
-            var complexProperty = model.FindEntityType(typeof(ComplexProperties)).GetComplexProperties().Single();
+            var complexProperty = model.FindEntityType(typeof(ComplexProperties))!.GetComplexProperties().Single();
             Assert.Equal(5, complexProperty.ComplexType.GetProperties().Count());
             Assert.Single(complexProperty.ComplexType.GetComplexProperties());
         }
@@ -1624,7 +1623,7 @@ public abstract partial class ModelBuilderTest
             var model = modelBuilder.FinalizeModel();
 
             Assert.All(
-                model.FindEntityType(typeof(ComplexProperties)).GetComplexProperties(),
+                model.FindEntityType(typeof(ComplexProperties))!.GetComplexProperties(),
                 p => Assert.Equal(typeof(Customer), p.ComplexType.ClrType));
         }
 
@@ -1643,7 +1642,7 @@ public abstract partial class ModelBuilderTest
 
             var model = modelBuilder.FinalizeModel();
 
-            var complexProperty = model.FindEntityType(typeof(ComplexProperties)).GetComplexProperties().Single();
+            var complexProperty = model.FindEntityType(typeof(ComplexProperties))!.GetComplexProperties().Single();
             Assert.True(complexProperty.IsNullable);
         }
 
@@ -2226,7 +2225,7 @@ public abstract partial class ModelBuilderTest
 
             var model = modelBuilder.FinalizeModel();
 
-            var complexType = model.FindEntityType(typeof(ComplexProperties)).GetComplexProperties().Single().ComplexType;
+            var complexType = model.FindEntityType(typeof(ComplexProperties))!.GetComplexProperties().Single().ComplexType;
             Assert.Equal(nameof(Quarks), complexType.GetDiscriminatorValue());
 
             var discriminator = complexType.FindDiscriminatorProperty()!;
@@ -2250,7 +2249,7 @@ public abstract partial class ModelBuilderTest
 
             var model = modelBuilder.FinalizeModel();
 
-            var complexType = model.FindEntityType(typeof(ComplexProperties)).GetComplexProperties().Single().ComplexType;
+            var complexType = model.FindEntityType(typeof(ComplexProperties))!.GetComplexProperties().Single().ComplexType;
             Assert.Equal(BasicEnum.Two, complexType.GetDiscriminatorValue());
         }
 
@@ -2500,7 +2499,7 @@ public abstract partial class ModelBuilderTest
                             cb.Ignore(c => c.Orders);
                             cb.Ignore(c => c.Details);
                         });
-                    b.Property(e => e.Customer.Name).IsRequired();
+                    b.Property(e => e.Customer!.Name).IsRequired();
                 });
 
             var model = modelBuilder.FinalizeModel();
@@ -2527,7 +2526,7 @@ public abstract partial class ModelBuilderTest
                             cb.Ignore(c => c.Orders);
                             cb.ComplexProperty(c => c.Details, db => db.Ignore(d => d.Customer));
                         });
-                    b.Property(e => e.Customer.Details.CustomerId).HasMaxLength(50);
+                    b.Property(e => e.Customer!.Details!.CustomerId).HasMaxLength(50);
                 });
 
             var model = modelBuilder.FinalizeModel();
@@ -2551,7 +2550,7 @@ public abstract partial class ModelBuilderTest
                     b.Ignore(e => e.Customers);
                     b.ComplexProperty(e => e.Customer, cb => cb.Ignore(c => c.Orders));
                     b.ComplexProperty(
-                        e => e.Customer.Details, cb =>
+                        e => e.Customer!.Details, cb =>
                         {
                             cb.Ignore(c => c.Customer);
                             cb.Property(c => c.CustomerId).HasMaxLength(3);
@@ -2583,7 +2582,7 @@ public abstract partial class ModelBuilderTest
                             cb.Ignore(c => c.Orders);
                             cb.ComplexProperty(c => c.Details, db => db.Ignore(d => d.Customer));
                         });
-                    b.Ignore(e => e.Customer.Details);
+                    b.Ignore(e => e.Customer!.Details);
                 });
 
             var model = modelBuilder.FinalizeModel();
@@ -2609,7 +2608,7 @@ public abstract partial class ModelBuilderTest
                         {
                             cb.Ignore(c => c.Orders);
                             cb.ComplexProperty(c => c.Details, db => db.Ignore(d => d.Customer));
-                            cb.Property(c => c.Details.CustomerId).HasMaxLength(50);
+                            cb.Property(c => c.Details!.CustomerId).HasMaxLength(50);
                         });
                 });
 
@@ -2637,7 +2636,7 @@ public abstract partial class ModelBuilderTest
                         {
                             cb.Ignore(c => c.Orders);
                             cb.ComplexProperty(c => c.Details, db => db.Ignore(d => d.Customer));
-                            cb.Ignore(c => c.Details.CustomerId);
+                            cb.Ignore(c => c.Details!.CustomerId);
                         });
                 });
 
@@ -2665,7 +2664,7 @@ public abstract partial class ModelBuilderTest
                             cb.Ignore(c => c.Orders);
                             cb.Ignore(c => c.Details);
                         });
-                    b.PrimitiveCollection(e => e.Customer.Notes).HasMaxLength(50);
+                    b.PrimitiveCollection(e => e.Customer!.Notes).HasMaxLength(50);
                 });
 
             var model = modelBuilder.FinalizeModel();

--- a/test/EFCore.Specification.Tests/ModelBuilding/ModelBuilderTest.Inheritance.cs
+++ b/test/EFCore.Specification.Tests/ModelBuilding/ModelBuilderTest.Inheritance.cs
@@ -8,8 +8,6 @@ using Microsoft.EntityFrameworkCore.Metadata.Internal;
 // ReSharper disable InconsistentNaming
 namespace Microsoft.EntityFrameworkCore.ModelBuilding;
 
-#nullable disable
-
 public abstract partial class ModelBuilderTest
 {
     public abstract class InheritanceTestBase(ModelBuilderFixtureBase fixture) : ModelBuilderTestBase(fixture)
@@ -41,9 +39,9 @@ public abstract partial class ModelBuilderTest
 
             var model = modelBuilder.FinalizeModel();
 
-            Assert.Empty(model.FindEntityType(typeof(ExtraSpecialBookLabel)).GetDeclaredProperties());
-            Assert.Empty(model.FindEntityType(typeof(SpecialBookLabel)).GetDeclaredProperties());
-            Assert.NotNull(model.FindEntityType(typeof(SpecialBookLabel)).FindProperty(nameof(BookLabel.BookId)));
+            Assert.Empty(model.FindEntityType(typeof(ExtraSpecialBookLabel))!.GetDeclaredProperties());
+            Assert.Empty(model.FindEntityType(typeof(SpecialBookLabel))!.GetDeclaredProperties());
+            Assert.NotNull(model.FindEntityType(typeof(SpecialBookLabel))!.FindProperty(nameof(BookLabel.BookId)));
         }
 
         [Fact]
@@ -62,8 +60,8 @@ public abstract partial class ModelBuilderTest
             var derived = model.FindEntityType(typeof(SpecialBookLabel));
             var baseType = model.FindEntityType(typeof(BookLabel));
 
-            Assert.Same(baseType, derived.BaseType);
-            Assert.Same(derived, moreDerived.BaseType);
+            Assert.Same(baseType, derived!.BaseType);
+            Assert.Same(derived, moreDerived!.BaseType);
         }
 
         [Fact]
@@ -76,7 +74,7 @@ public abstract partial class ModelBuilderTest
 
             var model = modelBuilder.FinalizeModel();
 
-            Assert.Equal("Q", model.FindEntityType(typeof(Q)).GetDiscriminatorValue());
+            Assert.Equal("Q", model.FindEntityType(typeof(Q))!.GetDiscriminatorValue());
         }
 
         [Fact]
@@ -95,10 +93,10 @@ public abstract partial class ModelBuilderTest
 
             var model = modelBuilder.FinalizeModel();
 
-            Assert.Null(model.FindEntityType(typeof(PBase)).GetDiscriminatorValue());
-            Assert.Null(model.FindEntityType(typeof(P)).GetDiscriminatorValue());
-            Assert.Equal(1, model.FindEntityType(typeof(T)).GetDiscriminatorValue());
-            Assert.Equal(2, model.FindEntityType(typeof(Q)).GetDiscriminatorValue());
+            Assert.Null(model.FindEntityType(typeof(PBase))!.GetDiscriminatorValue());
+            Assert.Null(model.FindEntityType(typeof(P))!.GetDiscriminatorValue());
+            Assert.Equal(1, model.FindEntityType(typeof(T))!.GetDiscriminatorValue());
+            Assert.Equal(2, model.FindEntityType(typeof(Q))!.GetDiscriminatorValue());
         }
 
         [Fact]
@@ -113,9 +111,9 @@ public abstract partial class ModelBuilderTest
             modelBuilder.FinalizeModel();
 
             var model = modelBuilder.Model;
-            Assert.Empty(model.FindEntityType(typeof(SelfRefManyToOneDerived)).GetDeclaredProperties());
-            var fk = model.FindEntityType(typeof(SelfRefManyToOne)).FindNavigation(nameof(SelfRefManyToOne.SelfRef1)).ForeignKey;
-            Assert.Equal(nameof(SelfRefManyToOne.SelfRef2), fk.PrincipalToDependent.Name);
+            Assert.Empty(model.FindEntityType(typeof(SelfRefManyToOneDerived))!.GetDeclaredProperties());
+            var fk = model.FindEntityType(typeof(SelfRefManyToOne))!.FindNavigation(nameof(SelfRefManyToOne.SelfRef1))!.ForeignKey;
+            Assert.Equal(nameof(SelfRefManyToOne.SelfRef2), fk.PrincipalToDependent!.Name);
             Assert.Equal(nameof(SelfRefManyToOne.SelfRef1Id), fk.Properties.Single().Name);
             Assert.True(fk.IsRequired);
         }
@@ -132,7 +130,7 @@ public abstract partial class ModelBuilderTest
 
             Assert.Null(pickle.BaseType);
             var pickleClone = Clone(modelBuilder.Model).FindEntityType(pickle.Name);
-            var initialProperties = pickleClone.GetProperties().ToList();
+            var initialProperties = pickleClone!.GetProperties().ToList();
             var initialKeys = pickleClone.GetKeys().ToList();
             var initialIndexes = pickleClone.GetIndexes().ToList();
             var initialForeignKeys = pickleClone.GetForeignKeys().ToList();
@@ -142,7 +140,7 @@ public abstract partial class ModelBuilderTest
             var ingredientBuilder = modelBuilder.Entity<Ingredient>();
             var ingredient = ingredientBuilder.Metadata;
 
-            Assert.Same(typeof(Ingredient), pickle.BaseType.ClrType);
+            Assert.Same(typeof(Ingredient), pickle.BaseType!.ClrType);
 
             var actualProperties = pickle.GetProperties();
             Fixture.TestHelpers.ModelAsserter.AssertEqual(
@@ -219,12 +217,12 @@ public abstract partial class ModelBuilderTest
             Assert.Same(dependentEntityBuilder.Metadata, derivedDependentEntityBuilder.Metadata.BaseType);
 
             var fk = dependentEntityBuilder.Metadata.GetNavigations().Single().ForeignKey;
-            Assert.Equal(nameof(Order.Customer), fk.DependentToPrincipal.Name);
+            Assert.Equal(nameof(Order.Customer), fk.DependentToPrincipal!.Name);
             Assert.Null(fk.PrincipalToDependent);
             Assert.Same(principalEntityBuilder.Metadata, fk.PrincipalEntityType);
             var derivedFk = derivedPrincipalEntityBuilder.Metadata.GetNavigations().Single().ForeignKey;
             Assert.Null(derivedFk.DependentToPrincipal);
-            Assert.Equal(nameof(SpecialCustomer.SpecialOrders), derivedFk.PrincipalToDependent.Name);
+            Assert.Equal(nameof(SpecialCustomer.SpecialOrders), derivedFk.PrincipalToDependent!.Name);
             Assert.Empty(derivedDependentEntityBuilder.Metadata.GetDeclaredNavigations());
             Assert.Empty(principalEntityBuilder.Metadata.GetNavigations());
 
@@ -233,15 +231,15 @@ public abstract partial class ModelBuilderTest
             modelBuilder.FinalizeModel();
 
             fk = dependentEntityBuilder.Metadata.GetNavigations().Single().ForeignKey;
-            Assert.Equal(nameof(Order.Customer), fk.DependentToPrincipal.Name);
+            Assert.Equal(nameof(Order.Customer), fk.DependentToPrincipal!.Name);
             Assert.Null(fk.PrincipalToDependent);
             Assert.Same(principalEntityBuilder.Metadata, fk.PrincipalEntityType);
             derivedFk = derivedPrincipalEntityBuilder.Metadata.GetNavigations().Single().ForeignKey;
             var anotherDerivedFk = derivedDependentEntityBuilder.Metadata.GetDeclaredNavigations().Single().ForeignKey;
             Assert.NotSame(derivedFk, anotherDerivedFk);
             Assert.Null(derivedFk.DependentToPrincipal);
-            Assert.Equal(nameof(SpecialCustomer.SpecialOrders), derivedFk.PrincipalToDependent.Name);
-            Assert.Equal(nameof(Order.Customer), anotherDerivedFk.DependentToPrincipal.Name);
+            Assert.Equal(nameof(SpecialCustomer.SpecialOrders), derivedFk.PrincipalToDependent!.Name);
+            Assert.Equal(nameof(Order.Customer), anotherDerivedFk.DependentToPrincipal!.Name);
             Assert.Null(anotherDerivedFk.PrincipalToDependent);
             Assert.Same(principalEntityBuilder.Metadata, anotherDerivedFk.PrincipalEntityType);
             Assert.Empty(principalEntityBuilder.Metadata.GetNavigations());
@@ -271,19 +269,19 @@ public abstract partial class ModelBuilderTest
             Assert.Same(dependentEntityBuilder.Metadata, otherDerivedDependentEntityBuilder.Metadata.BaseType);
 
             var fk = dependentEntityBuilder.Metadata.GetNavigations().Single().ForeignKey;
-            Assert.Equal(nameof(Order.Customer), fk.DependentToPrincipal.Name);
+            Assert.Equal(nameof(Order.Customer), fk.DependentToPrincipal!.Name);
             Assert.Null(fk.PrincipalToDependent);
             Assert.Same(principalEntityBuilder.Metadata, fk.PrincipalEntityType);
             var derivedFk = derivedPrincipalEntityBuilder.Metadata.GetNavigations().Single().ForeignKey;
             Assert.Null(derivedFk.DependentToPrincipal);
-            Assert.Equal(nameof(SpecialCustomer.SpecialOrders), derivedFk.PrincipalToDependent.Name);
+            Assert.Equal(nameof(SpecialCustomer.SpecialOrders), derivedFk.PrincipalToDependent!.Name);
             Assert.Empty(derivedDependentEntityBuilder.Metadata.GetDeclaredNavigations());
             Assert.Empty(otherDerivedDependentEntityBuilder.Metadata.GetDeclaredNavigations());
             Assert.Empty(principalEntityBuilder.Metadata.GetNavigations());
 
             derivedPrincipalEntityBuilder
                 .HasMany(e => e.SpecialOrders)
-                .WithOne(e => (SpecialCustomer)e.Customer);
+                .WithOne(e => (SpecialCustomer)e.Customer!);
 
             var model = modelBuilder.FinalizeModel();
 
@@ -292,11 +290,11 @@ public abstract partial class ModelBuilderTest
             var otherDerivedDependentEntityType = model.FindEntityType(otherDerivedDependentEntityBuilder.Metadata.Name);
             var derivedPrincipalEntityType = model.FindEntityType(derivedPrincipalEntityBuilder.Metadata.Name);
 
-            Assert.Empty(dependentEntityType.GetForeignKeys());
+            Assert.Empty(dependentEntityType!.GetForeignKeys());
             Assert.Empty(dependentEntityType.GetNavigations());
-            var newFk = derivedDependentEntityType.GetDeclaredNavigations().Single().ForeignKey;
-            Assert.Equal(nameof(Order.Customer), newFk.DependentToPrincipal.Name);
-            Assert.Equal(nameof(SpecialCustomer.SpecialOrders), newFk.PrincipalToDependent.Name);
+            var newFk = derivedDependentEntityType!.GetDeclaredNavigations().Single().ForeignKey;
+            Assert.Equal(nameof(Order.Customer), newFk.DependentToPrincipal!.Name);
+            Assert.Equal(nameof(SpecialCustomer.SpecialOrders), newFk.PrincipalToDependent!.Name);
             Assert.Same(derivedPrincipalEntityType, newFk.PrincipalEntityType);
             Assert.Same(
                 newFk.DependentToPrincipal,
@@ -308,14 +306,14 @@ public abstract partial class ModelBuilderTest
                 newFk, derivedDependentEntityType.FindForeignKey(newFk.Properties, newFk.PrincipalKey, newFk.PrincipalEntityType));
             Assert.Same(
                 newFk,
-                derivedPrincipalEntityType.GetReferencingForeignKeys()
+                derivedPrincipalEntityType!.GetReferencingForeignKeys()
                     .Single(fk => fk.DeclaringEntityType == derivedDependentEntityType));
             Assert.Equal(
                 derivedPrincipalEntityType.GetDeclaredReferencingForeignKeys(),
                 derivedPrincipalEntityType.GetReferencingForeignKeys()
                     .Where(fk => fk.DeclaringEntityType == derivedDependentEntityType));
-            var otherDerivedFk = otherDerivedDependentEntityType.GetDeclaredNavigations().Single().ForeignKey;
-            Assert.Equal(nameof(Order.Customer), otherDerivedFk.DependentToPrincipal.Name);
+            var otherDerivedFk = otherDerivedDependentEntityType!.GetDeclaredNavigations().Single().ForeignKey;
+            Assert.Equal(nameof(Order.Customer), otherDerivedFk.DependentToPrincipal!.Name);
             Assert.Null(otherDerivedFk.PrincipalToDependent);
             Assert.Equal(nameof(Order.CustomerId), otherDerivedFk.Properties.Single().Name);
         }
@@ -340,7 +338,7 @@ public abstract partial class ModelBuilderTest
             otherDerivedDependentEntityBuilder.Ignore(nameof(BackOrder.SpecialOrder));
 
             derivedDependentEntityBuilder
-                .HasOne(e => (SpecialCustomer)e.Customer)
+                .HasOne(e => (SpecialCustomer)e.Customer!)
                 .WithMany(e => e.SpecialOrders);
 
             modelBuilder.FinalizeModel();
@@ -348,11 +346,11 @@ public abstract partial class ModelBuilderTest
             Assert.Empty(dependentEntityBuilder.Metadata.GetForeignKeys());
             Assert.Empty(dependentEntityBuilder.Metadata.GetNavigations());
             var newFk = derivedDependentEntityBuilder.Metadata.GetDeclaredNavigations().Single().ForeignKey;
-            Assert.Equal(nameof(Order.Customer), newFk.DependentToPrincipal.Name);
-            Assert.Equal(nameof(SpecialCustomer.SpecialOrders), newFk.PrincipalToDependent.Name);
+            Assert.Equal(nameof(Order.Customer), newFk.DependentToPrincipal!.Name);
+            Assert.Equal(nameof(SpecialCustomer.SpecialOrders), newFk.PrincipalToDependent!.Name);
             Assert.Same(derivedPrincipalEntityBuilder.Metadata, newFk.PrincipalEntityType);
             var otherDerivedFk = otherDerivedDependentEntityBuilder.Metadata.GetDeclaredNavigations().Single().ForeignKey;
-            Assert.Equal(nameof(Order.Customer), otherDerivedFk.DependentToPrincipal.Name);
+            Assert.Equal(nameof(Order.Customer), otherDerivedFk.DependentToPrincipal!.Name);
             Assert.Null(otherDerivedFk.PrincipalToDependent);
             Assert.Equal(nameof(Order.CustomerId), otherDerivedFk.Properties.Single().Name);
         }
@@ -382,8 +380,8 @@ public abstract partial class ModelBuilderTest
             Assert.Empty(dependentEntityBuilder.Metadata.GetForeignKeys());
             Assert.Empty(dependentEntityBuilder.Metadata.GetNavigations());
             var newFk = derivedDependentEntityBuilder.Metadata.GetDeclaredNavigations().Single().ForeignKey;
-            Assert.Equal(nameof(Order.Customer), newFk.DependentToPrincipal.Name);
-            Assert.Equal(nameof(Customer.SomeOrders), newFk.PrincipalToDependent.Name);
+            Assert.Equal(nameof(Order.Customer), newFk.DependentToPrincipal!.Name);
+            Assert.Equal(nameof(Customer.SomeOrders), newFk.PrincipalToDependent!.Name);
             Assert.Same(principalEntityBuilder.Metadata, newFk.PrincipalEntityType);
         }
 
@@ -404,17 +402,17 @@ public abstract partial class ModelBuilderTest
             var otherDerivedPrincipalEntityBuilder = modelBuilder.Entity<OtherCustomer>();
 
             derivedPrincipalEntityBuilder
-                .HasMany(e => (IEnumerable<SpecialOrder>)e.Orders)
+                .HasMany(e => (IEnumerable<SpecialOrder>)e.Orders!)
                 .WithOne(e => e.SpecialCustomer);
 
             Assert.Empty(principalEntityBuilder.Metadata.GetNavigations());
             var newFk = derivedDependentEntityBuilder.Metadata.GetDeclaredNavigations().Single().ForeignKey;
-            Assert.Equal(nameof(SpecialOrder.SpecialCustomer), newFk.DependentToPrincipal.Name);
-            Assert.Equal(nameof(SpecialCustomer.Orders), newFk.PrincipalToDependent.Name);
+            Assert.Equal(nameof(SpecialOrder.SpecialCustomer), newFk.DependentToPrincipal!.Name);
+            Assert.Equal(nameof(SpecialCustomer.Orders), newFk.PrincipalToDependent!.Name);
             Assert.Same(derivedPrincipalEntityBuilder.Metadata, newFk.PrincipalEntityType);
             var otherDerivedFk = otherDerivedPrincipalEntityBuilder.Metadata.GetDeclaredNavigations().Single().ForeignKey;
             Assert.Null(otherDerivedFk.DependentToPrincipal);
-            Assert.Equal(nameof(OtherCustomer.Orders), otherDerivedFk.PrincipalToDependent.Name);
+            Assert.Equal(nameof(OtherCustomer.Orders), otherDerivedFk.PrincipalToDependent!.Name);
         }
 
         [Fact]
@@ -439,8 +437,8 @@ public abstract partial class ModelBuilderTest
 
             Assert.Null(dependentEntityBuilder.Metadata.GetNavigations().Single().Inverse);
             var newFk = derivedDependentEntityBuilder.Metadata.GetDeclaredNavigations().Single().ForeignKey;
-            Assert.Equal(nameof(SpecialOrder.SpecialOrderCombination), newFk.DependentToPrincipal.Name);
-            Assert.Equal(nameof(OrderCombination.Order), newFk.PrincipalToDependent.Name);
+            Assert.Equal(nameof(SpecialOrder.SpecialOrderCombination), newFk.DependentToPrincipal!.Name);
+            Assert.Equal(nameof(OrderCombination.Order), newFk.PrincipalToDependent!.Name);
             Assert.Same(derivedDependentEntityBuilder.Metadata, newFk.DeclaringEntityType);
         }
 
@@ -467,7 +465,7 @@ public abstract partial class ModelBuilderTest
             Assert.Null(dependentEntityBuilder.Metadata.GetNavigations().Single().Inverse);
             var newFk = principalEntityBuilder.Metadata.GetDeclaredNavigations().Single().ForeignKey;
             Assert.Null(newFk.DependentToPrincipal);
-            Assert.Equal(nameof(OrderCombination.Order), newFk.PrincipalToDependent.Name);
+            Assert.Equal(nameof(OrderCombination.Order), newFk.PrincipalToDependent!.Name);
             Assert.Same(derivedDependentEntityBuilder.Metadata, newFk.DeclaringEntityType);
         }
 
@@ -489,17 +487,17 @@ public abstract partial class ModelBuilderTest
             otherDerivedDependentEntityBuilder.Ignore(nameof(BackOrder.SpecialOrder));
 
             derivedDependentEntityBuilder
-                .HasOne(e => (SpecialCustomer)e.Customer)
+                .HasOne(e => (SpecialCustomer)e.Customer!)
                 .WithMany()
                 .HasForeignKey(e => e.SpecialCustomerId);
 
             Assert.Empty(dependentEntityBuilder.Metadata.GetForeignKeys());
             Assert.Empty(dependentEntityBuilder.Metadata.GetNavigations());
             var newFk = derivedDependentEntityBuilder.Metadata.GetDeclaredNavigations().Single().ForeignKey;
-            Assert.Equal(nameof(Order.Customer), newFk.DependentToPrincipal.Name);
+            Assert.Equal(nameof(Order.Customer), newFk.DependentToPrincipal!.Name);
             Assert.Null(newFk.PrincipalToDependent);
             var otherDerivedFk = otherDerivedDependentEntityBuilder.Metadata.GetDeclaredNavigations().Single().ForeignKey;
-            Assert.Equal(nameof(Order.Customer), otherDerivedFk.DependentToPrincipal.Name);
+            Assert.Equal(nameof(Order.Customer), otherDerivedFk.DependentToPrincipal!.Name);
             Assert.Null(otherDerivedFk.PrincipalToDependent);
             Assert.Equal(nameof(Order.CustomerId), otherDerivedFk.Properties.Single().Name);
         }
@@ -551,7 +549,7 @@ public abstract partial class ModelBuilderTest
             dependentEntityBuilder.Property<int?>("SpecialCustomerId");
 
             derivedPrincipalEntityBuilder
-                .HasMany(e => (IEnumerable<SpecialOrder>)e.Orders)
+                .HasMany(e => (IEnumerable<SpecialOrder>)e.Orders!)
                 .WithOne(e => e.SpecialCustomer);
 
             dependentEntityBuilder.HasKey("SpecialCustomerId");
@@ -563,8 +561,8 @@ public abstract partial class ModelBuilderTest
             Assert.NotNull(derivedDependentEntityBuilder.Metadata.FindProperty("SpecialCustomerId"));
             Assert.Empty(principalEntityBuilder.Metadata.GetNavigations());
             var newFk = derivedDependentEntityBuilder.Metadata.GetDeclaredNavigations().Single().ForeignKey;
-            Assert.Equal(nameof(SpecialOrder.SpecialCustomer), newFk.DependentToPrincipal.Name);
-            Assert.Equal(nameof(SpecialCustomer.Orders), newFk.PrincipalToDependent.Name);
+            Assert.Equal(nameof(SpecialOrder.SpecialCustomer), newFk.DependentToPrincipal!.Name);
+            Assert.Equal(nameof(SpecialCustomer.Orders), newFk.PrincipalToDependent!.Name);
             Assert.Same(derivedPrincipalEntityBuilder.Metadata, newFk.PrincipalEntityType);
         }
 
@@ -605,12 +603,12 @@ public abstract partial class ModelBuilderTest
 
             var fk = dependentEntityType.GetForeignKeys().Single();
             Assert.Single(dependentEntityType.GetIndexes());
-            Assert.False(dependentEntityType.FindIndex(fk.Properties).IsUnique);
+            Assert.False(dependentEntityType.FindIndex(fk.Properties)!.IsUnique);
             Assert.False(derivedDependentEntityType.GetDeclaredForeignKeys().Single().IsUnique);
             Assert.Empty(derivedDependentEntityType.GetDeclaredIndexes());
 
             var backOrderClone = Clone(modelBuilder.Model).FindEntityType(derivedDependentEntityType.Name);
-            var initialProperties = backOrderClone.GetProperties().ToList();
+            var initialProperties = backOrderClone!.GetProperties().ToList();
             var initialKeys = backOrderClone.GetKeys().ToList();
             var initialIndexes = backOrderClone.GetIndexes().ToList();
             var initialForeignKeys = backOrderClone.GetForeignKeys().ToList();
@@ -620,13 +618,13 @@ public abstract partial class ModelBuilderTest
             var derivedFk = derivedDependentEntityType.GetForeignKeys()
                 .Single(foreignKey => foreignKey.PrincipalEntityType == derivedPrincipalEntityBuilder.Metadata);
             Assert.Equal(2, derivedDependentEntityType.GetIndexes().Count());
-            Assert.False(derivedDependentEntityType.FindIndex(derivedFk.Properties).IsUnique);
+            Assert.False(derivedDependentEntityType.FindIndex(derivedFk.Properties)!.IsUnique);
 
             derivedDependentEntityBuilder.HasBaseType<Order>();
 
             fk = dependentEntityType.GetForeignKeys().Single();
             Assert.Single(dependentEntityType.GetIndexes());
-            Assert.False(dependentEntityType.FindIndex(fk.Properties).IsUnique);
+            Assert.False(dependentEntityType.FindIndex(fk.Properties)!.IsUnique);
 
             Fixture.TestHelpers.ModelAsserter.AssertEqual(initialProperties, derivedDependentEntityType.GetProperties());
             Fixture.TestHelpers.ModelAsserter.AssertEqual(initialKeys, derivedDependentEntityType.GetKeys());
@@ -647,7 +645,7 @@ public abstract partial class ModelBuilderTest
 
             fk = dependentEntityType.GetForeignKeys().Single(foreignKey => foreignKey.DependentToPrincipal == null);
             Assert.Equal(2, dependentEntityType.GetIndexes().Count());
-            Assert.True(dependentEntityType.FindIndex(fk.Properties).IsUnique);
+            Assert.True(dependentEntityType.FindIndex(fk.Properties)!.IsUnique);
             Assert.Empty(derivedDependentEntityType.GetDeclaredIndexes());
         }
 
@@ -681,13 +679,13 @@ public abstract partial class ModelBuilderTest
             var dependentEntityType = dependentEntityBuilder.Metadata;
             var derivedDependentEntityType = derivedDependentEntityBuilder.Metadata;
             var index = dependentEntityType.FindIndex(dependentEntityType.GetForeignKeys().Single().Properties);
-            Assert.False(index.IsUnique);
+            Assert.False(index!.IsUnique);
             Assert.True(dependentEntityType.GetIndexes().Single(i => i != index).IsUnique);
             Assert.False(derivedDependentEntityType.GetDeclaredForeignKeys().Single().IsUnique);
             Assert.Empty(derivedDependentEntityType.GetDeclaredIndexes());
 
             var backOrderClone = Clone(modelBuilder.Model).FindEntityType(derivedDependentEntityType.Name);
-            var initialProperties = backOrderClone.GetProperties().ToList();
+            var initialProperties = backOrderClone!.GetProperties().ToList();
             var initialKeys = backOrderClone.GetKeys().ToList();
             var initialIndexes = backOrderClone.GetIndexes().ToList();
             var initialForeignKeys = backOrderClone.GetForeignKeys().ToList();
@@ -697,13 +695,13 @@ public abstract partial class ModelBuilderTest
             var derivedFk = derivedDependentEntityType.GetForeignKeys()
                 .Single(foreignKey => foreignKey.PrincipalEntityType == derivedPrincipalEntityBuilder.Metadata);
             Assert.Equal(2, derivedDependentEntityType.GetIndexes().Count());
-            Assert.False(derivedDependentEntityType.FindIndex(derivedFk.Properties).IsUnique);
+            Assert.False(derivedDependentEntityType.FindIndex(derivedFk.Properties)!.IsUnique);
 
             derivedDependentEntityBuilder.HasBaseType<Order>();
 
             var baseFK = dependentEntityType.GetForeignKeys().Single();
             var baseIndex = dependentEntityType.FindIndex(baseFK.Properties);
-            Assert.False(baseIndex.IsUnique);
+            Assert.False(baseIndex!.IsUnique);
             Assert.True(dependentEntityType.GetIndexes().Single(i => i != baseIndex).IsUnique);
             Assert.False(derivedDependentEntityType.GetDeclaredForeignKeys().Single().IsUnique);
             Assert.Empty(derivedDependentEntityType.GetDeclaredIndexes());
@@ -729,8 +727,8 @@ public abstract partial class ModelBuilderTest
             modelBuilder.Entity<OrderDetails>();
             modelBuilder.Entity<SpecialOrder>();
 
-            var fkProperty = modelBuilder.Model.FindEntityType(typeof(OrderDetails)).FindProperty(OrderDetails.OrderIdProperty);
-            Assert.Equal(ValueGenerated.Never, fkProperty.ValueGenerated);
+            var fkProperty = modelBuilder.Model.FindEntityType(typeof(OrderDetails))!.FindProperty(OrderDetails.OrderIdProperty);
+            Assert.Equal(ValueGenerated.Never, fkProperty!.ValueGenerated);
         }
 
         [Fact]
@@ -745,8 +743,8 @@ public abstract partial class ModelBuilderTest
             Assert.NotNull(relationshipBuilder);
             Assert.Equal(typeof(BookLabel), relationshipBuilder.Metadata.DeclaringEntityType.ClrType);
             Assert.Equal(typeof(SpecialBookLabel), relationshipBuilder.Metadata.PrincipalEntityType.ClrType);
-            Assert.Equal(nameof(BookLabel.SpecialBookLabel), relationshipBuilder.Metadata.DependentToPrincipal.Name);
-            Assert.Equal(nameof(SpecialBookLabel.BookLabel), relationshipBuilder.Metadata.PrincipalToDependent.Name);
+            Assert.Equal(nameof(BookLabel.SpecialBookLabel), relationshipBuilder.Metadata.DependentToPrincipal!.Name);
+            Assert.Equal(nameof(SpecialBookLabel.BookLabel), relationshipBuilder.Metadata.PrincipalToDependent!.Name);
             Assert.Equal(nameof(SpecialBookLabel.Id), relationshipBuilder.Metadata.PrincipalKey.Properties.Single().Name);
         }
 
@@ -759,7 +757,7 @@ public abstract partial class ModelBuilderTest
             modelBuilder.Ignore<SpecialBookLabel>();
             modelBuilder.Ignore<AnotherBookLabel>();
 
-            Assert.Empty(modelBuilder.Model.FindEntityType(typeof(BookLabel).FullName).GetDirectlyDerivedTypes());
+            Assert.Empty(modelBuilder.Model.FindEntityType(typeof(BookLabel).FullName!)!.GetDirectlyDerivedTypes());
         }
 
         [Fact]
@@ -772,7 +770,7 @@ public abstract partial class ModelBuilderTest
             modelBuilder.Ignore<BookLabel>();
 
             var model = modelBuilder.Model;
-            Assert.Null(model.FindEntityType(typeof(BookLabel).FullName));
+            Assert.Null(model.FindEntityType(typeof(BookLabel).FullName!));
             foreach (var entityType in model.GetEntityTypes())
             {
                 Assert.DoesNotContain(
@@ -792,9 +790,9 @@ public abstract partial class ModelBuilderTest
             modelBuilder.Entity<AnotherBookLabel>();
 
             var bookLabel = modelBuilder.Model.FindEntityType(typeof(BookLabel));
-            var specialNavigation = bookLabel.GetDeclaredNavigations().Single(n => n.Name == nameof(BookLabel.SpecialBookLabel));
+            var specialNavigation = bookLabel!.GetDeclaredNavigations().Single(n => n.Name == nameof(BookLabel.SpecialBookLabel));
             Assert.Equal(typeof(SpecialBookLabel), specialNavigation.TargetEntityType.ClrType);
-            Assert.Equal(nameof(SpecialBookLabel.BookLabel), specialNavigation.Inverse.Name);
+            Assert.Equal(nameof(SpecialBookLabel.BookLabel), specialNavigation.Inverse!.Name);
             var anotherNavigation = bookLabel.GetDeclaredNavigations().Single(n => n.Name == nameof(BookLabel.AnotherBookLabel));
             Assert.Equal(typeof(AnotherBookLabel), anotherNavigation.TargetEntityType.ClrType);
             Assert.Null(anotherNavigation.Inverse);
@@ -813,13 +811,13 @@ public abstract partial class ModelBuilderTest
 
             var extraSpecialBookLabelEntityBuilder = modelBuilder.Entity<ExtraSpecialBookLabel>();
             modelBuilder.Entity<SpecialBookLabel>()
-                .HasOne(e => (ExtraSpecialBookLabel)e.SpecialBookLabel)
-                .WithOne(e => (SpecialBookLabel)e.BookLabel)
+                .HasOne(e => (ExtraSpecialBookLabel)e.SpecialBookLabel!)
+                .WithOne(e => (SpecialBookLabel)e.BookLabel!)
                 .HasForeignKey<ExtraSpecialBookLabel>();
 
-            var fk = bookLabelEntityBuilder.Metadata.FindNavigation(nameof(BookLabel.SpecialBookLabel)).ForeignKey;
+            var fk = bookLabelEntityBuilder.Metadata.FindNavigation(nameof(BookLabel.SpecialBookLabel))!.ForeignKey;
             Assert.Equal([fk], extraSpecialBookLabelEntityBuilder.Metadata.GetForeignKeys());
-            Assert.Equal(nameof(SpecialBookLabel.BookLabel), fk.DependentToPrincipal.Name);
+            Assert.Equal(nameof(SpecialBookLabel.BookLabel), fk.DependentToPrincipal!.Name);
             Assert.Equal([fk], extraSpecialBookLabelEntityBuilder.Metadata.GetForeignKeys());
         }
 
@@ -829,21 +827,21 @@ public abstract partial class ModelBuilderTest
             var modelBuilder = CreateModelBuilder();
             modelBuilder.Entity<PersonBaseViewModel>();
 
-            Assert.Empty(modelBuilder.Model.FindEntityType(typeof(PersonBaseViewModel)).GetForeignKeys());
+            Assert.Empty(modelBuilder.Model.FindEntityType(typeof(PersonBaseViewModel))!.GetForeignKeys());
 
             var citizen = modelBuilder.Model.FindEntityType(typeof(CitizenViewModel));
-            var citizenNavigation = citizen.GetDeclaredNavigations().Single(n => n.Name == nameof(CitizenViewModel.CityVM));
-            Assert.Equal(nameof(CityViewModel.People), citizenNavigation.Inverse.Name);
+            var citizenNavigation = citizen!.GetDeclaredNavigations().Single(n => n.Name == nameof(CitizenViewModel.CityVM));
+            Assert.Equal(nameof(CityViewModel.People), citizenNavigation.Inverse!.Name);
 
             var doctor = modelBuilder.Model.FindEntityType(typeof(DoctorViewModel));
-            var doctorNavigation = doctor.GetDeclaredNavigations().Single(n => n.Name == nameof(CitizenViewModel.CityVM));
-            Assert.Equal(nameof(CityViewModel.Medics), doctorNavigation.Inverse.Name);
+            var doctorNavigation = doctor!.GetDeclaredNavigations().Single(n => n.Name == nameof(CitizenViewModel.CityVM));
+            Assert.Equal(nameof(CityViewModel.Medics), doctorNavigation.Inverse!.Name);
 
             var police = modelBuilder.Model.FindEntityType(typeof(PoliceViewModel));
-            var policeNavigation = police.GetDeclaredNavigations().Single(n => n.Name == nameof(CitizenViewModel.CityVM));
-            Assert.Equal(nameof(CityViewModel.Police), policeNavigation.Inverse.Name);
+            var policeNavigation = police!.GetDeclaredNavigations().Single(n => n.Name == nameof(CitizenViewModel.CityVM));
+            Assert.Equal(nameof(CityViewModel.Police), policeNavigation.Inverse!.Name);
 
-            Assert.Empty(modelBuilder.Model.FindEntityType(typeof(CityViewModel)).GetForeignKeys());
+            Assert.Empty(modelBuilder.Model.FindEntityType(typeof(CityViewModel))!.GetForeignKeys());
 
             modelBuilder.Entity<CityViewModel>(c => c.Ignore(c => c.CustomValues));
 
@@ -865,7 +863,7 @@ public abstract partial class ModelBuilderTest
             Assert.Equal(ConfigurationSource.DataAnnotation, baseEntityType.GetPrimaryKeyConfigurationSource());
             Assert.Equal(
                 ConfigurationSource.DataAnnotation,
-                baseEntityType.FindNavigation(nameof(BaseTypeWithKeyAnnotation.Navigation)).ForeignKey.GetConfigurationSource());
+                baseEntityType.FindNavigation(nameof(BaseTypeWithKeyAnnotation.Navigation))!.ForeignKey.GetConfigurationSource());
             Assert.Equal(ConfigurationSource.Convention, derivedEntityType.GetBaseTypeConfigurationSource());
         }
 
@@ -885,10 +883,10 @@ public abstract partial class ModelBuilderTest
             Assert.Equal(ConfigurationSource.DataAnnotation, baseEntityType.GetPrimaryKeyConfigurationSource());
             Assert.Equal(
                 ConfigurationSource.DataAnnotation,
-                baseEntityType.FindNavigation(nameof(BaseTypeWithKeyAnnotation.Navigation)).ForeignKey.GetConfigurationSource());
+                baseEntityType.FindNavigation(nameof(BaseTypeWithKeyAnnotation.Navigation))!.ForeignKey.GetConfigurationSource());
             Assert.Equal(
                 ConfigurationSource.Explicit,
-                derivedEntityType.FindNavigation(nameof(DerivedTypeWithKeyAnnotation.Navigation)).ForeignKey.GetConfigurationSource());
+                derivedEntityType.FindNavigation(nameof(DerivedTypeWithKeyAnnotation.Navigation))!.ForeignKey.GetConfigurationSource());
             Assert.Equal(ConfigurationSource.Explicit, derivedEntityType.GetPrimaryKeyConfigurationSource());
         }
 
@@ -918,7 +916,7 @@ public abstract partial class ModelBuilderTest
             mb.Entity<AL>();
             mb.Entity<L>();
 
-            Assert.Equal(ValueGenerated.OnAdd, mb.Model.FindEntityType(typeof(Q)).FindProperty(nameof(Q.ID)).ValueGenerated);
+            Assert.Equal(ValueGenerated.OnAdd, mb.Model.FindEntityType(typeof(Q))!.FindProperty(nameof(Q.ID))!.ValueGenerated);
         }
 
         [Fact]
@@ -942,14 +940,14 @@ public abstract partial class ModelBuilderTest
         protected class L
         {
             public int Id { get; set; }
-            public IList<T> Ts { get; set; }
+            public IList<T> Ts { get; set; } = null!;
         }
 
         protected class T : P
         {
-            public Q D { get; set; }
-            public P P { get; set; }
-            public Q F { get; set; }
+            public Q D { get; set; } = null!;
+            public P P { get; set; } = null!;
+            public Q F { get; set; } = null!;
         }
 
         protected abstract class P : PBase;
@@ -959,13 +957,13 @@ public abstract partial class ModelBuilderTest
         protected abstract class PBase
         {
             public int ID { get; set; }
-            public string Stuff { get; set; }
+            public string Stuff { get; set; } = null!;
         }
 
         protected class AL
         {
             public int Id { get; set; }
-            public PBase L { get; set; }
+            public PBase L { get; set; } = null!;
         }
     }
 }

--- a/test/EFCore.Specification.Tests/ModelBuilding/ModelBuilderTest.ManyToOne.cs
+++ b/test/EFCore.Specification.Tests/ModelBuilding/ModelBuilderTest.ManyToOne.cs
@@ -5,8 +5,6 @@
 
 namespace Microsoft.EntityFrameworkCore.ModelBuilding;
 
-#nullable disable
-
 public abstract partial class ModelBuilderTest
 {
     public abstract class ManyToOneTestBase(ModelBuilderFixtureBase fixture) : ModelBuilderTestBase(fixture)
@@ -27,9 +25,9 @@ public abstract partial class ModelBuilderTest
 
             var dependentType = model.FindEntityType(typeof(Order));
             var principalType = model.FindEntityType(typeof(Customer));
-            var fk = dependentType.GetForeignKeys().Single();
+            var fk = dependentType!.GetForeignKeys().Single();
 
-            var principalKey = principalType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
             var dependentKey = dependentType.FindPrimaryKey();
 
             modelBuilder.Entity<Order>().HasOne(e => e.Customer).WithMany(e => e.Orders);
@@ -88,10 +86,10 @@ public abstract partial class ModelBuilderTest
 
             var dependentType = model.FindEntityType(typeof(DependentWithField));
             var principalType = model.FindEntityType(typeof(OneToManyPrincipalWithField));
-            var fk = dependentType.GetForeignKeys().Single();
+            var fk = dependentType!.GetForeignKeys().Single();
 
             var navToPrincipal = dependentType.FindNavigation("OneToManyPrincipal");
-            var navToDependent = principalType.FindNavigation("Dependents");
+            var navToDependent = principalType!.FindNavigation("Dependents");
 
             var principalKey = principalType.FindPrimaryKey();
             var dependentKey = dependentType.FindPrimaryKey();
@@ -103,7 +101,7 @@ public abstract partial class ModelBuilderTest
             modelBuilder.FinalizeModel();
 
             Assert.Same(fk, dependentType.GetForeignKeys().Single());
-            Assert.Equal(navToPrincipal.Name, dependentType.GetNavigations().Single().Name);
+            Assert.Equal(navToPrincipal!.Name, dependentType.GetNavigations().Single().Name);
             Assert.Same(navToDependent, principalType.GetNavigations().Single());
             Assert.Same(fk, dependentType.GetNavigations().Single().ForeignKey);
             Assert.Same(fk, principalType.GetNavigations().Single().ForeignKey);
@@ -140,8 +138,8 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(Order));
             var principalType = model.FindEntityType(typeof(Customer));
 
-            var principalKey = principalType.FindPrimaryKey();
-            var dependentKey = dependentType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
+            var dependentKey = dependentType!.FindPrimaryKey();
 
             modelBuilder.Entity<Order>().HasOne(e => e.Customer).WithMany(e => e.Orders);
 
@@ -182,10 +180,10 @@ public abstract partial class ModelBuilderTest
 
             var dependentType = model.FindEntityType(typeof(Order));
             var principalType = model.FindEntityType(typeof(Customer));
-            var fk = principalType.GetNavigations().Single().ForeignKey;
+            var fk = principalType!.GetNavigations().Single().ForeignKey;
 
             var principalKey = principalType.FindPrimaryKey();
-            var dependentKey = dependentType.FindPrimaryKey();
+            var dependentKey = dependentType!.FindPrimaryKey();
 
             modelBuilder.Entity<Order>().HasOne(e => e.Customer).WithMany(e => e.Orders);
 
@@ -194,8 +192,8 @@ public abstract partial class ModelBuilderTest
             var newFk = principalType.GetNavigations().Single().ForeignKey;
             AssertEqual(fk.Properties, newFk.Properties);
             Assert.Same(newFk, dependentType.GetNavigations().Single().ForeignKey);
-            Assert.Equal(nameof(Order.Customer), fk.DependentToPrincipal.Name);
-            Assert.Equal(nameof(Customer.Orders), fk.PrincipalToDependent.Name);
+            Assert.Equal(nameof(Order.Customer), fk.DependentToPrincipal!.Name);
+            Assert.Equal(nameof(Customer.Orders), fk.PrincipalToDependent!.Name);
             Assert.Empty(principalType.GetForeignKeys());
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
@@ -227,16 +225,16 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(Order));
             var principalType = model.FindEntityType(typeof(Customer));
 
-            var principalKey = principalType.FindPrimaryKey();
-            var dependentKey = dependentType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
+            var dependentKey = dependentType!.FindPrimaryKey();
 
             modelBuilder.Entity<Order>().HasOne(e => e.Customer).WithMany(e => e.Orders);
 
             modelBuilder.FinalizeModel();
 
             var fk = dependentType.GetNavigations().Single().ForeignKey;
-            Assert.Equal(nameof(Order.Customer), fk.DependentToPrincipal.Name);
-            Assert.Equal(nameof(Customer.Orders), fk.PrincipalToDependent.Name);
+            Assert.Equal(nameof(Order.Customer), fk.DependentToPrincipal!.Name);
+            Assert.Equal(nameof(Customer.Orders), fk.PrincipalToDependent!.Name);
 
             Assert.NotNull(dependentType.GetForeignKeys().Single(foreignKey => foreignKey != fk));
             Assert.Same(fk, dependentType.GetNavigations().Single().ForeignKey);
@@ -272,9 +270,9 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(Order));
             var principalType = model.FindEntityType(typeof(Customer));
 
-            var fkProperty = dependentType.FindProperty("CustomerId");
+            var fkProperty = dependentType!.FindProperty("CustomerId");
 
-            var principalKey = principalType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
             var dependentKey = dependentType.FindPrimaryKey();
 
             modelBuilder.Entity<Order>().HasOne(e => e.Customer).WithMany(e => e.Orders);
@@ -319,20 +317,20 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(Order));
             var principalType = model.FindEntityType(typeof(Customer));
 
-            var fkProperty = dependentType.FindProperty(nameof(Order.CustomerId));
+            var fkProperty = dependentType!.FindProperty(nameof(Order.CustomerId));
 
-            var principalKey = principalType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
             var dependentKey = dependentType.FindPrimaryKey();
 
             modelBuilder.Entity<Order>().HasOne(e => e.Customer).WithMany();
 
             var fk = dependentType.GetNavigations().Single().ForeignKey;
-            Assert.Equal(nameof(Order.Customer), fk.DependentToPrincipal.Name);
+            Assert.Equal(nameof(Order.Customer), fk.DependentToPrincipal!.Name);
             Assert.Null(fk.PrincipalToDependent);
             Assert.NotSame(fk, principalType.GetNavigations().Single().ForeignKey);
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
-            Assert.NotNull(dependentType.FindForeignKeys(fkProperty).SingleOrDefault());
+            Assert.NotNull(dependentType.FindForeignKeys(fkProperty!).SingleOrDefault());
 
             if (Fixture.ForeignKeysHaveIndexes)
             {
@@ -360,20 +358,20 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(Order));
             var principalType = model.FindEntityType(typeof(Customer));
 
-            var fkProperty = dependentType.FindProperty(nameof(Order.CustomerId));
+            var fkProperty = dependentType!.FindProperty(nameof(Order.CustomerId));
 
-            var principalKey = principalType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
             var dependentKey = dependentType.FindPrimaryKey();
 
             modelBuilder.Entity<Order>().HasOne<Customer>().WithMany(e => e.Orders);
 
             var fk = principalType.GetNavigations().Single().ForeignKey;
-            Assert.Equal(nameof(Customer.Orders), fk.PrincipalToDependent.Name);
+            Assert.Equal(nameof(Customer.Orders), fk.PrincipalToDependent!.Name);
             Assert.Null(fk.DependentToPrincipal);
             Assert.NotSame(fk, dependentType.GetNavigations().Single().ForeignKey);
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
-            Assert.NotNull(dependentType.FindForeignKeys(fkProperty).SingleOrDefault());
+            Assert.NotNull(dependentType.FindForeignKeys(fkProperty!).SingleOrDefault());
 
             if (Fixture.ForeignKeysHaveIndexes)
             {
@@ -402,11 +400,11 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(Order));
             var principalType = model.FindEntityType(typeof(Customer));
 
-            var fkProperty = dependentType.FindProperty("CustomerId");
+            var fkProperty = dependentType!.FindProperty("CustomerId");
             var existingFk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, existingFk.Properties.Single());
 
-            var principalKey = principalType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
             var dependentKey = dependentType.FindPrimaryKey();
 
             modelBuilder.Entity<Order>().HasOne<Customer>().WithMany();
@@ -449,9 +447,9 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(Order));
             var principalType = model.FindEntityType(typeof(Customer));
 
-            var fkProperty = dependentType.FindProperty("CustomerId");
+            var fkProperty = dependentType!.FindProperty("CustomerId");
 
-            var principalKey = principalType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
             var dependentKey = dependentType.FindPrimaryKey();
 
             modelBuilder
@@ -497,8 +495,8 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(Pickle));
             var principalType = model.FindEntityType(typeof(BigMak));
 
-            var principalKey = principalType.FindPrimaryKey();
-            var dependentKey = dependentType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
+            var dependentKey = dependentType!.FindPrimaryKey();
 
             var fk = dependentType.GetForeignKeys().Single(foreignKey => foreignKey.DependentToPrincipal == null);
 
@@ -542,9 +540,9 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(Pickle));
             var principalType = model.FindEntityType(typeof(BigMak));
 
-            var fkProperty = dependentType.FindProperty("BurgerId");
+            var fkProperty = dependentType!.FindProperty("BurgerId");
 
-            var principalKey = principalType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
             var dependentKey = dependentType.FindPrimaryKey();
 
             modelBuilder
@@ -589,8 +587,8 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(Pickle));
             var principalType = model.FindEntityType(typeof(BigMak));
 
-            var principalKey = principalType.FindPrimaryKey();
-            var dependentKey = dependentType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
+            var dependentKey = dependentType!.FindPrimaryKey();
 
             modelBuilder
                 .Entity<Pickle>().HasOne(e => e.BigMak).WithMany()
@@ -601,7 +599,7 @@ public abstract partial class ModelBuilderTest
             var fk = dependentType.GetNavigations().Single().ForeignKey;
             Assert.Same(dependentType.FindProperty(nameof(Pickle.BurgerId)), fk.Properties.Single());
 
-            Assert.Equal(nameof(Pickle.BigMak), fk.DependentToPrincipal.Name);
+            Assert.Equal(nameof(Pickle.BigMak), fk.DependentToPrincipal!.Name);
             Assert.Null(fk.PrincipalToDependent);
             Assert.NotSame(fk, principalType.GetNavigations().Single().ForeignKey);
             Assert.Same(principalKey, principalType.FindPrimaryKey());
@@ -632,9 +630,9 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(Pickle));
             var principalType = model.FindEntityType(typeof(BigMak));
 
-            var fkProperty = dependentType.FindProperty("BurgerId");
+            var fkProperty = dependentType!.FindProperty("BurgerId");
 
-            var principalKey = principalType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
             var dependentKey = dependentType.FindPrimaryKey();
 
             modelBuilder
@@ -646,7 +644,7 @@ public abstract partial class ModelBuilderTest
             var fk = principalType.GetNavigations().Single().ForeignKey;
             Assert.Same(fkProperty, fk.Properties.Single());
 
-            Assert.Equal(nameof(BigMak.Pickles), fk.PrincipalToDependent.Name);
+            Assert.Equal(nameof(BigMak.Pickles), fk.PrincipalToDependent!.Name);
             Assert.Null(fk.DependentToPrincipal);
             Assert.NotSame(fk, dependentType.GetNavigations().Single().ForeignKey);
             Assert.Same(principalKey, principalType.FindPrimaryKey());
@@ -677,10 +675,10 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(Pickle));
             var principalType = model.FindEntityType(typeof(BigMak));
 
-            var fkProperty = dependentType.FindProperty("BurgerId");
+            var fkProperty = dependentType!.FindProperty("BurgerId");
             var fk = dependentType.GetForeignKeys().SingleOrDefault();
 
-            var principalKey = principalType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
             var dependentKey = dependentType.FindPrimaryKey();
 
             modelBuilder
@@ -723,8 +721,8 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(Pickle));
             var principalType = model.FindEntityType(typeof(BigMak));
 
-            var principalKey = principalType.FindPrimaryKey();
-            var dependentKey = dependentType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
+            var dependentKey = dependentType!.FindPrimaryKey();
 
             modelBuilder.Entity<Pickle>().HasOne(e => e.BigMak).WithMany(e => e.Pickles);
 
@@ -769,8 +767,8 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(Pickle));
             var principalType = model.FindEntityType(typeof(BigMak));
 
-            var principalKey = principalType.FindPrimaryKey();
-            var dependentKey = dependentType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
+            var dependentKey = dependentType!.FindPrimaryKey();
 
             modelBuilder.Entity<Pickle>().HasOne(e => e.BigMak).WithMany();
 
@@ -812,8 +810,8 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(Pickle));
             var principalType = model.FindEntityType(typeof(BigMak));
 
-            var principalKey = principalType.FindPrimaryKey();
-            var dependentKey = dependentType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
+            var dependentKey = dependentType!.FindPrimaryKey();
 
             modelBuilder.Entity<Pickle>().HasOne<BigMak>().WithMany(e => e.Pickles);
 
@@ -826,7 +824,7 @@ public abstract partial class ModelBuilderTest
             Assert.Same(typeof(int?), fkProperty.ClrType);
             Assert.Same(dependentType, fkProperty.DeclaringType);
 
-            Assert.Equal(nameof(BigMak.Pickles), fk.PrincipalToDependent.Name);
+            Assert.Equal(nameof(BigMak.Pickles), fk.PrincipalToDependent!.Name);
             Assert.Null(fk.DependentToPrincipal);
             Assert.NotSame(fk, dependentType.GetNavigations().Single().ForeignKey);
 
@@ -855,8 +853,8 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(Pickle));
             var principalType = model.FindEntityType(typeof(BigMak));
 
-            var principalKey = principalType.FindPrimaryKey();
-            var dependentKey = dependentType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
+            var dependentKey = dependentType!.FindPrimaryKey();
 
             var fk = dependentType.GetForeignKeys().SingleOrDefault();
 
@@ -900,8 +898,8 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(Pickle));
             var principalType = model.FindEntityType(typeof(BigMak));
 
-            var principalKey = principalType.FindPrimaryKey();
-            var dependentKey = dependentType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
+            var dependentKey = dependentType!.FindPrimaryKey();
 
             var fkProperty = dependentType.FindProperty("BigMakId");
 
@@ -944,8 +942,8 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(Pickle));
             var principalType = model.FindEntityType(typeof(BigMak));
 
-            var principalKey = principalType.FindPrimaryKey();
-            var dependentKey = dependentType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
+            var dependentKey = dependentType!.FindPrimaryKey();
 
             modelBuilder
                 .Entity<Pickle>().HasOne(e => e.BigMak).WithMany(e => e.Pickles)
@@ -987,7 +985,7 @@ public abstract partial class ModelBuilderTest
 
             modelBuilder.FinalizeModel();
 
-            Assert.Equal(2, model.FindEntityType(typeof(Friendship)).GetNavigations().Count());
+            Assert.Equal(2, model.FindEntityType(typeof(Friendship))!.GetNavigations().Count());
         }
 
         [Fact]
@@ -1005,8 +1003,8 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(Order));
             var principalType = model.FindEntityType(typeof(Customer));
 
-            var fkProperty = dependentType.FindProperty("CustomerId");
-            var principalProperty = principalType.FindProperty(Customer.IdProperty.Name);
+            var fkProperty = dependentType!.FindProperty("CustomerId");
+            var principalProperty = principalType!.FindProperty(Customer.IdProperty.Name);
 
             var principalKey = principalType.FindPrimaryKey();
             var dependentKey = dependentType.FindPrimaryKey();
@@ -1054,10 +1052,10 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(Order));
             var principalType = model.FindEntityType(typeof(Customer));
 
-            var principalProperty = principalType.FindProperty("AlternateKey");
+            var principalProperty = principalType!.FindProperty("AlternateKey");
 
             var expectedPrincipalProperties = principalType.GetProperties().ToList();
-            var expectedDependentProperties = dependentType.GetProperties().ToList();
+            var expectedDependentProperties = dependentType!.GetProperties().ToList();
 
             var principalKey = principalType.FindPrimaryKey();
             var dependentKey = dependentType.FindPrimaryKey();
@@ -1116,8 +1114,8 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(Order));
             var principalType = model.FindEntityType(typeof(Customer));
 
-            var fkProperty = dependentType.FindProperty("CustomerId");
-            var principalProperty = principalType.FindProperty(Customer.IdProperty.Name);
+            var fkProperty = dependentType!.FindProperty("CustomerId");
+            var principalProperty = principalType!.FindProperty(Customer.IdProperty.Name);
 
             var principalKey = principalType.FindPrimaryKey();
             var dependentKey = dependentType.FindPrimaryKey();
@@ -1167,8 +1165,8 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(Order));
             var principalType = model.FindEntityType(typeof(Customer));
 
-            var fkProperty = dependentType.FindProperty("CustomerId");
-            var principalProperty = principalType.FindProperty(Customer.IdProperty.Name);
+            var fkProperty = dependentType!.FindProperty("CustomerId");
+            var principalProperty = principalType!.FindProperty(Customer.IdProperty.Name);
 
             var principalKey = principalType.FindPrimaryKey();
             var dependentKey = dependentType.FindPrimaryKey();
@@ -1216,8 +1214,8 @@ public abstract partial class ModelBuilderTest
 
             var dependentType = model.FindEntityType(typeof(Order));
             var principalType = model.FindEntityType(typeof(Customer));
-            var expectedPrincipalProperties = principalType.GetProperties().ToList();
-            var expectedDependentProperties = dependentType.GetProperties().ToList();
+            var expectedPrincipalProperties = principalType!.GetProperties().ToList();
+            var expectedDependentProperties = dependentType!.GetProperties().ToList();
             var principalKey = principalType.FindPrimaryKey();
             var dependentKey = dependentType.FindPrimaryKey();
 
@@ -1271,8 +1269,8 @@ public abstract partial class ModelBuilderTest
 
             var dependentType = model.FindEntityType(typeof(Order));
             var principalType = model.FindEntityType(typeof(Customer));
-            var expectedPrincipalProperties = principalType.GetProperties().ToList();
-            var expectedDependentProperties = dependentType.GetProperties().ToList();
+            var expectedPrincipalProperties = principalType!.GetProperties().ToList();
+            var expectedDependentProperties = dependentType!.GetProperties().ToList();
             var principalKey = principalType.FindPrimaryKey();
             var dependentKey = dependentType.FindPrimaryKey();
 
@@ -1325,8 +1323,8 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(Pickle));
             var principalType = model.FindEntityType(typeof(BigMak));
 
-            var fkProperty = dependentType.FindProperty("BurgerId");
-            var principalProperty = principalType.FindProperty("AlternateKey");
+            var fkProperty = dependentType!.FindProperty("BurgerId");
+            var principalProperty = principalType!.FindProperty("AlternateKey");
 
             var principalKey = principalType.FindPrimaryKey();
             var dependentKey = dependentType.FindPrimaryKey();
@@ -1380,8 +1378,8 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(Pickle));
             var principalType = model.FindEntityType(typeof(BigMak));
 
-            var fkProperty = dependentType.FindProperty("BurgerId");
-            var principalProperty = principalType.FindProperty("AlternateKey");
+            var fkProperty = dependentType!.FindProperty("BurgerId");
+            var principalProperty = principalType!.FindProperty("AlternateKey");
 
             var principalKey = principalType.FindPrimaryKey();
             var dependentKey = dependentType.FindPrimaryKey();
@@ -1442,9 +1440,9 @@ public abstract partial class ModelBuilderTest
 
             var model = modelBuilder.FinalizeModel();
 
-            var fk = model.FindEntityType(typeof(Profile13300)).GetForeignKeys().Single();
-            Assert.Equal("_profiles", fk.PrincipalToDependent.Name);
-            Assert.Equal("User", fk.DependentToPrincipal.Name);
+            var fk = model.FindEntityType(typeof(Profile13300))!.GetForeignKeys().Single();
+            Assert.Equal("_profiles", fk.PrincipalToDependent!.Name);
+            Assert.Equal("User", fk.DependentToPrincipal!.Name);
             Assert.Equal("Email", fk.Properties[0].Name);
             Assert.Equal(typeof(string), fk.Properties[0].ClrType);
             Assert.Equal("_email", fk.PrincipalKey.Properties[0].Name);
@@ -1460,7 +1458,7 @@ public abstract partial class ModelBuilderTest
         protected class Profile13300
         {
             public Guid Id { get; set; }
-            public User13300 User { get; set; }
+            public User13300 User { get; set; } = null!;
         }
 
         [Fact]
@@ -1478,8 +1476,8 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(Tomato));
             var principalType = model.FindEntityType(typeof(Whoopper));
 
-            var principalKey = principalType.FindPrimaryKey();
-            var dependentKey = dependentType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
+            var dependentKey = dependentType!.FindPrimaryKey();
 
             modelBuilder
                 .Entity<Tomato>().HasOne(e => e.Whoopper).WithMany(e => e.Tomatoes)
@@ -1523,10 +1521,10 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(Tomato));
             var principalType = model.FindEntityType(typeof(Whoopper));
 
-            var fkProperty1 = dependentType.FindProperty("BurgerId1");
+            var fkProperty1 = dependentType!.FindProperty("BurgerId1");
             var fkProperty2 = dependentType.FindProperty("BurgerId2");
 
-            var principalKey = principalType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
             var dependentKey = dependentType.FindPrimaryKey();
 
             modelBuilder
@@ -1573,9 +1571,9 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(Tomato));
             var principalType = model.FindEntityType(typeof(Whoopper));
 
-            var fkProperty1 = dependentType.FindProperty("BurgerId1");
+            var fkProperty1 = dependentType!.FindProperty("BurgerId1");
             var fkProperty2 = dependentType.FindProperty("BurgerId2");
-            var principalProperty1 = principalType.FindProperty("AlternateKey1");
+            var principalProperty1 = principalType!.FindProperty("AlternateKey1");
             var principalProperty2 = principalType.FindProperty("AlternateKey2");
 
             var principalKey = principalType.FindPrimaryKey();
@@ -1633,9 +1631,9 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(Tomato));
             var principalType = model.FindEntityType(typeof(Whoopper));
 
-            var fkProperty1 = dependentType.FindProperty("BurgerId1");
+            var fkProperty1 = dependentType!.FindProperty("BurgerId1");
             var fkProperty2 = dependentType.FindProperty("BurgerId2");
-            var principalProperty1 = principalType.FindProperty("AlternateKey1");
+            var principalProperty1 = principalType!.FindProperty("AlternateKey1");
             var principalProperty2 = principalType.FindProperty("AlternateKey2");
 
             var principalKey = principalType.FindPrimaryKey();
@@ -1693,10 +1691,10 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(Tomato));
             var principalType = model.FindEntityType(typeof(Whoopper));
 
-            var fkProperty1 = dependentType.FindProperty(nameof(Tomato.BurgerId1));
+            var fkProperty1 = dependentType!.FindProperty(nameof(Tomato.BurgerId1));
             var fkProperty2 = dependentType.FindProperty(nameof(Tomato.BurgerId2));
 
-            var principalKey = principalType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
             var dependentKey = dependentType.FindPrimaryKey();
 
             modelBuilder
@@ -1709,7 +1707,7 @@ public abstract partial class ModelBuilderTest
             Assert.Same(fkProperty1, fk.Properties[0]);
             Assert.Same(fkProperty2, fk.Properties[1]);
 
-            Assert.Equal(nameof(Tomato.Whoopper), fk.DependentToPrincipal.Name);
+            Assert.Equal(nameof(Tomato.Whoopper), fk.DependentToPrincipal!.Name);
             Assert.Null(fk.PrincipalToDependent);
             Assert.NotSame(fk, principalType.GetNavigations().Single().ForeignKey);
             Assert.Same(principalKey, principalType.FindPrimaryKey());
@@ -1741,10 +1739,10 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(Tomato));
             var principalType = model.FindEntityType(typeof(Whoopper));
 
-            var fkProperty1 = dependentType.FindProperty(nameof(Tomato.BurgerId1));
+            var fkProperty1 = dependentType!.FindProperty(nameof(Tomato.BurgerId1));
             var fkProperty2 = dependentType.FindProperty(nameof(Tomato.BurgerId2));
 
-            var principalKey = principalType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
             var dependentKey = dependentType.FindPrimaryKey();
 
             modelBuilder
@@ -1757,7 +1755,7 @@ public abstract partial class ModelBuilderTest
             Assert.Same(fkProperty1, fk.Properties[0]);
             Assert.Same(fkProperty2, fk.Properties[1]);
 
-            Assert.Equal(nameof(Whoopper.Tomatoes), fk.PrincipalToDependent.Name);
+            Assert.Equal(nameof(Whoopper.Tomatoes), fk.PrincipalToDependent!.Name);
             Assert.Null(fk.DependentToPrincipal);
             Assert.NotSame(fk, dependentType.GetNavigations().Single().ForeignKey);
             Assert.Same(principalKey, principalType.FindPrimaryKey());
@@ -1790,9 +1788,9 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(Tomato));
             var principalType = model.FindEntityType(typeof(Whoopper));
 
-            var existingFk = dependentType.GetForeignKeys().SingleOrDefault();
+            var existingFk = dependentType!.GetForeignKeys().SingleOrDefault();
 
-            var expectedPrincipalProperties = principalType.GetProperties().ToList();
+            var expectedPrincipalProperties = principalType!.GetProperties().ToList();
             var expectedDependentProperties = dependentType.GetProperties().ToList();
 
             var principalKey = principalType.FindPrimaryKey();
@@ -1845,8 +1843,8 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(ToastedBun));
             var principalType = model.FindEntityType(typeof(Whoopper));
 
-            var principalKey = principalType.FindPrimaryKey();
-            var dependentKey = dependentType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
+            var dependentKey = dependentType!.FindPrimaryKey();
 
             modelBuilder
                 .Entity<ToastedBun>().HasOne<Whoopper>().WithMany()
@@ -1857,7 +1855,7 @@ public abstract partial class ModelBuilderTest
             var existingFk = navigation.ForeignKey;
             Assert.Same(existingFk, principalType.GetNavigations().Single().ForeignKey);
             Assert.Equal(nameof(ToastedBun.Whoopper), navigation.Name);
-            Assert.Equal(nameof(Whoopper.ToastedBun), navigation.Inverse.Name);
+            Assert.Equal(nameof(Whoopper.ToastedBun), navigation.Inverse!.Name);
             Assert.Equal(existingFk.DeclaringEntityType == dependentType ? 0 : 1, principalType.GetForeignKeys().Count());
             Assert.Same(principalKey, principalType.FindPrimaryKey());
 
@@ -1878,8 +1876,8 @@ public abstract partial class ModelBuilderTest
 
             Assert.Equal(
                 CoreStrings.AmbiguousOneToOneRelationship(
-                    existingFk.DeclaringEntityType.DisplayName() + "." + existingFk.DependentToPrincipal.Name,
-                    existingFk.PrincipalEntityType.DisplayName() + "." + existingFk.PrincipalToDependent.Name),
+                    existingFk.DeclaringEntityType.DisplayName() + "." + existingFk.DependentToPrincipal!.Name,
+                    existingFk.PrincipalEntityType.DisplayName() + "." + existingFk.PrincipalToDependent!.Name),
                 Assert.Throws<InvalidOperationException>(modelBuilder.FinalizeModel).Message);
         }
 
@@ -1897,8 +1895,8 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(ToastedBun));
             var principalType = model.FindEntityType(typeof(Whoopper));
 
-            var principalKey = principalType.FindPrimaryKey();
-            var dependentKey = dependentType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
+            var dependentKey = dependentType!.FindPrimaryKey();
 
             modelBuilder
                 .Entity<ToastedBun>().HasOne<Whoopper>().WithMany()
@@ -1907,8 +1905,8 @@ public abstract partial class ModelBuilderTest
 
             var existingFk = dependentType.GetNavigations().Single().ForeignKey;
             Assert.Same(existingFk, principalType.GetNavigations().Single().ForeignKey);
-            Assert.Equal(nameof(Tomato.Whoopper), existingFk.DependentToPrincipal.Name);
-            Assert.Equal(nameof(Whoopper.ToastedBun), existingFk.PrincipalToDependent.Name);
+            Assert.Equal(nameof(Tomato.Whoopper), existingFk.DependentToPrincipal!.Name);
+            Assert.Equal(nameof(Whoopper.ToastedBun), existingFk.PrincipalToDependent!.Name);
             Assert.Empty(principalType.GetForeignKeys());
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
@@ -1942,8 +1940,8 @@ public abstract partial class ModelBuilderTest
 
             Assert.Equal(
                 CoreStrings.ConflictingRelationshipNavigation(
-                    principalType.DisplayName() + "." + nameof(Nob.Hobs),
-                    dependentType.DisplayName() + "." + nameof(Hob.Nob),
+                    principalType!.DisplayName() + "." + nameof(Nob.Hobs),
+                    dependentType!.DisplayName() + "." + nameof(Hob.Nob),
                     principalType.DisplayName() + "." + nameof(Nob.Hob),
                     dependentType.DisplayName() + "." + nameof(Hob.Nob)),
                 Assert.Throws<InvalidOperationException>(() =>
@@ -1966,8 +1964,8 @@ public abstract partial class ModelBuilderTest
 
             var dependentType = model.FindEntityType(typeof(Hob));
             var principalType = model.FindEntityType(typeof(Nob));
-            var principalKey = principalType.FindPrimaryKey();
-            var dependentKey = dependentType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
+            var dependentKey = dependentType!.FindPrimaryKey();
 
             modelBuilder.Entity<Hob>().HasOne(e => e.Nob).WithMany(e => e.Hobs);
 
@@ -2005,9 +2003,9 @@ public abstract partial class ModelBuilderTest
             var hobType = model.FindEntityType(typeof(Hob));
             var nobType = model.FindEntityType(typeof(Nob));
 
-            Assert.Null(hobType.GetNavigations().Single(n => n.Name == nameof(Hob.Nob)).Inverse);
+            Assert.Null(hobType!.GetNavigations().Single(n => n.Name == nameof(Hob.Nob)).Inverse);
             Assert.Null(hobType.GetNavigations().Single(n => n.Name == nameof(Hob.Nobs)).Inverse);
-            Assert.Null(nobType.GetNavigations().Single(n => n.Name == nameof(Nob.Hob)).Inverse);
+            Assert.Null(nobType!.GetNavigations().Single(n => n.Name == nameof(Nob.Hob)).Inverse);
             Assert.DoesNotContain(nobType.GetNavigations(), n => n.Name == nameof(Nob.Hobs));
         }
 
@@ -2026,7 +2024,7 @@ public abstract partial class ModelBuilderTest
             var builder = modelBuilder.Entity<Order>().HasOne(e => e.Customer).WithMany(e => e.Orders);
             builder = builder.HasAnnotation("Fus", "Ro");
 
-            var fk = dependentType.GetForeignKeys().Single();
+            var fk = dependentType!.GetForeignKeys().Single();
             Assert.Same(fk, builder.Metadata);
             Assert.Equal("Ro", fk["Fus"]);
         }
@@ -2042,13 +2040,13 @@ public abstract partial class ModelBuilderTest
 
             modelBuilder.FinalizeModel();
 
-            var entityType = (IReadOnlyEntityType)modelBuilder.Model.FindEntityType(typeof(Nob));
-            var fk = entityType.GetForeignKeys().Single();
+            var entityType = (IReadOnlyEntityType)modelBuilder.Model.FindEntityType(typeof(Nob))!;
+            var fk = entityType!.GetForeignKeys().Single();
             Assert.False(fk.IsRequired);
             var fkProperty1 = entityType.FindProperty(nameof(Nob.HobId1));
             var fkProperty2 = entityType.FindProperty(nameof(Nob.HobId2));
-            Assert.True(fkProperty1.IsNullable);
-            Assert.True(fkProperty2.IsNullable);
+            Assert.True(fkProperty1!.IsNullable);
+            Assert.True(fkProperty2!.IsNullable);
             Assert.Contains(fkProperty1, fk.Properties);
             Assert.Contains(fkProperty2, fk.Properties);
         }
@@ -2064,13 +2062,13 @@ public abstract partial class ModelBuilderTest
 
             modelBuilder.FinalizeModel();
 
-            var entityType = (IReadOnlyEntityType)modelBuilder.Model.FindEntityType(typeof(Hob));
-            var fk = entityType.GetForeignKeys().Single();
+            var entityType = (IReadOnlyEntityType)modelBuilder.Model.FindEntityType(typeof(Hob))!;
+            var fk = entityType!.GetForeignKeys().Single();
             Assert.True(fk.IsRequired);
             var fkProperty1 = entityType.FindProperty(nameof(Hob.NobId1));
             var fkProperty2 = entityType.FindProperty(nameof(Hob.NobId2));
-            Assert.False(fkProperty1.IsNullable);
-            Assert.False(fkProperty2.IsNullable);
+            Assert.False(fkProperty1!.IsNullable);
+            Assert.False(fkProperty2!.IsNullable);
             Assert.Contains(fkProperty1, fk.Properties);
             Assert.Contains(fkProperty2, fk.Properties);
         }
@@ -2087,13 +2085,13 @@ public abstract partial class ModelBuilderTest
 
             modelBuilder.FinalizeModel();
 
-            var entityType = (IReadOnlyEntityType)modelBuilder.Model.FindEntityType(typeof(Nob));
-            var fk = entityType.GetForeignKeys().Single();
+            var entityType = (IReadOnlyEntityType)modelBuilder.Model.FindEntityType(typeof(Nob))!;
+            var fk = entityType!.GetForeignKeys().Single();
             Assert.True(fk.IsRequired);
             var fkProperty1 = entityType.FindProperty(nameof(Nob.HobId1));
             var fkProperty2 = entityType.FindProperty(nameof(Nob.HobId2));
-            Assert.False(fkProperty1.IsNullable);
-            Assert.False(fkProperty2.IsNullable);
+            Assert.False(fkProperty1!.IsNullable);
+            Assert.False(fkProperty2!.IsNullable);
             Assert.Contains(fkProperty1, fk.Properties);
             Assert.Contains(fkProperty2, fk.Properties);
         }
@@ -2110,13 +2108,13 @@ public abstract partial class ModelBuilderTest
 
             modelBuilder.FinalizeModel();
 
-            var entityType = (IReadOnlyEntityType)modelBuilder.Model.FindEntityType(typeof(Hob));
-            var fk = entityType.GetForeignKeys().Single();
+            var entityType = (IReadOnlyEntityType)modelBuilder.Model.FindEntityType(typeof(Hob))!;
+            var fk = entityType!.GetForeignKeys().Single();
             Assert.False(fk.IsRequired);
             var fkProperty1 = entityType.FindProperty(nameof(Hob.NobId1));
             var fkProperty2 = entityType.FindProperty(nameof(Hob.NobId2));
-            Assert.False(fkProperty1.IsNullable);
-            Assert.False(fkProperty2.IsNullable);
+            Assert.False(fkProperty1!.IsNullable);
+            Assert.False(fkProperty2!.IsNullable);
             Assert.Contains(fkProperty1, fk.Properties);
             Assert.Contains(fkProperty2, fk.Properties);
         }
@@ -2136,13 +2134,13 @@ public abstract partial class ModelBuilderTest
 
             modelBuilder.FinalizeModel();
 
-            var entityType = (IReadOnlyEntityType)modelBuilder.Model.FindEntityType(typeof(Hob));
-            var fk = entityType.GetForeignKeys().Single();
+            var entityType = (IReadOnlyEntityType)modelBuilder.Model.FindEntityType(typeof(Hob))!;
+            var fk = entityType!.GetForeignKeys().Single();
             Assert.False(fk.IsRequired);
             var fkProperty1 = entityType.FindProperty(nameof(Hob.NobId1));
             var fkProperty2 = entityType.FindProperty(nameof(Hob.NobId2));
-            Assert.False(fkProperty1.IsNullable);
-            Assert.False(fkProperty2.IsNullable);
+            Assert.False(fkProperty1!.IsNullable);
+            Assert.False(fkProperty2!.IsNullable);
             Assert.Contains(fkProperty1, fk.Properties);
             Assert.Contains(fkProperty2, fk.Properties);
         }
@@ -2151,13 +2149,13 @@ public abstract partial class ModelBuilderTest
         public virtual void Can_change_delete_behavior()
         {
             var modelBuilder = HobNobBuilder();
-            var dependentType = (IReadOnlyEntityType)modelBuilder.Model.FindEntityType(typeof(Nob));
+            var dependentType = (IReadOnlyEntityType)modelBuilder.Model.FindEntityType(typeof(Nob))!;
 
             modelBuilder
                 .Entity<Nob>().HasOne(e => e.Hob).WithMany(e => e.Nobs)
                 .OnDelete(DeleteBehavior.Cascade);
 
-            Assert.Equal(DeleteBehavior.Cascade, dependentType.GetForeignKeys().Single().DeleteBehavior);
+            Assert.Equal(DeleteBehavior.Cascade, dependentType!.GetForeignKeys().Single().DeleteBehavior);
 
             modelBuilder
                 .Entity<Nob>().HasOne(e => e.Hob).WithMany(e => e.Nobs)
@@ -2179,12 +2177,12 @@ public abstract partial class ModelBuilderTest
             var model = modelBuilder.Model;
             modelBuilder.Entity<PrincipalEntity>();
 
-            var foreignKey = model.FindEntityType(typeof(DependentEntity)).GetForeignKeys().Single();
+            var foreignKey = model.FindEntityType(typeof(DependentEntity))!.GetForeignKeys().Single();
             Assert.Equal("NavId", foreignKey.Properties.Single().Name);
 
             modelBuilder.Entity<DependentEntity>().Property(et => et.PrincipalEntityId);
 
-            var newForeignKey = model.FindEntityType(typeof(DependentEntity)).GetForeignKeys().Single();
+            var newForeignKey = model.FindEntityType(typeof(DependentEntity))!.GetForeignKeys().Single();
             Assert.Equal("PrincipalEntityId", newForeignKey.Properties.Single().Name);
         }
 
@@ -2199,8 +2197,8 @@ public abstract partial class ModelBuilderTest
             var model = modelBuilder.FinalizeModel();
 
             var beta = model.FindEntityType(typeof(Beta));
-            Assert.Equal("FirstNavId", beta.FindNavigation("FirstNav").ForeignKey.Properties.First().Name);
-            Assert.Equal("SecondNavId", beta.FindNavigation("SecondNav").ForeignKey.Properties.First().Name);
+            Assert.Equal("FirstNavId", beta!.FindNavigation("FirstNav")!.ForeignKey.Properties.First().Name);
+            Assert.Equal("SecondNavId", beta.FindNavigation("SecondNav")!.ForeignKey.Properties.First().Name);
         }
 
         [Fact]
@@ -2210,7 +2208,7 @@ public abstract partial class ModelBuilderTest
             var modelBuilder = CreateModelBuilder();
             var gamma = modelBuilder.Entity<Gamma>().Metadata;
 
-            Assert.Equal("GammaId", gamma.FindNavigation("Alphas").ForeignKey.Properties.First().Name);
+            Assert.Equal("GammaId", gamma.FindNavigation("Alphas")!.ForeignKey.Properties.First().Name);
         }
 
         [Fact]
@@ -2230,7 +2228,7 @@ public abstract partial class ModelBuilderTest
 
             var model = modelBuilder.FinalizeModel();
 
-            var fk = model.FindEntityType(typeof(Beta)).FindNavigation("FirstNav").ForeignKey;
+            var fk = model.FindEntityType(typeof(Beta))!.FindNavigation("FirstNav")!.ForeignKey;
             Assert.Equal("ShadowId", fk.Properties.Single().Name);
             Assert.True(fk.IsRequired);
             Assert.Equal("foo", fk["Test"]);
@@ -2256,7 +2254,7 @@ public abstract partial class ModelBuilderTest
 
             Assert.Equal(
                 "ShadowId",
-                modelBuilder.Model.FindEntityType(typeof(Beta)).FindNavigation("FirstNav").ForeignKey.Properties.Single().Name);
+                modelBuilder.Model.FindEntityType(typeof(Beta))!.FindNavigation("FirstNav")!.ForeignKey.Properties.Single().Name);
         }
 
         [Fact]
@@ -2268,8 +2266,8 @@ public abstract partial class ModelBuilderTest
 
             modelBuilder.FinalizeModel();
 
-            var property = modelBuilder.Model.FindEntityType(typeof(Epsilon)).FindProperty("Id");
-            Assert.Equal(ValueGenerated.Never, property.ValueGenerated);
+            var property = modelBuilder.Model.FindEntityType(typeof(Epsilon))!.FindProperty("Id");
+            Assert.Equal(ValueGenerated.Never, property!.ValueGenerated);
         }
 
         [Fact]
@@ -2285,7 +2283,7 @@ public abstract partial class ModelBuilderTest
 
             Assert.Equal(
                 "KappaId",
-                modelBuilder.Model.FindEntityType(typeof(Omega)).FindNavigation(nameof(Omega.Kappa)).ForeignKey.Properties.Single()
+                modelBuilder.Model.FindEntityType(typeof(Omega))!.FindNavigation(nameof(Omega.Kappa))!.ForeignKey.Properties.Single()
                     .Name);
         }
 
@@ -2307,11 +2305,11 @@ public abstract partial class ModelBuilderTest
                 .Navigation(e => e.OneToManyPrincipal)
                 .UsePropertyAccessMode(PropertyAccessMode.Property);
 
-            var principal = (IReadOnlyEntityType)model.FindEntityType(typeof(OneToManyNavPrincipal));
-            var dependent = (IReadOnlyEntityType)model.FindEntityType(typeof(NavDependent));
+            var principal = (IReadOnlyEntityType)model.FindEntityType(typeof(OneToManyNavPrincipal))!;
+            var dependent = (IReadOnlyEntityType)model.FindEntityType(typeof(NavDependent))!;
 
-            Assert.Equal(PropertyAccessMode.Field, principal.FindNavigation("Dependents").GetPropertyAccessMode());
-            Assert.Equal(PropertyAccessMode.Property, dependent.FindNavigation("OneToManyPrincipal").GetPropertyAccessMode());
+            Assert.Equal(PropertyAccessMode.Field, principal!.FindNavigation("Dependents")!.GetPropertyAccessMode());
+            Assert.Equal(PropertyAccessMode.Property, dependent!.FindNavigation("OneToManyPrincipal")!.GetPropertyAccessMode());
         }
 
         [Fact]
@@ -2343,10 +2341,10 @@ public abstract partial class ModelBuilderTest
             Assert.Equal(PropertyAccessMode.FieldDuringConstruction, model.GetPropertyAccessMode());
 
             Assert.Equal(PropertyAccessMode.PreferProperty, principal.Metadata.GetPropertyAccessMode());
-            Assert.Equal(PropertyAccessMode.Field, principal.Metadata.FindNavigation("Dependents").GetPropertyAccessMode());
+            Assert.Equal(PropertyAccessMode.Field, principal.Metadata.FindNavigation("Dependents")!.GetPropertyAccessMode());
 
             Assert.Equal(PropertyAccessMode.Field, dependent.Metadata.GetPropertyAccessMode());
-            Assert.Equal(PropertyAccessMode.Property, dependent.Metadata.FindNavigation("OneToManyPrincipal").GetPropertyAccessMode());
+            Assert.Equal(PropertyAccessMode.Property, dependent.Metadata.FindNavigation("OneToManyPrincipal")!.GetPropertyAccessMode());
         }
     }
 }

--- a/test/EFCore.Specification.Tests/ModelBuilding/ModelBuilderTest.OneToMany.cs
+++ b/test/EFCore.Specification.Tests/ModelBuilding/ModelBuilderTest.OneToMany.cs
@@ -5,8 +5,6 @@
 
 namespace Microsoft.EntityFrameworkCore.ModelBuilding;
 
-#nullable disable
-
 public abstract partial class ModelBuilderTest
 {
     public abstract class OneToManyTestBase(ModelBuilderFixtureBase fixture) : ModelBuilderTestBase(fixture)
@@ -27,10 +25,10 @@ public abstract partial class ModelBuilderTest
 
             var dependentType = model.FindEntityType(typeof(Order));
             var principalType = model.FindEntityType(typeof(Customer));
-            var fk = dependentType.GetForeignKeys().Single();
+            var fk = dependentType!.GetForeignKeys().Single();
 
             var navToPrincipal = dependentType.FindNavigation("Customer");
-            var navToDependent = principalType.FindNavigation("Orders");
+            var navToDependent = principalType!.FindNavigation("Orders");
 
             var principalKey = principalType.FindPrimaryKey();
             var dependentKey = dependentType.FindPrimaryKey();
@@ -40,7 +38,7 @@ public abstract partial class ModelBuilderTest
             modelBuilder.FinalizeModel();
 
             Assert.Same(fk, dependentType.GetForeignKeys().Single());
-            Assert.Equal(navToPrincipal.Name, dependentType.GetNavigations().Single().Name);
+            Assert.Equal(navToPrincipal!.Name, dependentType.GetNavigations().Single().Name);
             Assert.Same(navToDependent, principalType.GetNavigations().Single());
             Assert.Same(fk, dependentType.GetNavigations().Single().ForeignKey);
             Assert.Same(fk, principalType.GetNavigations().Single().ForeignKey);
@@ -91,10 +89,10 @@ public abstract partial class ModelBuilderTest
 
             var dependentType = model.FindEntityType(typeof(DependentWithField));
             var principalType = model.FindEntityType(typeof(OneToManyPrincipalWithField));
-            var fk = dependentType.GetForeignKeys().Single();
+            var fk = dependentType!.GetForeignKeys().Single();
 
             var navToPrincipal = dependentType.FindNavigation("OneToManyPrincipal");
-            var navToDependent = principalType.FindNavigation("Dependents");
+            var navToDependent = principalType!.FindNavigation("Dependents");
 
             var principalKey = principalType.FindPrimaryKey();
             var dependentKey = dependentType.FindPrimaryKey();
@@ -106,7 +104,7 @@ public abstract partial class ModelBuilderTest
             modelBuilder.FinalizeModel();
 
             Assert.Same(fk, dependentType.GetForeignKeys().Single());
-            Assert.Equal(navToPrincipal.Name, dependentType.GetNavigations().Single().Name);
+            Assert.Equal(navToPrincipal!.Name, dependentType.GetNavigations().Single().Name);
             Assert.Same(navToDependent, principalType.GetNavigations().Single());
             Assert.Same(fk, dependentType.GetNavigations().Single().ForeignKey);
             Assert.Same(fk, principalType.GetNavigations().Single().ForeignKey);
@@ -143,8 +141,8 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(Order));
             var principalType = model.FindEntityType(typeof(Customer));
 
-            var principalKey = principalType.FindPrimaryKey();
-            var dependentKey = dependentType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
+            var dependentKey = dependentType!.FindPrimaryKey();
 
             modelBuilder.Entity<Customer>().HasMany(e => e.Orders).WithOne(e => e.Customer);
 
@@ -184,10 +182,10 @@ public abstract partial class ModelBuilderTest
 
             var dependentType = model.FindEntityType(typeof(Order));
             var principalType = model.FindEntityType(typeof(Customer));
-            var fk = principalType.GetNavigations().Single().ForeignKey;
+            var fk = principalType!.GetNavigations().Single().ForeignKey;
 
             var principalKey = principalType.FindPrimaryKey();
-            var dependentKey = dependentType.FindPrimaryKey();
+            var dependentKey = dependentType!.FindPrimaryKey();
 
             modelBuilder.Entity<Customer>().HasMany(e => e.Orders).WithOne(e => e.Customer);
 
@@ -196,8 +194,8 @@ public abstract partial class ModelBuilderTest
             var newFk = principalType.GetNavigations().Single().ForeignKey;
             AssertEqual(fk.Properties, newFk.Properties);
             Assert.Same(newFk, dependentType.GetNavigations().Single().ForeignKey);
-            Assert.Equal(nameof(Order.Customer), newFk.DependentToPrincipal.Name);
-            Assert.Equal(nameof(Customer.Orders), newFk.PrincipalToDependent.Name);
+            Assert.Equal(nameof(Order.Customer), newFk.DependentToPrincipal!.Name);
+            Assert.Equal(nameof(Customer.Orders), newFk.PrincipalToDependent!.Name);
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
 
@@ -230,9 +228,9 @@ public abstract partial class ModelBuilderTest
 
             var dependentType = model.FindEntityType(typeof(Order));
             var principalType = model.FindEntityType(typeof(Customer));
-            var fk = dependentType.GetForeignKeys().Single();
+            var fk = dependentType!.GetForeignKeys().Single();
 
-            var principalKey = principalType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
             var dependentKey = dependentType.FindPrimaryKey();
 
             modelBuilder.Entity<Customer>().HasMany(e => e.Orders).WithOne(e => e.Customer);
@@ -276,9 +274,9 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(Order));
             var principalType = model.FindEntityType(typeof(Customer));
 
-            var fkProperty = dependentType.FindProperty("CustomerId");
+            var fkProperty = dependentType!.FindProperty("CustomerId");
 
-            var principalKey = principalType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
             var dependentKey = dependentType.FindPrimaryKey();
 
             modelBuilder.Entity<Customer>().HasMany(e => e.Orders).WithOne(e => e.Customer);
@@ -322,19 +320,19 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(Order));
             var principalType = model.FindEntityType(typeof(Customer));
 
-            var fkProperty = dependentType.FindProperty(nameof(Order.CustomerId));
+            var fkProperty = dependentType!.FindProperty(nameof(Order.CustomerId));
 
-            var principalKey = principalType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
             var dependentKey = dependentType.FindPrimaryKey();
 
             modelBuilder.Entity<Customer>().HasMany(e => e.Orders).WithOne();
 
             var fk = principalType.GetNavigations().Single().ForeignKey;
-            Assert.Equal(nameof(Customer.Orders), fk.PrincipalToDependent.Name);
+            Assert.Equal(nameof(Customer.Orders), fk.PrincipalToDependent!.Name);
             Assert.Null(fk.DependentToPrincipal);
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
-            Assert.NotNull(dependentType.FindForeignKeys(fkProperty).SingleOrDefault());
+            Assert.NotNull(dependentType.FindForeignKeys(fkProperty!).SingleOrDefault());
 
             if (Fixture.ForeignKeysHaveIndexes)
             {
@@ -362,20 +360,20 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(Order));
             var principalType = model.FindEntityType(typeof(Customer));
 
-            var fkProperty = dependentType.FindProperty(nameof(Order.CustomerId));
+            var fkProperty = dependentType!.FindProperty(nameof(Order.CustomerId));
 
-            var principalKey = principalType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
             var dependentKey = dependentType.FindPrimaryKey();
 
             modelBuilder.Entity<Customer>().HasMany<Order>().WithOne(e => e.Customer);
 
             var fk = dependentType.GetNavigations().Single().ForeignKey;
-            Assert.Equal(nameof(Order.Customer), fk.DependentToPrincipal.Name);
+            Assert.Equal(nameof(Order.Customer), fk.DependentToPrincipal!.Name);
             Assert.Null(fk.PrincipalToDependent);
             Assert.NotSame(fk, principalType.GetNavigations().Single().ForeignKey);
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
-            Assert.NotNull(dependentType.FindForeignKeys(fkProperty).SingleOrDefault());
+            Assert.NotNull(dependentType.FindForeignKeys(fkProperty!).SingleOrDefault());
 
             if (Fixture.ForeignKeysHaveIndexes)
             {
@@ -404,11 +402,11 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(Order));
             var principalType = model.FindEntityType(typeof(Customer));
 
-            var fkProperty = dependentType.FindProperty("CustomerId");
+            var fkProperty = dependentType!.FindProperty("CustomerId");
             var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
 
-            var principalKey = principalType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
             var dependentKey = dependentType.FindPrimaryKey();
 
             modelBuilder.Entity<Customer>().HasMany<Order>().WithOne();
@@ -452,9 +450,9 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(Order));
             var principalType = model.FindEntityType(typeof(Customer));
 
-            var fkProperty = dependentType.FindProperty("CustomerId");
+            var fkProperty = dependentType!.FindProperty("CustomerId");
 
-            var principalKey = principalType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
             var dependentKey = dependentType.FindPrimaryKey();
 
             modelBuilder
@@ -500,10 +498,10 @@ public abstract partial class ModelBuilderTest
 
             var dependentType = model.FindEntityType(typeof(Pickle));
             var principalType = model.FindEntityType(typeof(BigMak));
-            var fk = dependentType.GetForeignKeys().Single(foreignKey => foreignKey.Properties.Single().Name == "BurgerId");
-            fk.SetDependentToPrincipal((string)null);
+            var fk = dependentType!.GetForeignKeys().Single(foreignKey => foreignKey.Properties.Single().Name == "BurgerId");
+            fk.SetDependentToPrincipal((string)null!);
 
-            var principalKey = principalType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
             var dependentKey = dependentType.FindPrimaryKey();
 
             modelBuilder
@@ -546,9 +544,9 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(Pickle));
             var principalType = model.FindEntityType(typeof(BigMak));
 
-            var fkProperty = dependentType.FindProperty("BurgerId");
+            var fkProperty = dependentType!.FindProperty("BurgerId");
 
-            var principalKey = principalType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
             var dependentKey = dependentType.FindPrimaryKey();
 
             modelBuilder
@@ -593,9 +591,9 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(Pickle));
             var principalType = model.FindEntityType(typeof(BigMak));
 
-            var fkProperty = dependentType.FindProperty(nameof(Pickle.BurgerId));
+            var fkProperty = dependentType!.FindProperty(nameof(Pickle.BurgerId));
 
-            var principalKey = principalType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
             var dependentKey = dependentType.FindPrimaryKey();
 
             modelBuilder
@@ -607,7 +605,7 @@ public abstract partial class ModelBuilderTest
             var fk = principalType.GetNavigations().Single().ForeignKey;
             Assert.Same(fkProperty, fk.Properties.Single());
             Assert.NotSame(fk, dependentType.GetNavigations().Single().ForeignKey);
-            Assert.Equal(nameof(BigMak.Pickles), fk.PrincipalToDependent.Name);
+            Assert.Equal(nameof(BigMak.Pickles), fk.PrincipalToDependent!.Name);
             Assert.Null(fk.DependentToPrincipal);
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
@@ -637,8 +635,8 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(Pickle));
             var principalType = model.FindEntityType(typeof(BigMak));
 
-            var principalKey = principalType.FindPrimaryKey();
-            var dependentKey = dependentType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
+            var dependentKey = dependentType!.FindPrimaryKey();
 
             modelBuilder
                 .Entity<BigMak>().HasMany<Pickle>().WithOne(e => e.BigMak)
@@ -648,7 +646,7 @@ public abstract partial class ModelBuilderTest
 
             var fk = dependentType.GetNavigations().Single().ForeignKey;
             Assert.Same(dependentType.FindProperty(nameof(Pickle.BurgerId)), fk.Properties.Single());
-            Assert.Equal(nameof(Pickle.BigMak), fk.DependentToPrincipal.Name);
+            Assert.Equal(nameof(Pickle.BigMak), fk.DependentToPrincipal!.Name);
             Assert.Null(fk.PrincipalToDependent);
             Assert.NotSame(fk, principalType.GetNavigations().Single().ForeignKey);
             Assert.Same(principalKey, principalType.FindPrimaryKey());
@@ -679,10 +677,10 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(Pickle));
             var principalType = model.FindEntityType(typeof(BigMak));
 
-            var fkProperty = dependentType.FindProperty("BurgerId");
+            var fkProperty = dependentType!.FindProperty("BurgerId");
             var fk = dependentType.GetForeignKeys().SingleOrDefault();
 
-            var principalKey = principalType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
             var dependentKey = dependentType.FindPrimaryKey();
 
             modelBuilder
@@ -703,7 +701,7 @@ public abstract partial class ModelBuilderTest
             if (Fixture.ForeignKeysHaveIndexes)
             {
                 Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-                Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+                Assert.False(fk!.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
             }
             else
             {
@@ -725,8 +723,8 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(Pickle));
             var principalType = model.FindEntityType(typeof(BigMak));
 
-            var principalKey = principalType.FindPrimaryKey();
-            var dependentKey = dependentType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
+            var dependentKey = dependentType!.FindPrimaryKey();
 
             modelBuilder.Entity<BigMak>().HasMany(e => e.Pickles).WithOne(e => e.BigMak);
 
@@ -773,8 +771,8 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(Pickle));
             var principalType = model.FindEntityType(typeof(BigMak));
 
-            var principalKey = principalType.FindPrimaryKey();
-            var dependentKey = dependentType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
+            var dependentKey = dependentType!.FindPrimaryKey();
 
             modelBuilder.Entity<BigMak>().HasMany(e => e.Pickles).WithOne();
 
@@ -787,7 +785,7 @@ public abstract partial class ModelBuilderTest
             Assert.Same(typeof(int?), fkProperty.ClrType);
             Assert.Same(dependentType, fkProperty.DeclaringType);
 
-            Assert.Equal(nameof(BigMak.Pickles), fk.PrincipalToDependent.Name);
+            Assert.Equal(nameof(BigMak.Pickles), fk.PrincipalToDependent!.Name);
             Assert.Null(fk.DependentToPrincipal);
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
@@ -817,8 +815,8 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(Pickle));
             var principalType = model.FindEntityType(typeof(BigMak));
 
-            var principalKey = principalType.FindPrimaryKey();
-            var dependentKey = dependentType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
+            var dependentKey = dependentType!.FindPrimaryKey();
 
             modelBuilder.Entity<BigMak>().HasMany<Pickle>().WithOne(e => e.BigMak);
 
@@ -831,7 +829,7 @@ public abstract partial class ModelBuilderTest
             Assert.Same(typeof(int?), fkProperty.ClrType);
             Assert.Same(dependentType, fkProperty.DeclaringType);
 
-            Assert.Equal(nameof(Pickle.BigMak), fk.DependentToPrincipal.Name);
+            Assert.Equal(nameof(Pickle.BigMak), fk.DependentToPrincipal!.Name);
             Assert.Null(fk.PrincipalToDependent);
             Assert.NotSame(fk, principalType.GetNavigations().Single().ForeignKey);
             Assert.Same(principalKey, principalType.FindPrimaryKey());
@@ -862,8 +860,8 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(Pickle));
             var principalType = model.FindEntityType(typeof(BigMak));
 
-            var principalKey = principalType.FindPrimaryKey();
-            var dependentKey = dependentType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
+            var dependentKey = dependentType!.FindPrimaryKey();
             var existingFk = dependentType.GetForeignKeys().Single();
 
             modelBuilder.Entity<BigMak>().HasMany<Pickle>().WithOne();
@@ -908,8 +906,8 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(Pickle));
             var principalType = model.FindEntityType(typeof(BigMak));
 
-            var principalKey = principalType.FindPrimaryKey();
-            var dependentKey = dependentType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
+            var dependentKey = dependentType!.FindPrimaryKey();
 
             var fkProperty = dependentType.FindProperty("BigMakId");
 
@@ -953,8 +951,8 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(Pickle));
             var principalType = model.FindEntityType(typeof(BigMak));
 
-            var principalKey = principalType.FindPrimaryKey();
-            var dependentKey = dependentType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
+            var dependentKey = dependentType!.FindPrimaryKey();
 
             var fk = dependentType.GetForeignKeys()
                 .Single(foreignKey => foreignKey.Properties.Any(p => p.Name == "BurgerId"));
@@ -1001,7 +999,7 @@ public abstract partial class ModelBuilderTest
 
             modelBuilder.FinalizeModel();
 
-            Assert.Equal(2, model.FindEntityType(typeof(Friendship)).GetNavigations().Count());
+            Assert.Equal(2, model.FindEntityType(typeof(Friendship))!.GetNavigations().Count());
         }
 
         [Fact]
@@ -1019,8 +1017,8 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(Order));
             var principalType = model.FindEntityType(typeof(Customer));
 
-            var fkProperty = dependentType.FindProperty("CustomerId");
-            var principalProperty = principalType.FindProperty(Customer.IdProperty.Name);
+            var fkProperty = dependentType!.FindProperty("CustomerId");
+            var principalProperty = principalType!.FindProperty(Customer.IdProperty.Name);
 
             var principalKey = principalType.FindPrimaryKey();
             var dependentKey = dependentType.FindPrimaryKey();
@@ -1070,8 +1068,8 @@ public abstract partial class ModelBuilderTest
 
             var dependentType = model.FindEntityType(typeof(Order));
             var principalType = model.FindEntityType(typeof(Customer));
-            var expectedPrincipalProperties = principalType.GetProperties().ToList();
-            var expectedDependentProperties = dependentType.GetProperties().ToList();
+            var expectedPrincipalProperties = principalType!.GetProperties().ToList();
+            var expectedDependentProperties = dependentType!.GetProperties().ToList();
             var principalKey = principalType.FindPrimaryKey();
             var dependentKey = dependentType.FindPrimaryKey();
 
@@ -1144,7 +1142,7 @@ public abstract partial class ModelBuilderTest
             var model = modelBuilder.FinalizeModel();
 
             var customer = model.FindEntityType(typeof(Customer));
-            Assert.Empty(customer.GetNavigations());
+            Assert.Empty(customer!.GetNavigations());
             Assert.Null(customer.FindPrimaryKey());
             Assert.Null(model.FindEntityType(typeof(Order)));
         }
@@ -1165,7 +1163,7 @@ public abstract partial class ModelBuilderTest
 
             var keyless = model.FindEntityType(typeof(KeylessEntity));
             Assert.Null(model.FindEntityType(typeof(Customer))?.FindProperty("TempId"));
-            Assert.Null(keyless.FindPrimaryKey());
+            Assert.Null(keyless!.FindPrimaryKey());
 
             var customerNavigation = keyless.GetNavigations().Single();
             Assert.Same(keyless, customerNavigation.ForeignKey.DeclaringEntityType);
@@ -1186,8 +1184,8 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(Order));
             var principalType = model.FindEntityType(typeof(Customer));
 
-            var fkProperty = dependentType.FindProperty("CustomerId");
-            var principalProperty = principalType.FindProperty(Customer.IdProperty.Name);
+            var fkProperty = dependentType!.FindProperty("CustomerId");
+            var principalProperty = principalType!.FindProperty(Customer.IdProperty.Name);
 
             var principalKey = principalType.FindPrimaryKey();
             var dependentKey = dependentType.FindPrimaryKey();
@@ -1239,8 +1237,8 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(Order));
             var principalType = model.FindEntityType(typeof(Customer));
 
-            var fkProperty = dependentType.FindProperty("CustomerId");
-            var principalProperty = principalType.FindProperty(Customer.IdProperty.Name);
+            var fkProperty = dependentType!.FindProperty("CustomerId");
+            var principalProperty = principalType!.FindProperty(Customer.IdProperty.Name);
 
             var principalKey = principalType.FindPrimaryKey();
             var dependentKey = dependentType.FindPrimaryKey();
@@ -1290,8 +1288,8 @@ public abstract partial class ModelBuilderTest
 
             var dependentType = model.FindEntityType(typeof(Order));
             var principalType = model.FindEntityType(typeof(Customer));
-            var expectedPrincipalProperties = principalType.GetProperties().ToList();
-            var expectedDependentProperties = dependentType.GetProperties().ToList();
+            var expectedPrincipalProperties = principalType!.GetProperties().ToList();
+            var expectedDependentProperties = dependentType!.GetProperties().ToList();
             var principalKey = principalType.FindPrimaryKey();
             var dependentKey = dependentType.FindPrimaryKey();
 
@@ -1345,8 +1343,8 @@ public abstract partial class ModelBuilderTest
 
             var dependentType = model.FindEntityType(typeof(Order));
             var principalType = model.FindEntityType(typeof(Customer));
-            var expectedPrincipalProperties = principalType.GetProperties().ToList();
-            var expectedDependentProperties = dependentType.GetProperties().ToList();
+            var expectedPrincipalProperties = principalType!.GetProperties().ToList();
+            var expectedDependentProperties = dependentType!.GetProperties().ToList();
             var principalKey = principalType.FindPrimaryKey();
             var dependentKey = dependentType.FindPrimaryKey();
 
@@ -1400,8 +1398,8 @@ public abstract partial class ModelBuilderTest
 
             var dependentType = model.FindEntityType(typeof(Order));
             var principalType = model.FindEntityType(typeof(Customer));
-            var expectedPrincipalProperties = principalType.GetProperties().ToList();
-            var expectedDependentProperties = dependentType.GetProperties().ToList();
+            var expectedPrincipalProperties = principalType!.GetProperties().ToList();
+            var expectedDependentProperties = dependentType!.GetProperties().ToList();
 
             modelBuilder
                 .Entity<Order>().HasOne(e => e.Customer).WithMany(e => e.Orders)
@@ -1458,8 +1456,8 @@ public abstract partial class ModelBuilderTest
 
             var dependentType = model.FindEntityType(typeof(Order));
             var principalType = model.FindEntityType(typeof(Customer));
-            var expectedPrincipalProperties = principalType.GetProperties().ToList();
-            var expectedDependentProperties = dependentType.GetProperties().ToList();
+            var expectedPrincipalProperties = principalType!.GetProperties().ToList();
+            var expectedDependentProperties = dependentType!.GetProperties().ToList();
 
             modelBuilder
                 .Entity<Order>().HasOne(e => e.Customer).WithMany(e => e.Orders)
@@ -1511,8 +1509,8 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(Pickle));
             var principalType = model.FindEntityType(typeof(BigMak));
 
-            var fkProperty = dependentType.FindProperty("BurgerId");
-            var principalProperty = principalType.FindProperty("AlternateKey");
+            var fkProperty = dependentType!.FindProperty("BurgerId");
+            var principalProperty = principalType!.FindProperty("AlternateKey");
 
             var principalKey = principalType.FindPrimaryKey();
             var dependentKey = dependentType.FindPrimaryKey();
@@ -1566,8 +1564,8 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(Pickle));
             var principalType = model.FindEntityType(typeof(BigMak));
 
-            var fkProperty = dependentType.FindProperty("BurgerId");
-            var principalProperty = principalType.FindProperty("AlternateKey");
+            var fkProperty = dependentType!.FindProperty("BurgerId");
+            var principalProperty = principalType!.FindProperty("AlternateKey");
 
             var principalKey = principalType.FindPrimaryKey();
             var dependentKey = dependentType.FindPrimaryKey();
@@ -1622,9 +1620,9 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(Pickle));
             var principalType = model.FindEntityType(typeof(BigMak));
 
-            var dependentKey = dependentType.FindPrimaryKey();
+            var dependentKey = dependentType!.FindPrimaryKey();
 
-            var expectedPrincipalProperties = principalType.GetProperties().ToList();
+            var expectedPrincipalProperties = principalType!.GetProperties().ToList();
             var expectedDependentProperties = dependentType.GetProperties().ToList();
 
             modelBuilder.Entity<BigMak>().HasKey(e => e.AlternateKey);
@@ -1643,7 +1641,7 @@ public abstract partial class ModelBuilderTest
             Assert.Empty(principalType.GetForeignKeys());
 
             var principalKey = principalType.FindPrimaryKey();
-            Assert.Same(principalProperty, principalKey.Properties.Single());
+            Assert.Same(principalProperty, principalKey!.Properties.Single());
             Assert.Same(principalKey, fk.PrincipalKey);
 
             Assert.Same(principalKey, principalType.FindPrimaryKey());
@@ -1676,12 +1674,12 @@ public abstract partial class ModelBuilderTest
             var principalType = model.FindEntityType(typeof(BigMak));
 
             var modelClone = Clone(modelBuilder.Model);
-            var nonPrimaryPrincipalKey = modelClone.FindEntityType(typeof(BigMak).FullName)
+            var nonPrimaryPrincipalKey = modelClone.FindEntityType(typeof(BigMak).FullName!)!
                 .GetKeys().First(k => !k.IsPrimaryKey());
-            var dependentKey = dependentType.FindPrimaryKey();
+            var dependentKey = dependentType!.FindPrimaryKey();
 
             var expectedDependentProperties = dependentType.GetProperties().ToList();
-            var expectedPrincipalProperties = principalType.GetProperties().ToList();
+            var expectedPrincipalProperties = principalType!.GetProperties().ToList();
 
             modelBuilder.Entity<BigMak>().HasKey(e => e.AlternateKey);
 
@@ -1698,7 +1696,7 @@ public abstract partial class ModelBuilderTest
             Assert.Empty(principalType.GetForeignKeys());
 
             var primaryPrincipalKey = principalType.FindPrimaryKey();
-            Assert.Same(principalProperty, primaryPrincipalKey.Properties.Single());
+            Assert.Same(principalProperty, primaryPrincipalKey!.Properties.Single());
             Assert.Contains(fk.PrincipalKey, principalType.GetKeys());
 
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
@@ -1729,8 +1727,8 @@ public abstract partial class ModelBuilderTest
             var principalType = model.FindEntityType(typeof(BigMak));
             var dependentType = model.FindEntityType(typeof(Pickle));
 
-            var nonPrimaryPrincipalKey = principalType.FindPrimaryKey();
-            var dependentKey = dependentType.FindPrimaryKey();
+            var nonPrimaryPrincipalKey = principalType!.FindPrimaryKey();
+            var dependentKey = dependentType!.FindPrimaryKey();
 
             modelBuilder.Entity<BigMak>().HasKey(e => e.AlternateKey);
 
@@ -1745,7 +1743,7 @@ public abstract partial class ModelBuilderTest
             Assert.Empty(principalType.GetForeignKeys());
 
             var primaryPrincipalKey = principalType.FindPrimaryKey();
-            Assert.Same(principalProperty, primaryPrincipalKey.Properties.Single());
+            Assert.Same(principalProperty, primaryPrincipalKey!.Properties.Single());
             Assert.Contains(nonPrimaryPrincipalKey, principalType.GetKeys());
             var oldKeyProperty = principalType.FindProperty(nameof(BigMak.Id));
             var newKeyProperty = principalType.FindProperty(nameof(BigMak.AlternateKey));
@@ -1779,8 +1777,8 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(Tomato));
             var principalType = model.FindEntityType(typeof(Whoopper));
 
-            var principalKey = principalType.FindPrimaryKey();
-            var dependentKey = dependentType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
+            var dependentKey = dependentType!.FindPrimaryKey();
 
             modelBuilder
                 .Entity<Whoopper>().HasMany(e => e.Tomatoes).WithOne(e => e.Whoopper)
@@ -1823,10 +1821,10 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(Tomato));
             var principalType = model.FindEntityType(typeof(Whoopper));
 
-            var fkProperty1 = dependentType.FindProperty("BurgerId1");
+            var fkProperty1 = dependentType!.FindProperty("BurgerId1");
             var fkProperty2 = dependentType.FindProperty("BurgerId2");
 
-            var principalKey = principalType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
             var dependentKey = dependentType.FindPrimaryKey();
 
             modelBuilder
@@ -1873,9 +1871,9 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(Tomato));
             var principalType = model.FindEntityType(typeof(Whoopper));
 
-            var fkProperty1 = dependentType.FindProperty("BurgerId1");
+            var fkProperty1 = dependentType!.FindProperty("BurgerId1");
             var fkProperty2 = dependentType.FindProperty("BurgerId2");
-            var principalProperty1 = principalType.FindProperty("AlternateKey1");
+            var principalProperty1 = principalType!.FindProperty("AlternateKey1");
             var principalProperty2 = principalType.FindProperty("AlternateKey2");
 
             var principalKey = principalType.FindPrimaryKey();
@@ -1933,9 +1931,9 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(Tomato));
             var principalType = model.FindEntityType(typeof(Whoopper));
 
-            var fkProperty1 = dependentType.FindProperty("BurgerId1");
+            var fkProperty1 = dependentType!.FindProperty("BurgerId1");
             var fkProperty2 = dependentType.FindProperty("BurgerId2");
-            var principalProperty1 = principalType.FindProperty("AlternateKey1");
+            var principalProperty1 = principalType!.FindProperty("AlternateKey1");
             var principalProperty2 = principalType.FindProperty("AlternateKey2");
 
             var principalKey = principalType.FindPrimaryKey();
@@ -1997,10 +1995,10 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(Tomato));
             var principalType = model.FindEntityType(typeof(Whoopper));
 
-            var fkProperty1 = dependentType.FindProperty(nameof(Tomato.BurgerId1));
+            var fkProperty1 = dependentType!.FindProperty(nameof(Tomato.BurgerId1));
             var fkProperty2 = dependentType.FindProperty(nameof(Tomato.BurgerId2));
 
-            var principalKey = principalType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
             var dependentKey = dependentType.FindPrimaryKey();
 
             modelBuilder
@@ -2013,7 +2011,7 @@ public abstract partial class ModelBuilderTest
             Assert.Same(fkProperty1, fk.Properties[0]);
             Assert.Same(fkProperty2, fk.Properties[1]);
 
-            Assert.Equal(nameof(Whoopper.Tomatoes), fk.PrincipalToDependent.Name);
+            Assert.Equal(nameof(Whoopper.Tomatoes), fk.PrincipalToDependent!.Name);
             Assert.Null(fk.DependentToPrincipal);
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
@@ -2044,8 +2042,8 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(Tomato));
             var principalType = model.FindEntityType(typeof(Whoopper));
 
-            var principalKey = principalType.FindPrimaryKey();
-            var dependentKey = dependentType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
+            var dependentKey = dependentType!.FindPrimaryKey();
 
             modelBuilder
                 .Entity<Whoopper>().HasMany<Tomato>().WithOne(e => e.Whoopper)
@@ -2057,7 +2055,7 @@ public abstract partial class ModelBuilderTest
             Assert.Same(dependentType.FindProperty(nameof(Tomato.BurgerId1)), fk.Properties[0]);
             Assert.Same(dependentType.FindProperty(nameof(Tomato.BurgerId2)), fk.Properties[1]);
 
-            Assert.Equal(nameof(Tomato.Whoopper), fk.DependentToPrincipal.Name);
+            Assert.Equal(nameof(Tomato.Whoopper), fk.DependentToPrincipal!.Name);
             Assert.Null(fk.PrincipalToDependent);
             Assert.NotSame(fk, principalType.GetNavigations().Single().ForeignKey);
             Assert.Same(principalKey, principalType.FindPrimaryKey());
@@ -2090,11 +2088,11 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(Tomato));
             var principalType = model.FindEntityType(typeof(Whoopper));
 
-            var fk = dependentType.GetForeignKeys().SingleOrDefault();
+            var fk = dependentType!.GetForeignKeys().SingleOrDefault();
             var fkProperty1 = dependentType.FindProperty("BurgerId1");
             var fkProperty2 = dependentType.FindProperty("BurgerId2");
 
-            var principalKey = principalType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
             var dependentKey = dependentType.FindPrimaryKey();
 
             modelBuilder
@@ -2116,7 +2114,7 @@ public abstract partial class ModelBuilderTest
             if (Fixture.ForeignKeysHaveIndexes)
             {
                 Assert.Equal(dependentType.GetForeignKeys().Count(), dependentType.GetIndexes().Count());
-                Assert.False(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
+                Assert.False(fk!.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
             }
             else
             {
@@ -2140,8 +2138,8 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(ToastedBun));
             var principalType = model.FindEntityType(typeof(Whoopper));
 
-            var principalKey = principalType.FindPrimaryKey();
-            var dependentKey = dependentType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
+            var dependentKey = dependentType!.FindPrimaryKey();
 
             modelBuilder
                 .Entity<Whoopper>().HasMany<ToastedBun>().WithOne()
@@ -2152,7 +2150,7 @@ public abstract partial class ModelBuilderTest
             var existingFk = navigation.ForeignKey;
             Assert.Same(existingFk, principalType.GetNavigations().Single().ForeignKey);
             Assert.Equal(nameof(ToastedBun.Whoopper), navigation.Name);
-            Assert.Equal(nameof(Whoopper.ToastedBun), navigation.Inverse.Name);
+            Assert.Equal(nameof(Whoopper.ToastedBun), navigation.Inverse!.Name);
             Assert.Equal(existingFk.DeclaringEntityType == dependentType ? 0 : 1, principalType.GetForeignKeys().Count());
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
@@ -2175,8 +2173,8 @@ public abstract partial class ModelBuilderTest
 
             Assert.Equal(
                 CoreStrings.AmbiguousOneToOneRelationship(
-                    existingFk.DeclaringEntityType.DisplayName() + "." + existingFk.DependentToPrincipal.Name,
-                    existingFk.PrincipalEntityType.DisplayName() + "." + existingFk.PrincipalToDependent.Name),
+                    existingFk.DeclaringEntityType.DisplayName() + "." + existingFk.DependentToPrincipal!.Name,
+                    existingFk.PrincipalEntityType.DisplayName() + "." + existingFk.PrincipalToDependent!.Name),
                 Assert.Throws<InvalidOperationException>(modelBuilder.FinalizeModel).Message);
         }
 
@@ -2194,8 +2192,8 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(ToastedBun));
             var principalType = model.FindEntityType(typeof(Whoopper));
 
-            var principalKey = principalType.FindPrimaryKey();
-            var dependentKey = dependentType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
+            var dependentKey = dependentType!.FindPrimaryKey();
 
             modelBuilder
                 .Entity<Whoopper>().HasMany<ToastedBun>().WithOne()
@@ -2204,8 +2202,8 @@ public abstract partial class ModelBuilderTest
 
             var existingFk = dependentType.GetNavigations().Single().ForeignKey;
             Assert.Same(existingFk, principalType.GetNavigations().Single().ForeignKey);
-            Assert.Equal(nameof(Tomato.Whoopper), existingFk.DependentToPrincipal.Name);
-            Assert.Equal(nameof(Whoopper.ToastedBun), existingFk.PrincipalToDependent.Name);
+            Assert.Equal(nameof(Tomato.Whoopper), existingFk.DependentToPrincipal!.Name);
+            Assert.Equal(nameof(Whoopper.ToastedBun), existingFk.PrincipalToDependent!.Name);
             Assert.Empty(principalType.GetForeignKeys());
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
@@ -2252,7 +2250,7 @@ public abstract partial class ModelBuilderTest
 
             var dependentType = model.FindEntityType(typeof(Product));
 
-            var optionalFk = dependentType.GetNavigations().Single().ForeignKey;
+            var optionalFk = dependentType!.GetNavigations().Single().ForeignKey;
             Assert.False(optionalFk.IsRequired);
             Assert.True(optionalFk.Properties.Last().IsNullable);
 
@@ -2261,10 +2259,10 @@ public abstract partial class ModelBuilderTest
             Assert.False(requiredFk.Properties.Last().IsNullable);
 
             var dependentKey = dependentType.FindPrimaryKey();
-            Assert.True(dependentKey.Properties.All(p => p.ValueGenerated == ValueGenerated.Never));
+            Assert.True(dependentKey!.Properties.All(p => p.ValueGenerated == ValueGenerated.Never));
 
             var index = dependentType.FindIndex([dependentKey.Properties[0], optionalFk.Properties[1]]);
-            Assert.True(index.IsUnique);
+            Assert.True(index!.IsUnique);
         }
 
         [Fact]
@@ -2308,8 +2306,8 @@ public abstract partial class ModelBuilderTest
 
             Assert.Equal(
                 CoreStrings.ConflictingRelationshipNavigation(
-                    principalType.DisplayName() + "." + nameof(Nob.Hobs),
-                    dependentType.DisplayName() + "." + nameof(Hob.Nob),
+                    principalType!.DisplayName() + "." + nameof(Nob.Hobs),
+                    dependentType!.DisplayName() + "." + nameof(Hob.Nob),
                     dependentType.DisplayName() + "." + nameof(Hob.Nob),
                     principalType.DisplayName() + "." + nameof(Nob.Hob)),
                 Assert.Throws<InvalidOperationException>(() =>
@@ -2340,16 +2338,16 @@ public abstract partial class ModelBuilderTest
 
             var dependentType = model.FindEntityType(typeof(Hob));
             var principalType = model.FindEntityType(typeof(Nob));
-            var principalKey = principalType.FindPrimaryKey();
-            var dependentKey = dependentType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
+            var dependentKey = dependentType!.FindPrimaryKey();
 
             modelBuilder.Entity<Nob>().HasMany(e => e.Hobs).WithOne(e => e.Nob);
 
             // assert the 1:N relationship defined through the HasMany().WithOne() call above
             var fk = dependentType.GetForeignKeys().Single();
             Assert.False(fk.IsUnique);
-            Assert.Equal(nameof(Nob.Hobs), fk.PrincipalToDependent.Name);
-            Assert.Equal(nameof(Hob.Nob), fk.DependentToPrincipal.Name);
+            Assert.Equal(nameof(Nob.Hobs), fk.PrincipalToDependent!.Name);
+            Assert.Equal(nameof(Hob.Nob), fk.DependentToPrincipal!.Name);
 
             // The 1:N relationship above has "used up" Hob.Nob and Nob.Hobs,
             // so now the RelationshipDiscoveryConvention should be able
@@ -2357,8 +2355,8 @@ public abstract partial class ModelBuilderTest
             // in a different 1:N relationship.
             var otherFk = principalType.GetForeignKeys().Single();
             Assert.False(fk.IsUnique);
-            Assert.Equal(nameof(Hob.Nobs), otherFk.PrincipalToDependent.Name);
-            Assert.Equal(nameof(Nob.Hob), otherFk.DependentToPrincipal.Name);
+            Assert.Equal(nameof(Hob.Nobs), otherFk.PrincipalToDependent!.Name);
+            Assert.Equal(nameof(Nob.Hob), otherFk.DependentToPrincipal!.Name);
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
 
@@ -2388,7 +2386,7 @@ public abstract partial class ModelBuilderTest
             var builder = modelBuilder.Entity<Customer>().HasMany(e => e.Orders).WithOne(e => e.Customer);
             builder = builder.HasAnnotation("Fus", "Ro");
 
-            var fk = dependentType.GetForeignKeys().Single();
+            var fk = dependentType!.GetForeignKeys().Single();
             Assert.Same(fk, builder.Metadata);
             Assert.Equal("Ro", fk["Fus"]);
         }
@@ -2420,13 +2418,13 @@ public abstract partial class ModelBuilderTest
 
             modelBuilder.FinalizeModel();
 
-            var entityType = (IReadOnlyEntityType)modelBuilder.Model.FindEntityType(typeof(Nob));
-            var fk = entityType.GetForeignKeys().Single();
+            var entityType = (IReadOnlyEntityType)modelBuilder.Model.FindEntityType(typeof(Nob))!;
+            var fk = entityType!.GetForeignKeys().Single();
             Assert.False(fk.IsRequired);
             var fkProperty1 = entityType.FindProperty(nameof(Nob.HobId1));
             var fkProperty2 = entityType.FindProperty(nameof(Nob.HobId2));
-            Assert.True(fkProperty1.IsNullable);
-            Assert.True(fkProperty2.IsNullable);
+            Assert.True(fkProperty1!.IsNullable);
+            Assert.True(fkProperty2!.IsNullable);
             Assert.Contains(fkProperty1, fk.Properties);
             Assert.Contains(fkProperty2, fk.Properties);
         }
@@ -2442,13 +2440,13 @@ public abstract partial class ModelBuilderTest
 
             modelBuilder.FinalizeModel();
 
-            var entityType = (IReadOnlyEntityType)modelBuilder.Model.FindEntityType(typeof(Hob));
-            var fk = entityType.GetForeignKeys().Single();
+            var entityType = (IReadOnlyEntityType)modelBuilder.Model.FindEntityType(typeof(Hob))!;
+            var fk = entityType!.GetForeignKeys().Single();
             Assert.True(fk.IsRequired);
             var fkProperty1 = entityType.FindProperty(nameof(Hob.NobId1));
             var fkProperty2 = entityType.FindProperty(nameof(Hob.NobId2));
-            Assert.False(fkProperty1.IsNullable);
-            Assert.False(fkProperty2.IsNullable);
+            Assert.False(fkProperty1!.IsNullable);
+            Assert.False(fkProperty2!.IsNullable);
             Assert.Contains(fkProperty1, fk.Properties);
             Assert.Contains(fkProperty2, fk.Properties);
         }
@@ -2465,13 +2463,13 @@ public abstract partial class ModelBuilderTest
 
             modelBuilder.FinalizeModel();
 
-            var entityType = (IReadOnlyEntityType)modelBuilder.Model.FindEntityType(typeof(Nob));
-            var fk = entityType.GetForeignKeys().Single();
+            var entityType = (IReadOnlyEntityType)modelBuilder.Model.FindEntityType(typeof(Nob))!;
+            var fk = entityType!.GetForeignKeys().Single();
             Assert.True(fk.IsRequired);
             var fkProperty1 = entityType.FindProperty(nameof(Nob.HobId1));
             var fkProperty2 = entityType.FindProperty(nameof(Nob.HobId2));
-            Assert.False(fkProperty1.IsNullable);
-            Assert.False(fkProperty2.IsNullable);
+            Assert.False(fkProperty1!.IsNullable);
+            Assert.False(fkProperty2!.IsNullable);
             Assert.Contains(fkProperty1, fk.Properties);
             Assert.Contains(fkProperty2, fk.Properties);
         }
@@ -2488,13 +2486,13 @@ public abstract partial class ModelBuilderTest
 
             modelBuilder.FinalizeModel();
 
-            var entityType = (IReadOnlyEntityType)modelBuilder.Model.FindEntityType(typeof(Hob));
-            var fk = entityType.GetForeignKeys().Single();
+            var entityType = (IReadOnlyEntityType)modelBuilder.Model.FindEntityType(typeof(Hob))!;
+            var fk = entityType!.GetForeignKeys().Single();
             Assert.False(fk.IsRequired);
             var fkProperty1 = entityType.FindProperty(nameof(Hob.NobId1));
             var fkProperty2 = entityType.FindProperty(nameof(Hob.NobId2));
-            Assert.False(fkProperty1.IsNullable);
-            Assert.False(fkProperty2.IsNullable);
+            Assert.False(fkProperty1!.IsNullable);
+            Assert.False(fkProperty2!.IsNullable);
             Assert.Contains(fkProperty1, fk.Properties);
             Assert.Contains(fkProperty2, fk.Properties);
         }
@@ -2514,13 +2512,13 @@ public abstract partial class ModelBuilderTest
 
             modelBuilder.FinalizeModel();
 
-            var entityType = (IReadOnlyEntityType)modelBuilder.Model.FindEntityType(typeof(Hob));
-            var fk = entityType.GetForeignKeys().Single();
+            var entityType = (IReadOnlyEntityType)modelBuilder.Model.FindEntityType(typeof(Hob))!;
+            var fk = entityType!.GetForeignKeys().Single();
             Assert.False(fk.IsRequired);
             var fkProperty1 = entityType.FindProperty(nameof(Hob.NobId1));
             var fkProperty2 = entityType.FindProperty(nameof(Hob.NobId2));
-            Assert.False(fkProperty1.IsNullable);
-            Assert.False(fkProperty2.IsNullable);
+            Assert.False(fkProperty1!.IsNullable);
+            Assert.False(fkProperty2!.IsNullable);
             Assert.Contains(fkProperty1, fk.Properties);
             Assert.Contains(fkProperty2, fk.Properties);
         }
@@ -2539,10 +2537,10 @@ public abstract partial class ModelBuilderTest
             var model = modelBuilder.FinalizeModel();
 
             var entityType = model.FindEntityType(typeof(DependentEntity));
-            var fk = entityType.GetForeignKeys().Single();
+            var fk = entityType!.GetForeignKeys().Single();
             Assert.False(fk.IsRequired);
             var fkProperty = entityType.FindProperty(nameof(DependentEntity.PrincipalEntityId));
-            Assert.True(fkProperty.IsNullable);
+            Assert.True(fkProperty!.IsNullable);
             Assert.Contains(fkProperty, fk.Properties);
         }
 
@@ -2550,13 +2548,13 @@ public abstract partial class ModelBuilderTest
         public virtual void Can_change_delete_behavior()
         {
             var modelBuilder = HobNobBuilder();
-            var dependentType = (IReadOnlyEntityType)modelBuilder.Model.FindEntityType(typeof(Nob));
+            var dependentType = (IReadOnlyEntityType)modelBuilder.Model.FindEntityType(typeof(Nob))!;
 
             modelBuilder
                 .Entity<Hob>().HasMany(e => e.Nobs).WithOne(e => e.Hob)
                 .OnDelete(DeleteBehavior.Cascade);
 
-            Assert.Equal(DeleteBehavior.Cascade, dependentType.GetForeignKeys().Single().DeleteBehavior);
+            Assert.Equal(DeleteBehavior.Cascade, dependentType!.GetForeignKeys().Single().DeleteBehavior);
 
             modelBuilder
                 .Entity<Hob>().HasMany(e => e.Nobs).WithOne(e => e.Hob)
@@ -2578,12 +2576,12 @@ public abstract partial class ModelBuilderTest
             var model = modelBuilder.Model;
             modelBuilder.Entity<PrincipalEntity>();
 
-            var foreignKey = model.FindEntityType(typeof(DependentEntity)).GetForeignKeys().Single();
+            var foreignKey = model.FindEntityType(typeof(DependentEntity))!.GetForeignKeys().Single();
             Assert.Equal("NavId", foreignKey.Properties.Single().Name);
 
             modelBuilder.Entity<DependentEntity>().Property(et => et.PrincipalEntityId);
 
-            var newForeignKey = model.FindEntityType(typeof(DependentEntity)).GetForeignKeys().Single();
+            var newForeignKey = model.FindEntityType(typeof(DependentEntity))!.GetForeignKeys().Single();
             Assert.Equal("PrincipalEntityId", newForeignKey.Properties.Single().Name);
         }
 
@@ -2598,8 +2596,8 @@ public abstract partial class ModelBuilderTest
             var model = modelBuilder.FinalizeModel();
 
             var entityB = model.FindEntityType(typeof(Beta));
-            Assert.Equal("FirstNavId", entityB.FindNavigation("FirstNav").ForeignKey.Properties.First().Name);
-            Assert.Equal("SecondNavId", entityB.FindNavigation("SecondNav").ForeignKey.Properties.First().Name);
+            Assert.Equal("FirstNavId", entityB!.FindNavigation("FirstNav")!.ForeignKey.Properties.First().Name);
+            Assert.Equal("SecondNavId", entityB.FindNavigation("SecondNav")!.ForeignKey.Properties.First().Name);
         }
 
         [Fact]
@@ -2609,7 +2607,7 @@ public abstract partial class ModelBuilderTest
             var modelBuilder = CreateModelBuilder();
             var gamma = modelBuilder.Entity<Gamma>().Metadata;
 
-            Assert.Equal("GammaId", gamma.FindNavigation("Alphas").ForeignKey.Properties.First().Name);
+            Assert.Equal("GammaId", gamma.FindNavigation("Alphas")!.ForeignKey.Properties.First().Name);
         }
 
         [Fact]
@@ -2626,7 +2624,7 @@ public abstract partial class ModelBuilderTest
 
             Assert.Equal(
                 "ShadowId",
-                modelBuilder.Model.FindEntityType(typeof(Beta)).FindNavigation("FirstNav").ForeignKey.Properties.Single().Name);
+                modelBuilder.Model.FindEntityType(typeof(Beta))!.FindNavigation("FirstNav")!.ForeignKey.Properties.Single().Name);
         }
 
         [Fact]
@@ -2646,7 +2644,7 @@ public abstract partial class ModelBuilderTest
 
             Assert.Equal(
                 "ShadowId",
-                modelBuilder.Model.FindEntityType(typeof(Beta)).FindNavigation("FirstNav").ForeignKey.Properties.Single().Name);
+                modelBuilder.Model.FindEntityType(typeof(Beta))!.FindNavigation("FirstNav")!.ForeignKey.Properties.Single().Name);
         }
 
         [Fact]
@@ -2656,8 +2654,8 @@ public abstract partial class ModelBuilderTest
             modelBuilder.Ignore<Delta>();
             modelBuilder.Entity<Epsilon>().HasOne<Alpha>().WithMany(b => b.Epsilons);
 
-            var property = modelBuilder.Model.FindEntityType(typeof(Epsilon)).FindProperty("Id");
-            Assert.Equal(ValueGenerated.Never, property.ValueGenerated);
+            var property = modelBuilder.Model.FindEntityType(typeof(Epsilon))!.FindProperty("Id");
+            Assert.Equal(ValueGenerated.Never, property!.ValueGenerated);
 
             modelBuilder.FinalizeModel();
 
@@ -2691,23 +2689,23 @@ public abstract partial class ModelBuilderTest
 
             var model = modelBuilder.Model;
 
-            var alphaFk = model.FindEntityType(typeof(Epsilon)).FindNavigation(nameof(Epsilon.Alpha)).ForeignKey;
+            var alphaFk = model.FindEntityType(typeof(Epsilon))!.FindNavigation(nameof(Epsilon.Alpha))!.ForeignKey;
             Assert.Null(alphaFk.PrincipalToDependent);
             Assert.False(alphaFk.IsUnique);
             Assert.Equal(nameof(Epsilon.Id), alphaFk.Properties.First().Name);
 
-            var epsilonFk = model.FindEntityType(typeof(Alpha)).FindNavigation(nameof(Alpha.Epsilons)).ForeignKey;
+            var epsilonFk = model.FindEntityType(typeof(Alpha))!.FindNavigation(nameof(Alpha.Epsilons))!.ForeignKey;
             Assert.Null(epsilonFk.DependentToPrincipal);
             Assert.False(epsilonFk.IsUnique);
             Assert.Equal(nameof(Alpha) + nameof(Alpha.Id), epsilonFk.Properties.First().Name);
 
-            var etaFk = model.FindEntityType(typeof(Alpha)).FindNavigation(nameof(Alpha.Etas)).ForeignKey;
-            Assert.Equal(nameof(Eta.Alpha), etaFk.DependentToPrincipal.Name);
+            var etaFk = model.FindEntityType(typeof(Alpha))!.FindNavigation(nameof(Alpha.Etas))!.ForeignKey;
+            Assert.Equal(nameof(Eta.Alpha), etaFk.DependentToPrincipal!.Name);
             Assert.False(etaFk.IsUnique);
             Assert.Equal("Id", etaFk.Properties.First().Name);
 
-            var kappaFk = model.FindEntityType(typeof(Alpha)).FindNavigation(nameof(Alpha.Kappas)).ForeignKey;
-            Assert.Equal(nameof(Kappa.Alpha), kappaFk.DependentToPrincipal.Name);
+            var kappaFk = model.FindEntityType(typeof(Alpha))!.FindNavigation(nameof(Alpha.Kappas))!.ForeignKey;
+            Assert.Equal(nameof(Kappa.Alpha), kappaFk.DependentToPrincipal!.Name);
             Assert.False(kappaFk.IsUnique);
             Assert.Equal("Id", kappaFk.Properties.First().Name);
         }
@@ -2723,12 +2721,12 @@ public abstract partial class ModelBuilderTest
 
             var model = modelBuilder.Model;
 
-            var alphaFk = model.FindEntityType(typeof(Eta)).FindNavigation(nameof(Eta.Alpha)).ForeignKey;
+            var alphaFk = model.FindEntityType(typeof(Eta))!.FindNavigation(nameof(Eta.Alpha))!.ForeignKey;
             Assert.Null(alphaFk.PrincipalToDependent);
             Assert.False(alphaFk.IsUnique);
             Assert.Equal(nameof(Eta.Id), alphaFk.Properties.Single().Name);
 
-            var etasFk = model.FindEntityType(typeof(Alpha)).FindNavigation(nameof(Alpha.Etas)).ForeignKey;
+            var etasFk = model.FindEntityType(typeof(Alpha))!.FindNavigation(nameof(Alpha.Etas))!.ForeignKey;
             Assert.Null(etasFk.DependentToPrincipal);
             Assert.False(etasFk.IsUnique);
             Assert.NotSame(alphaFk, etasFk);
@@ -2747,13 +2745,13 @@ public abstract partial class ModelBuilderTest
 
             var model = modelBuilder.Model;
 
-            var thetasFk = model.FindEntityType(typeof(Alpha)).FindNavigation(nameof(Alpha.Thetas)).ForeignKey;
+            var thetasFk = model.FindEntityType(typeof(Alpha))!.FindNavigation(nameof(Alpha.Thetas))!.ForeignKey;
             Assert.Null(thetasFk.DependentToPrincipal);
             Assert.False(thetasFk.IsUnique);
             Assert.Equal("Id", thetasFk.Properties.Single().Name);
             Assert.True(thetasFk.Properties.Single().IsShadowProperty());
 
-            var alphaFk = model.FindEntityType(typeof(Theta)).FindNavigation(nameof(Theta.Alpha)).ForeignKey;
+            var alphaFk = model.FindEntityType(typeof(Theta))!.FindNavigation(nameof(Theta.Alpha))!.ForeignKey;
             Assert.Null(alphaFk.PrincipalToDependent);
             Assert.False(alphaFk.IsUnique);
             Assert.NotSame(alphaFk, thetasFk);
@@ -2780,8 +2778,8 @@ public abstract partial class ModelBuilderTest
 
             modelBuilder.FinalizeModel();
 
-            var fk = modelBuilder.Model.FindEntityType(typeof(OneToOneDependentEntity))
-                .FindNavigation(OneToOneDependentEntity.NavigationProperty).ForeignKey;
+            var fk = modelBuilder.Model.FindEntityType(typeof(OneToOneDependentEntity))!
+                .FindNavigation(OneToOneDependentEntity.NavigationProperty)!.ForeignKey;
 
             Assert.Equal(typeof(OneToOnePrincipalEntity), fk.PrincipalEntityType.ClrType);
             Assert.Equal(typeof(OneToOneDependentEntity), fk.DeclaringEntityType.ClrType);
@@ -2806,8 +2804,8 @@ public abstract partial class ModelBuilderTest
 
             modelBuilder.FinalizeModel();
 
-            var fk = modelBuilder.Model.FindEntityType(typeof(OneToOneDependentEntity))
-                .FindNavigation(OneToOneDependentEntity.NavigationProperty).ForeignKey;
+            var fk = modelBuilder.Model.FindEntityType(typeof(OneToOneDependentEntity))!
+                .FindNavigation(OneToOneDependentEntity.NavigationProperty)!.ForeignKey;
 
             Assert.Equal(typeof(OneToOnePrincipalEntity), fk.PrincipalEntityType.ClrType);
             Assert.Equal(typeof(OneToOneDependentEntity), fk.DeclaringEntityType.ClrType);
@@ -2833,8 +2831,8 @@ public abstract partial class ModelBuilderTest
 
             modelBuilder.FinalizeModel();
 
-            var fk = modelBuilder.Model.FindEntityType(typeof(OneToOneDependentEntity))
-                .FindNavigation(OneToOneDependentEntity.NavigationProperty).ForeignKey;
+            var fk = modelBuilder.Model.FindEntityType(typeof(OneToOneDependentEntity))!
+                .FindNavigation(OneToOneDependentEntity.NavigationProperty)!.ForeignKey;
 
             Assert.Equal(typeof(OneToOnePrincipalEntity), fk.PrincipalEntityType.ClrType);
             Assert.Equal(typeof(OneToOneDependentEntity), fk.DeclaringEntityType.ClrType);
@@ -2856,8 +2854,8 @@ public abstract partial class ModelBuilderTest
 
             modelBuilder.FinalizeModel();
 
-            var fk = modelBuilder.Model.FindEntityType(typeof(OneToOneDependentEntity))
-                .FindNavigation(OneToOneDependentEntity.NavigationProperty).ForeignKey;
+            var fk = modelBuilder.Model.FindEntityType(typeof(OneToOneDependentEntity))!
+                .FindNavigation(OneToOneDependentEntity.NavigationProperty)!.ForeignKey;
 
             Assert.Equal(typeof(OneToOnePrincipalEntity), fk.PrincipalEntityType.ClrType);
             Assert.Equal(typeof(OneToOneDependentEntity), fk.DeclaringEntityType.ClrType);
@@ -2874,7 +2872,7 @@ public abstract partial class ModelBuilderTest
 
             Assert.NotNull(theta.FindNavigation("NavTheta"));
             Assert.NotNull(theta.FindNavigation("InverseNavThetas"));
-            Assert.Same(theta.FindNavigation("NavTheta").ForeignKey, theta.FindNavigation("InverseNavThetas").ForeignKey);
+            Assert.Same(theta.FindNavigation("NavTheta")!.ForeignKey, theta.FindNavigation("InverseNavThetas")!.ForeignKey);
         }
 
         [Fact]
@@ -2883,8 +2881,8 @@ public abstract partial class ModelBuilderTest
             var modelBuilder = CreateModelBuilder();
             modelBuilder.Entity<Customer>().HasMany(c => c.Orders).WithOne(o => o.Customer).HasForeignKey("MyShadowFk");
 
-            Assert.True(modelBuilder.Model.FindEntityType(typeof(Order)).FindProperty("MyShadowFk").IsNullable);
-            Assert.Equal(typeof(int?), modelBuilder.Model.FindEntityType(typeof(Order)).FindProperty("MyShadowFk").ClrType);
+            Assert.True(modelBuilder.Model.FindEntityType(typeof(Order))!.FindProperty("MyShadowFk")!.IsNullable);
+            Assert.Equal(typeof(int?), modelBuilder.Model.FindEntityType(typeof(Order))!.FindProperty("MyShadowFk")!.ClrType);
         }
 
         [Fact]
@@ -2896,7 +2894,7 @@ public abstract partial class ModelBuilderTest
 
             Assert.Equal(
                 "KappaId",
-                modelBuilder.Model.FindEntityType(typeof(Kappa)).FindNavigation(nameof(Kappa.Omegas)).ForeignKey.Properties.Single()
+                modelBuilder.Model.FindEntityType(typeof(Kappa))!.FindNavigation(nameof(Kappa.Omegas))!.ForeignKey.Properties.Single()
                     .Name);
         }
 
@@ -2912,7 +2910,7 @@ public abstract partial class ModelBuilderTest
 
             Assert.Equal(
                 "KappaId",
-                modelBuilder.Model.FindEntityType(typeof(Omega)).FindNavigation(nameof(Omega.Kappa)).ForeignKey.Properties.Single()
+                modelBuilder.Model.FindEntityType(typeof(Omega))!.FindNavigation(nameof(Omega.Kappa))!.ForeignKey.Properties.Single()
                     .Name);
         }
 
@@ -2922,7 +2920,7 @@ public abstract partial class ModelBuilderTest
             var modelBuilder = CreateModelBuilder();
             var entityTypeBuilder = modelBuilder.Entity<Alpha>();
 
-            Assert.Equal(nameof(Alpha.Id), entityTypeBuilder.Metadata.FindPrimaryKey().Properties.Single().Name);
+            Assert.Equal(nameof(Alpha.Id), entityTypeBuilder.Metadata.FindPrimaryKey()!.Properties.Single().Name);
 
             entityTypeBuilder.Property(e => e.Id).IsRequired(false);
 
@@ -2930,7 +2928,7 @@ public abstract partial class ModelBuilderTest
 
             entityTypeBuilder.HasKey(e => e.AnotherId);
 
-            Assert.Equal(nameof(Alpha.AnotherId), entityTypeBuilder.Metadata.FindPrimaryKey().Properties.Single().Name);
+            Assert.Equal(nameof(Alpha.AnotherId), entityTypeBuilder.Metadata.FindPrimaryKey()!.Properties.Single().Name);
         }
 
         [Fact]
@@ -2943,7 +2941,7 @@ public abstract partial class ModelBuilderTest
 
             Assert.Equal(
                 "PrincipalShadowFkId",
-                modelBuilder.Model.FindEntityType(typeof(DependentShadowFk)).GetForeignKeys().Single().Properties[0].Name);
+                modelBuilder.Model.FindEntityType(typeof(DependentShadowFk))!.GetForeignKeys().Single().Properties[0].Name);
         }
 
         [Fact]
@@ -2957,7 +2955,7 @@ public abstract partial class ModelBuilderTest
             var model = modelBuilder.FinalizeModel();
 
             var child = model.FindEntityType(typeof(CompositeChild));
-            var fk = child.GetForeignKeys().Single();
+            var fk = child!.GetForeignKeys().Single();
             Assert.Equal("ParentId", fk.Properties[0].Name);
         }
 
@@ -2979,11 +2977,11 @@ public abstract partial class ModelBuilderTest
                 .Navigation(e => e.Dependents)
                 .UsePropertyAccessMode(PropertyAccessMode.Field);
 
-            var principal = (IReadOnlyEntityType)model.FindEntityType(typeof(OneToManyNavPrincipal));
-            var dependent = (IReadOnlyEntityType)model.FindEntityType(typeof(NavDependent));
+            var principal = (IReadOnlyEntityType)model.FindEntityType(typeof(OneToManyNavPrincipal))!;
+            var dependent = (IReadOnlyEntityType)model.FindEntityType(typeof(NavDependent))!;
 
-            Assert.Equal(PropertyAccessMode.Field, principal.FindNavigation("Dependents").GetPropertyAccessMode());
-            Assert.Equal(PropertyAccessMode.Property, dependent.FindNavigation("OneToManyPrincipal").GetPropertyAccessMode());
+            Assert.Equal(PropertyAccessMode.Field, principal!.FindNavigation("Dependents")!.GetPropertyAccessMode());
+            Assert.Equal(PropertyAccessMode.Property, dependent!.FindNavigation("OneToManyPrincipal")!.GetPropertyAccessMode());
         }
 
         [Fact]
@@ -3093,7 +3091,7 @@ public abstract partial class ModelBuilderTest
                     Assert.Equal(typeof(Discount).DisplayName(), e.Name);
                     var fk = Assert.Single(e.GetForeignKeys());
                     Assert.False(fk.IsUnique);
-                    Assert.Equal(nameof(Discount.Store), fk.DependentToPrincipal.Name);
+                    Assert.Equal(nameof(Discount.Store), fk.DependentToPrincipal!.Name);
                 },
                 e => Assert.Equal(typeof(Store).DisplayName(), e.Name));
         }

--- a/test/EFCore.Specification.Tests/ModelBuilding/ModelBuilderTest.OneToOne.cs
+++ b/test/EFCore.Specification.Tests/ModelBuilding/ModelBuilderTest.OneToOne.cs
@@ -7,8 +7,6 @@ using Microsoft.EntityFrameworkCore.Metadata.Internal;
 // ReSharper disable InconsistentNaming
 namespace Microsoft.EntityFrameworkCore.ModelBuilding;
 
-#nullable disable
-
 public abstract partial class ModelBuilderTest
 {
     public abstract class OneToOneTestBase(ModelBuilderFixtureBase fixture) : ModelBuilderTestBase(fixture)
@@ -26,10 +24,10 @@ public abstract partial class ModelBuilderTest
 
             var dependentType = model.FindEntityType(typeof(CustomerDetails));
             var principalType = model.FindEntityType(typeof(Customer));
-            var fk = dependentType.GetForeignKeys().Single();
+            var fk = dependentType!.GetForeignKeys().Single();
 
             var navToPrincipal = dependentType.FindNavigation(nameof(CustomerDetails.Customer));
-            var navToDependent = principalType.FindNavigation(nameof(Customer.Details));
+            var navToDependent = principalType!.FindNavigation(nameof(Customer.Details));
 
             var principalKey = principalType.FindPrimaryKey();
             var dependentKey = dependentType.FindPrimaryKey();
@@ -75,10 +73,10 @@ public abstract partial class ModelBuilderTest
 
             var dependentType = model.FindEntityType(typeof(DependentWithField));
             var principalType = model.FindEntityType(typeof(OneToOnePrincipalWithField));
-            var fk = dependentType.GetForeignKeys().Single();
+            var fk = dependentType!.GetForeignKeys().Single();
 
             var navToPrincipal = dependentType.FindNavigation("OneToOnePrincipal");
-            var navToDependent = principalType.FindNavigation("Dependent");
+            var navToDependent = principalType!.FindNavigation("Dependent");
 
             var principalKey = principalType.FindPrimaryKey();
             var dependentKey = dependentType.FindPrimaryKey();
@@ -111,7 +109,7 @@ public abstract partial class ModelBuilderTest
                 .HasPrincipalKey<Order>(e => e.OrderId)
                 .HasForeignKey<CustomerDetails>(c => c.Id);
 
-            var foreignKeys = model.FindEntityType(typeof(CustomerDetails)).GetForeignKeys()
+            var foreignKeys = model.FindEntityType(typeof(CustomerDetails))!.GetForeignKeys()
                 .Where(fk => fk.Properties.Single().Name == nameof(CustomerDetails.Id)).ToList();
 
             Assert.Equal(2, foreignKeys.Count);
@@ -119,8 +117,8 @@ public abstract partial class ModelBuilderTest
             var orderFk = foreignKeys.Single(fk => fk.PrincipalEntityType.ClrType == typeof(Order));
             var dependentType = customerFk.DeclaringEntityType;
             var principalType = customerFk.PrincipalEntityType;
-            Assert.Equal(nameof(CustomerDetails.Customer), customerFk.DependentToPrincipal.Name);
-            Assert.Equal(nameof(Customer.Details), customerFk.PrincipalToDependent.Name);
+            Assert.Equal(nameof(CustomerDetails.Customer), customerFk.DependentToPrincipal!.Name);
+            Assert.Equal(nameof(Customer.Details), customerFk.PrincipalToDependent!.Name);
             Assert.Null(orderFk.DependentToPrincipal);
             Assert.Null(orderFk.PrincipalToDependent);
             Assert.Empty(dependentType.GetIndexes());
@@ -138,8 +136,8 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(CustomerDetails));
             var principalType = model.FindEntityType(typeof(Customer));
 
-            var principalKey = principalType.FindPrimaryKey();
-            var dependentKey = dependentType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
+            var dependentKey = dependentType!.FindPrimaryKey();
 
             modelBuilder.Entity<Customer>().HasOne(e => e.Details).WithOne(e => e.Customer);
 
@@ -174,8 +172,8 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(CustomerDetails));
             var principalType = model.FindEntityType(typeof(Customer));
 
-            var principalKey = principalType.FindPrimaryKey();
-            var dependentKey = dependentType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
+            var dependentKey = dependentType!.FindPrimaryKey();
 
             modelBuilder.Entity<Customer>().HasOne(e => e.Details).WithOne(e => e.Customer);
 
@@ -201,8 +199,8 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(CustomerDetails));
             var principalType = model.FindEntityType(typeof(Customer));
 
-            var principalKey = principalType.FindPrimaryKey();
-            var dependentKey = dependentType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
+            var dependentKey = dependentType!.FindPrimaryKey();
             var expectedPrincipalProperties = principalType.GetProperties().ToList();
             var expectedDependentProperties = dependentType.GetProperties().ToList();
 
@@ -223,7 +221,7 @@ public abstract partial class ModelBuilderTest
             if (Fixture.ForeignKeysHaveIndexes)
             {
                 Assert.Single(dependentType.GetIndexes());
-                Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties).IsUnique);
+                Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
             }
             else
             {
@@ -245,8 +243,8 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(CustomerDetails));
             var principalType = model.FindEntityType(typeof(Customer));
 
-            var principalKey = principalType.FindPrimaryKey();
-            var dependentKey = dependentType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
+            var dependentKey = dependentType!.FindPrimaryKey();
 
             modelBuilder.Entity<CustomerDetails>().HasOne(e => e.Customer).WithOne(e => e.Details);
 
@@ -289,8 +287,8 @@ public abstract partial class ModelBuilderTest
 
             modelBuilder.Entity<OrderDetails>().HasOne(e => e.Order).WithOne(e => e.Details);
 
-            var fk = dependentType.GetNavigations().Single().ForeignKey;
-            Assert.Same(fk, principalType.GetNavigations().Single().ForeignKey);
+            var fk = dependentType!.GetNavigations().Single().ForeignKey;
+            Assert.Same(fk, principalType!.GetNavigations().Single().ForeignKey);
             Assert.True(fk.IsUnique);
             Assert.Empty(dependentType.GetIndexes());
             Assert.Empty(principalType.GetIndexes());
@@ -309,9 +307,9 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(OrderDetails));
             var principalType = model.FindEntityType(typeof(Order));
 
-            var fkProperty = dependentType.FindProperty("OrderId");
+            var fkProperty = dependentType!.FindProperty("OrderId");
 
-            var principalKey = principalType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
             var dependentKey = dependentType.FindPrimaryKey();
 
             modelBuilder.Entity<OrderDetails>().HasOne(e => e.Order).WithOne(e => e.Details);
@@ -355,13 +353,13 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(OrderDetails));
             var principalType = model.FindEntityType(typeof(Order));
 
-            var fkProperty = dependentType.FindProperty(nameof(OrderDetails.OrderId));
+            var fkProperty = dependentType!.FindProperty(nameof(OrderDetails.OrderId));
 
             modelBuilder.Entity<OrderDetails>().HasKey(d => d.OrderId);
             var fkBuilder = modelBuilder.Entity<OrderDetails>().HasOne(d => d.Order).WithOne();
 
             var fk = dependentType.GetForeignKeys().Single();
-            var principalKey = principalType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
             var dependentKey = dependentType.FindPrimaryKey();
             Assert.Equal(nameof(OrderDetails.Order), dependentType.GetNavigations().Single().Name);
             Assert.Empty(principalType.GetNavigations());
@@ -396,9 +394,9 @@ public abstract partial class ModelBuilderTest
 
             modelBuilder.Entity<Customer>().HasOne(e => e.Details).WithOne();
 
-            var fk = dependentType.GetNavigations().Single().ForeignKey;
+            var fk = dependentType!.GetNavigations().Single().ForeignKey;
             Assert.True(fk.IsUnique);
-            Assert.NotSame(fk, principalType.GetNavigations().Single().ForeignKey);
+            Assert.NotSame(fk, principalType!.GetNavigations().Single().ForeignKey);
 
             if (Fixture.ForeignKeysHaveIndexes)
             {
@@ -406,7 +404,7 @@ public abstract partial class ModelBuilderTest
                 Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
                 Assert.True(
                     principalType.GetForeignKeys()
-                        .All(foreignKey => principalType.FindIndex(foreignKey.Properties).IsUnique == foreignKey.IsUnique));
+                        .All(foreignKey => principalType.FindIndex(foreignKey.Properties)!.IsUnique == foreignKey.IsUnique));
             }
             else
             {
@@ -426,8 +424,8 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(CustomerDetails));
             var principalType = model.FindEntityType(typeof(Customer));
 
-            var principalKey = principalType.FindPrimaryKey();
-            var dependentKey = dependentType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
+            var dependentKey = dependentType!.FindPrimaryKey();
 
             modelBuilder.Entity<CustomerDetails>().HasOne<Customer>().WithOne(e => e.Details);
 
@@ -461,8 +459,8 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(CustomerDetails));
             var principalType = model.FindEntityType(typeof(Customer));
 
-            var principalKey = principalType.FindPrimaryKey();
-            var dependentKey = dependentType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
+            var dependentKey = dependentType!.FindPrimaryKey();
             var expectedPrincipalProperties = principalType.GetProperties().ToList();
             var expectedDependentProperties = dependentType.GetProperties().ToList();
 
@@ -503,9 +501,9 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(OrderDetails));
             var principalType = model.FindEntityType(typeof(Order));
 
-            var fkProperty = dependentType.FindProperty("OrderId");
+            var fkProperty = dependentType!.FindProperty("OrderId");
 
-            var principalKey = principalType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
             var dependentKey = dependentType.FindPrimaryKey();
 
             modelBuilder
@@ -548,9 +546,9 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(CustomerDetails));
             var principalType = model.FindEntityType(typeof(Customer));
 
-            var fkProperty = dependentType.FindProperty(Customer.IdProperty.Name);
+            var fkProperty = dependentType!.FindProperty(Customer.IdProperty.Name);
 
-            var principalKey = principalType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
             var dependentKey = dependentType.FindPrimaryKey();
 
             modelBuilder
@@ -588,10 +586,10 @@ public abstract partial class ModelBuilderTest
 
             var dependentType = model.FindEntityType(typeof(Bun));
             var principalType = model.FindEntityType(typeof(BigMak));
-            var fk = dependentType.GetForeignKeys().Single(foreignKey => foreignKey.Properties.All(p => p.Name == "BurgerId"));
+            var fk = dependentType!.GetForeignKeys().Single(foreignKey => foreignKey.Properties.All(p => p.Name == "BurgerId"));
             Assert.True(fk.IsUnique);
 
-            var principalKey = principalType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
             var dependentKey = dependentType.FindPrimaryKey();
 
             Assert.Same(fk, dependentType.GetForeignKeys().Single());
@@ -628,9 +626,9 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(Bun));
             var principalType = model.FindEntityType(typeof(BigMak));
 
-            var fkProperty = dependentType.FindProperty("BurgerId");
+            var fkProperty = dependentType!.FindProperty("BurgerId");
 
-            var principalKey = principalType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
             var dependentKey = dependentType.FindPrimaryKey();
 
             modelBuilder
@@ -673,9 +671,9 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(Bun));
             var principalType = model.FindEntityType(typeof(BigMak));
 
-            var fkProperty = dependentType.FindProperty("BurgerId");
+            var fkProperty = dependentType!.FindProperty("BurgerId");
 
-            var principalKey = principalType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
             var dependentKey = dependentType.FindPrimaryKey();
 
             modelBuilder
@@ -715,9 +713,9 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(Bun));
             var principalType = model.FindEntityType(typeof(BigMak));
 
-            var fkProperty = dependentType.FindProperty(nameof(Bun.BurgerId));
+            var fkProperty = dependentType!.FindProperty(nameof(Bun.BurgerId));
 
-            var principalKey = principalType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
             var dependentKey = dependentType.FindPrimaryKey();
 
             modelBuilder
@@ -740,7 +738,7 @@ public abstract partial class ModelBuilderTest
                 Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
                 Assert.True(
                     principalType.GetForeignKeys()
-                        .All(foreignKey => principalType.FindIndex(foreignKey.Properties).IsUnique == foreignKey.IsUnique));
+                        .All(foreignKey => principalType.FindIndex(foreignKey.Properties)!.IsUnique == foreignKey.IsUnique));
             }
             else
             {
@@ -760,8 +758,8 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(Bun));
             var principalType = model.FindEntityType(typeof(BigMak));
 
-            var principalKey = principalType.FindPrimaryKey();
-            var dependentKey = dependentType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
+            var dependentKey = dependentType!.FindPrimaryKey();
             var expectedPrincipalProperties = principalType.GetProperties().ToList();
             var expectedDependentProperties = dependentType.GetProperties().ToList();
 
@@ -803,11 +801,11 @@ public abstract partial class ModelBuilderTest
                 .HasForeignKey(e => e.BurgerId);
             modelBuilder.Ignore<Pickle>();
 
-            var dependentType = (IReadOnlyEntityType)model.FindEntityType(typeof(Bun));
+            var dependentType = (IReadOnlyEntityType)model.FindEntityType(typeof(Bun))!;
             var principalType = model.FindEntityType(typeof(BigMak));
-            var fkProperty = dependentType.FindProperty(nameof(Bun.BurgerId));
+            var fkProperty = dependentType!.FindProperty(nameof(Bun.BurgerId));
 
-            var principalKey = principalType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
             var dependentKey = dependentType.FindPrimaryKey();
 
             modelBuilder
@@ -853,9 +851,9 @@ public abstract partial class ModelBuilderTest
 
             var dependentType = model.FindEntityType(typeof(OrderDetails));
             var principalType = model.FindEntityType(typeof(Order));
-            var existingFk = dependentType.GetForeignKeys().Single(foreignKey => foreignKey.Properties.All(p => p.Name == "Id"));
+            var existingFk = dependentType!.GetForeignKeys().Single(foreignKey => foreignKey.Properties.All(p => p.Name == "Id"));
 
-            var principalKey = principalType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
             var dependentKey = dependentType.FindPrimaryKey();
 
             modelBuilder
@@ -888,9 +886,9 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(OrderDetails));
             var principalType = model.FindEntityType(typeof(Order));
 
-            var fkProperty = dependentType.FindProperty("OrderId");
+            var fkProperty = dependentType!.FindProperty("OrderId");
 
-            var principalKey = principalType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
             var dependentKey = dependentType.FindPrimaryKey();
             var expectedPrincipalProperties = principalType.GetProperties().ToList();
             var expectedDependentProperties = dependentType.GetProperties().ToList();
@@ -937,9 +935,9 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(Order));
             var principalType = model.FindEntityType(typeof(OrderDetails));
 
-            var fkProperty = dependentType.FindProperty("OrderId");
+            var fkProperty = dependentType!.FindProperty("OrderId");
 
-            var principalKey = principalType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
             var dependentKey = dependentType.FindPrimaryKey();
             var expectedPrincipalProperties = principalType.GetProperties().ToList();
             var expectedDependentProperties = dependentType.GetProperties().ToList();
@@ -976,9 +974,9 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(Customer));
             var principalType = model.FindEntityType(typeof(CustomerDetails));
 
-            var fkProperty = dependentType.FindProperty(Customer.IdProperty.Name);
+            var fkProperty = dependentType!.FindProperty(Customer.IdProperty.Name);
 
-            var principalKey = principalType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
             var dependentKey = dependentType.FindPrimaryKey();
 
             modelBuilder
@@ -1008,9 +1006,9 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(CustomerDetails));
             var principalType = model.FindEntityType(typeof(Customer));
 
-            var fkProperty = dependentType.FindProperty(Customer.IdProperty.Name);
+            var fkProperty = dependentType!.FindProperty(Customer.IdProperty.Name);
 
-            var principalKey = principalType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
             var dependentKey = dependentType.FindPrimaryKey();
 
             var fk = modelBuilder
@@ -1048,9 +1046,9 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(Customer));
             var principalType = model.FindEntityType(typeof(CustomerDetails));
 
-            var fkProperty = dependentType.FindProperty(Customer.IdProperty.Name);
+            var fkProperty = dependentType!.FindProperty(Customer.IdProperty.Name);
 
-            var principalKey = principalType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
             var dependentKey = dependentType.FindPrimaryKey();
 
             modelBuilder
@@ -1059,7 +1057,7 @@ public abstract partial class ModelBuilderTest
 
             var fk = dependentType.GetNavigations().Single().ForeignKey;
             Assert.Same(fkProperty, fk.Properties.Single());
-            Assert.Equal(nameof(Customer.Details), fk.DependentToPrincipal.Name);
+            Assert.Equal(nameof(Customer.Details), fk.DependentToPrincipal!.Name);
             Assert.Null(fk.PrincipalToDependent);
             Assert.NotSame(fk, principalType.GetNavigations().Single().ForeignKey);
             Assert.Same(principalKey, principalType.FindPrimaryKey());
@@ -1091,9 +1089,9 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(CustomerDetails));
             var principalType = model.FindEntityType(typeof(Customer));
 
-            var fkProperty = dependentType.FindProperty(Customer.IdProperty.Name);
+            var fkProperty = dependentType!.FindProperty(Customer.IdProperty.Name);
 
-            var principalKey = principalType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
             var dependentKey = dependentType.FindPrimaryKey();
 
             modelBuilder
@@ -1102,7 +1100,7 @@ public abstract partial class ModelBuilderTest
 
             var fk = principalType.GetNavigations().Single().ForeignKey;
             Assert.Same(fkProperty, fk.Properties.Single());
-            Assert.Equal(nameof(Customer.Details), fk.PrincipalToDependent.Name);
+            Assert.Equal(nameof(Customer.Details), fk.PrincipalToDependent!.Name);
             Assert.Null(fk.DependentToPrincipal);
             Assert.NotSame(fk, dependentType.GetNavigations().Single().ForeignKey);
             Assert.Same(principalKey, principalType.FindPrimaryKey());
@@ -1132,8 +1130,8 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(CustomerDetails));
             var principalType = model.FindEntityType(typeof(Customer));
 
-            var principalKey = principalType.FindPrimaryKey();
-            var dependentKey = dependentType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
+            var dependentKey = dependentType!.FindPrimaryKey();
 
             modelBuilder
                 .Entity<CustomerDetails>().HasOne<Customer>().WithOne()
@@ -1174,9 +1172,9 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(Customer));
             var principalType = model.FindEntityType(typeof(CustomerDetails));
 
-            var fkProperty = dependentType.FindProperty(Customer.IdProperty.Name);
+            var fkProperty = dependentType!.FindProperty(Customer.IdProperty.Name);
 
-            var principalKey = principalType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
             var dependentKey = dependentType.FindPrimaryKey();
 
             var principalFk = principalType.GetForeignKeys().SingleOrDefault();
@@ -1223,9 +1221,9 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(CustomerDetails));
             var principalType = model.FindEntityType(typeof(Customer));
 
-            var fkProperty = dependentType.FindProperty(Customer.IdProperty.Name);
+            var fkProperty = dependentType!.FindProperty(Customer.IdProperty.Name);
 
-            var principalKey = principalType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
             var dependentKey = dependentType.FindPrimaryKey();
 
             modelBuilder
@@ -1257,10 +1255,10 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(CustomerDetails));
             var principalType = model.FindEntityType(typeof(Customer));
 
-            var principalProperty = principalType.FindProperty(Customer.IdProperty.Name);
+            var principalProperty = principalType!.FindProperty(Customer.IdProperty.Name);
 
             var principalKey = principalType.FindPrimaryKey();
-            var dependentKey = dependentType.FindPrimaryKey();
+            var dependentKey = dependentType!.FindPrimaryKey();
             var expectedPrincipalProperties = principalType.GetProperties().ToList();
             var expectedDependentProperties = dependentType.GetProperties().ToList();
 
@@ -1304,9 +1302,9 @@ public abstract partial class ModelBuilderTest
 
             var dependentType = model.FindEntityType(typeof(CustomerDetails));
             var principalType = model.FindEntityType(typeof(Customer));
-            var principalProperty = principalType.FindProperty("AlternateKey");
+            var principalProperty = principalType!.FindProperty("AlternateKey");
             var principalKey = principalType.FindPrimaryKey();
-            var dependentKey = dependentType.FindPrimaryKey();
+            var dependentKey = dependentType!.FindPrimaryKey();
 
             modelBuilder
                 .Entity<Customer>().HasOne(e => e.Details).WithOne(e => e.Customer)
@@ -1354,8 +1352,8 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(OrderDetails));
             var principalType = model.FindEntityType(typeof(Order));
 
-            var fkProperty = dependentType.FindProperty("OrderId");
-            var principalProperty = principalType.FindProperty("OrderId");
+            var fkProperty = dependentType!.FindProperty("OrderId");
+            var principalProperty = principalType!.FindProperty("OrderId");
 
             var principalPropertyCount = principalType.GetProperties().Count();
             var dependentPropertyCount = dependentType.GetProperties().Count();
@@ -1409,8 +1407,8 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(OrderDetails));
             var principalType = model.FindEntityType(typeof(Order));
 
-            var fkProperty = dependentType.FindProperty("OrderId");
-            var principalProperty = principalType.FindProperty("OrderId");
+            var fkProperty = dependentType!.FindProperty("OrderId");
+            var principalProperty = principalType!.FindProperty("OrderId");
 
             var principalPropertyCount = principalType.GetProperties().Count();
             var dependentPropertyCount = dependentType.GetProperties().Count();
@@ -1463,8 +1461,8 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(Bun));
             var principalType = model.FindEntityType(typeof(BigMak));
 
-            var fkProperty = dependentType.FindProperty("BurgerId");
-            var principalProperty = principalType.FindProperty("AlternateKey");
+            var fkProperty = dependentType!.FindProperty("BurgerId");
+            var principalProperty = principalType!.FindProperty("AlternateKey");
 
             var principalKey = principalType.FindPrimaryKey();
             var dependentKey = dependentType.FindPrimaryKey();
@@ -1516,8 +1514,8 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(Bun));
             var principalType = model.FindEntityType(typeof(BigMak));
 
-            var fkProperty = dependentType.FindProperty("BurgerId");
-            var principalProperty = principalType.FindProperty("AlternateKey");
+            var fkProperty = dependentType!.FindProperty("BurgerId");
+            var principalProperty = principalType!.FindProperty("AlternateKey");
 
             var principalKey = principalType.FindPrimaryKey();
             var dependentKey = dependentType.FindPrimaryKey();
@@ -1570,10 +1568,10 @@ public abstract partial class ModelBuilderTest
 
             var dependentType = model.FindEntityType(typeof(CustomerDetails));
             var principalType = model.FindEntityType(typeof(Customer));
-            var fk = dependentType.GetForeignKeys().Single();
+            var fk = dependentType!.GetForeignKeys().Single();
 
             var navToPrincipal = dependentType.FindNavigation(nameof(CustomerDetails.Customer));
-            var navToDependent = principalType.FindNavigation(nameof(Customer.Details));
+            var navToDependent = principalType!.FindNavigation(nameof(Customer.Details));
 
             var principalKey = principalType.FindPrimaryKey();
             var dependentKey = dependentType.FindPrimaryKey();
@@ -1602,9 +1600,9 @@ public abstract partial class ModelBuilderTest
 
             var dependentType = model.FindEntityType(typeof(OrderDetails));
             var principalType = model.FindEntityType(typeof(Order));
-            var existingFk = dependentType.GetForeignKeys().Single(foreignKey => foreignKey.Properties.All(p => p.Name == "Id"));
+            var existingFk = dependentType!.GetForeignKeys().Single(foreignKey => foreignKey.Properties.All(p => p.Name == "Id"));
 
-            var principalKey = principalType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
             var dependentKey = dependentType.FindPrimaryKey();
             var expectedPrincipalProperties = principalType.GetProperties().ToList();
             var expectedDependentProperties = dependentType.GetProperties().ToList();
@@ -1651,10 +1649,10 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(OrderDetails));
             var principalType = model.FindEntityType(typeof(Order));
 
-            var keyProperty = principalType.FindProperty("OrderId");
+            var keyProperty = principalType!.FindProperty("OrderId");
 
             var principalKey = principalType.FindPrimaryKey();
-            var dependentKey = dependentType.FindPrimaryKey();
+            var dependentKey = dependentType!.FindPrimaryKey();
             var expectedPrincipalProperties = principalType.GetProperties().ToList();
             var expectedDependentProperties = dependentType.GetProperties().ToList();
 
@@ -1701,10 +1699,10 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(Order));
             var principalType = model.FindEntityType(typeof(OrderDetails));
 
-            var keyProperty = principalType.FindProperty("OrderId");
+            var keyProperty = principalType!.FindProperty("OrderId");
 
             var principalKey = principalType.FindPrimaryKey();
-            var dependentKey = dependentType.FindPrimaryKey();
+            var dependentKey = dependentType!.FindPrimaryKey();
             var expectedPrincipalProperties = principalType.GetProperties().ToList();
             var expectedDependentProperties = dependentType.GetProperties().ToList();
 
@@ -1742,9 +1740,9 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(OrderDetails));
             var principalType = model.FindEntityType(typeof(Order));
 
-            var fkProperty = dependentType.FindProperty("OrderId");
+            var fkProperty = dependentType!.FindProperty("OrderId");
 
-            var principalKey = principalType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
             var dependentKey = dependentType.FindPrimaryKey();
             var expectedPrincipalProperties = principalType.GetProperties().ToList();
             var expectedDependentProperties = dependentType.GetProperties().ToList();
@@ -1792,9 +1790,9 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(OrderDetails));
             var principalType = model.FindEntityType(typeof(Order));
 
-            var fkProperty = dependentType.FindProperty("OrderId");
+            var fkProperty = dependentType!.FindProperty("OrderId");
 
-            var principalKey = principalType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
             var dependentKey = dependentType.FindPrimaryKey();
             var expectedPrincipalProperties = principalType.GetProperties().ToList();
             var expectedDependentProperties = dependentType.GetProperties().ToList();
@@ -1842,9 +1840,9 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(Order));
             var principalType = model.FindEntityType(typeof(OrderDetails));
 
-            var fkProperty = dependentType.FindProperty("OrderId");
+            var fkProperty = dependentType!.FindProperty("OrderId");
 
-            var principalKey = principalType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
             var dependentKey = dependentType.FindPrimaryKey();
             var expectedPrincipalProperties = principalType.GetProperties().ToList();
             var expectedDependentProperties = dependentType.GetProperties().ToList();
@@ -1918,8 +1916,8 @@ public abstract partial class ModelBuilderTest
 
             var dependentType = model.FindEntityType(typeof(Order));
             var principalType = model.FindEntityType(typeof(OrderDetails));
-            var fk = dependentType.GetForeignKeys().Single();
-            Assert.Same(principalType.FindProperty(nameof(OrderDetails.OrderId)), fk.PrincipalKey.Properties.Single());
+            var fk = dependentType!.GetForeignKeys().Single();
+            Assert.Same(principalType!.FindProperty(nameof(OrderDetails.OrderId)), fk.PrincipalKey.Properties.Single());
             Assert.Same(fk.DependentToPrincipal, dependentType.GetNavigations().Single());
             Assert.Same(fk.PrincipalToDependent, principalType.GetNavigations().Single());
             Assert.Same(fk, dependentType.GetNavigations().Single().ForeignKey);
@@ -1975,11 +1973,11 @@ public abstract partial class ModelBuilderTest
 
             var dependentType = model.FindEntityType(typeof(Order));
             var principalType = model.FindEntityType(typeof(OrderDetails));
-            var fk = dependentType.GetForeignKeys().Single();
+            var fk = dependentType!.GetForeignKeys().Single();
 
             Assert.Same(dependentType.FindProperty(nameof(Order.OrderId)), fk.Properties.Single());
             Assert.Same(fk.DependentToPrincipal, dependentType.GetNavigations().Single());
-            Assert.Same(fk.PrincipalToDependent, principalType.GetNavigations().Single());
+            Assert.Same(fk.PrincipalToDependent, principalType!.GetNavigations().Single());
             Assert.Same(fk, dependentType.GetNavigations().Single().ForeignKey);
             Assert.Same(fk, principalType.GetNavigations().Single().ForeignKey);
             Assert.Empty(principalType.GetForeignKeys());
@@ -2053,15 +2051,15 @@ public abstract partial class ModelBuilderTest
             modelBuilder.Ignore<Customer>();
             modelBuilder.Ignore<CustomerDetails>();
 
-            var orderEntityType = (IEntityType)modelBuilder.Model.FindEntityType(typeof(Order));
-            Assert.False(orderEntityType.FindNavigation(nameof(Order.Details)).IsOnDependent);
+            var orderEntityType = (IEntityType)modelBuilder.Model.FindEntityType(typeof(Order))!;
+            Assert.False(orderEntityType!.FindNavigation(nameof(Order.Details))!.IsOnDependent);
 
             modelBuilder.Entity<Order>().HasNoKey();
 
             var model = modelBuilder.FinalizeModel();
 
             orderEntityType = model.FindEntityType(typeof(Order))!;
-            Assert.True(orderEntityType.FindNavigation(nameof(Order.Details)).IsOnDependent);
+            Assert.True(orderEntityType.FindNavigation(nameof(Order.Details))!.IsOnDependent);
         }
 
         [Fact]
@@ -2076,8 +2074,8 @@ public abstract partial class ModelBuilderTest
             modelBuilder.Ignore<Customer>();
             modelBuilder.Ignore<CustomerDetails>();
 
-            var orderEntityType = (IEntityType)modelBuilder.Model.FindEntityType(typeof(Order));
-            Assert.False(orderEntityType.FindNavigation(nameof(Order.Details)).IsOnDependent);
+            var orderEntityType = (IEntityType)modelBuilder.Model.FindEntityType(typeof(Order))!;
+            Assert.False(orderEntityType!.FindNavigation(nameof(Order.Details))!.IsOnDependent);
 
             Assert.Equal(
                 CoreStrings.PrincipalKeylessType(
@@ -2097,8 +2095,8 @@ public abstract partial class ModelBuilderTest
             modelBuilder.Ignore<Customer>();
             modelBuilder.Ignore<CustomerDetails>();
 
-            var orderEntityType = (IEntityType)modelBuilder.Model.FindEntityType(typeof(Order));
-            Assert.False(orderEntityType.FindNavigation(nameof(Order.Details)).IsOnDependent);
+            var orderEntityType = (IEntityType)modelBuilder.Model.FindEntityType(typeof(Order))!;
+            Assert.False(orderEntityType!.FindNavigation(nameof(Order.Details))!.IsOnDependent);
 
             Assert.Equal(
                 CoreStrings.NavigationToKeylessType(
@@ -2119,17 +2117,17 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(CustomerDetails));
             var principalType = model.FindEntityType(typeof(Customer));
 
-            var principalKey = principalType.FindPrimaryKey();
-            var dependentKey = dependentType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
+            var dependentKey = dependentType!.FindPrimaryKey();
 
             modelBuilder
                 .Entity<Customer>().HasOne(e => e.Details).WithOne()
                 .HasPrincipalKey<Customer>(e => e.Id);
 
             var fk = principalType.GetNavigations().Single().ForeignKey;
-            Assert.Same(principalKey.Properties.Single(), fk.PrincipalKey.Properties.Single());
+            Assert.Same(principalKey!.Properties.Single(), fk.PrincipalKey.Properties.Single());
             Assert.NotSame(fk, dependentType.GetNavigations().Single().ForeignKey);
-            Assert.Equal(nameof(Customer.Details), fk.PrincipalToDependent.Name);
+            Assert.Equal(nameof(Customer.Details), fk.PrincipalToDependent!.Name);
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
 
@@ -2158,15 +2156,15 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(CustomerDetails));
             var principalType = model.FindEntityType(typeof(Customer));
 
-            var principalKey = principalType.FindPrimaryKey();
-            var dependentKey = dependentType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
+            var dependentKey = dependentType!.FindPrimaryKey();
 
             modelBuilder
                 .Entity<CustomerDetails>().HasOne(e => e.Customer).WithOne()
                 .HasPrincipalKey<Customer>(e => e.Id);
 
             var fk = dependentType.GetNavigations().Single().ForeignKey;
-            Assert.Same(principalKey.Properties.Single(), fk.PrincipalKey.Properties.Single());
+            Assert.Same(principalKey!.Properties.Single(), fk.PrincipalKey.Properties.Single());
             Assert.Same(fk.DependentToPrincipal, dependentType.GetNavigations().Single());
             Assert.NotSame(fk, principalType.GetNavigations().Single().ForeignKey);
             Assert.Same(principalKey, principalType.FindPrimaryKey());
@@ -2196,15 +2194,15 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(CustomerDetails));
             var principalType = model.FindEntityType(typeof(Customer));
 
-            var principalKey = principalType.FindPrimaryKey();
-            var dependentKey = dependentType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
+            var dependentKey = dependentType!.FindPrimaryKey();
 
             modelBuilder
                 .Entity<Customer>().HasOne<CustomerDetails>().WithOne(e => e.Customer)
                 .HasPrincipalKey<Customer>(e => e.Id);
 
             var fk = dependentType.GetNavigations().Single().ForeignKey;
-            Assert.Same(principalKey.Properties.Single(), fk.PrincipalKey.Properties.Single());
+            Assert.Same(principalKey!.Properties.Single(), fk.PrincipalKey.Properties.Single());
             Assert.Same(fk.DependentToPrincipal, dependentType.GetNavigations().Single());
             Assert.NotSame(fk, principalType.GetNavigations().Single().ForeignKey);
             Assert.Same(principalKey, principalType.FindPrimaryKey());
@@ -2233,15 +2231,15 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(CustomerDetails));
             var principalType = model.FindEntityType(typeof(Customer));
 
-            var principalKey = principalType.FindPrimaryKey();
-            var dependentKey = dependentType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
+            var dependentKey = dependentType!.FindPrimaryKey();
 
             modelBuilder
                 .Entity<CustomerDetails>().HasOne<Customer>().WithOne(e => e.Details)
                 .HasPrincipalKey<Customer>(e => e.Id);
 
             var fk = principalType.GetNavigations().Single().ForeignKey;
-            Assert.Same(principalKey.Properties.Single(), fk.PrincipalKey.Properties.Single());
+            Assert.Same(principalKey!.Properties.Single(), fk.PrincipalKey.Properties.Single());
             Assert.NotSame(fk, dependentType.GetNavigations().Single().ForeignKey);
             Assert.Null(fk.DependentToPrincipal);
             Assert.Empty(principalType.GetForeignKeys());
@@ -2273,8 +2271,8 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(CustomerDetails));
             var principalType = model.FindEntityType(typeof(Customer));
 
-            var principalKey = principalType.FindPrimaryKey();
-            var dependentKey = dependentType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
+            var dependentKey = dependentType!.FindPrimaryKey();
             var expectedPrincipalProperties = principalType.GetProperties().ToList();
             var expectedDependentProperties = dependentType.GetProperties().ToList();
 
@@ -2289,7 +2287,7 @@ public abstract partial class ModelBuilderTest
             modelBuilder.FinalizeModel();
 
             var fk = dependentType.GetForeignKeys().Single(foreignKey => foreignKey.DependentToPrincipal == null);
-            Assert.Same(principalKey.Properties.Single(), fk.PrincipalKey.Properties.Single());
+            Assert.Same(principalKey!.Properties.Single(), fk.PrincipalKey.Properties.Single());
             Assert.DoesNotContain(dependentType.GetNavigations(), nav => nav.ForeignKey == fk);
             Assert.DoesNotContain(principalType.GetNavigations(), nav => nav.ForeignKey == fk);
             Assert.Equal(expectedPrincipalProperties, principalType.GetProperties());
@@ -2324,8 +2322,8 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(CustomerDetails));
             var principalType = model.FindEntityType(typeof(Customer));
 
-            var existingFk = dependentType.GetForeignKeys().SingleOrDefault();
-            var principalKey = principalType.FindPrimaryKey();
+            var existingFk = dependentType!.GetForeignKeys().SingleOrDefault();
+            var principalKey = principalType!.FindPrimaryKey();
             var dependentKey = dependentType.FindPrimaryKey();
             var expectedPrincipalProperties = principalType.GetProperties().ToList();
             var expectedDependentProperties = dependentType.GetProperties().ToList();
@@ -2335,7 +2333,7 @@ public abstract partial class ModelBuilderTest
                 .HasPrincipalKey<Customer>(e => e.Id);
 
             var fk = dependentType.GetForeignKeys().Single(foreignKey => foreignKey != existingFk);
-            Assert.Same(principalKey.Properties.Single(), fk.PrincipalKey.Properties.Single());
+            Assert.Same(principalKey!.Properties.Single(), fk.PrincipalKey.Properties.Single());
             Assert.DoesNotContain(dependentType.GetNavigations(), nav => nav.ForeignKey == fk);
             Assert.DoesNotContain(principalType.GetNavigations(), nav => nav.ForeignKey == fk);
             Assert.Equal(expectedPrincipalProperties, principalType.GetProperties());
@@ -2372,8 +2370,8 @@ public abstract partial class ModelBuilderTest
 
             var principalType = model.FindEntityType(typeof(Whoopper));
 
-            var principalKey = principalType.FindPrimaryKey();
-            var dependentKey = dependentType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
+            var dependentKey = dependentType!.FindPrimaryKey();
 
             modelBuilder
                 .Entity<Whoopper>().HasOne(e => e.ToastedBun).WithOne(e => e.Whoopper)
@@ -2416,10 +2414,10 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(ToastedBun));
             var principalType = model.FindEntityType(typeof(Whoopper));
 
-            var fkProperty1 = dependentType.FindProperty("BurgerId1");
+            var fkProperty1 = dependentType!.FindProperty("BurgerId1");
             var fkProperty2 = dependentType.FindProperty("BurgerId2");
 
-            var principalKey = principalType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
             var dependentKey = dependentType.FindPrimaryKey();
 
             modelBuilder
@@ -2462,10 +2460,10 @@ public abstract partial class ModelBuilderTest
 
             var dependentType = model.FindEntityType(typeof(ToastedBun));
             var principalType = model.FindEntityType(typeof(Whoopper));
-            var principalProperty1 = principalType.FindProperty("AlternateKey1");
+            var principalProperty1 = principalType!.FindProperty("AlternateKey1");
             var principalProperty2 = principalType.FindProperty("AlternateKey2");
 
-            var fkProperty1 = dependentType.FindProperty("BurgerId1");
+            var fkProperty1 = dependentType!.FindProperty("BurgerId1");
             var fkProperty2 = dependentType.FindProperty("BurgerId2");
 
             var principalKey = principalType.FindPrimaryKey();
@@ -2520,10 +2518,10 @@ public abstract partial class ModelBuilderTest
 
             var dependentType = model.FindEntityType(typeof(ToastedBun));
             var principalType = model.FindEntityType(typeof(Whoopper));
-            var principalProperty1 = principalType.FindProperty("AlternateKey1");
+            var principalProperty1 = principalType!.FindProperty("AlternateKey1");
             var principalProperty2 = principalType.FindProperty("AlternateKey2");
 
-            var fkProperty1 = dependentType.FindProperty("BurgerId1");
+            var fkProperty1 = dependentType!.FindProperty("BurgerId1");
             var fkProperty2 = dependentType.FindProperty("BurgerId2");
 
             var principalKey = principalType.FindPrimaryKey();
@@ -2579,10 +2577,10 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(Mustard));
             var principalType = model.FindEntityType(typeof(Whoopper));
 
-            var fkProperty1 = dependentType.FindProperty("Id1");
+            var fkProperty1 = dependentType!.FindProperty("Id1");
             var fkProperty2 = dependentType.FindProperty("Id2");
 
-            var principalKey = principalType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
             var dependentKey = dependentType.FindPrimaryKey();
 
             modelBuilder
@@ -2620,10 +2618,10 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(Mustard));
             var principalType = model.FindEntityType(typeof(Whoopper));
 
-            var fkProperty1 = dependentType.FindProperty("Id1");
+            var fkProperty1 = dependentType!.FindProperty("Id1");
             var fkProperty2 = dependentType.FindProperty("Id2");
 
-            var principalKey = principalType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
             var dependentKey = dependentType.FindPrimaryKey();
 
             modelBuilder
@@ -2660,10 +2658,10 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(Mustard));
             var principalType = model.FindEntityType(typeof(Whoopper));
 
-            var fkProperty1 = dependentType.FindProperty("Id1");
+            var fkProperty1 = dependentType!.FindProperty("Id1");
             var fkProperty2 = dependentType.FindProperty("Id2");
 
-            var principalKey = principalType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
             var dependentKey = dependentType.FindPrimaryKey();
 
             modelBuilder
@@ -2700,10 +2698,10 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(ToastedBun));
             var principalType = model.FindEntityType(typeof(Whoopper));
 
-            var fkProperty1 = dependentType.FindProperty(nameof(ToastedBun.BurgerId1));
+            var fkProperty1 = dependentType!.FindProperty(nameof(ToastedBun.BurgerId1));
             var fkProperty2 = dependentType.FindProperty(nameof(ToastedBun.BurgerId2));
 
-            var principalKey = principalType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
             var dependentKey = dependentType.FindPrimaryKey();
 
             modelBuilder
@@ -2715,7 +2713,7 @@ public abstract partial class ModelBuilderTest
             Assert.Same(fkProperty2, fk.Properties[1]);
 
             Assert.NotSame(fk, dependentType.GetNavigations().Single().ForeignKey);
-            Assert.Equal(nameof(Whoopper.ToastedBun), fk.PrincipalToDependent.Name);
+            Assert.Equal(nameof(Whoopper.ToastedBun), fk.PrincipalToDependent!.Name);
             Assert.Null(fk.DependentToPrincipal);
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
@@ -2746,10 +2744,10 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(ToastedBun));
             var principalType = model.FindEntityType(typeof(Whoopper));
 
-            var fkProperty1 = dependentType.FindProperty(nameof(ToastedBun.BurgerId1));
+            var fkProperty1 = dependentType!.FindProperty(nameof(ToastedBun.BurgerId1));
             var fkProperty2 = dependentType.FindProperty(nameof(ToastedBun.BurgerId2));
 
-            var principalKey = principalType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
             var dependentKey = dependentType.FindPrimaryKey();
 
             modelBuilder
@@ -2760,7 +2758,7 @@ public abstract partial class ModelBuilderTest
             Assert.Same(fkProperty1, fk.Properties[0]);
             Assert.Same(fkProperty2, fk.Properties[1]);
 
-            Assert.Equal(nameof(ToastedBun.Whoopper), fk.DependentToPrincipal.Name);
+            Assert.Equal(nameof(ToastedBun.Whoopper), fk.DependentToPrincipal!.Name);
             Assert.Null(fk.PrincipalToDependent);
             Assert.NotSame(fk, principalType.GetNavigations().Single().ForeignKey);
             Assert.Same(principalKey, principalType.FindPrimaryKey());
@@ -2794,10 +2792,10 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(ToastedBun));
             var principalType = model.FindEntityType(typeof(Whoopper));
 
-            var fkProperty1 = dependentType.FindProperty("BurgerId1");
+            var fkProperty1 = dependentType!.FindProperty("BurgerId1");
             var fkProperty2 = dependentType.FindProperty("BurgerId2");
 
-            var principalKey = principalType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
             var dependentKey = dependentType.FindPrimaryKey();
 
             modelBuilder
@@ -2821,7 +2819,7 @@ public abstract partial class ModelBuilderTest
                 Assert.True(fk.DeclaringEntityType.FindIndex(fk.Properties)!.IsUnique);
                 Assert.True(
                     principalType.GetForeignKeys()
-                        .All(foreignKey => principalType.FindIndex(foreignKey.Properties).IsUnique == foreignKey.IsUnique));
+                        .All(foreignKey => principalType.FindIndex(foreignKey.Properties)!.IsUnique == foreignKey.IsUnique));
             }
             else
             {
@@ -2836,7 +2834,7 @@ public abstract partial class ModelBuilderTest
             modelBuilder.Entity<SelfRef>().HasOne(e => e.SelfRef1).WithOne(e => e.SelfRef2);
 
             var entityType = modelBuilder.Model.FindEntityType(typeof(SelfRef));
-            var fk = entityType.GetForeignKeys().Single();
+            var fk = entityType!.GetForeignKeys().Single();
 
             var navigationToPrincipal = fk.DependentToPrincipal;
             var navigationToDependent = fk.PrincipalToDependent;
@@ -2844,15 +2842,15 @@ public abstract partial class ModelBuilderTest
             modelBuilder.Entity<SelfRef>().HasOne(e => e.SelfRef1).WithOne(e => e.SelfRef2);
 
             fk = entityType.GetForeignKeys().Single();
-            Assert.Equal(navigationToDependent.Name, fk.PrincipalToDependent.Name);
-            Assert.Equal(navigationToPrincipal.Name, fk.DependentToPrincipal.Name);
+            Assert.Equal(navigationToDependent!.Name, fk.PrincipalToDependent!.Name);
+            Assert.Equal(navigationToPrincipal!.Name, fk.DependentToPrincipal!.Name);
             Assert.True(fk.IsRequired);
 
             modelBuilder.Entity<SelfRef>().HasOne(e => e.SelfRef2).WithOne(e => e.SelfRef1);
 
             fk = entityType.GetForeignKeys().Single();
-            Assert.Equal(navigationToPrincipal.Name, fk.PrincipalToDependent.Name);
-            Assert.Equal(navigationToDependent.Name, fk.DependentToPrincipal.Name);
+            Assert.Equal(navigationToPrincipal.Name, fk.PrincipalToDependent!.Name);
+            Assert.Equal(navigationToDependent.Name, fk.DependentToPrincipal!.Name);
             Assert.True(fk.IsRequired);
 
             if (Fixture.ForeignKeysHaveIndexes)
@@ -2882,11 +2880,11 @@ public abstract partial class ModelBuilderTest
 
             modelBuilder.Entity<SelfRef>().HasOne(e => e.SelfRef1).WithOne();
 
-            var fk = entityType.FindNavigation(nameof(SelfRef.SelfRef1)).ForeignKey;
-            var conventionFk = entityType.FindNavigation(nameof(SelfRef.SelfRef2)).ForeignKey;
+            var fk = entityType!.FindNavigation(nameof(SelfRef.SelfRef1))!.ForeignKey;
+            var conventionFk = entityType.FindNavigation(nameof(SelfRef.SelfRef2))!.ForeignKey;
 
             Assert.NotEqual(fk, conventionFk);
-            Assert.NotEqual(fk.Properties, entityType.FindPrimaryKey().Properties);
+            Assert.NotEqual(fk.Properties, entityType.FindPrimaryKey()!.Properties);
             Assert.Equal(fk.PrincipalKey, entityType.FindPrimaryKey());
             Assert.Null(fk.PrincipalToDependent);
             Assert.Equal(nameof(SelfRef.SelfRef1), fk.DependentToPrincipal?.Name);
@@ -2917,11 +2915,11 @@ public abstract partial class ModelBuilderTest
 
             modelBuilder.Entity<SelfRef>().HasOne<SelfRef>().WithOne(e => e.SelfRef1);
 
-            var fk = entityType.FindNavigation(nameof(SelfRef.SelfRef1)).ForeignKey;
-            var conventionFk = entityType.FindNavigation(nameof(SelfRef.SelfRef2)).ForeignKey;
+            var fk = entityType!.FindNavigation(nameof(SelfRef.SelfRef1))!.ForeignKey;
+            var conventionFk = entityType.FindNavigation(nameof(SelfRef.SelfRef2))!.ForeignKey;
 
             Assert.NotEqual(fk, conventionFk);
-            Assert.NotEqual(fk.Properties, entityType.FindPrimaryKey().Properties);
+            Assert.NotEqual(fk.Properties, entityType.FindPrimaryKey()!.Properties);
             Assert.Equal(fk.PrincipalKey, entityType.FindPrimaryKey());
             Assert.Equal(nameof(SelfRef.SelfRef1), fk.PrincipalToDependent?.Name);
             Assert.Null(fk.DependentToPrincipal);
@@ -2950,9 +2948,9 @@ public abstract partial class ModelBuilderTest
 
             modelBuilder.FinalizeModel();
 
-            var fk = entityType.FindNavigation(nameof(SelfRef.SelfRef1)).ForeignKey;
+            var fk = entityType!.FindNavigation(nameof(SelfRef.SelfRef1))!.ForeignKey;
 
-            Assert.Equal(fk.Properties, entityType.FindPrimaryKey().Properties);
+            Assert.Equal(fk.Properties, entityType.FindPrimaryKey()!.Properties);
             Assert.Equal(fk.PrincipalKey, entityType.FindPrimaryKey());
             Assert.Equal(nameof(SelfRef.SelfRef1), fk.DependentToPrincipal?.Name);
             Assert.Equal(nameof(SelfRef.SelfRef2), fk.PrincipalToDependent?.Name);
@@ -2970,7 +2968,7 @@ public abstract partial class ModelBuilderTest
             entityBuilder.HasOne(e => e.SelfRef1).WithOne();
 
             var entityType = modelBuilder.Model.FindEntityType(typeof(SelfRef));
-            var existingFk = entityType.GetForeignKeys().Single();
+            var existingFk = entityType!.GetForeignKeys().Single();
 
             var navigationToPrincipal = existingFk.DependentToPrincipal;
             var navigationToDependent = existingFk.PrincipalToDependent;
@@ -2979,7 +2977,7 @@ public abstract partial class ModelBuilderTest
 
             Assert.Same(existingFk, entityType.GetForeignKeys().Single());
             Assert.Equal(navigationToDependent?.Name, existingFk.PrincipalToDependent?.Name);
-            Assert.Equal(navigationToPrincipal.Name, existingFk.DependentToPrincipal.Name);
+            Assert.Equal(navigationToPrincipal!.Name, existingFk.DependentToPrincipal!.Name);
             Assert.True(((IReadOnlyForeignKey)existingFk).IsRequired);
 
             modelBuilder.Entity<SelfRef>().HasOne<SelfRef>().WithOne(e => e.SelfRef1);
@@ -2988,7 +2986,7 @@ public abstract partial class ModelBuilderTest
 
             Assert.Equal(existingFk.Properties, fk.Properties);
             Assert.Equal(existingFk.PrincipalKey, fk.PrincipalKey);
-            Assert.Equal(navigationToPrincipal.Name, fk.PrincipalToDependent.Name);
+            Assert.Equal(navigationToPrincipal.Name, fk.PrincipalToDependent!.Name);
             Assert.Equal(navigationToDependent?.Name, fk.DependentToPrincipal?.Name);
             Assert.True(fk.IsRequired);
             Assert.False(fk.IsRequiredDependent);
@@ -3011,26 +3009,26 @@ public abstract partial class ModelBuilderTest
             modelBuilder.Entity<SelfRef>().HasOne<SelfRef>().WithOne(e => e.SelfRef2);
 
             var entityType = modelBuilder.Model.FindEntityType(typeof(SelfRef));
-            var fk = entityType.FindNavigation(nameof(SelfRef.SelfRef2)).ForeignKey;
+            var fk = entityType!.FindNavigation(nameof(SelfRef.SelfRef2))!.ForeignKey;
 
             var navigationToPrincipal = fk.DependentToPrincipal;
             var navigationToDependent = fk.PrincipalToDependent;
 
             modelBuilder.Entity<SelfRef>().HasOne<SelfRef>().WithOne(e => e.SelfRef2);
 
-            Assert.Same(fk, entityType.FindNavigation(nameof(SelfRef.SelfRef2)).ForeignKey);
-            Assert.Equal(navigationToDependent.Name, fk.PrincipalToDependent.Name);
+            Assert.Same(fk, entityType.FindNavigation(nameof(SelfRef.SelfRef2))!.ForeignKey);
+            Assert.Equal(navigationToDependent!.Name, fk.PrincipalToDependent!.Name);
             Assert.Equal(navigationToPrincipal?.Name, fk.DependentToPrincipal?.Name);
             Assert.True(fk.IsUnique);
 
             modelBuilder.Entity<SelfRef>().HasOne(e => e.SelfRef2).WithOne();
 
-            var newFk = entityType.FindNavigation(nameof(SelfRef.SelfRef2)).ForeignKey;
+            var newFk = entityType.FindNavigation(nameof(SelfRef.SelfRef2))!.ForeignKey;
 
             Assert.Equal(fk.Properties, newFk.Properties);
             Assert.Equal(fk.PrincipalKey, newFk.PrincipalKey);
             Assert.Equal(navigationToPrincipal?.Name, newFk.PrincipalToDependent?.Name);
-            Assert.Equal(navigationToDependent.Name, newFk.DependentToPrincipal.Name);
+            Assert.Equal(navigationToDependent.Name, newFk.DependentToPrincipal!.Name);
             Assert.True(newFk.IsUnique);
 
             if (Fixture.ForeignKeysHaveIndexes)
@@ -3066,7 +3064,7 @@ public abstract partial class ModelBuilderTest
             modelBuilder.FinalizeModel();
 
             var entityType = modelBuilder.Model.FindEntityType(typeof(SelfRef));
-            var fk = entityType.GetForeignKeys().Single();
+            var fk = entityType!.GetForeignKeys().Single();
             Assert.Equal("SelfRef1Id", fk.Properties.Single().Name);
             Assert.True(fk.IsRequired);
             Assert.False(fk.IsRequiredDependent);
@@ -3097,7 +3095,7 @@ public abstract partial class ModelBuilderTest
             modelBuilder.FinalizeModel();
 
             var entityType = modelBuilder.Model.FindEntityType(typeof(SelfRef));
-            var fk = entityType.GetForeignKeys().Single();
+            var fk = entityType!.GetForeignKeys().Single();
             Assert.Equal("SelfRef2Id", fk.Properties.Single().Name);
             Assert.Equal(fk.PrincipalKey, entityType.FindPrimaryKey());
             Assert.Equal(nameof(SelfRef.SelfRef1), fk.PrincipalToDependent?.Name);
@@ -3179,9 +3177,9 @@ public abstract partial class ModelBuilderTest
             modelBuilder.FinalizeModel();
 
             Assert.Equal(
-                typeof(int?), modelBuilder.Model.FindEntityType(typeof(Nob)).GetForeignKeys().Single().Properties.Single().ClrType);
+                typeof(int?), modelBuilder.Model.FindEntityType(typeof(Nob))!.GetForeignKeys().Single().Properties.Single().ClrType);
             Assert.Equal(
-                typeof(string), modelBuilder.Model.FindEntityType(typeof(Hob)).GetForeignKeys().Single().Properties.Single().ClrType);
+                typeof(string), modelBuilder.Model.FindEntityType(typeof(Hob))!.GetForeignKeys().Single().Properties.Single().ClrType);
         }
 
         [Fact]
@@ -3206,9 +3204,9 @@ public abstract partial class ModelBuilderTest
             modelBuilder.FinalizeModel();
 
             Assert.Equal(
-                typeof(int?), modelBuilder.Model.FindEntityType(typeof(Nob)).GetForeignKeys().Single().Properties.Single().ClrType);
+                typeof(int?), modelBuilder.Model.FindEntityType(typeof(Nob))!.GetForeignKeys().Single().Properties.Single().ClrType);
             Assert.Equal(
-                typeof(string), modelBuilder.Model.FindEntityType(typeof(Hob)).GetForeignKeys().Single().Properties.Single().ClrType);
+                typeof(string), modelBuilder.Model.FindEntityType(typeof(Hob))!.GetForeignKeys().Single().Properties.Single().ClrType);
         }
 
         [Fact]
@@ -3243,7 +3241,7 @@ public abstract partial class ModelBuilderTest
             modelBuilder.FinalizeModel();
 
             var dependent = modelBuilder.Model.FindEntityType(typeof(Hob));
-            var fk = dependent.GetForeignKeys().Single();
+            var fk = dependent!.GetForeignKeys().Single();
             Assert.Equal(typeof(Guid), fk.Properties.Single().ClrType);
         }
 
@@ -3282,7 +3280,7 @@ public abstract partial class ModelBuilderTest
                 .HasForeignKey<CustomerDetails>("GuidProperty");
 
             var dependentType = model.FindEntityType(typeof(CustomerDetails));
-            var fk = dependentType.GetForeignKeys().Single();
+            var fk = dependentType!.GetForeignKeys().Single();
             Assert.Same(guidProperty, fk.Properties.Single());
             Assert.Equal(typeof(Guid), fk.PrincipalKey.Properties.Single().ClrType);
         }
@@ -3324,8 +3322,8 @@ public abstract partial class ModelBuilderTest
 
             var dependentType = model.FindEntityType(typeof(CustomerDetails));
             var principalType = model.FindEntityType(typeof(Customer));
-            var fk = dependentType.GetForeignKeys().Single();
-            Assert.Same(principalType.FindProperty(nameof(Customer.Id)), fk.PrincipalKey.Properties.Single());
+            var fk = dependentType!.GetForeignKeys().Single();
+            Assert.Same(principalType!.FindProperty(nameof(Customer.Id)), fk.PrincipalKey.Properties.Single());
             Assert.False(fk.IsRequired);
             Assert.Equal(typeof(int?), fk.Properties.Single().ClrType);
         }
@@ -3365,8 +3363,8 @@ public abstract partial class ModelBuilderTest
                 .HasForeignKey<CustomerDetails>(nameof(CustomerDetails.Id), "GuidProperty");
 
             var dependentType = model.FindEntityType(typeof(CustomerDetails));
-            var fk = dependentType.GetForeignKeys().Single();
-            AssertEqual([dependentType.FindProperty(nameof(CustomerDetails.Id)), guidProperty], fk.Properties);
+            var fk = dependentType!.GetForeignKeys().Single();
+            AssertEqual([dependentType.FindProperty(nameof(CustomerDetails.Id))!, guidProperty], fk.Properties);
             Assert.Equal(2, fk.PrincipalKey.Properties.Count);
         }
 
@@ -3406,7 +3404,7 @@ public abstract partial class ModelBuilderTest
                 .Entity<Customer>().HasOne(c => c.Details).WithOne(d => d.Customer)
                 .HasPrincipalKey<Customer>(nameof(Customer.Id)).Metadata;
 
-            Assert.Same(principalType.FindProperty(nameof(Customer.Id)), fk.PrincipalKey.Properties.Single());
+            Assert.Same(principalType!.FindProperty(nameof(Customer.Id)), fk.PrincipalKey.Properties.Single());
             Assert.Single(fk.Properties);
         }
 
@@ -3422,8 +3420,8 @@ public abstract partial class ModelBuilderTest
 
             var dependentType = model.FindEntityType(typeof(Hob));
             var principalType = model.FindEntityType(typeof(Nob));
-            var fk = dependentType.GetNavigations().First().ForeignKey;
-            Assert.Same(fk, principalType.GetNavigations().First().ForeignKey);
+            var fk = dependentType!.GetNavigations().First().ForeignKey;
+            Assert.Same(fk, principalType!.GetNavigations().First().ForeignKey);
             Assert.True(fk.Properties.All(p => p.IsShadowProperty()));
 
             Assert.Equal(
@@ -3448,8 +3446,8 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(Tomato));
             var principalType = model.FindEntityType(typeof(Whoopper));
 
-            var principalKey = principalType.FindPrimaryKey();
-            var dependentKey = dependentType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
+            var dependentKey = dependentType!.FindPrimaryKey();
 
             modelBuilder
                 .Entity<Whoopper>().HasOne<Tomato>().WithOne()
@@ -3458,8 +3456,8 @@ public abstract partial class ModelBuilderTest
 
             var existingFk = dependentType.GetNavigations().Single().ForeignKey;
             Assert.Same(existingFk, principalType.GetNavigations().Single().ForeignKey);
-            Assert.Equal(nameof(Tomato.Whoopper), existingFk.DependentToPrincipal.Name);
-            Assert.Equal(nameof(Whoopper.Tomatoes), existingFk.PrincipalToDependent.Name);
+            Assert.Equal(nameof(Tomato.Whoopper), existingFk.DependentToPrincipal!.Name);
+            Assert.Equal(nameof(Whoopper.Tomatoes), existingFk.PrincipalToDependent!.Name);
             Assert.Empty(principalType.GetForeignKeys());
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
@@ -3497,8 +3495,8 @@ public abstract partial class ModelBuilderTest
             var dependentType = model.FindEntityType(typeof(Tomato));
             var principalType = model.FindEntityType(typeof(Whoopper));
 
-            var principalKey = principalType.FindPrimaryKey();
-            var dependentKey = dependentType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
+            var dependentKey = dependentType!.FindPrimaryKey();
 
             modelBuilder
                 .Entity<Whoopper>().HasOne<Tomato>().WithOne()
@@ -3507,8 +3505,8 @@ public abstract partial class ModelBuilderTest
 
             var existingFk = dependentType.GetNavigations().Single().ForeignKey;
             Assert.Same(existingFk, principalType.GetNavigations().Single().ForeignKey);
-            Assert.Equal(nameof(Tomato.Whoopper), existingFk.DependentToPrincipal.Name);
-            Assert.Equal(nameof(Whoopper.Tomatoes), existingFk.PrincipalToDependent.Name);
+            Assert.Equal(nameof(Tomato.Whoopper), existingFk.DependentToPrincipal!.Name);
+            Assert.Equal(nameof(Whoopper.Tomatoes), existingFk.PrincipalToDependent!.Name);
             Assert.Empty(principalType.GetForeignKeys());
             Assert.Same(principalKey, principalType.FindPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
@@ -3548,8 +3546,8 @@ public abstract partial class ModelBuilderTest
                 .HasForeignKey<Tomato>(e => new { e.BurgerId1 })
                 .HasPrincipalKey<Whoopper>(e => new { e.AlternateKey1 });
 
-            var existingFk = dependentType.GetNavigations().Single().ForeignKey;
-            Assert.Empty(principalType.GetForeignKeys());
+            var existingFk = dependentType!.GetNavigations().Single().ForeignKey;
+            Assert.Empty(principalType!.GetForeignKeys());
             var fk = dependentType.GetForeignKeys().Single(foreignKey => foreignKey != existingFk);
             Assert.Empty(principalType.GetIndexes());
 
@@ -3589,8 +3587,8 @@ public abstract partial class ModelBuilderTest
 
             Assert.Equal(
                 CoreStrings.ConflictingRelationshipNavigation(
-                    principalType.DisplayName() + "." + nameof(Hob.Nob),
-                    dependentType.DisplayName() + "." + nameof(Nob.Hob),
+                    principalType!.DisplayName() + "." + nameof(Hob.Nob),
+                    dependentType!.DisplayName() + "." + nameof(Nob.Hob),
                     dependentType.DisplayName() + "." + nameof(Nob.Hobs),
                     principalType.DisplayName() + "." + nameof(Hob.Nob)),
                 Assert.Throws<InvalidOperationException>(() =>
@@ -3608,8 +3606,8 @@ public abstract partial class ModelBuilderTest
 
             var dependentType = model.FindEntityType(typeof(Nob));
             var principalType = model.FindEntityType(typeof(Hob));
-            var principalKey = principalType.FindPrimaryKey();
-            var dependentKey = dependentType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
+            var dependentKey = dependentType!.FindPrimaryKey();
 
             modelBuilder.Entity<Nob>().HasOne(e => e.Hob).WithOne(e => e.Nob);
 
@@ -3635,8 +3633,8 @@ public abstract partial class ModelBuilderTest
 
             Assert.Equal(
                 CoreStrings.ConflictingRelationshipNavigation(
-                    principalType.DisplayName() + "." + nameof(Hob.Nob),
-                    dependentType.DisplayName() + "." + nameof(Nob.Hob),
+                    principalType!.DisplayName() + "." + nameof(Hob.Nob),
+                    dependentType!.DisplayName() + "." + nameof(Nob.Hob),
                     principalType.DisplayName() + "." + nameof(Hob.Nobs),
                     dependentType.DisplayName() + "." + nameof(Nob.Hob)),
                 Assert.Throws<InvalidOperationException>(() =>
@@ -3654,8 +3652,8 @@ public abstract partial class ModelBuilderTest
 
             var dependentType = model.FindEntityType(typeof(Nob));
             var principalType = model.FindEntityType(typeof(Hob));
-            var principalKey = principalType.FindPrimaryKey();
-            var dependentKey = dependentType.FindPrimaryKey();
+            var principalKey = principalType!.FindPrimaryKey();
+            var dependentKey = dependentType!.FindPrimaryKey();
 
             modelBuilder.Entity<Nob>().HasOne(e => e.Hob).WithOne(e => e.Nob);
 
@@ -3685,7 +3683,7 @@ public abstract partial class ModelBuilderTest
             var builder = modelBuilder.Entity<CustomerDetails>().HasOne(e => e.Customer).WithOne(e => e.Details);
             builder = builder.HasAnnotation("Fus", "Ro");
 
-            var fk = dependentType.FindNavigation(nameof(CustomerDetails.Customer)).ForeignKey;
+            var fk = dependentType!.FindNavigation(nameof(CustomerDetails.Customer))!.ForeignKey;
             Assert.Same(fk, builder.Metadata);
             Assert.Equal("Ro", fk["Fus"]);
         }
@@ -3699,12 +3697,12 @@ public abstract partial class ModelBuilderTest
                 .Entity<Hob>().HasOne(e => e.Nob).WithOne(e => e.Hob)
                 .HasForeignKey<Nob>(e => new { e.HobId1, e.HobId2 });
 
-            var entityType = (IReadOnlyEntityType)modelBuilder.Model.FindEntityType(typeof(Nob));
+            var entityType = (IReadOnlyEntityType)modelBuilder.Model.FindEntityType(typeof(Nob))!;
 
-            Assert.False(entityType.GetForeignKeys().Single().IsRequired);
+            Assert.False(entityType!.GetForeignKeys().Single().IsRequired);
             Assert.True(
-                entityType.FindProperty(nameof(Nob.HobId1)).IsNullable
-                || entityType.FindProperty(nameof(Nob.HobId2)).IsNullable);
+                entityType.FindProperty(nameof(Nob.HobId1))!.IsNullable
+                || entityType.FindProperty(nameof(Nob.HobId2))!.IsNullable);
         }
 
         [Fact]
@@ -3716,10 +3714,10 @@ public abstract partial class ModelBuilderTest
                 .Entity<Nob>().HasOne(e => e.Hob).WithOne(e => e.Nob)
                 .HasForeignKey<Hob>(e => new { e.NobId1, e.NobId2 });
 
-            var entityType = (IReadOnlyEntityType)modelBuilder.Model.FindEntityType(typeof(Hob));
+            var entityType = (IReadOnlyEntityType)modelBuilder.Model.FindEntityType(typeof(Hob))!;
 
-            Assert.False(entityType.FindProperty(nameof(Hob.NobId1)).IsNullable);
-            Assert.False(entityType.FindProperty(nameof(Hob.NobId2)).IsNullable);
+            Assert.False(entityType!.FindProperty(nameof(Hob.NobId1))!.IsNullable);
+            Assert.False(entityType.FindProperty(nameof(Hob.NobId2))!.IsNullable);
             Assert.True(entityType.GetForeignKeys().Single().IsRequired);
         }
 
@@ -3746,17 +3744,17 @@ public abstract partial class ModelBuilderTest
 
             modelBuilder.FinalizeModel();
 
-            var principalType = (IReadOnlyEntityType)modelBuilder.Model.FindEntityType(typeof(Hob));
-            var dependentType = (IReadOnlyEntityType)modelBuilder.Model.FindEntityType(typeof(Nob));
-            var expectedPrincipalProperties = principalType.GetProperties().ToList();
-            var expectedDependentProperties = dependentType.GetProperties().ToList();
+            var principalType = (IReadOnlyEntityType)modelBuilder.Model.FindEntityType(typeof(Hob))!;
+            var dependentType = (IReadOnlyEntityType)modelBuilder.Model.FindEntityType(typeof(Nob))!;
+            var expectedPrincipalProperties = principalType!.GetProperties().ToList();
+            var expectedDependentProperties = dependentType!.GetProperties().ToList();
             var fkProperty1 = dependentType.FindProperty(nameof(Nob.HobId1));
             var fkProperty2 = dependentType.FindProperty(nameof(Nob.HobId2));
             var fk = dependentType.GetForeignKeys().Single();
 
             Assert.True(fk.IsRequired);
-            Assert.True(fkProperty1.IsNullable);
-            Assert.True(fkProperty2.IsNullable);
+            Assert.True(fkProperty1!.IsNullable);
+            Assert.True(fkProperty2!.IsNullable);
             AssertEqual([fkProperty1, fkProperty2], fk.Properties);
             AssertEqual(expectedDependentProperties, dependentType.GetProperties());
         }
@@ -3779,14 +3777,14 @@ public abstract partial class ModelBuilderTest
 
             modelBuilder.FinalizeModel();
 
-            var dependentType = (IReadOnlyEntityType)modelBuilder.Model.FindEntityType(typeof(Hob));
-            var fkProperty1 = dependentType.FindProperty(nameof(Hob.NobId1));
+            var dependentType = (IReadOnlyEntityType)modelBuilder.Model.FindEntityType(typeof(Hob))!;
+            var fkProperty1 = dependentType!.FindProperty(nameof(Hob.NobId1));
             var fkProperty2 = dependentType.FindProperty(nameof(Hob.NobId2));
             var fk = dependentType.GetForeignKeys().Single();
 
             Assert.False(fk.IsRequired);
-            Assert.False(fkProperty1.IsNullable);
-            Assert.False(fkProperty2.IsNullable);
+            Assert.False(fkProperty1!.IsNullable);
+            Assert.False(fkProperty2!.IsNullable);
             Assert.Contains(fkProperty1, fk.Properties);
             Assert.Contains(fkProperty2, fk.Properties);
         }
@@ -3813,14 +3811,14 @@ public abstract partial class ModelBuilderTest
 
             modelBuilder.FinalizeModel();
 
-            var dependentType = (IReadOnlyEntityType)modelBuilder.Model.FindEntityType(typeof(Hob));
-            var fkProperty1 = dependentType.FindProperty(nameof(Hob.NobId1));
+            var dependentType = (IReadOnlyEntityType)modelBuilder.Model.FindEntityType(typeof(Hob))!;
+            var fkProperty1 = dependentType!.FindProperty(nameof(Hob.NobId1));
             var fkProperty2 = dependentType.FindProperty(nameof(Hob.NobId2));
             var fk = dependentType.GetForeignKeys().Single();
 
             Assert.False(fk.IsRequired);
-            Assert.False(fkProperty1.IsNullable);
-            Assert.False(fkProperty2.IsNullable);
+            Assert.False(fkProperty1!.IsNullable);
+            Assert.False(fkProperty2!.IsNullable);
             Assert.Contains(fkProperty1, fk.Properties);
             Assert.Contains(fkProperty2, fk.Properties);
         }
@@ -3829,10 +3827,10 @@ public abstract partial class ModelBuilderTest
         public virtual void Unspecified_FK_can_be_made_optional()
         {
             var modelBuilder = HobNobBuilder();
-            var principalType = (IReadOnlyEntityType)modelBuilder.Model.FindEntityType(typeof(Nob));
-            var dependentType = (IReadOnlyEntityType)modelBuilder.Model.FindEntityType(typeof(Hob));
-            var expectedPrincipalProperties = principalType.GetProperties().ToList();
-            var expectedDependentProperties = dependentType.GetProperties().ToList();
+            var principalType = (IReadOnlyEntityType)modelBuilder.Model.FindEntityType(typeof(Nob))!;
+            var dependentType = (IReadOnlyEntityType)modelBuilder.Model.FindEntityType(typeof(Hob))!;
+            var expectedPrincipalProperties = principalType!.GetProperties().ToList();
+            var expectedDependentProperties = dependentType!.GetProperties().ToList();
 
             modelBuilder
                 .Entity<Hob>().HasOne(e => e.Nob).WithOne(e => e.Hob)
@@ -3850,10 +3848,10 @@ public abstract partial class ModelBuilderTest
         public virtual void Unspecified_FK_can_be_made_optional_in_any_order()
         {
             var modelBuilder = HobNobBuilder();
-            var principalType = (IReadOnlyEntityType)modelBuilder.Model.FindEntityType(typeof(Nob));
-            var dependentType = (IReadOnlyEntityType)modelBuilder.Model.FindEntityType(typeof(Hob));
-            var expectedPrincipalProperties = principalType.GetProperties().ToList();
-            var expectedDependentProperties = dependentType.GetProperties().ToList();
+            var principalType = (IReadOnlyEntityType)modelBuilder.Model.FindEntityType(typeof(Nob))!;
+            var dependentType = (IReadOnlyEntityType)modelBuilder.Model.FindEntityType(typeof(Hob))!;
+            var expectedPrincipalProperties = principalType!.GetProperties().ToList();
+            var expectedDependentProperties = dependentType!.GetProperties().ToList();
 
             modelBuilder
                 .Entity<Hob>().HasOne(e => e.Nob).WithOne(e => e.Hob)
@@ -3871,10 +3869,10 @@ public abstract partial class ModelBuilderTest
         public virtual void Unspecified_FK_can_be_made_required()
         {
             var modelBuilder = HobNobBuilder();
-            var principalType = (IReadOnlyEntityType)modelBuilder.Model.FindEntityType(typeof(Nob));
-            var dependentType = (IReadOnlyEntityType)modelBuilder.Model.FindEntityType(typeof(Hob));
-            var expectedPrincipalProperties = principalType.GetProperties().ToList();
-            var expectedDependentProperties = dependentType.GetProperties().ToList();
+            var principalType = (IReadOnlyEntityType)modelBuilder.Model.FindEntityType(typeof(Nob))!;
+            var dependentType = (IReadOnlyEntityType)modelBuilder.Model.FindEntityType(typeof(Hob))!;
+            var expectedPrincipalProperties = principalType!.GetProperties().ToList();
+            var expectedDependentProperties = dependentType!.GetProperties().ToList();
 
             modelBuilder
                 .Entity<Hob>().HasOne(e => e.Nob).WithOne(e => e.Hob)
@@ -3928,12 +3926,12 @@ public abstract partial class ModelBuilderTest
             modelBuilder.Entity<Nob>().HasKey(e => new { e.Id1, e.Id2 });
 
             var dependentEntityType = modelBuilder.Model.FindEntityType(typeof(Nob));
-            var fk = dependentEntityType.GetForeignKeys().Single();
+            var fk = dependentEntityType!.GetForeignKeys().Single();
             AssertEqual(
-                [dependentEntityType.FindProperty("HobId1"), dependentEntityType.FindProperty("HobId2")], fk.Properties);
+                [dependentEntityType.FindProperty("HobId1")!, dependentEntityType.FindProperty("HobId2")!], fk.Properties);
             Assert.False(fk.IsRequired);
             var principalEntityType = modelBuilder.Model.FindEntityType(typeof(Hob));
-            AssertEqual(fk.PrincipalKey.Properties, principalEntityType.FindPrimaryKey().Properties);
+            AssertEqual(fk.PrincipalKey.Properties, principalEntityType!.FindPrimaryKey()!.Properties);
         }
 
         [Fact]
@@ -3954,12 +3952,12 @@ public abstract partial class ModelBuilderTest
             modelBuilder.Entity<Nob>().HasKey(e => new { e.Id1, e.Id2 });
 
             var dependentEntityType = modelBuilder.Model.FindEntityType(typeof(Hob));
-            var fk = dependentEntityType.GetForeignKeys().Single();
+            var fk = dependentEntityType!.GetForeignKeys().Single();
             AssertEqual(
-                [dependentEntityType.FindProperty("NobId1"), dependentEntityType.FindProperty("NobId2")], fk.Properties);
+                [dependentEntityType.FindProperty("NobId1")!, dependentEntityType.FindProperty("NobId2")!], fk.Properties);
             Assert.True(fk.IsRequired);
             var principalEntityType = modelBuilder.Model.FindEntityType(typeof(Nob));
-            AssertEqual(fk.PrincipalKey.Properties, principalEntityType.FindPrimaryKey().Properties);
+            AssertEqual(fk.PrincipalKey.Properties, principalEntityType!.FindPrimaryKey()!.Properties);
         }
 
         [Fact]
@@ -3972,7 +3970,7 @@ public abstract partial class ModelBuilderTest
                 .Entity<Hob>().HasOne(e => e.Nob).WithOne(e => e.Hob)
                 .OnDelete(DeleteBehavior.Cascade);
 
-            Assert.Equal(DeleteBehavior.Cascade, dependentType.GetNavigations().Single().ForeignKey.DeleteBehavior);
+            Assert.Equal(DeleteBehavior.Cascade, dependentType!.GetNavigations().Single().ForeignKey.DeleteBehavior);
 
             modelBuilder
                 .Entity<Hob>().HasOne(e => e.Nob).WithOne(e => e.Hob)
@@ -3997,7 +3995,7 @@ public abstract partial class ModelBuilderTest
                 .Entity<Hob>().HasOne(e => e.Nob).WithOne(e => e.Hob)
                 .HasForeignKey<Nob>(e => e.HobId1);
 
-            Assert.Equal(DeleteBehavior.ClientSetNull, dependentType.GetNavigations().Single().ForeignKey.DeleteBehavior);
+            Assert.Equal(DeleteBehavior.ClientSetNull, dependentType!.GetNavigations().Single().ForeignKey.DeleteBehavior);
 
             modelBuilder
                 .Entity<Nob>().HasKey(e => e.HobId1);
@@ -4019,7 +4017,7 @@ public abstract partial class ModelBuilderTest
 
             Assert.Equal(
                 "ShadowId",
-                modelBuilder.Model.FindEntityType(typeof(Beta)).FindNavigation("FirstNav").ForeignKey.Properties.Single().Name);
+                modelBuilder.Model.FindEntityType(typeof(Beta))!.FindNavigation("FirstNav")!.ForeignKey.Properties.Single().Name);
         }
 
         [Fact]
@@ -4038,7 +4036,7 @@ public abstract partial class ModelBuilderTest
 
             Assert.Equal(
                 "ShadowId",
-                modelBuilder.Model.FindEntityType(typeof(Beta)).FindNavigation("FirstNav").ForeignKey.Properties.Single().Name);
+                modelBuilder.Model.FindEntityType(typeof(Beta))!.FindNavigation("FirstNav")!.ForeignKey.Properties.Single().Name);
         }
 
         [Fact]
@@ -4050,10 +4048,10 @@ public abstract partial class ModelBuilderTest
 
             modelBuilder.Entity<Quarks>(b => b.HasOne<Beta>().WithOne().HasForeignKey<Quarks>("_forUp").IsRequired());
 
-            var fkProperty = modelBuilder.Model.FindEntityType(typeof(Quarks)).GetForeignKeys().Single().Properties.Single();
+            var fkProperty = modelBuilder.Model.FindEntityType(typeof(Quarks))!.GetForeignKeys().Single().Properties.Single();
             Assert.Equal("_forUp", fkProperty.Name);
             Assert.Equal(typeof(int), fkProperty.ClrType);
-            Assert.Equal("_forUp", fkProperty.FieldInfo.Name);
+            Assert.Equal("_forUp", fkProperty.FieldInfo!.Name);
         }
 
         [Fact]
@@ -4063,8 +4061,8 @@ public abstract partial class ModelBuilderTest
             modelBuilder.Ignore<Epsilon>();
             modelBuilder.Entity<Alpha>().HasOne(b => b.NavDelta).WithOne();
 
-            var property = modelBuilder.Model.FindEntityType(typeof(Delta)).FindProperty("Id");
-            Assert.Equal(ValueGenerated.Never, property.ValueGenerated);
+            var property = modelBuilder.Model.FindEntityType(typeof(Delta))!.FindProperty("Id");
+            Assert.Equal(ValueGenerated.Never, property!.ValueGenerated);
         }
 
         [Fact]
@@ -4091,7 +4089,7 @@ public abstract partial class ModelBuilderTest
                 .Metadata;
 
             var entityType = modelBuilder.Model.FindEntityType(typeof(SelfRef));
-            Assert.Empty(entityType.GetNavigations());
+            Assert.Empty(entityType!.GetNavigations());
             Assert.Same(relationship, entityType.GetForeignKeys().Single());
             Assert.Null(relationship.PrincipalToDependent);
             Assert.Null(relationship.DependentToPrincipal);
@@ -4113,7 +4111,7 @@ public abstract partial class ModelBuilderTest
 
             modelBuilder.FinalizeModel();
 
-            var fk = modelBuilder.Model.FindEntityType(typeof(OneToOnePrincipalEntity)).FindNavigation("NavOneToOneDependentEntity")
+            var fk = modelBuilder.Model.FindEntityType(typeof(OneToOnePrincipalEntity))!.FindNavigation("NavOneToOneDependentEntity")!
                 .ForeignKey;
 
             Assert.Equal(typeof(OneToOneDependentEntity), fk.DeclaringEntityType.ClrType);
@@ -4137,7 +4135,7 @@ public abstract partial class ModelBuilderTest
 
             modelBuilder.FinalizeModel();
 
-            var fk = modelBuilder.Model.FindEntityType(typeof(OneToOnePrincipalEntity)).FindNavigation("NavOneToOneDependentEntity")
+            var fk = modelBuilder.Model.FindEntityType(typeof(OneToOnePrincipalEntity))!.FindNavigation("NavOneToOneDependentEntity")!
                 .ForeignKey;
 
             Assert.Equal(typeof(OneToOneDependentEntity), fk.DeclaringEntityType.ClrType);
@@ -4161,7 +4159,7 @@ public abstract partial class ModelBuilderTest
 
             modelBuilder.FinalizeModel();
 
-            var fk = modelBuilder.Model.FindEntityType(typeof(OneToOnePrincipalEntity)).FindNavigation("NavOneToOneDependentEntity")
+            var fk = modelBuilder.Model.FindEntityType(typeof(OneToOnePrincipalEntity))!.FindNavigation("NavOneToOneDependentEntity")!
                 .ForeignKey;
 
             Assert.Equal(typeof(OneToOnePrincipalEntity), fk.DeclaringEntityType.ClrType);
@@ -4185,7 +4183,7 @@ public abstract partial class ModelBuilderTest
 
             modelBuilder.FinalizeModel();
 
-            var fk = modelBuilder.Model.FindEntityType(typeof(OneToOnePrincipalEntity)).FindNavigation("NavOneToOneDependentEntity")
+            var fk = modelBuilder.Model.FindEntityType(typeof(OneToOnePrincipalEntity))!.FindNavigation("NavOneToOneDependentEntity")!
                 .ForeignKey;
 
             Assert.Equal(typeof(OneToOnePrincipalEntity), fk.DeclaringEntityType.ClrType);
@@ -4377,7 +4375,7 @@ public abstract partial class ModelBuilderTest
 
             modelBuilder.FinalizeModel();
 
-            var fk = modelBuilder.Model.FindEntityType(typeof(OneToOnePrincipalEntity)).FindNavigation("NavOneToOneDependentEntity")
+            var fk = modelBuilder.Model.FindEntityType(typeof(OneToOnePrincipalEntity))!.FindNavigation("NavOneToOneDependentEntity")!
                 .ForeignKey;
 
             Assert.Equal(typeof(OneToOneDependentEntity), fk.DeclaringEntityType.ClrType);
@@ -4398,8 +4396,8 @@ public abstract partial class ModelBuilderTest
 
             modelBuilder.FinalizeModel();
 
-            var fk = modelBuilder.Model.FindEntityType(typeof(OneToOnePrincipalEntity))
-                .FindNavigation(nameof(OneToOnePrincipalEntity.NavOneToOneDependentEntity)).ForeignKey;
+            var fk = modelBuilder.Model.FindEntityType(typeof(OneToOnePrincipalEntity))!
+                .FindNavigation(nameof(OneToOnePrincipalEntity.NavOneToOneDependentEntity))!.ForeignKey;
 
             Assert.Equal(typeof(OneToOnePrincipalEntity), fk.DeclaringEntityType.ClrType);
             Assert.Equal(typeof(OneToOneDependentEntity), fk.PrincipalEntityType.ClrType);
@@ -4419,8 +4417,8 @@ public abstract partial class ModelBuilderTest
 
             modelBuilder.FinalizeModel();
 
-            var fk = modelBuilder.Model.FindEntityType(typeof(OneToOnePrincipalEntityWithAnnotation))
-                .FindNavigation("NavOneToOneDependentEntityWithAnnotation").ForeignKey;
+            var fk = modelBuilder.Model.FindEntityType(typeof(OneToOnePrincipalEntityWithAnnotation))!
+                .FindNavigation("NavOneToOneDependentEntityWithAnnotation")!.ForeignKey;
 
             Assert.Equal(typeof(OneToOnePrincipalEntityWithAnnotation), fk.DeclaringEntityType.ClrType);
             Assert.Equal(typeof(OneToOneDependentEntityWithAnnotation), fk.PrincipalEntityType.ClrType);
@@ -4439,7 +4437,7 @@ public abstract partial class ModelBuilderTest
 
             Assert.Equal(
                 "Id",
-                modelBuilder.Model.FindEntityType(typeof(Book)).FindNavigation(Book.BookDetailsNavigation.Name).ForeignKey.Properties
+                modelBuilder.Model.FindEntityType(typeof(Book))!.FindNavigation(Book.BookDetailsNavigation.Name)!.ForeignKey.Properties
                     .Single().Name);
         }
 
@@ -4470,8 +4468,8 @@ public abstract partial class ModelBuilderTest
 
             modelBuilder.Entity<OneToOneDependentEntity>().HasOne(e => e.NavOneToOnePrincipalEntity);
 
-            var fk = modelBuilder.Model.FindEntityType(typeof(OneToOneDependentEntity))
-                .FindNavigation(OneToOneDependentEntity.NavigationProperty).ForeignKey;
+            var fk = modelBuilder.Model.FindEntityType(typeof(OneToOneDependentEntity))!
+                .FindNavigation(OneToOneDependentEntity.NavigationProperty)!.ForeignKey;
 
             Assert.Equal(typeof(OneToOneDependentEntity), fk.PrincipalEntityType.ClrType);
             Assert.Equal(typeof(OneToOnePrincipalEntity), fk.DeclaringEntityType.ClrType);
@@ -4511,11 +4509,11 @@ public abstract partial class ModelBuilderTest
                 .Navigation(e => e.Dependent)
                 .UsePropertyAccessMode(PropertyAccessMode.Field);
 
-            var principal = (IReadOnlyEntityType)model.FindEntityType(typeof(OneToOneNavPrincipal));
-            var dependent = (IReadOnlyEntityType)model.FindEntityType(typeof(NavDependent));
+            var principal = (IReadOnlyEntityType)model.FindEntityType(typeof(OneToOneNavPrincipal))!;
+            var dependent = (IReadOnlyEntityType)model.FindEntityType(typeof(NavDependent))!;
 
-            Assert.Equal(PropertyAccessMode.Field, principal.FindNavigation("Dependent").GetPropertyAccessMode());
-            Assert.Equal(PropertyAccessMode.Property, dependent.FindNavigation("OneToOnePrincipal").GetPropertyAccessMode());
+            Assert.Equal(PropertyAccessMode.Field, principal!.FindNavigation("Dependent")!.GetPropertyAccessMode());
+            Assert.Equal(PropertyAccessMode.Property, dependent!.FindNavigation("OneToOnePrincipal")!.GetPropertyAccessMode());
         }
 
         [Fact]
@@ -4545,7 +4543,7 @@ public abstract partial class ModelBuilderTest
             var model = modelBuilder.FinalizeModel();
 
             var queryResult = model.FindEntityType(typeof(QueryResult));
-            Assert.NotNull(queryResult.FindNavigation(nameof(QueryResult.Value)));
+            Assert.NotNull(queryResult!.FindNavigation(nameof(QueryResult.Value)));
             Assert.Null(queryResult.FindProperty("TempId"));
         }
     }

--- a/test/EFCore.Specification.Tests/ModelBuilding/ModelBuilderTest.OwnedTypes.cs
+++ b/test/EFCore.Specification.Tests/ModelBuilding/ModelBuilderTest.OwnedTypes.cs
@@ -5,8 +5,6 @@
 
 namespace Microsoft.EntityFrameworkCore.ModelBuilding;
 
-#nullable disable
-
 public abstract partial class ModelBuilderTest
 {
     public abstract class OwnedTypesTestBase(ModelBuilderFixtureBase fixture) : ModelBuilderTestBase(fixture)
@@ -30,11 +28,11 @@ public abstract partial class ModelBuilderTest
             var model = modelBuilder.FinalizeModel();
 
             var owner = model.FindEntityType(typeof(Customer));
-            Assert.Equal(typeof(Customer).FullName, owner.Name);
-            var ownership = owner.FindNavigation(nameof(Customer.Details)).ForeignKey;
+            Assert.Equal(typeof(Customer).FullName, owner!.Name);
+            var ownership = owner.FindNavigation(nameof(Customer.Details))!.ForeignKey;
             Assert.True(ownership.IsOwnership);
-            Assert.Equal(nameof(Customer.Details), ownership.PrincipalToDependent.Name);
-            Assert.Equal(nameof(CustomerDetails.Customer), ownership.DependentToPrincipal.Name);
+            Assert.Equal(nameof(Customer.Details), ownership.PrincipalToDependent!.Name);
+            Assert.Equal(nameof(CustomerDetails.Customer), ownership.DependentToPrincipal!.Name);
             Assert.Equal("CustomerAlternateKey", ownership.Properties.Single().Name);
             Assert.Equal(nameof(Customer.AlternateKey), ownership.PrincipalKey.Properties.Single().Name);
             var owned = ownership.DeclaringEntityType;
@@ -58,10 +56,10 @@ public abstract partial class ModelBuilderTest
 
             var model = modelBuilder.FinalizeModel();
 
-            var ownership = model.FindEntityType(typeof(Customer)).FindNavigation(nameof(Customer.Details)).ForeignKey;
+            var ownership = model.FindEntityType(typeof(Customer))!.FindNavigation(nameof(Customer.Details))!.ForeignKey;
             var owned = ownership.DeclaringEntityType;
             Assert.True(ownership.IsOwnership);
-            Assert.Equal("bar", owned.FindAnnotation("foo").Value);
+            Assert.Equal("bar", owned.FindAnnotation("foo")!.Value);
             Assert.Single(owned.GetForeignKeys());
         }
 
@@ -97,11 +95,11 @@ public abstract partial class ModelBuilderTest
             var model = modelBuilder.FinalizeModel();
 
             var owner = model.FindEntityType(typeof(OneToOneOwnerWithField));
-            Assert.Equal(typeof(OneToOneOwnerWithField).FullName, owner.Name);
-            var ownership = owner.FindNavigation(nameof(OneToOneOwnerWithField.OwnedDependent)).ForeignKey;
+            Assert.Equal(typeof(OneToOneOwnerWithField).FullName, owner!.Name);
+            var ownership = owner.FindNavigation(nameof(OneToOneOwnerWithField.OwnedDependent))!.ForeignKey;
             Assert.True(ownership.IsOwnership);
-            Assert.Equal(nameof(OneToOneOwnerWithField.OwnedDependent), ownership.PrincipalToDependent.Name);
-            Assert.Equal(nameof(OneToOneOwnedWithField.OneToOneOwner), ownership.DependentToPrincipal.Name);
+            Assert.Equal(nameof(OneToOneOwnerWithField.OwnedDependent), ownership.PrincipalToDependent!.Name);
+            Assert.Equal(nameof(OneToOneOwnedWithField.OneToOneOwner), ownership.DependentToPrincipal!.Name);
             Assert.Equal(nameof(OneToOneOwnedWithField.OneToOneOwnerId), ownership.Properties.Single().Name);
             Assert.Equal(nameof(OneToOneOwnerWithField.Id), ownership.PrincipalKey.Properties.Single().Name);
             var owned = ownership.DeclaringEntityType;
@@ -142,11 +140,11 @@ public abstract partial class ModelBuilderTest
             var model = modelBuilder.FinalizeModel();
 
             var owner = model.FindEntityType(typeof(OneToManyOwnerWithField));
-            Assert.Equal(typeof(OneToManyOwnerWithField).FullName, owner.Name);
-            var ownership = owner.FindNavigation(nameof(OneToManyOwnerWithField.OwnedDependents)).ForeignKey;
+            Assert.Equal(typeof(OneToManyOwnerWithField).FullName, owner!.Name);
+            var ownership = owner.FindNavigation(nameof(OneToManyOwnerWithField.OwnedDependents))!.ForeignKey;
             Assert.True(ownership.IsOwnership);
-            Assert.Equal(nameof(OneToManyOwnerWithField.OwnedDependents), ownership.PrincipalToDependent.Name);
-            Assert.Equal(nameof(OneToManyOwnedWithField.OneToManyOwner), ownership.DependentToPrincipal.Name);
+            Assert.Equal(nameof(OneToManyOwnerWithField.OwnedDependents), ownership.PrincipalToDependent!.Name);
+            Assert.Equal(nameof(OneToManyOwnedWithField.OneToManyOwner), ownership.DependentToPrincipal!.Name);
             Assert.Equal(nameof(OneToManyOwnedWithField.OneToManyOwnerId), ownership.Properties.Single().Name);
             Assert.Equal(nameof(OneToManyOwnerWithField.Id), ownership.PrincipalKey.Properties.Single().Name);
             var owned = ownership.DeclaringEntityType;
@@ -166,19 +164,19 @@ public abstract partial class ModelBuilderTest
             modelBuilder.Entity<Customer>().OwnsOne(c => c.Details);
 
             var owner = model.FindEntityType(typeof(Customer));
-            var ownee = owner.FindNavigation(nameof(Customer.Details)).ForeignKey.DeclaringEntityType;
-            Assert.Equal(nameof(CustomerDetails.CustomerId), ownee.FindPrimaryKey().Properties.Single().Name);
+            var ownee = owner!.FindNavigation(nameof(Customer.Details))!.ForeignKey.DeclaringEntityType;
+            Assert.Equal(nameof(CustomerDetails.CustomerId), ownee.FindPrimaryKey()!.Properties.Single().Name);
 
             modelBuilder.Entity<Customer>().OwnsOne(c => c.Details)
                 .HasOne(d => d.Customer);
 
             model = modelBuilder.FinalizeModel();
 
-            var ownership = owner.FindNavigation(nameof(Customer.Details)).ForeignKey;
+            var ownership = owner.FindNavigation(nameof(Customer.Details))!.ForeignKey;
             Assert.True(ownership.IsOwnership);
-            Assert.Equal(nameof(CustomerDetails.Customer), ownership.DependentToPrincipal.Name);
+            Assert.Equal(nameof(CustomerDetails.Customer), ownership.DependentToPrincipal!.Name);
             Assert.Same(ownee, ownership.DeclaringEntityType);
-            Assert.Equal(nameof(CustomerDetails.CustomerId), ownee.FindPrimaryKey().Properties.Single().Name);
+            Assert.Equal(nameof(CustomerDetails.CustomerId), ownee.FindPrimaryKey()!.Properties.Single().Name);
             Assert.Single(ownership.DeclaringEntityType.GetForeignKeys());
         }
 
@@ -197,7 +195,7 @@ public abstract partial class ModelBuilderTest
             var model = modelBuilder.FinalizeModel();
 
             var owner = model.FindEntityType(typeof(Customer));
-            var owned = owner.FindNavigation(nameof(Customer.Details)).ForeignKey.DeclaringEntityType;
+            var owned = owner!.FindNavigation(nameof(Customer.Details))!.ForeignKey.DeclaringEntityType;
             Assert.Null(owner.FindProperty("foo"));
             Assert.Contains("foo", owned.GetProperties().Select(p => p.Name));
             Assert.Equal(PropertyAccessMode.FieldDuringConstruction, owned.GetPropertyAccessMode());
@@ -216,8 +214,8 @@ public abstract partial class ModelBuilderTest
             var model = modelBuilder.FinalizeModel();
 
             var owner = model.FindEntityType(typeof(Customer));
-            var owned = owner.FindNavigation(nameof(Customer.Details)).ForeignKey.DeclaringEntityType;
-            Assert.Equal(nameof(CustomerDetails.Id), owned.FindPrimaryKey().Properties.Single().Name);
+            var owned = owner!.FindNavigation(nameof(Customer.Details))!.ForeignKey.DeclaringEntityType;
+            Assert.Equal(nameof(CustomerDetails.Id), owned.FindPrimaryKey()!.Properties.Single().Name);
         }
 
         [Fact]
@@ -233,9 +231,9 @@ public abstract partial class ModelBuilderTest
 
             var model = modelBuilder.FinalizeModel();
 
-            var ownership = model.FindEntityType(typeof(Customer)).FindNavigation(nameof(Customer.Details)).ForeignKey;
+            var ownership = model.FindEntityType(typeof(Customer))!.FindNavigation(nameof(Customer.Details))!.ForeignKey;
             Assert.Equal(nameof(CustomerDetails.Id), ownership.Properties.Single().Name);
-            Assert.Equal(nameof(CustomerDetails.Id), ownership.DeclaringEntityType.FindPrimaryKey().Properties.Single().Name);
+            Assert.Equal(nameof(CustomerDetails.Id), ownership.DeclaringEntityType.FindPrimaryKey()!.Properties.Single().Name);
             Assert.Single(ownership.DeclaringEntityType.GetForeignKeys());
         }
 
@@ -256,16 +254,16 @@ public abstract partial class ModelBuilderTest
 
             var model = modelBuilder.FinalizeModel();
 
-            var ownership = model.FindEntityType(typeof(Customer)).FindNavigation(nameof(Customer.Details)).ForeignKey;
+            var ownership = model.FindEntityType(typeof(Customer))!.FindNavigation(nameof(Customer.Details))!.ForeignKey;
             var owned = ownership.DeclaringEntityType;
             Assert.True(ownership.IsOwnership);
-            Assert.Equal(nameof(Customer.Details), ownership.PrincipalToDependent.Name);
+            Assert.Equal(nameof(Customer.Details), ownership.PrincipalToDependent!.Name);
             Assert.Null(ownership.DependentToPrincipal);
             Assert.Equal("CustomerId", ownership.Properties.Single().Name);
 
             var otherFk = owned.GetForeignKeys().Single(fk => fk != ownership);
             Assert.Null(otherFk.PrincipalToDependent);
-            Assert.Equal(nameof(CustomerDetails.Customer), otherFk.DependentToPrincipal.Name);
+            Assert.Equal(nameof(CustomerDetails.Customer), otherFk.DependentToPrincipal!.Name);
             Assert.Equal("CustomerId1", otherFk.Properties.Single().Name);
             Assert.False(otherFk.IsOwnership);
             Assert.False(otherFk.IsUnique);
@@ -302,7 +300,7 @@ public abstract partial class ModelBuilderTest
 
             var model = modelBuilder.FinalizeModel();
 
-            var ownership = model.FindEntityType(typeof(Customer)).FindNavigation(nameof(Customer.Details)).ForeignKey;
+            var ownership = model.FindEntityType(typeof(Customer))!.FindNavigation(nameof(Customer.Details))!.ForeignKey;
             Assert.Equal(typeof(CustomerDetails), ownership.DeclaringEntityType.ClrType);
             Assert.Equal(1, model.GetEntityTypes().Count(e => e.ClrType == typeof(CustomerDetails)));
             Assert.Single(ownership.DeclaringEntityType.GetForeignKeys());
@@ -321,7 +319,7 @@ public abstract partial class ModelBuilderTest
 
             var model = modelBuilder.FinalizeModel();
 
-            var ownership = model.FindEntityType(typeof(Customer)).FindNavigation(nameof(Customer.Details)).ForeignKey;
+            var ownership = model.FindEntityType(typeof(Customer))!.FindNavigation(nameof(Customer.Details))!.ForeignKey;
             Assert.Equal(typeof(CustomerDetails), ownership.DeclaringEntityType.ClrType);
             Assert.Equal(1, model.GetEntityTypes().Count(e => e.ClrType == typeof(CustomerDetails)));
             Assert.Single(ownership.DeclaringEntityType.GetForeignKeys());
@@ -339,8 +337,8 @@ public abstract partial class ModelBuilderTest
 
             var model = modelBuilder.FinalizeModel();
 
-            var ownership1 = model.FindEntityType(typeof(OtherCustomer)).FindNavigation(nameof(Customer.Details)).ForeignKey;
-            var ownership2 = model.FindEntityType(typeof(SpecialCustomer)).FindNavigation(nameof(Customer.Details)).ForeignKey;
+            var ownership1 = model.FindEntityType(typeof(OtherCustomer))!.FindNavigation(nameof(Customer.Details))!.ForeignKey;
+            var ownership2 = model.FindEntityType(typeof(SpecialCustomer))!.FindNavigation(nameof(Customer.Details))!.ForeignKey;
             Assert.Equal(typeof(CustomerDetails), ownership1.DeclaringEntityType.ClrType);
             Assert.Equal(typeof(CustomerDetails), ownership2.DeclaringEntityType.ClrType);
             Assert.NotSame(ownership1.DeclaringEntityType, ownership2.DeclaringEntityType);
@@ -366,8 +364,8 @@ public abstract partial class ModelBuilderTest
 
             var model = modelBuilder.FinalizeModel();
 
-            var ownership = model.FindEntityType(typeof(OtherCustomer)).FindNavigation(nameof(Customer.Details)).ForeignKey;
-            var foreignKey = model.FindEntityType(typeof(SpecialCustomer)).GetReferencingForeignKeys()
+            var ownership = model.FindEntityType(typeof(OtherCustomer))!.FindNavigation(nameof(Customer.Details))!.ForeignKey;
+            var foreignKey = model.FindEntityType(typeof(SpecialCustomer))!.GetReferencingForeignKeys()
                 .Single(fk => fk.DeclaringEntityType.ClrType == typeof(CustomerDetails)
                     && fk.PrincipalToDependent == null);
             Assert.Same(ownership.DeclaringEntityType, foreignKey.DeclaringEntityType);
@@ -387,13 +385,13 @@ public abstract partial class ModelBuilderTest
             var entityBuilder = modelBuilder.Entity<CustomerDetails>().OwnsOne(o => o.Customer)
                 .OwnsMany(c => c.Orders);
 
-            var ownership = model.FindEntityType(typeof(CustomerDetails)).FindNavigation(nameof(CustomerDetails.Customer)).ForeignKey;
+            var ownership = model.FindEntityType(typeof(CustomerDetails))!.FindNavigation(nameof(CustomerDetails.Customer))!.ForeignKey;
             var owned = ownership.DeclaringEntityType;
-            var chainedOwnership = owned.FindNavigation(nameof(Customer.Orders)).ForeignKey;
+            var chainedOwnership = owned.FindNavigation(nameof(Customer.Orders))!.ForeignKey;
             var chainedOwned = chainedOwnership.DeclaringEntityType;
             Assert.Equal(
                 [nameof(Order.CustomerId), nameof(Order.OrderId)],
-                chainedOwned.FindPrimaryKey().Properties.Select(p => p.Name));
+                chainedOwned.FindPrimaryKey()!.Properties.Select(p => p.Name));
 
             entityBuilder.HasKey(o => o.OrderId);
 
@@ -401,15 +399,15 @@ public abstract partial class ModelBuilderTest
 
             Assert.True(ownership.IsOwnership);
             Assert.True(ownership.IsUnique);
-            Assert.Equal(nameof(Customer.Details), ownership.DependentToPrincipal.Name);
+            Assert.Equal(nameof(Customer.Details), ownership.DependentToPrincipal!.Name);
             Assert.Equal("DetailsId", ownership.Properties.Single().Name);
-            Assert.Equal("DetailsId", owned.FindPrimaryKey().Properties.Single().Name);
+            Assert.Equal("DetailsId", owned.FindPrimaryKey()!.Properties.Single().Name);
             Assert.Empty(owned.GetIndexes());
             Assert.True(chainedOwnership.IsOwnership);
             Assert.False(chainedOwnership.IsUnique);
-            Assert.Equal(nameof(Order.Customer), chainedOwnership.DependentToPrincipal.Name);
+            Assert.Equal(nameof(Order.Customer), chainedOwnership.DependentToPrincipal!.Name);
             Assert.Equal(nameof(Order.CustomerId), chainedOwnership.Properties.Single().Name);
-            Assert.Equal(nameof(Order.OrderId), chainedOwned.FindPrimaryKey().Properties.Single().Name);
+            Assert.Equal(nameof(Order.OrderId), chainedOwned.FindPrimaryKey()!.Properties.Single().Name);
             Assert.Single(chainedOwned.GetForeignKeys());
 
             if (Fixture.ForeignKeysHaveIndexes)
@@ -449,15 +447,15 @@ public abstract partial class ModelBuilderTest
             var model = modelBuilder.FinalizeModel();
 
             var owner = model.FindEntityType(typeof(Customer));
-            var ownership = owner.FindNavigation(nameof(Customer.Orders)).ForeignKey;
+            var ownership = owner!.FindNavigation(nameof(Customer.Orders))!.ForeignKey;
             var owned = ownership.DeclaringEntityType;
             Assert.True(ownership.IsOwnership);
             Assert.Equal("CustomerAlternateKey", ownership.Properties.Single().Name);
             Assert.Equal(nameof(Customer.AlternateKey), ownership.PrincipalKey.Properties.Single().Name);
-            Assert.Equal(nameof(Order.Customer), ownership.DependentToPrincipal.Name);
+            Assert.Equal(nameof(Order.Customer), ownership.DependentToPrincipal!.Name);
 
             Assert.Null(owner.FindProperty("foo"));
-            Assert.Equal(nameof(Order.AnotherCustomerId), owned.FindPrimaryKey().Properties.Single().Name);
+            Assert.Equal(nameof(Order.AnotherCustomerId), owned.FindPrimaryKey()!.Properties.Single().Name);
 
             var unnamedIndexes = owned.GetIndexes().Where(i => i.Name == null).ToList();
             if (Fixture.ForeignKeysHaveIndexes)
@@ -511,13 +509,13 @@ public abstract partial class ModelBuilderTest
 
             var model = modelBuilder.FinalizeModel();
 
-            var ownership = model.FindEntityType(typeof(Customer)).FindNavigation(nameof(Customer.Orders)).ForeignKey;
+            var ownership = model.FindEntityType(typeof(Customer))!.FindNavigation(nameof(Customer.Orders))!.ForeignKey;
             var owned = ownership.DeclaringEntityType;
             Assert.True(ownership.IsOwnership);
             Assert.Equal("DifferentCustomerId", ownership.Properties.Single().Name);
-            Assert.Equal("bar", owned.FindAnnotation("foo").Value);
+            Assert.Equal("bar", owned.FindAnnotation("foo")!.Value);
             Assert.Single(owned.GetForeignKeys());
-            Assert.Equal("Id", owned.FindPrimaryKey().Properties.Single().Name);
+            Assert.Equal("Id", owned.FindPrimaryKey()!.Properties.Single().Name);
 
             if (Fixture.ForeignKeysHaveIndexes)
             {
@@ -530,8 +528,8 @@ public abstract partial class ModelBuilderTest
             }
 
             Assert.Equal(nameof(Order.AnotherCustomerId), owned.GetIndexes().First().Properties.Single().Name);
-            Assert.False(owned.FindProperty(nameof(Order.AnotherCustomerId)).IsNullable);
-            Assert.Equal(nameof(Order.Customer), ownership.DependentToPrincipal.Name);
+            Assert.False(owned.FindProperty(nameof(Order.AnotherCustomerId))!.IsNullable);
+            Assert.Equal(nameof(Order.Customer), ownership.DependentToPrincipal!.Name);
         }
 
         [Fact]
@@ -557,17 +555,17 @@ public abstract partial class ModelBuilderTest
             var model = modelBuilder.FinalizeModel();
 
             Assert.Null(model.FindEntityType(typeof(Order)));
-            var ownership1 = model.FindEntityType(typeof(OtherCustomer)).FindNavigation(nameof(Customer.Orders)).ForeignKey;
-            var ownership2 = model.FindEntityType(typeof(SpecialCustomer)).FindNavigation(nameof(Customer.Orders)).ForeignKey;
+            var ownership1 = model.FindEntityType(typeof(OtherCustomer))!.FindNavigation(nameof(Customer.Orders))!.ForeignKey;
+            var ownership2 = model.FindEntityType(typeof(SpecialCustomer))!.FindNavigation(nameof(Customer.Orders))!.ForeignKey;
             Assert.Equal(typeof(Order), ownership1.DeclaringEntityType.ClrType);
             Assert.Equal(typeof(Order), ownership2.DeclaringEntityType.ClrType);
             Assert.NotSame(ownership1.DeclaringEntityType, ownership2.DeclaringEntityType);
-            Assert.Equal(nameof(Order.Customer), ownership1.DependentToPrincipal.Name);
-            Assert.Equal(nameof(Order.Customer), ownership2.DependentToPrincipal.Name);
+            Assert.Equal(nameof(Order.Customer), ownership1.DependentToPrincipal!.Name);
+            Assert.Equal(nameof(Order.Customer), ownership2.DependentToPrincipal!.Name);
             Assert.Equal("CustomerId", ownership1.Properties.Single().Name);
             Assert.Equal("CustomerId", ownership2.Properties.Single().Name);
 
-            var foreignKey = model.FindEntityType(typeof(SpecialCustomer)).GetReferencingForeignKeys()
+            var foreignKey = model.FindEntityType(typeof(SpecialCustomer))!.GetReferencingForeignKeys()
                 .Single(fk => fk.DeclaringEntityType.ClrType == typeof(Order)
                     && fk.PrincipalToDependent == null);
             Assert.Same(ownership1.DeclaringEntityType, foreignKey.DeclaringEntityType);
@@ -653,19 +651,19 @@ public abstract partial class ModelBuilderTest
 
             var model = modelBuilder.FinalizeModel();
 
-            var ownership = model.FindEntityType(typeof(Customer)).FindNavigation(nameof(Customer.Orders)).ForeignKey;
+            var ownership = model.FindEntityType(typeof(Customer))!.FindNavigation(nameof(Customer.Orders))!.ForeignKey;
             var owned = ownership.DeclaringEntityType;
             Assert.Equal(nameof(Order.CustomerId), ownership.Properties.Single().Name);
             Assert.Single(ownership.DeclaringEntityType.GetForeignKeys());
-            var chainedOwnership = owned.FindNavigation(nameof(Order.Details)).ForeignKey;
+            var chainedOwnership = owned.FindNavigation(nameof(Order.Details))!.ForeignKey;
             var chainedOwned = chainedOwnership.DeclaringEntityType;
             Assert.True(chainedOwnership.IsOwnership);
             Assert.True(chainedOwnership.IsUnique);
-            Assert.Equal(nameof(OrderDetails.OrderId), chainedOwned.FindPrimaryKey().Properties.Single().Name);
+            Assert.Equal(nameof(OrderDetails.OrderId), chainedOwned.FindPrimaryKey()!.Properties.Single().Name);
             Assert.Empty(chainedOwned.GetIndexes());
             Assert.Equal(-1, chainedOwned.GetSeedData().Single()[nameof(OrderDetails.OrderId)]);
             Assert.Equal(nameof(OrderDetails.OrderId), chainedOwnership.Properties.Single().Name);
-            Assert.Equal(nameof(OrderDetails.Order), chainedOwnership.DependentToPrincipal.Name);
+            Assert.Equal(nameof(OrderDetails.Order), chainedOwnership.DependentToPrincipal!.Name);
 
             Assert.Equal(4, model.GetEntityTypes().Count());
         }
@@ -693,18 +691,18 @@ public abstract partial class ModelBuilderTest
 
             var model = modelBuilder.FinalizeModel();
 
-            var ownership = model.FindEntityType(typeof(Customer)).FindNavigation(nameof(Customer.Orders)).ForeignKey;
+            var ownership = model.FindEntityType(typeof(Customer))!.FindNavigation(nameof(Customer.Orders))!.ForeignKey;
             var owned = ownership.DeclaringEntityType;
             Assert.Single(ownership.DeclaringEntityType.GetForeignKeys());
             var seedData = owned.GetSeedData().Single();
             Assert.Equal(-2, seedData[nameof(Order.OrderId)]);
             Assert.Equal(-1, seedData[nameof(Order.CustomerId)]);
-            var chainedOwnership = owned.FindNavigation(nameof(Order.Products)).ForeignKey;
+            var chainedOwnership = owned.FindNavigation(nameof(Order.Products))!.ForeignKey;
             var chainedOwned = chainedOwnership.DeclaringEntityType;
             Assert.True(chainedOwnership.IsOwnership);
             Assert.False(chainedOwnership.IsUnique);
             Assert.Equal("OrderId", chainedOwnership.Properties.Single().Name);
-            Assert.Equal(nameof(Product.Id), chainedOwned.FindPrimaryKey().Properties.Single().Name);
+            Assert.Equal(nameof(Product.Id), chainedOwned.FindPrimaryKey()!.Properties.Single().Name);
 
             if (Fixture.ForeignKeysHaveIndexes)
             {
@@ -717,7 +715,7 @@ public abstract partial class ModelBuilderTest
                 Assert.Empty(chainedOwned.GetIndexes());
             }
 
-            Assert.Equal(nameof(Product.Order), chainedOwnership.DependentToPrincipal.Name);
+            Assert.Equal(nameof(Product.Order), chainedOwnership.DependentToPrincipal!.Name);
 
             Assert.Equal(4, model.GetEntityTypes().Count());
         }
@@ -743,24 +741,24 @@ public abstract partial class ModelBuilderTest
 
             var model = modelBuilder.FinalizeModel();
 
-            var ownership = model.FindEntityType(typeof(Customer)).FindNavigation(nameof(Customer.Orders)).ForeignKey;
+            var ownership = model.FindEntityType(typeof(Customer))!.FindNavigation(nameof(Customer.Orders))!.ForeignKey;
             var owned = ownership.DeclaringEntityType;
             Assert.True(ownership.IsOwnership);
-            Assert.Equal(nameof(Order.Customer), ownership.DependentToPrincipal.Name);
+            Assert.Equal(nameof(Order.Customer), ownership.DependentToPrincipal!.Name);
             Assert.Equal(nameof(Order.CustomerId), ownership.Properties.Single().Name);
             Assert.Single(owned.GetForeignKeys());
             var pk = owned.FindPrimaryKey();
-            Assert.Equal([nameof(Order.CustomerId), nameof(Order.OrderId)], pk.Properties.Select(p => p.Name));
+            Assert.Equal([nameof(Order.CustomerId), nameof(Order.OrderId)], pk!.Properties.Select(p => p.Name));
             Assert.Empty(owned.GetIndexes());
 
-            var chainedOwnership = owned.FindNavigation(nameof(Order.Products)).ForeignKey;
+            var chainedOwnership = owned.FindNavigation(nameof(Order.Products))!.ForeignKey;
             var chainedOwned = chainedOwnership.DeclaringEntityType;
             Assert.True(chainedOwnership.IsOwnership);
             Assert.False(chainedOwnership.IsUnique);
-            Assert.Equal(nameof(Product.Order), chainedOwnership.DependentToPrincipal.Name);
+            Assert.Equal(nameof(Product.Order), chainedOwnership.DependentToPrincipal!.Name);
             Assert.Equal(["OrderCustomerId", "OrderId"], chainedOwnership.Properties.Select(p => p.Name));
             var chainedPk = chainedOwned.FindPrimaryKey();
-            Assert.Equal(["OrderCustomerId", "OrderId", nameof(Product.Id)], chainedPk.Properties.Select(p => p.Name));
+            Assert.Equal(["OrderCustomerId", "OrderId", nameof(Product.Id)], chainedPk!.Properties.Select(p => p.Name));
             Assert.Empty(chainedOwned.GetIndexes());
 
             Assert.Equal(4, model.GetEntityTypes().Count());
@@ -789,25 +787,25 @@ public abstract partial class ModelBuilderTest
 
             var model = modelBuilder.FinalizeModel();
 
-            var ownership = model.FindEntityType(typeof(Customer)).FindNavigation(nameof(Customer.Orders)).ForeignKey;
+            var ownership = model.FindEntityType(typeof(Customer))!.FindNavigation(nameof(Customer.Orders))!.ForeignKey;
             var owned = ownership.DeclaringEntityType;
             Assert.True(ownership.IsOwnership);
             Assert.False(ownership.IsUnique);
-            Assert.Equal(nameof(Order.Customer), ownership.DependentToPrincipal.Name);
+            Assert.Equal(nameof(Order.Customer), ownership.DependentToPrincipal!.Name);
             Assert.Equal(nameof(Order.CustomerId), ownership.Properties.Single().Name);
             Assert.Single(owned.GetForeignKeys());
             var pk = owned.FindPrimaryKey();
-            Assert.Equal([nameof(Order.CustomerId), "Id"], pk.Properties.Select(p => p.Name));
+            Assert.Equal([nameof(Order.CustomerId), "Id"], pk!.Properties.Select(p => p.Name));
             Assert.Empty(owned.GetIndexes());
 
-            var chainedOwnership = owned.FindNavigation(nameof(Order.Products)).ForeignKey;
+            var chainedOwnership = owned.FindNavigation(nameof(Order.Products))!.ForeignKey;
             var chainedOwned = chainedOwnership.DeclaringEntityType;
             Assert.True(chainedOwnership.IsOwnership);
             Assert.False(chainedOwnership.IsUnique);
-            Assert.Equal(nameof(Product.Order), chainedOwnership.DependentToPrincipal.Name);
+            Assert.Equal(nameof(Product.Order), chainedOwnership.DependentToPrincipal!.Name);
             Assert.Equal(["OrderCustomerId", "OrderId"], chainedOwnership.Properties.Select(p => p.Name));
             var chainedPk = chainedOwned.FindPrimaryKey();
-            Assert.Equal(["OrderCustomerId", "OrderId", "Id1"], chainedPk.Properties.Select(p => p.Name));
+            Assert.Equal(["OrderCustomerId", "OrderId", "Id1"], chainedPk!.Properties.Select(p => p.Name));
             Assert.Empty(chainedOwned.GetIndexes());
 
             Assert.Equal(4, model.GetEntityTypes().Count());
@@ -855,20 +853,20 @@ public abstract partial class ModelBuilderTest
             var customer = model.FindEntityType(typeof(Customer));
             var specialCustomer = model.FindEntityType(typeof(SpecialCustomer));
 
-            var ownership = customer.FindNavigation(nameof(Customer.Orders)).ForeignKey;
+            var ownership = customer!.FindNavigation(nameof(Customer.Orders))!.ForeignKey;
             Assert.True(ownership.IsOwnership);
             Assert.False(ownership.IsUnique);
-            Assert.Equal(nameof(Order.OrderId), ownership.DeclaringEntityType.FindPrimaryKey().Properties.Single().Name);
+            Assert.Equal(nameof(Order.OrderId), ownership.DeclaringEntityType.FindPrimaryKey()!.Properties.Single().Name);
             Assert.Same(
                 ownership.DeclaringEntityType,
                 model.FindEntityType(typeof(Order), nameof(Customer.Orders), customer));
             Assert.True(model.IsShared(typeof(Order)));
 
-            var specialOwnership = specialCustomer.FindNavigation(nameof(SpecialCustomer.SpecialOrders)).ForeignKey;
+            var specialOwnership = specialCustomer!.FindNavigation(nameof(SpecialCustomer.SpecialOrders))!.ForeignKey;
             Assert.True(specialOwnership.IsOwnership);
             Assert.False(specialOwnership.IsUnique);
             Assert.Equal(
-                nameof(SpecialOrder.SpecialOrderId), specialOwnership.DeclaringEntityType.FindPrimaryKey().Properties.Single().Name);
+                nameof(SpecialOrder.SpecialOrderId), specialOwnership.DeclaringEntityType.FindPrimaryKey()!.Properties.Single().Name);
             Assert.Same(
                 specialOwnership.DeclaringEntityType,
                 model.FindEntityType(typeof(SpecialOrder)));
@@ -912,15 +910,15 @@ public abstract partial class ModelBuilderTest
 
             var customer = model.FindEntityType(typeof(Customer));
 
-            var ownership = customer.FindNavigation(nameof(Customer.Orders)).ForeignKey;
+            var ownership = customer!.FindNavigation(nameof(Customer.Orders))!.ForeignKey;
             Assert.True(ownership.IsOwnership);
             Assert.False(ownership.IsUnique);
-            Assert.Equal(nameof(Order.OrderId), ownership.DeclaringEntityType.FindPrimaryKey().Properties.Single().Name);
-            var specialOwnership = specialCustomer.FindNavigation(nameof(SpecialCustomer.SpecialOrders)).ForeignKey;
+            Assert.Equal(nameof(Order.OrderId), ownership.DeclaringEntityType.FindPrimaryKey()!.Properties.Single().Name);
+            var specialOwnership = specialCustomer.FindNavigation(nameof(SpecialCustomer.SpecialOrders))!.ForeignKey;
             Assert.True(specialOwnership.IsOwnership);
             Assert.False(specialOwnership.IsUnique);
             Assert.Equal(
-                nameof(SpecialOrder.SpecialOrderId), specialOwnership.DeclaringEntityType.FindPrimaryKey().Properties.Single().Name);
+                nameof(SpecialOrder.SpecialOrderId), specialOwnership.DeclaringEntityType.FindPrimaryKey()!.Properties.Single().Name);
 
             Assert.Equal(2, modelBuilder.Model.FindEntityTypes(typeof(Order)).Count());
 
@@ -945,7 +943,7 @@ public abstract partial class ModelBuilderTest
             var model = modelBuilder.FinalizeModel();
 
             var owner = model.FindEntityType(typeof(SpecialOrder));
-            var ownership = owner.FindNavigation(nameof(SpecialOrder.ShippingAddress)).ForeignKey;
+            var ownership = owner!.FindNavigation(nameof(SpecialOrder.ShippingAddress))!.ForeignKey;
             Assert.True(ownership.IsOwnership);
             Assert.True(ownership.IsRequired);
             Assert.True(ownership.IsRequiredDependent);
@@ -980,8 +978,8 @@ public abstract partial class ModelBuilderTest
 
             var model = modelBuilder.FinalizeModel();
 
-            var bookOwnership1 = model.FindEntityType(typeof(Book)).FindNavigation(nameof(Book.Label)).ForeignKey;
-            var bookOwnership2 = model.FindEntityType(typeof(Book)).FindNavigation(nameof(Book.AlternateLabel)).ForeignKey;
+            var bookOwnership1 = model.FindEntityType(typeof(Book))!.FindNavigation(nameof(Book.Label))!.ForeignKey;
+            var bookOwnership2 = model.FindEntityType(typeof(Book))!.FindNavigation(nameof(Book.AlternateLabel))!.ForeignKey;
             Assert.NotSame(bookOwnership1.DeclaringEntityType, bookOwnership2.DeclaringEntityType);
             Assert.Equal(typeof(int), bookOwnership1.DeclaringEntityType.GetForeignKeys().Single().Properties.Single().ClrType);
             Assert.Equal(typeof(int), bookOwnership1.DeclaringEntityType.GetForeignKeys().Single().Properties.Single().ClrType);
@@ -1010,7 +1008,7 @@ public abstract partial class ModelBuilderTest
             Assert.Null(model.FindEntityType(typeof(BookDetailsBase)));
             var baseType = model.FindEntityType(typeof(DetailsBase));
             var owner = model.FindEntityType(typeof(Customer));
-            var owned = owner.FindNavigation(nameof(Customer.Details)).ForeignKey.DeclaringEntityType;
+            var owned = owner!.FindNavigation(nameof(Customer.Details))!.ForeignKey.DeclaringEntityType;
             Assert.Null(owned.BaseType);
             Assert.Null(owned.GetDiscriminatorPropertyName());
             Assert.NotNull(model.FindEntityType(typeof(CustomerDetails)));
@@ -1037,7 +1035,7 @@ public abstract partial class ModelBuilderTest
             Assert.Null(model.FindEntityType(typeof(BookDetailsBase)));
             var baseType = model.FindEntityType(typeof(DetailsBase));
             var owner = model.FindEntityType(typeof(Customer));
-            var owned = owner.FindNavigation(nameof(Customer.Details)).ForeignKey.DeclaringEntityType;
+            var owned = owner!.FindNavigation(nameof(Customer.Details))!.ForeignKey.DeclaringEntityType;
             Assert.Null(owned.BaseType);
             Assert.Null(owned.GetDiscriminatorPropertyName());
             Assert.NotNull(model.FindEntityType(typeof(CustomerDetails)));
@@ -1061,7 +1059,7 @@ public abstract partial class ModelBuilderTest
             IReadOnlyModel model = modelBuilder.Model;
 
             var owner = model.FindEntityType(typeof(OrderCombination));
-            var owned = owner.FindNavigation(nameof(OrderCombination.Details)).ForeignKey.DeclaringEntityType;
+            var owned = owner!.FindNavigation(nameof(OrderCombination.Details))!.ForeignKey.DeclaringEntityType;
             Assert.Empty(owned.GetDirectlyDerivedTypes());
             Assert.Null(owned.GetDiscriminatorPropertyName());
             var navToCustomerDetails = model.GetEntityTypes().SelectMany(e => e.GetDeclaredNavigations()).Where(n =>
@@ -1073,7 +1071,7 @@ public abstract partial class ModelBuilderTest
             Assert.Equal(1, model.GetEntityTypes().Count(e => e.ClrType == typeof(DetailsBase)));
             var derivedType = model.FindEntityType(typeof(CustomerDetails));
             Assert.Same(derivedType, navToCustomerDetails.TargetEntityType);
-            Assert.Null(derivedType.BaseType);
+            Assert.Null(derivedType!.BaseType);
             Assert.Null(derivedType.GetDiscriminatorPropertyName());
 
             modelBuilder.Entity<Customer>().Ignore(c => c.Details);
@@ -1097,7 +1095,7 @@ public abstract partial class ModelBuilderTest
             IReadOnlyModel model = modelBuilder.Model;
 
             var owner = model.FindEntityType(typeof(OrderCombination));
-            var owned = owner.FindNavigation(nameof(OrderCombination.Details)).ForeignKey.DeclaringEntityType;
+            var owned = owner!.FindNavigation(nameof(OrderCombination.Details))!.ForeignKey.DeclaringEntityType;
             Assert.Empty(owned.GetDirectlyDerivedTypes());
             Assert.Null(owned.GetDiscriminatorPropertyName());
             var navToCustomerDetails = model.GetEntityTypes().SelectMany(e => e.GetDeclaredNavigations()).Where(n =>
@@ -1108,7 +1106,7 @@ public abstract partial class ModelBuilderTest
             Assert.Single(owned.GetForeignKeys());
             Assert.Single(model.FindEntityTypes(typeof(DetailsBase)));
             var derivedType = model.FindEntityType(typeof(CustomerDetails));
-            Assert.Null(derivedType.BaseType);
+            Assert.Null(derivedType!.BaseType);
             Assert.Null(derivedType.GetDiscriminatorPropertyName());
 
             modelBuilder.Entity<Customer>().Ignore(c => c.Details);
@@ -1137,18 +1135,18 @@ public abstract partial class ModelBuilderTest
             var model = modelBuilder.FinalizeModel();
 
             var result = model.FindEntityType(typeof(QueryResult));
-            Assert.Null(result.FindProperty("TempId"));
+            Assert.Null(result!.FindProperty("TempId"));
 
             var owned = result.GetDeclaredNavigations().Single().TargetEntityType;
             Assert.Null(owned.FindProperty("TempId"));
 
-            var ownedPkProperty = owned.FindPrimaryKey().Properties.Single();
+            var ownedPkProperty = owned.FindPrimaryKey()!.Properties.Single();
             Assert.NotNull(ownedPkProperty.GetValueConverter());
             Assert.Null(ownedPkProperty.GetElementType());
 
             var category = model.FindEntityType(typeof(ValueCategory));
-            Assert.Null(category.FindProperty("TempId"));
-            Assert.Null(category.FindPrimaryKey().Properties.Single().GetElementType());
+            Assert.Null(category!.FindProperty("TempId"));
+            Assert.Null(category.FindPrimaryKey()!.Properties.Single().GetElementType());
 
             var categoryNavigation = owned.GetDeclaredNavigations().Single(n => !n.ForeignKey.IsOwnership);
             Assert.Same(category, categoryNavigation.TargetEntityType);
@@ -1178,12 +1176,12 @@ public abstract partial class ModelBuilderTest
             var model = modelBuilder.FinalizeModel();
 
             var result = model.FindEntityType(typeof(QueryResult));
-            Assert.Null(result.FindProperty("TempId"));
+            Assert.Null(result!.FindProperty("TempId"));
 
             var owned = result.GetDeclaredNavigations().Single().TargetEntityType;
             Assert.Null(owned.FindProperty("TempId"));
 
-            var ownedPkProperty = owned.FindPrimaryKey().Properties.Single();
+            var ownedPkProperty = owned.FindPrimaryKey()!.Properties.Single();
             Assert.NotNull(ownedPkProperty.GetValueConverter());
             Assert.Null(ownedPkProperty.GetElementType());
 
@@ -1212,13 +1210,13 @@ public abstract partial class ModelBuilderTest
             var model = modelBuilder.FinalizeModel();
 
             var result = model.FindEntityType(typeof(QueryResult));
-            Assert.Null(result.FindProperty("TempId"));
-            Assert.Null(result.FindPrimaryKey().Properties.Single().GetElementType());
+            Assert.Null(result!.FindProperty("TempId"));
+            Assert.Null(result.FindPrimaryKey()!.Properties.Single().GetElementType());
 
             var owned = result.GetDeclaredNavigations().Single().TargetEntityType;
             Assert.Null(owned.FindProperty("TempId"));
 
-            var ownedPkProperty = owned.FindPrimaryKey().Properties.Single();
+            var ownedPkProperty = owned.FindPrimaryKey()!.Properties.Single();
             Assert.NotNull(ownedPkProperty.GetValueConverter());
             Assert.Null(ownedPkProperty.GetElementType());
 
@@ -1453,8 +1451,8 @@ public abstract partial class ModelBuilderTest
 
         protected virtual void VerifyOwnedBookLabelModel(IReadOnlyModel model)
         {
-            var bookOwnership1 = model.FindEntityType(typeof(Book)).FindNavigation(nameof(Book.Label)).ForeignKey;
-            var bookOwnership2 = model.FindEntityType(typeof(Book)).FindNavigation(nameof(Book.AlternateLabel)).ForeignKey;
+            var bookOwnership1 = model.FindEntityType(typeof(Book))!.FindNavigation(nameof(Book.Label))!.ForeignKey;
+            var bookOwnership2 = model.FindEntityType(typeof(Book))!.FindNavigation(nameof(Book.AlternateLabel))!.ForeignKey;
 
             Assert.NotSame(bookOwnership1.DeclaringEntityType, bookOwnership2.DeclaringEntityType);
             Assert.Single(bookOwnership1.DeclaringEntityType.GetForeignKeys());
@@ -1463,27 +1461,27 @@ public abstract partial class ModelBuilderTest
             Assert.Null(bookOwnership2.DependentToPrincipal);
 
             var bookLabel1Ownership1 = bookOwnership1.DeclaringEntityType.FindNavigation(
-                nameof(BookLabel.AnotherBookLabel)).ForeignKey;
+                nameof(BookLabel.AnotherBookLabel))!.ForeignKey;
             var bookLabel1Ownership2 = bookOwnership1.DeclaringEntityType.FindNavigation(
-                nameof(BookLabel.SpecialBookLabel)).ForeignKey;
+                nameof(BookLabel.SpecialBookLabel))!.ForeignKey;
             var bookLabel2Ownership1 = bookOwnership2.DeclaringEntityType.FindNavigation(
-                nameof(BookLabel.AnotherBookLabel)).ForeignKey;
+                nameof(BookLabel.AnotherBookLabel))!.ForeignKey;
             var bookLabel2Ownership2 = bookOwnership2.DeclaringEntityType.FindNavigation(
-                nameof(BookLabel.SpecialBookLabel)).ForeignKey;
+                nameof(BookLabel.SpecialBookLabel))!.ForeignKey;
 
             Assert.Null(bookLabel1Ownership1.DependentToPrincipal);
-            Assert.Equal(nameof(SpecialBookLabel.BookLabel), bookLabel1Ownership2.DependentToPrincipal.Name);
+            Assert.Equal(nameof(SpecialBookLabel.BookLabel), bookLabel1Ownership2.DependentToPrincipal!.Name);
             Assert.Null(bookLabel2Ownership1.DependentToPrincipal);
-            Assert.Equal(nameof(SpecialBookLabel.BookLabel), bookLabel2Ownership2.DependentToPrincipal.Name);
+            Assert.Equal(nameof(SpecialBookLabel.BookLabel), bookLabel2Ownership2.DependentToPrincipal!.Name);
 
             var bookLabel1Ownership1Subownership = bookLabel1Ownership1.DeclaringEntityType.FindNavigation(
-                nameof(BookLabel.SpecialBookLabel)).ForeignKey;
+                nameof(BookLabel.SpecialBookLabel))!.ForeignKey;
             var bookLabel1Ownership2Subownership = bookLabel1Ownership2.DeclaringEntityType.FindNavigation(
-                nameof(BookLabel.AnotherBookLabel)).ForeignKey;
+                nameof(BookLabel.AnotherBookLabel))!.ForeignKey;
             var bookLabel2Ownership1Subownership = bookLabel2Ownership1.DeclaringEntityType.FindNavigation(
-                nameof(BookLabel.SpecialBookLabel)).ForeignKey;
+                nameof(BookLabel.SpecialBookLabel))!.ForeignKey;
             var bookLabel2Ownership2Subownership = bookLabel2Ownership2.DeclaringEntityType.FindNavigation(
-                nameof(BookLabel.AnotherBookLabel)).ForeignKey;
+                nameof(BookLabel.AnotherBookLabel))!.ForeignKey;
 
             Assert.NotSame(bookLabel1Ownership1.DeclaringEntityType, bookLabel2Ownership1.DeclaringEntityType);
             Assert.NotSame(bookLabel1Ownership2.DeclaringEntityType, bookLabel2Ownership2.DeclaringEntityType);
@@ -1495,10 +1493,10 @@ public abstract partial class ModelBuilderTest
             Assert.Single(bookLabel1Ownership2Subownership.DeclaringEntityType.GetForeignKeys());
             Assert.Single(bookLabel2Ownership1Subownership.DeclaringEntityType.GetForeignKeys());
             Assert.Single(bookLabel2Ownership2Subownership.DeclaringEntityType.GetForeignKeys());
-            Assert.Equal(nameof(SpecialBookLabel.AnotherBookLabel), bookLabel1Ownership1Subownership.DependentToPrincipal.Name);
-            Assert.Equal(nameof(AnotherBookLabel.SpecialBookLabel), bookLabel1Ownership2Subownership.DependentToPrincipal.Name);
-            Assert.Equal(nameof(SpecialBookLabel.AnotherBookLabel), bookLabel2Ownership1Subownership.DependentToPrincipal.Name);
-            Assert.Equal(nameof(AnotherBookLabel.SpecialBookLabel), bookLabel2Ownership2Subownership.DependentToPrincipal.Name);
+            Assert.Equal(nameof(SpecialBookLabel.AnotherBookLabel), bookLabel1Ownership1Subownership.DependentToPrincipal!.Name);
+            Assert.Equal(nameof(AnotherBookLabel.SpecialBookLabel), bookLabel1Ownership2Subownership.DependentToPrincipal!.Name);
+            Assert.Equal(nameof(SpecialBookLabel.AnotherBookLabel), bookLabel2Ownership1Subownership.DependentToPrincipal!.Name);
+            Assert.Equal(nameof(AnotherBookLabel.SpecialBookLabel), bookLabel2Ownership2Subownership.DependentToPrincipal!.Name);
 
             Assert.Equal(2, model.GetEntityTypes().Count(e => e.ClrType == typeof(BookLabel)));
             Assert.Equal(4, model.GetEntityTypes().Count(e => e.ClrType == typeof(AnotherBookLabel)));
@@ -1531,28 +1529,28 @@ public abstract partial class ModelBuilderTest
 
             var model = modelBuilder.FinalizeModel();
 
-            var bookOwnership = model.FindEntityType(typeof(Book)).FindNavigation(nameof(Book.AlternateLabel)).ForeignKey;
-            Assert.Equal(nameof(BookLabel.Book), bookOwnership.DependentToPrincipal.Name);
+            var bookOwnership = model.FindEntityType(typeof(Book))!.FindNavigation(nameof(Book.AlternateLabel))!.ForeignKey;
+            Assert.Equal(nameof(BookLabel.Book), bookOwnership.DependentToPrincipal!.Name);
 
             var bookLabelOwnership1 = bookOwnership.DeclaringEntityType.FindNavigation(
-                nameof(BookLabel.AnotherBookLabel)).ForeignKey;
+                nameof(BookLabel.AnotherBookLabel))!.ForeignKey;
             var bookLabelOwnership2 = bookOwnership.DeclaringEntityType.FindNavigation(
-                nameof(BookLabel.SpecialBookLabel)).ForeignKey;
+                nameof(BookLabel.SpecialBookLabel))!.ForeignKey;
 
             Assert.Null(bookLabelOwnership1.DependentToPrincipal);
-            Assert.Equal(nameof(SpecialBookLabel.BookLabel), bookLabelOwnership2.DependentToPrincipal.Name);
+            Assert.Equal(nameof(SpecialBookLabel.BookLabel), bookLabelOwnership2.DependentToPrincipal!.Name);
 
             var bookLabel2Ownership1Subownership = bookLabelOwnership1.DeclaringEntityType.FindNavigation(
-                nameof(BookLabel.SpecialBookLabel)).ForeignKey;
+                nameof(BookLabel.SpecialBookLabel))!.ForeignKey;
             var bookLabel2Ownership2Subownership = bookLabelOwnership2.DeclaringEntityType.FindNavigation(
-                nameof(BookLabel.AnotherBookLabel)).ForeignKey;
+                nameof(BookLabel.AnotherBookLabel))!.ForeignKey;
 
             Assert.NotNull(bookLabelOwnership1.DeclaringEntityType.FindNavigation(nameof(BookLabel.Book)));
             Assert.NotNull(bookLabelOwnership2.DeclaringEntityType.FindNavigation(nameof(BookLabel.Book)));
             Assert.NotNull(bookLabel2Ownership1Subownership.DeclaringEntityType.FindNavigation(nameof(BookLabel.Book)));
             Assert.NotNull(bookLabel2Ownership2Subownership.DeclaringEntityType.FindNavigation(nameof(BookLabel.Book)));
-            Assert.Equal(nameof(SpecialBookLabel.AnotherBookLabel), bookLabel2Ownership1Subownership.DependentToPrincipal.Name);
-            Assert.Equal(nameof(AnotherBookLabel.SpecialBookLabel), bookLabel2Ownership2Subownership.DependentToPrincipal.Name);
+            Assert.Equal(nameof(SpecialBookLabel.AnotherBookLabel), bookLabel2Ownership1Subownership.DependentToPrincipal!.Name);
+            Assert.Equal(nameof(AnotherBookLabel.SpecialBookLabel), bookLabel2Ownership2Subownership.DependentToPrincipal!.Name);
 
             Assert.Equal(1, model.GetEntityTypes().Count(e => e.ClrType == typeof(BookLabel)));
             Assert.Equal(2, model.GetEntityTypes().Count(e => e.ClrType == typeof(AnotherBookLabel)));
@@ -1570,9 +1568,9 @@ public abstract partial class ModelBuilderTest
 
             var model = modelBuilder.FinalizeModel();
 
-            var bookLabelOwnership = model.FindEntityType(typeof(BookLabel)).FindNavigation(nameof(BookLabel.AnotherBookLabel))
+            var bookLabelOwnership = model.FindEntityType(typeof(BookLabel))!.FindNavigation(nameof(BookLabel.AnotherBookLabel))!
                 .ForeignKey;
-            var selfOwnership = bookLabelOwnership.DeclaringEntityType.FindNavigation(nameof(BookLabel.AnotherBookLabel)).ForeignKey;
+            var selfOwnership = bookLabelOwnership.DeclaringEntityType.FindNavigation(nameof(BookLabel.AnotherBookLabel))!.ForeignKey;
             Assert.NotSame(selfOwnership.PrincipalEntityType, selfOwnership.DeclaringEntityType);
             Assert.Equal(selfOwnership.PrincipalEntityType.ClrType, selfOwnership.DeclaringEntityType.ClrType);
             Assert.True(selfOwnership.IsOwnership);
@@ -1662,8 +1660,8 @@ public abstract partial class ModelBuilderTest
 
         protected class Department
         {
-            public DepartmentId Id { get; protected set; }
-            public List<DepartmentId> DepartmentIds { get; set; }
+            public DepartmentId Id { get; protected set; } = null!;
+            public List<DepartmentId> DepartmentIds { get; set; } = null!;
         }
 
         protected class DepartmentId
@@ -1679,7 +1677,7 @@ public abstract partial class ModelBuilderTest
         protected class Office
         {
             public int Id { get; protected set; }
-            public List<DepartmentId> DepartmentIds { get; set; }
+            public List<DepartmentId> DepartmentIds { get; set; } = null!;
         }
 
         [Fact]
@@ -1838,13 +1836,13 @@ public abstract partial class ModelBuilderTest
 
             var model = modelBuilder.FinalizeModel();
 
-            var bookLabelOwnership = model.FindEntityType(typeof(Book)).FindNavigation(nameof(Book.Label))
+            var bookLabelOwnership = model.FindEntityType(typeof(Book))!.FindNavigation(nameof(Book.Label))!
                 .ForeignKey;
 
             Assert.True(bookLabelOwnership.IsOwnership);
-            Assert.Equal(nameof(BookLabel.Book), bookLabelOwnership.DependentToPrincipal.Name);
+            Assert.Equal(nameof(BookLabel.Book), bookLabelOwnership.DependentToPrincipal!.Name);
 
-            Assert.Null(model.FindEntityType(typeof(AnotherBookLabel)).BaseType);
+            Assert.Null(model.FindEntityType(typeof(AnotherBookLabel))!.BaseType);
         }
 
         [Fact]
@@ -1882,11 +1880,11 @@ public abstract partial class ModelBuilderTest
 
             var owner = model.FindEntityType(typeof(BillingOwner));
 
-            var bill1 = owner.FindNavigation(nameof(BillingOwner.Bill1)).TargetEntityType;
+            var bill1 = owner!.FindNavigation(nameof(BillingOwner.Bill1))!.TargetEntityType;
             Assert.Equal(2, bill1.GetForeignKeys().Count());
             Assert.Single(bill1.GetIndexes());
 
-            var bill2 = owner.FindNavigation(nameof(BillingOwner.Bill2)).TargetEntityType;
+            var bill2 = owner.FindNavigation(nameof(BillingOwner.Bill2))!.TargetEntityType;
             Assert.Equal(2, bill2.GetForeignKeys().Count());
             Assert.Equal(Fixture.ForeignKeysHaveIndexes ? 1 : 0, bill2.GetIndexes().Count());
         }
@@ -1903,15 +1901,15 @@ public abstract partial class ModelBuilderTest
             Assert.Equal(6, model.GetEntityTypes().Count());
             var owner = model.FindEntityType(typeof(BaseOwner));
 
-            var ownership1 = owner.FindNavigation(nameof(BaseOwner.Owned1)).ForeignKey;
+            var ownership1 = owner!.FindNavigation(nameof(BaseOwner.Owned1))!.ForeignKey;
             var owned1 = ownership1.DeclaringEntityType;
             Assert.True(ownership1.IsOwnership);
             Assert.Same(owner, ownership1.PrincipalEntityType);
 
-            var ownership3 = owner.FindNavigation(nameof(BaseOwner.OwnedWithRef1)).ForeignKey;
+            var ownership3 = owner.FindNavigation(nameof(BaseOwner.OwnedWithRef1))!.ForeignKey;
             var owned3 = ownership3.DeclaringEntityType;
             Assert.True(ownership3.IsOwnership);
-            Assert.Same(owner, ownership3.DependentToPrincipal.TargetEntityType);
+            Assert.Same(owner, ownership3.DependentToPrincipal!.TargetEntityType);
         }
 
         [Fact]
@@ -1934,11 +1932,11 @@ public abstract partial class ModelBuilderTest
                 .Navigation(e => e.OwnedDependent)
                 .UsePropertyAccessMode(PropertyAccessMode.Field);
 
-            var principal = (IReadOnlyEntityType)model.FindEntityType(typeof(OneToOneNavPrincipalOwner));
-            var dependent = (IReadOnlyEntityType)model.FindEntityType(typeof(OwnedNavDependent));
+            var principal = (IReadOnlyEntityType)model.FindEntityType(typeof(OneToOneNavPrincipalOwner))!;
+            var dependent = (IReadOnlyEntityType)model.FindEntityType(typeof(OwnedNavDependent))!;
 
-            Assert.Equal(PropertyAccessMode.Field, principal.FindNavigation("OwnedDependent").GetPropertyAccessMode());
-            Assert.Equal(PropertyAccessMode.Property, dependent.FindNavigation("OneToOneOwner").GetPropertyAccessMode());
+            Assert.Equal(PropertyAccessMode.Field, principal!.FindNavigation("OwnedDependent")!.GetPropertyAccessMode());
+            Assert.Equal(PropertyAccessMode.Property, dependent!.FindNavigation("OneToOneOwner")!.GetPropertyAccessMode());
         }
 
         [Fact]
@@ -1961,11 +1959,11 @@ public abstract partial class ModelBuilderTest
                 .Navigation(e => e.OwnedDependents)
                 .UsePropertyAccessMode(PropertyAccessMode.Field);
 
-            var principal = (IReadOnlyEntityType)model.FindEntityType(typeof(OneToManyNavPrincipalOwner));
-            var dependent = (IReadOnlyEntityType)model.FindEntityType(typeof(OwnedOneToManyNavDependent));
+            var principal = (IReadOnlyEntityType)model.FindEntityType(typeof(OneToManyNavPrincipalOwner))!;
+            var dependent = (IReadOnlyEntityType)model.FindEntityType(typeof(OwnedOneToManyNavDependent))!;
 
-            Assert.Equal(PropertyAccessMode.Field, principal.FindNavigation("OwnedDependents").GetPropertyAccessMode());
-            Assert.Equal(PropertyAccessMode.Property, dependent.FindNavigation("OneToManyOwner").GetPropertyAccessMode());
+            Assert.Equal(PropertyAccessMode.Field, principal!.FindNavigation("OwnedDependents")!.GetPropertyAccessMode());
+            Assert.Equal(PropertyAccessMode.Property, dependent!.FindNavigation("OneToManyOwner")!.GetPropertyAccessMode());
         }
 
         [Fact]
@@ -2167,7 +2165,7 @@ public abstract partial class ModelBuilderTest
 
             Assert.Equal(
                 CoreStrings.ComplexPropertyChainInvalidMember(nameof(Customer.Details), nameof(Customer)),
-                Assert.Throws<InvalidOperationException>(() => modelBuilder.Entity<Customer>().Property(c => c.Details.CustomerId))
+                Assert.Throws<InvalidOperationException>(() => modelBuilder.Entity<Customer>().Property(c => c.Details!.CustomerId))
                     .Message);
         }
 

--- a/test/EFCore.Specification.Tests/ModelBuilding101OneToManyTestBase.cs
+++ b/test/EFCore.Specification.Tests/ModelBuilding101OneToManyTestBase.cs
@@ -7,8 +7,6 @@ using Xunit.Sdk;
 
 namespace Microsoft.EntityFrameworkCore;
 
-#nullable disable
-
 public abstract partial class ModelBuilding101TestBase
 {
     [Fact]
@@ -27,7 +25,7 @@ public abstract partial class ModelBuilding101TestBase
         {
             public int Id { get; set; }
             public int BlogId { get; set; }
-            public Blog Blog { get; set; }
+            public Blog Blog { get; set; } = null!;
         }
 
         public class Context0 : Context101
@@ -87,7 +85,7 @@ public abstract partial class ModelBuilding101TestBase
                 public int BlogId { get; set; }
 
                 [InverseProperty("Posts"), ForeignKey("BlogId"), Required]
-                public Blog Blog { get; set; }
+                public Blog Blog { get; set; } = null!;
             }
 
             public DbSet<Blog> Blogs
@@ -114,7 +112,7 @@ public abstract partial class ModelBuilding101TestBase
         {
             public int Id { get; set; }
             public int? BlogId { get; set; }
-            public Blog Blog { get; set; }
+            public Blog Blog { get; set; } = null!;
         }
 
         public class Context0 : Context101
@@ -174,7 +172,7 @@ public abstract partial class ModelBuilding101TestBase
                 public int? BlogId { get; set; }
 
                 [InverseProperty("Posts"), ForeignKey("BlogId")]
-                public Blog Blog { get; set; }
+                public Blog Blog { get; set; } = null!;
             }
 
             public DbSet<Blog> Blogs
@@ -200,7 +198,7 @@ public abstract partial class ModelBuilding101TestBase
         public class Post
         {
             public int Id { get; set; }
-            public Blog Blog { get; set; }
+            public Blog? Blog { get; set; }
         }
 
         public class Context0 : Context101
@@ -261,7 +259,7 @@ public abstract partial class ModelBuilding101TestBase
                 public int Id { get; set; }
 
                 [Required]
-                public Blog Blog { get; set; }
+                public Blog Blog { get; set; } = null!;
             }
 
             public DbSet<Blog> Blogs
@@ -286,7 +284,7 @@ public abstract partial class ModelBuilding101TestBase
                 public int Id { get; set; }
 
                 [InverseProperty("Posts"), ForeignKey("BlogId"), Required]
-                public Blog Blog { get; set; }
+                public Blog Blog { get; set; } = null!;
             }
 
             public DbSet<Blog> Blogs
@@ -312,7 +310,7 @@ public abstract partial class ModelBuilding101TestBase
         public class Post
         {
             public int Id { get; set; }
-            public Blog Blog { get; set; }
+            public Blog? Blog { get; set; }
         }
 
         public class Context0 : Context101
@@ -369,7 +367,7 @@ public abstract partial class ModelBuilding101TestBase
                 public int Id { get; set; }
 
                 [InverseProperty("Posts"), ForeignKey("BlogId")]
-                public Blog Blog { get; set; }
+                public Blog? Blog { get; set; }
             }
 
             public DbSet<Blog> Blogs
@@ -717,7 +715,7 @@ public abstract partial class ModelBuilding101TestBase
         {
             public int Id { get; set; }
             public int BlogId { get; set; }
-            public Blog Blog { get; set; }
+            public Blog Blog { get; set; } = null!;
         }
 
         public class Context0 : Context101
@@ -774,7 +772,7 @@ public abstract partial class ModelBuilding101TestBase
                 public int BlogId { get; set; }
 
                 [ForeignKey("BlogId")]
-                public Blog Blog { get; set; }
+                public Blog Blog { get; set; } = null!;
             }
 
             public DbSet<Blog> Blogs
@@ -800,7 +798,7 @@ public abstract partial class ModelBuilding101TestBase
         {
             public int Id { get; set; }
             public int? BlogId { get; set; }
-            public Blog Blog { get; set; }
+            public Blog Blog { get; set; } = null!;
         }
 
         public class Context0 : Context101
@@ -857,7 +855,7 @@ public abstract partial class ModelBuilding101TestBase
                 public int? BlogId { get; set; }
 
                 [ForeignKey("BlogId")]
-                public Blog Blog { get; set; }
+                public Blog Blog { get; set; } = null!;
             }
 
             public DbSet<Blog> Blogs
@@ -882,7 +880,7 @@ public abstract partial class ModelBuilding101TestBase
         public class Post
         {
             public int Id { get; set; }
-            public Blog Blog { get; set; }
+            public Blog? Blog { get; set; }
         }
 
         public class Context0 : Context101
@@ -941,7 +939,7 @@ public abstract partial class ModelBuilding101TestBase
                 public int Id { get; set; }
 
                 [Required]
-                public Blog Blog { get; set; }
+                public Blog Blog { get; set; } = null!;
             }
 
             public DbSet<Blog> Blogs
@@ -963,7 +961,7 @@ public abstract partial class ModelBuilding101TestBase
                 public int Id { get; set; }
 
                 [Required, ForeignKey("BlogId")]
-                public Blog Blog { get; set; }
+                public Blog Blog { get; set; } = null!;
             }
 
             public DbSet<Blog> Blogs
@@ -988,7 +986,7 @@ public abstract partial class ModelBuilding101TestBase
         public class Post
         {
             public int Id { get; set; }
-            public Blog Blog { get; set; }
+            public Blog? Blog { get; set; }
         }
 
         public class Context0 : Context101
@@ -1042,7 +1040,7 @@ public abstract partial class ModelBuilding101TestBase
                 public int Id { get; set; }
 
                 [ForeignKey("BlogId")]
-                public Blog Blog { get; set; }
+                public Blog? Blog { get; set; }
             }
 
             public DbSet<Blog> Blogs
@@ -1285,7 +1283,7 @@ public abstract partial class ModelBuilding101TestBase
         {
             public int Id { get; set; }
             public int BlogId { get; set; }
-            public Blog Blog { get; set; }
+            public Blog Blog { get; set; } = null!;
         }
 
         public class Context0 : Context101
@@ -1360,7 +1358,7 @@ public abstract partial class ModelBuilding101TestBase
                 public int BlogId { get; set; }
 
                 [ForeignKey("BlogId"), Required, InverseProperty("Posts")]
-                public Blog Blog { get; set; }
+                public Blog Blog { get; set; } = null!;
             }
 
             public DbSet<Blog> Blogs
@@ -1407,7 +1405,7 @@ public abstract partial class ModelBuilding101TestBase
         {
             public int Id { get; set; }
             public int? BlogId { get; set; }
-            public Blog Blog { get; set; }
+            public Blog Blog { get; set; } = null!;
         }
 
         public class Context0 : Context101
@@ -1466,7 +1464,7 @@ public abstract partial class ModelBuilding101TestBase
                 public int? BlogId { get; set; }
 
                 [InverseProperty("Posts"), ForeignKey("BlogId")]
-                public Blog Blog { get; set; }
+                public Blog Blog { get; set; } = null!;
             }
 
             public DbSet<Blog> Blogs
@@ -1499,7 +1497,7 @@ public abstract partial class ModelBuilding101TestBase
         public class Post
         {
             public int Id { get; set; }
-            public Blog Blog { get; set; }
+            public Blog? Blog { get; set; }
         }
 
         public class Context0 : Context101
@@ -1554,7 +1552,7 @@ public abstract partial class ModelBuilding101TestBase
                 public int Id { get; set; }
 
                 [Required]
-                public Blog Blog { get; set; }
+                public Blog Blog { get; set; } = null!;
             }
 
             public DbSet<Blog> Blogs
@@ -1586,7 +1584,7 @@ public abstract partial class ModelBuilding101TestBase
                 public int Id { get; set; }
 
                 [Required, ForeignKey("BlogAlternateId"), InverseProperty("Posts")]
-                public Blog Blog { get; set; }
+                public Blog Blog { get; set; } = null!;
             }
 
             public DbSet<Blog> Blogs
@@ -1619,7 +1617,7 @@ public abstract partial class ModelBuilding101TestBase
         public class Post
         {
             public int Id { get; set; }
-            public Blog Blog { get; set; }
+            public Blog Blog { get; set; } = null!;
         }
 
         public class Context0 : Context101
@@ -1675,7 +1673,7 @@ public abstract partial class ModelBuilding101TestBase
                 public int Id { get; set; }
 
                 [ForeignKey("BlogAlternateId"), InverseProperty("Posts")]
-                public Blog Blog { get; set; }
+                public Blog Blog { get; set; } = null!;
             }
 
             public DbSet<Blog> Blogs
@@ -1710,7 +1708,7 @@ public abstract partial class ModelBuilding101TestBase
             public int Id { get; set; }
             public int BlogId1 { get; set; }
             public int BlogId2 { get; set; }
-            public Blog Blog { get; set; }
+            public Blog Blog { get; set; } = null!;
         }
 
         public class Context0 : Context101
@@ -1785,7 +1783,7 @@ public abstract partial class ModelBuilding101TestBase
                 public int Id { get; set; }
                 public int BlogId1 { get; set; }
                 public int BlogId2 { get; set; }
-                public Blog Blog { get; set; }
+                public Blog Blog { get; set; } = null!;
             }
 
             public DbSet<Blog> Blogs
@@ -1814,7 +1812,7 @@ public abstract partial class ModelBuilding101TestBase
                 public int BlogId2 { get; set; }
 
                 [ForeignKey("BlogId1, BlogId2"), InverseProperty("Posts"), Required]
-                public Blog Blog { get; set; }
+                public Blog Blog { get; set; } = null!;
             }
 
             public DbSet<Blog> Blogs
@@ -1843,7 +1841,7 @@ public abstract partial class ModelBuilding101TestBase
             public int Id { get; set; }
             public int BlogId1 { get; set; }
             public int? BlogId2 { get; set; }
-            public Blog Blog { get; set; }
+            public Blog Blog { get; set; } = null!;
         }
 
         public class Context0 : Context101
@@ -1917,7 +1915,7 @@ public abstract partial class ModelBuilding101TestBase
                 public int Id { get; set; }
                 public int BlogId1 { get; set; }
                 public int? BlogId2 { get; set; }
-                public Blog Blog { get; set; }
+                public Blog Blog { get; set; } = null!;
             }
 
             public DbSet<Blog> Blogs
@@ -1946,7 +1944,7 @@ public abstract partial class ModelBuilding101TestBase
                 public int? BlogId2 { get; set; }
 
                 [InverseProperty("Posts"), ForeignKey("BlogId1, BlogId2")]
-                public Blog Blog { get; set; }
+                public Blog Blog { get; set; } = null!;
             }
 
             public DbSet<Blog> Blogs
@@ -1973,7 +1971,7 @@ public abstract partial class ModelBuilding101TestBase
         public class Post
         {
             public int Id { get; set; }
-            public Blog Blog { get; set; }
+            public Blog Blog { get; set; } = null!;
         }
 
         public class Context0 : Context101
@@ -2056,7 +2054,7 @@ public abstract partial class ModelBuilding101TestBase
                 public int Id { get; set; }
 
                 [Required]
-                public Blog Blog { get; set; }
+                public Blog Blog { get; set; } = null!;
             }
 
             public DbSet<Blog> Blogs
@@ -2083,7 +2081,7 @@ public abstract partial class ModelBuilding101TestBase
                 public int Id { get; set; }
 
                 [Required, ForeignKey("BlogId1, BlogId2"), InverseProperty("Posts")]
-                public Blog Blog { get; set; }
+                public Blog Blog { get; set; } = null!;
             }
 
             public DbSet<Blog> Blogs
@@ -2110,7 +2108,7 @@ public abstract partial class ModelBuilding101TestBase
         public class Post
         {
             public int Id { get; set; }
-            public Blog Blog { get; set; }
+            public Blog? Blog { get; set; }
         }
 
         public class Context0 : Context101
@@ -2182,7 +2180,7 @@ public abstract partial class ModelBuilding101TestBase
             public class Post
             {
                 public int Id { get; set; }
-                public Blog Blog { get; set; }
+                public Blog? Blog { get; set; }
             }
 
             public DbSet<Blog> Blogs
@@ -2209,7 +2207,7 @@ public abstract partial class ModelBuilding101TestBase
                 public int Id { get; set; }
 
                 [InverseProperty("Posts"), ForeignKey("BlogId1, BlogId2")]
-                public Blog Blog { get; set; }
+                public Blog? Blog { get; set; }
             }
 
             public DbSet<Blog> Blogs
@@ -2231,7 +2229,7 @@ public abstract partial class ModelBuilding101TestBase
             public int Id { get; set; }
 
             public int? ManagerId { get; set; }
-            public Employee Manager { get; set; }
+            public Employee Manager { get; set; } = null!;
             public ICollection<Employee> Reports { get; } = [];
         }
 
@@ -2270,7 +2268,7 @@ public abstract partial class ModelBuilding101TestBase
                 public int? ManagerId { get; set; }
 
                 [InverseProperty("Reports"), ForeignKey("ManagerId")]
-                public Employee Manager { get; set; }
+                public Employee Manager { get; set; } = null!;
 
                 [InverseProperty("Manager")]
                 public ICollection<Employee> Reports { get; } = [];
@@ -2297,7 +2295,7 @@ public abstract partial class ModelBuilding101TestBase
         {
             public int Id { get; set; }
             public int BlogId { get; set; }
-            public Blog Blog { get; set; }
+            public Blog Blog { get; set; } = null!;
         }
 
         public class Context0 : Context101
@@ -2353,7 +2351,7 @@ public abstract partial class ModelBuilding101TestBase
                 public int BlogId { get; set; }
 
                 [DeleteBehavior(DeleteBehavior.Restrict)]
-                public Blog Blog { get; set; }
+                public Blog Blog { get; set; } = null!;
             }
 
             public DbSet<Blog> Blogs
@@ -2381,7 +2379,7 @@ public abstract partial class ModelBuilding101TestBase
                 public int BlogId { get; set; }
 
                 [DeleteBehavior(DeleteBehavior.Restrict), InverseProperty("Posts"), Required, ForeignKey("BlogId")]
-                public Blog Blog { get; set; }
+                public Blog Blog { get; set; } = null!;
             }
 
             public DbSet<Blog> Blogs

--- a/test/EFCore.Specification.Tests/ModelBuilding101OneToOneTestBase.cs
+++ b/test/EFCore.Specification.Tests/ModelBuilding101OneToOneTestBase.cs
@@ -7,8 +7,6 @@ using Xunit.Sdk;
 
 namespace Microsoft.EntityFrameworkCore;
 
-#nullable disable
-
 public abstract partial class ModelBuilding101TestBase
 {
     [Fact]
@@ -20,14 +18,14 @@ public abstract partial class ModelBuilding101TestBase
         public class Blog
         {
             public int Id { get; set; }
-            public BlogHeader Header { get; set; }
+            public BlogHeader Header { get; set; } = null!;
         }
 
         public class BlogHeader
         {
             public int Id { get; set; }
             public int BlogId { get; set; }
-            public Blog Blog { get; set; }
+            public Blog Blog { get; set; } = null!;
         }
 
         public class BlogContext0 : Context101
@@ -72,7 +70,7 @@ public abstract partial class ModelBuilding101TestBase
                 public int Id { get; set; }
 
                 [InverseProperty("Blog")]
-                public BlogHeader Header { get; set; }
+                public BlogHeader Header { get; set; } = null!;
             }
 
             public class BlogHeader
@@ -83,7 +81,7 @@ public abstract partial class ModelBuilding101TestBase
                 public int BlogId { get; set; }
 
                 [InverseProperty("Header"), ForeignKey("BlogId"), Required]
-                public Blog Blog { get; set; }
+                public Blog Blog { get; set; } = null!;
             }
         }
     }
@@ -97,14 +95,14 @@ public abstract partial class ModelBuilding101TestBase
         public class Blog
         {
             public int Id { get; set; }
-            public BlogHeader Header { get; set; }
+            public BlogHeader Header { get; set; } = null!;
         }
 
         public class BlogHeader
         {
             public int Id { get; set; }
             public int? BlogId { get; set; }
-            public Blog Blog { get; set; }
+            public Blog Blog { get; set; } = null!;
         }
 
         public class BlogContext0 : Context101
@@ -143,7 +141,7 @@ public abstract partial class ModelBuilding101TestBase
                 public int Id { get; set; }
 
                 [InverseProperty("Blog")]
-                public BlogHeader Header { get; set; }
+                public BlogHeader Header { get; set; } = null!;
             }
 
             public class BlogHeader
@@ -154,7 +152,7 @@ public abstract partial class ModelBuilding101TestBase
                 public int? BlogId { get; set; }
 
                 [InverseProperty("Header"), ForeignKey("BlogId")]
-                public Blog Blog { get; set; }
+                public Blog Blog { get; set; } = null!;
             }
 
             public DbSet<Blog> Blogs
@@ -174,13 +172,13 @@ public abstract partial class ModelBuilding101TestBase
         public class Blog
         {
             public int Id { get; set; }
-            public BlogHeader Header { get; set; }
+            public BlogHeader Header { get; set; } = null!;
         }
 
         public class BlogHeader
         {
             public int Id { get; set; }
-            public Blog Blog { get; set; }
+            public Blog Blog { get; set; } = null!;
         }
 
         public class BlogContext0 : Context101
@@ -225,7 +223,7 @@ public abstract partial class ModelBuilding101TestBase
             {
                 public int Id { get; set; }
 
-                public BlogHeader Header { get; set; }
+                public BlogHeader Header { get; set; } = null!;
             }
 
             public class BlogHeader
@@ -233,7 +231,7 @@ public abstract partial class ModelBuilding101TestBase
                 public int Id { get; set; }
 
                 [ForeignKey("Id"), Required]
-                public Blog Blog { get; set; }
+                public Blog Blog { get; set; } = null!;
             }
 
             public DbSet<Blog> Blogs
@@ -250,7 +248,7 @@ public abstract partial class ModelBuilding101TestBase
                 public int Id { get; set; }
 
                 [InverseProperty("Blog")]
-                public BlogHeader Header { get; set; }
+                public BlogHeader Header { get; set; } = null!;
             }
 
             public class BlogHeader
@@ -258,7 +256,7 @@ public abstract partial class ModelBuilding101TestBase
                 public int Id { get; set; }
 
                 [InverseProperty("Header"), ForeignKey("Id"), Required]
-                public Blog Blog { get; set; }
+                public Blog Blog { get; set; } = null!;
             }
 
             public DbSet<Blog> Blogs
@@ -278,13 +276,13 @@ public abstract partial class ModelBuilding101TestBase
         public class Blog
         {
             public int Id { get; set; }
-            public BlogHeader Header { get; set; }
+            public BlogHeader Header { get; set; } = null!;
         }
 
         public class BlogHeader
         {
             public int Id { get; set; }
-            public Blog Blog { get; set; }
+            public Blog Blog { get; set; } = null!;
         }
 
         public class BlogContext0 : Context101
@@ -328,7 +326,7 @@ public abstract partial class ModelBuilding101TestBase
             public class Blog
             {
                 public int Id { get; set; }
-                public BlogHeader Header { get; set; }
+                public BlogHeader Header { get; set; } = null!;
             }
 
             public class BlogHeader
@@ -336,7 +334,7 @@ public abstract partial class ModelBuilding101TestBase
                 public int Id { get; set; }
 
                 [ForeignKey("BlogId"), Required]
-                public Blog Blog { get; set; }
+                public Blog Blog { get; set; } = null!;
             }
 
             public DbSet<Blog> Blogs
@@ -353,7 +351,7 @@ public abstract partial class ModelBuilding101TestBase
                 public int Id { get; set; }
 
                 [InverseProperty("Blog")]
-                public BlogHeader Header { get; set; }
+                public BlogHeader Header { get; set; } = null!;
             }
 
             public class BlogHeader
@@ -361,7 +359,7 @@ public abstract partial class ModelBuilding101TestBase
                 public int Id { get; set; }
 
                 [InverseProperty("Header"), ForeignKey("BlogId"), Required]
-                public Blog Blog { get; set; }
+                public Blog Blog { get; set; } = null!;
             }
 
             public DbSet<Blog> Blogs
@@ -381,13 +379,13 @@ public abstract partial class ModelBuilding101TestBase
         public class Blog
         {
             public int Id { get; set; }
-            public BlogHeader Header { get; set; }
+            public BlogHeader? Header { get; set; }
         }
 
         public class BlogHeader
         {
             public int Id { get; set; }
-            public Blog Blog { get; set; }
+            public Blog? Blog { get; set; }
         }
 
         public class BlogContext0 : Context101
@@ -430,7 +428,7 @@ public abstract partial class ModelBuilding101TestBase
             public class Blog
             {
                 public int Id { get; set; }
-                public BlogHeader Header { get; set; }
+                public BlogHeader? Header { get; set; }
             }
 
             public class BlogHeader
@@ -438,7 +436,7 @@ public abstract partial class ModelBuilding101TestBase
                 public int Id { get; set; }
 
                 [ForeignKey("BlogId")]
-                public Blog Blog { get; set; }
+                public Blog? Blog { get; set; }
             }
 
             public DbSet<Blog> Blogs
@@ -455,7 +453,7 @@ public abstract partial class ModelBuilding101TestBase
                 public int Id { get; set; }
 
                 [InverseProperty("Blog")]
-                public BlogHeader Header { get; set; }
+                public BlogHeader? Header { get; set; }
             }
 
             public class BlogHeader
@@ -463,7 +461,7 @@ public abstract partial class ModelBuilding101TestBase
                 public int Id { get; set; }
 
                 [InverseProperty("Header"), ForeignKey("BlogId")]
-                public Blog Blog { get; set; }
+                public Blog? Blog { get; set; }
             }
 
             public DbSet<Blog> Blogs
@@ -483,7 +481,7 @@ public abstract partial class ModelBuilding101TestBase
         public class Blog
         {
             public int Id { get; set; }
-            public BlogHeader Header { get; set; }
+            public BlogHeader Header { get; set; } = null!;
         }
 
         public class BlogHeader
@@ -526,7 +524,7 @@ public abstract partial class ModelBuilding101TestBase
             public class Blog
             {
                 public int Id { get; set; }
-                public BlogHeader Header { get; set; }
+                public BlogHeader Header { get; set; } = null!;
             }
 
             public class BlogHeader
@@ -554,7 +552,7 @@ public abstract partial class ModelBuilding101TestBase
         public class Blog
         {
             public int Id { get; set; }
-            public BlogHeader Header { get; set; }
+            public BlogHeader Header { get; set; } = null!;
         }
 
         public class BlogHeader
@@ -602,7 +600,7 @@ public abstract partial class ModelBuilding101TestBase
         public class Blog
         {
             public int Id { get; set; }
-            public BlogHeader Header { get; set; }
+            public BlogHeader Header { get; set; } = null!;
         }
 
         public class BlogHeader
@@ -656,7 +654,7 @@ public abstract partial class ModelBuilding101TestBase
         public class Blog
         {
             public int Id { get; set; }
-            public BlogHeader Header { get; set; }
+            public BlogHeader Header { get; set; } = null!;
         }
 
         public class BlogHeader
@@ -715,7 +713,7 @@ public abstract partial class ModelBuilding101TestBase
         {
             public int Id { get; set; }
             public int BlogId { get; set; }
-            public Blog Blog { get; set; }
+            public Blog Blog { get; set; } = null!;
         }
 
         public class BlogContext0 : Context101
@@ -767,7 +765,7 @@ public abstract partial class ModelBuilding101TestBase
                 public int BlogId { get; set; }
 
                 [ForeignKey("BlogId"), Required]
-                public Blog Blog { get; set; }
+                public Blog Blog { get; set; } = null!;
             }
 
             public DbSet<Blog> Blogs
@@ -798,7 +796,7 @@ public abstract partial class ModelBuilding101TestBase
         {
             public int Id { get; set; }
             public int? BlogId { get; set; }
-            public Blog Blog { get; set; }
+            public Blog Blog { get; set; } = null!;
         }
 
         public class BlogContext0 : Context101
@@ -850,7 +848,7 @@ public abstract partial class ModelBuilding101TestBase
                 public int? BlogId { get; set; }
 
                 [ForeignKey("BlogId")]
-                public Blog Blog { get; set; }
+                public Blog Blog { get; set; } = null!;
             }
 
             public DbSet<Blog> Blogs
@@ -880,7 +878,7 @@ public abstract partial class ModelBuilding101TestBase
         public class BlogHeader
         {
             public int Id { get; set; }
-            public Blog Blog { get; set; }
+            public Blog? Blog { get; set; }
         }
 
         public class BlogContext0 : Context101
@@ -931,7 +929,7 @@ public abstract partial class ModelBuilding101TestBase
                 public int Id { get; set; }
 
                 [ForeignKey("BlogId"), Required]
-                public Blog Blog { get; set; }
+                public Blog Blog { get; set; } = null!;
             }
 
             public DbSet<Blog> Blogs
@@ -961,7 +959,7 @@ public abstract partial class ModelBuilding101TestBase
         public class BlogHeader
         {
             public int Id { get; set; }
-            public Blog Blog { get; set; }
+            public Blog? Blog { get; set; }
         }
 
         public class BlogContext0 : Context101
@@ -1011,7 +1009,7 @@ public abstract partial class ModelBuilding101TestBase
                 public int Id { get; set; }
 
                 [ForeignKey("BlogId")]
-                public Blog Blog { get; set; }
+                public Blog? Blog { get; set; }
             }
 
             public DbSet<Blog> Blogs
@@ -1273,14 +1271,14 @@ public abstract partial class ModelBuilding101TestBase
         {
             public int Id { get; set; }
             public int AlternateId { get; set; }
-            public BlogHeader Header { get; set; }
+            public BlogHeader Header { get; set; } = null!;
         }
 
         public class BlogHeader
         {
             public int Id { get; set; }
             public int BlogId { get; set; }
-            public Blog Blog { get; set; }
+            public Blog Blog { get; set; } = null!;
         }
 
         public class BlogContext0 : Context101
@@ -1328,7 +1326,7 @@ public abstract partial class ModelBuilding101TestBase
                 public int AlternateId { get; set; }
 
                 [InverseProperty("Blog")]
-                public BlogHeader Header { get; set; }
+                public BlogHeader Header { get; set; } = null!;
             }
 
             public class BlogHeader
@@ -1339,7 +1337,7 @@ public abstract partial class ModelBuilding101TestBase
                 public int BlogId { get; set; }
 
                 [InverseProperty("Header"), ForeignKey("BlogId"), Required]
-                public Blog Blog { get; set; }
+                public Blog Blog { get; set; } = null!;
             }
 
             public DbSet<Blog> Blogs
@@ -1366,14 +1364,14 @@ public abstract partial class ModelBuilding101TestBase
         {
             public int Id { get; set; }
             public int AlternateId { get; set; }
-            public BlogHeader Header { get; set; }
+            public BlogHeader Header { get; set; } = null!;
         }
 
         public class BlogHeader
         {
             public int Id { get; set; }
             public int? BlogId { get; set; }
-            public Blog Blog { get; set; }
+            public Blog Blog { get; set; } = null!;
         }
 
         public class BlogContext0 : Context101
@@ -1421,7 +1419,7 @@ public abstract partial class ModelBuilding101TestBase
                 public int AlternateId { get; set; }
 
                 [InverseProperty("Blog")]
-                public BlogHeader Header { get; set; }
+                public BlogHeader Header { get; set; } = null!;
             }
 
             public class BlogHeader
@@ -1432,7 +1430,7 @@ public abstract partial class ModelBuilding101TestBase
                 public int? BlogId { get; set; }
 
                 [InverseProperty("Header"), ForeignKey("BlogId")]
-                public Blog Blog { get; set; }
+                public Blog Blog { get; set; } = null!;
             }
 
             public DbSet<Blog> Blogs
@@ -1459,13 +1457,13 @@ public abstract partial class ModelBuilding101TestBase
         {
             public int Id { get; set; }
             public int AlternateId { get; set; }
-            public BlogHeader Header { get; set; }
+            public BlogHeader Header { get; set; } = null!;
         }
 
         public class BlogHeader
         {
             public int Id { get; set; }
-            public Blog Blog { get; set; }
+            public Blog Blog { get; set; } = null!;
         }
 
         public class BlogContext0 : Context101
@@ -1512,7 +1510,7 @@ public abstract partial class ModelBuilding101TestBase
             {
                 public int Id { get; set; }
                 public int AlternateId { get; set; }
-                public BlogHeader Header { get; set; }
+                public BlogHeader Header { get; set; } = null!;
             }
 
             public class BlogHeader
@@ -1520,7 +1518,7 @@ public abstract partial class ModelBuilding101TestBase
                 public int Id { get; set; }
 
                 [Required]
-                public Blog Blog { get; set; }
+                public Blog Blog { get; set; } = null!;
             }
 
             public DbSet<Blog> Blogs
@@ -1544,7 +1542,7 @@ public abstract partial class ModelBuilding101TestBase
                 public int AlternateId { get; set; }
 
                 [InverseProperty("Blog")]
-                public BlogHeader Header { get; set; }
+                public BlogHeader Header { get; set; } = null!;
             }
 
             public class BlogHeader
@@ -1552,7 +1550,7 @@ public abstract partial class ModelBuilding101TestBase
                 public int Id { get; set; }
 
                 [InverseProperty("Header"), ForeignKey("BlogId"), Required]
-                public Blog Blog { get; set; }
+                public Blog Blog { get; set; } = null!;
             }
 
             public DbSet<Blog> Blogs
@@ -1579,13 +1577,13 @@ public abstract partial class ModelBuilding101TestBase
         {
             public int Id { get; set; }
             public int AlternateId { get; set; }
-            public BlogHeader Header { get; set; }
+            public BlogHeader Header { get; set; } = null!;
         }
 
         public class BlogHeader
         {
             public int Id { get; set; }
-            public Blog Blog { get; set; }
+            public Blog Blog { get; set; } = null!;
         }
 
         public class BlogContext0 : Context101
@@ -1633,7 +1631,7 @@ public abstract partial class ModelBuilding101TestBase
                 public int AlternateId { get; set; }
 
                 [InverseProperty("Blog")]
-                public BlogHeader Header { get; set; }
+                public BlogHeader Header { get; set; } = null!;
             }
 
             public class BlogHeader
@@ -1641,7 +1639,7 @@ public abstract partial class ModelBuilding101TestBase
                 public int Id { get; set; }
 
                 [InverseProperty("Header"), ForeignKey("BlogId")]
-                public Blog Blog { get; set; }
+                public Blog Blog { get; set; } = null!;
             }
 
             public DbSet<Blog> Blogs
@@ -1668,7 +1666,7 @@ public abstract partial class ModelBuilding101TestBase
         {
             public int Id1 { get; set; }
             public int Id2 { get; set; }
-            public BlogHeader Header { get; set; }
+            public BlogHeader Header { get; set; } = null!;
         }
 
         public class BlogHeader
@@ -1676,7 +1674,7 @@ public abstract partial class ModelBuilding101TestBase
             public int Id { get; set; }
             public int BlogId1 { get; set; }
             public int BlogId2 { get; set; }
-            public Blog Blog { get; set; }
+            public Blog Blog { get; set; } = null!;
         }
 
         public class BlogContext0 : Context101
@@ -1730,7 +1728,7 @@ public abstract partial class ModelBuilding101TestBase
             {
                 public int Id1 { get; set; }
                 public int Id2 { get; set; }
-                public BlogHeader Header { get; set; }
+                public BlogHeader Header { get; set; } = null!;
             }
 
             public class BlogHeader
@@ -1740,7 +1738,7 @@ public abstract partial class ModelBuilding101TestBase
                 public int BlogId2 { get; set; }
 
                 [ForeignKey("BlogId1, BlogId2")]
-                public Blog Blog { get; set; }
+                public Blog Blog { get; set; } = null!;
             }
 
             public DbSet<Blog> Blogs
@@ -1759,7 +1757,7 @@ public abstract partial class ModelBuilding101TestBase
                 public int Id2 { get; set; }
 
                 [InverseProperty("Blog")]
-                public BlogHeader Header { get; set; }
+                public BlogHeader Header { get; set; } = null!;
             }
 
             public class BlogHeader
@@ -1773,7 +1771,7 @@ public abstract partial class ModelBuilding101TestBase
                 public int BlogId2 { get; set; }
 
                 [InverseProperty("Header"), ForeignKey("BlogId1, BlogId2"), Required]
-                public Blog Blog { get; set; }
+                public Blog Blog { get; set; } = null!;
             }
 
             public DbSet<Blog> Blogs
@@ -1794,7 +1792,7 @@ public abstract partial class ModelBuilding101TestBase
         {
             public int Id1 { get; set; }
             public int Id2 { get; set; }
-            public BlogHeader Header { get; set; }
+            public BlogHeader Header { get; set; } = null!;
         }
 
         public class BlogHeader
@@ -1802,7 +1800,7 @@ public abstract partial class ModelBuilding101TestBase
             public int Id { get; set; }
             public int BlogId1 { get; set; }
             public int? BlogId2 { get; set; }
-            public Blog Blog { get; set; }
+            public Blog Blog { get; set; } = null!;
         }
 
         public class BlogContext0 : Context101
@@ -1856,7 +1854,7 @@ public abstract partial class ModelBuilding101TestBase
             {
                 public int Id1 { get; set; }
                 public int Id2 { get; set; }
-                public BlogHeader Header { get; set; }
+                public BlogHeader Header { get; set; } = null!;
             }
 
             public class BlogHeader
@@ -1866,7 +1864,7 @@ public abstract partial class ModelBuilding101TestBase
                 public int? BlogId2 { get; set; }
 
                 [ForeignKey("BlogId1, BlogId2")]
-                public Blog Blog { get; set; }
+                public Blog Blog { get; set; } = null!;
             }
 
             public DbSet<Blog> Blogs
@@ -1885,7 +1883,7 @@ public abstract partial class ModelBuilding101TestBase
                 public int Id2 { get; set; }
 
                 [InverseProperty("Blog")]
-                public BlogHeader Header { get; set; }
+                public BlogHeader Header { get; set; } = null!;
             }
 
             public class BlogHeader
@@ -1898,7 +1896,7 @@ public abstract partial class ModelBuilding101TestBase
                 public int? BlogId2 { get; set; }
 
                 [InverseProperty("Header"), ForeignKey("BlogId1, BlogId2")]
-                public Blog Blog { get; set; }
+                public Blog Blog { get; set; } = null!;
             }
 
             public DbSet<Blog> Blogs
@@ -1919,13 +1917,13 @@ public abstract partial class ModelBuilding101TestBase
         {
             public int Id1 { get; set; }
             public int Id2 { get; set; }
-            public BlogHeader Header { get; set; }
+            public BlogHeader Header { get; set; } = null!;
         }
 
         public class BlogHeader
         {
             public int Id { get; set; }
-            public Blog Blog { get; set; }
+            public Blog Blog { get; set; } = null!;
         }
 
         public class BlogContext0 : Context101
@@ -1986,7 +1984,7 @@ public abstract partial class ModelBuilding101TestBase
             {
                 public int Id1 { get; set; }
                 public int Id2 { get; set; }
-                public BlogHeader Header { get; set; }
+                public BlogHeader Header { get; set; } = null!;
             }
 
             public class BlogHeader
@@ -1994,7 +1992,7 @@ public abstract partial class ModelBuilding101TestBase
                 public int Id { get; set; }
 
                 [ForeignKey("BlogId1, BlogId2"), Required]
-                public Blog Blog { get; set; }
+                public Blog Blog { get; set; } = null!;
             }
 
             public DbSet<Blog> Blogs
@@ -2013,7 +2011,7 @@ public abstract partial class ModelBuilding101TestBase
                 public int Id2 { get; set; }
 
                 [InverseProperty("Blog")]
-                public BlogHeader Header { get; set; }
+                public BlogHeader Header { get; set; } = null!;
             }
 
             public class BlogHeader
@@ -2021,7 +2019,7 @@ public abstract partial class ModelBuilding101TestBase
                 public int Id { get; set; }
 
                 [InverseProperty("Header"), ForeignKey("BlogId1, BlogId2"), Required]
-                public Blog Blog { get; set; }
+                public Blog Blog { get; set; } = null!;
             }
 
             public DbSet<Blog> Blogs
@@ -2042,13 +2040,13 @@ public abstract partial class ModelBuilding101TestBase
         {
             public int Id1 { get; set; }
             public int Id2 { get; set; }
-            public BlogHeader Header { get; set; }
+            public BlogHeader? Header { get; set; }
         }
 
         public class BlogHeader
         {
             public int Id { get; set; }
-            public Blog Blog { get; set; }
+            public Blog? Blog { get; set; }
         }
 
         public class BlogContext0 : Context101
@@ -2108,7 +2106,7 @@ public abstract partial class ModelBuilding101TestBase
             {
                 public int Id1 { get; set; }
                 public int Id2 { get; set; }
-                public BlogHeader Header { get; set; }
+                public BlogHeader? Header { get; set; }
             }
 
             public class BlogHeader
@@ -2116,7 +2114,7 @@ public abstract partial class ModelBuilding101TestBase
                 public int Id { get; set; }
 
                 [ForeignKey("BlogId1, BlogId2")]
-                public Blog Blog { get; set; }
+                public Blog? Blog { get; set; }
             }
 
             public DbSet<Blog> Blogs
@@ -2135,7 +2133,7 @@ public abstract partial class ModelBuilding101TestBase
                 public int Id2 { get; set; }
 
                 [InverseProperty("Blog")]
-                public BlogHeader Header { get; set; }
+                public BlogHeader? Header { get; set; }
             }
 
             public class BlogHeader
@@ -2143,7 +2141,7 @@ public abstract partial class ModelBuilding101TestBase
                 public int Id { get; set; }
 
                 [InverseProperty("Header"), ForeignKey("BlogId1, BlogId2")]
-                public Blog Blog { get; set; }
+                public Blog? Blog { get; set; }
             }
 
             public DbSet<Blog> Blogs
@@ -2165,8 +2163,8 @@ public abstract partial class ModelBuilding101TestBase
             public int Id { get; set; }
 
             public int? HusbandId { get; set; }
-            public Person Husband { get; set; }
-            public Person Wife { get; set; }
+            public Person Husband { get; set; } = null!;
+            public Person Wife { get; set; } = null!;
         }
 
         public class PersonContext0 : Context101
@@ -2203,10 +2201,10 @@ public abstract partial class ModelBuilding101TestBase
                 public int? HusbandId { get; set; }
 
                 [InverseProperty("Wife"), ForeignKey("HusbandId")]
-                public Person Husband { get; set; }
+                public Person Husband { get; set; } = null!;
 
                 [InverseProperty("Husband")]
-                public Person Wife { get; set; }
+                public Person Wife { get; set; } = null!;
             }
 
             public DbSet<Person> People
@@ -2223,14 +2221,14 @@ public abstract partial class ModelBuilding101TestBase
         public class Blog
         {
             public int Id { get; set; }
-            public BlogHeader Header { get; set; }
+            public BlogHeader Header { get; set; } = null!;
         }
 
         public class BlogHeader
         {
             public int Id { get; set; }
             public int BlogId { get; set; }
-            public Blog Blog { get; set; }
+            public Blog Blog { get; set; } = null!;
         }
 
         public class BlogContext0 : Context101
@@ -2275,7 +2273,7 @@ public abstract partial class ModelBuilding101TestBase
             public class Blog
             {
                 public int Id { get; set; }
-                public BlogHeader Header { get; set; }
+                public BlogHeader Header { get; set; } = null!;
             }
 
             public class BlogHeader
@@ -2284,7 +2282,7 @@ public abstract partial class ModelBuilding101TestBase
                 public int BlogId { get; set; }
 
                 [DeleteBehavior(DeleteBehavior.Restrict)]
-                public Blog Blog { get; set; }
+                public Blog Blog { get; set; } = null!;
             }
 
             public DbSet<Blog> Blogs
@@ -2301,7 +2299,7 @@ public abstract partial class ModelBuilding101TestBase
                 public int Id { get; set; }
 
                 [InverseProperty("Blog")]
-                public BlogHeader Header { get; set; }
+                public BlogHeader Header { get; set; } = null!;
             }
 
             public class BlogHeader
@@ -2312,7 +2310,7 @@ public abstract partial class ModelBuilding101TestBase
                 public int BlogId { get; set; }
 
                 [InverseProperty("Header"), ForeignKey("BlogId"), Required, DeleteBehavior(DeleteBehavior.Restrict)]
-                public Blog Blog { get; set; }
+                public Blog Blog { get; set; } = null!;
             }
 
             public DbSet<Blog> Blogs

--- a/test/EFCore.Specification.Tests/ModelBuilding101TestBase.cs
+++ b/test/EFCore.Specification.Tests/ModelBuilding101TestBase.cs
@@ -5,8 +5,6 @@ using System.Runtime.CompilerServices;
 
 namespace Microsoft.EntityFrameworkCore;
 
-#nullable disable
-
 public abstract partial class ModelBuilding101TestBase
 {
     protected virtual void Model101Test([CallerMemberName] string testMame = "")
@@ -14,11 +12,11 @@ public abstract partial class ModelBuilding101TestBase
         var models = new List<ModelMetadata>();
         var testTypeName = "Microsoft.EntityFrameworkCore.ModelBuilding101TestBase+" + testMame[..^4];
 
-        foreach (Context101 context in Type.GetType(testTypeName, throwOnError: true)!.GetNestedTypes()
+        foreach (var context in Type.GetType(testTypeName, throwOnError: true)!.GetNestedTypes()
                      .Where(t => t.IsAssignableTo(typeof(DbContext)))
-                     .Select(Activator.CreateInstance))
+                 .Select(t => (Context101)Activator.CreateInstance(t)!))
         {
-            context.ConfigureAction = b => ConfigureContext(b);
+            context!.ConfigureAction = b => ConfigureContext(b);
             models.Add(GetModelMetadata(context));
             context.Dispose();
         }
@@ -42,7 +40,7 @@ public abstract partial class ModelBuilding101TestBase
         protected bool Equals(ModelMetadata other)
             => ModelDebugView == other.ModelDebugView;
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => !ReferenceEquals(null, obj)
                 && (ReferenceEquals(this, obj)
                     || (obj.GetType() == GetType()
@@ -54,7 +52,7 @@ public abstract partial class ModelBuilding101TestBase
 
     protected abstract class Context101 : DbContext
     {
-        public virtual Action<DbContextOptionsBuilder> ConfigureAction { get; set; }
+        public virtual Action<DbContextOptionsBuilder> ConfigureAction { get; set; } = null!;
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
             => ConfigureAction(optionsBuilder);

--- a/test/EFCore.Specification.Tests/MonsterFixupTestBase.cs
+++ b/test/EFCore.Specification.Tests/MonsterFixupTestBase.cs
@@ -11,8 +11,6 @@ using Microsoft.EntityFrameworkCore.TestModels;
 // ReSharper disable InconsistentNaming
 namespace Microsoft.EntityFrameworkCore;
 
-#nullable disable
-
 public abstract class MonsterFixupTestBase<TFixture> : IClassFixture<TFixture>, IAsyncLifetime
     where TFixture : MonsterFixupTestBase<TFixture>.MonsterFixupFixtureBase, new()
 {
@@ -133,7 +131,7 @@ public abstract class MonsterFixupTestBase<TFixture> : IClassFixture<TFixture>, 
             AssertSentMessagesConsistent(login3);
 
             // Remove the relationship
-            message2.ToUsername = null;
+            message2.ToUsername = null!;
 
             if (UseDetectChanges)
             {
@@ -143,7 +141,7 @@ public abstract class MonsterFixupTestBase<TFixture> : IClassFixture<TFixture>, 
             AssertReceivedMessagesConsistent(login1);
             AssertReceivedMessagesConsistent(login2, message1, message3);
             AssertReceivedMessagesConsistent(login3);
-            AssertReceivedMessagesConsistent(null, message2);
+            AssertReceivedMessagesConsistent(null!, message2);
 
             AssertSentMessagesConsistent(login1, message1, message3);
             AssertSentMessagesConsistent(login2, message2);
@@ -223,7 +221,7 @@ public abstract class MonsterFixupTestBase<TFixture> : IClassFixture<TFixture>, 
             AssertSentMessagesConsistent(login3);
 
             // Remove the relationship
-            message2.Recipient = null;
+            message2.Recipient = null!;
 
             if (UseDetectChanges)
             {
@@ -233,7 +231,7 @@ public abstract class MonsterFixupTestBase<TFixture> : IClassFixture<TFixture>, 
             AssertReceivedMessagesConsistent(login1);
             AssertReceivedMessagesConsistent(login2, message1, message3);
             AssertReceivedMessagesConsistent(login3);
-            AssertReceivedMessagesConsistent(null, message2);
+            AssertReceivedMessagesConsistent(null!, message2);
 
             AssertSentMessagesConsistent(login1, message1, message3);
             AssertSentMessagesConsistent(login2, message2);
@@ -292,7 +290,7 @@ public abstract class MonsterFixupTestBase<TFixture> : IClassFixture<TFixture>, 
             AssertReceivedMessagesConsistent(login1);
             AssertReceivedMessagesConsistent(login2, message1);
             AssertReceivedMessagesConsistent(login3);
-            AssertReceivedMessagesConsistent(null, message2, message3);
+            AssertReceivedMessagesConsistent(null!, message2, message3);
 
             AssertSentMessagesConsistent(login1, message1, message3);
             AssertSentMessagesConsistent(login2, message2);
@@ -348,13 +346,13 @@ public abstract class MonsterFixupTestBase<TFixture> : IClassFixture<TFixture>, 
             var customer2 = context.Customers.Single(e => e.Name == "Sue Pandy");
             var customer3 = context.Customers.Single(e => e.Name == "Tarquin Tiger");
 
-            AssertSpousesConsistent(customer0, null);
-            AssertSpousesConsistent(customer1, null);
+            AssertSpousesConsistent(customer0, null!);
+            AssertSpousesConsistent(customer1, null!);
             AssertSpousesConsistent(customer2, customer0);
-            AssertSpousesConsistent(customer3, null);
-            AssertSpousesConsistent(null, customer1);
-            AssertSpousesConsistent(null, customer2);
-            AssertSpousesConsistent(null, customer3);
+            AssertSpousesConsistent(customer3, null!);
+            AssertSpousesConsistent(null!, customer1);
+            AssertSpousesConsistent(null!, customer2);
+            AssertSpousesConsistent(null!, customer3);
 
             // Add a new relationship
             customer1.HusbandId = customer3.CustomerId;
@@ -364,12 +362,12 @@ public abstract class MonsterFixupTestBase<TFixture> : IClassFixture<TFixture>, 
                 context.ChangeTracker.DetectChanges();
             }
 
-            AssertSpousesConsistent(customer0, null);
+            AssertSpousesConsistent(customer0, null!);
             AssertSpousesConsistent(customer1, customer3);
             AssertSpousesConsistent(customer2, customer0);
-            AssertSpousesConsistent(customer3, null);
-            AssertSpousesConsistent(null, customer1);
-            AssertSpousesConsistent(null, customer2);
+            AssertSpousesConsistent(customer3, null!);
+            AssertSpousesConsistent(null!, customer1);
+            AssertSpousesConsistent(null!, customer2);
 
             // Remove the relationship
             customer1.HusbandId = null;
@@ -379,13 +377,13 @@ public abstract class MonsterFixupTestBase<TFixture> : IClassFixture<TFixture>, 
                 context.ChangeTracker.DetectChanges();
             }
 
-            AssertSpousesConsistent(customer0, null);
-            AssertSpousesConsistent(customer1, null);
+            AssertSpousesConsistent(customer0, null!);
+            AssertSpousesConsistent(customer1, null!);
             AssertSpousesConsistent(customer2, customer0);
-            AssertSpousesConsistent(customer3, null);
-            AssertSpousesConsistent(null, customer1);
-            AssertSpousesConsistent(null, customer2);
-            AssertSpousesConsistent(null, customer3);
+            AssertSpousesConsistent(customer3, null!);
+            AssertSpousesConsistent(null!, customer1);
+            AssertSpousesConsistent(null!, customer2);
+            AssertSpousesConsistent(null!, customer3);
 
             // Change existing relationship
             customer2.HusbandId = customer3.CustomerId;
@@ -395,13 +393,13 @@ public abstract class MonsterFixupTestBase<TFixture> : IClassFixture<TFixture>, 
                 context.ChangeTracker.DetectChanges();
             }
 
-            AssertSpousesConsistent(customer0, null);
-            AssertSpousesConsistent(customer1, null);
+            AssertSpousesConsistent(customer0, null!);
+            AssertSpousesConsistent(customer1, null!);
             AssertSpousesConsistent(customer2, customer3);
-            AssertSpousesConsistent(customer3, null);
-            AssertSpousesConsistent(null, customer0);
-            AssertSpousesConsistent(null, customer1);
-            AssertSpousesConsistent(null, customer2);
+            AssertSpousesConsistent(customer3, null!);
+            AssertSpousesConsistent(null!, customer0);
+            AssertSpousesConsistent(null!, customer1);
+            AssertSpousesConsistent(null!, customer2);
 
             // Give Tarquin a husband and a wife
             customer3.HusbandId = customer2.CustomerId;
@@ -411,12 +409,12 @@ public abstract class MonsterFixupTestBase<TFixture> : IClassFixture<TFixture>, 
                 context.ChangeTracker.DetectChanges();
             }
 
-            AssertSpousesConsistent(customer0, null);
-            AssertSpousesConsistent(customer1, null);
+            AssertSpousesConsistent(customer0, null!);
+            AssertSpousesConsistent(customer1, null!);
             AssertSpousesConsistent(customer2, customer3);
             AssertSpousesConsistent(customer3, customer2);
-            AssertSpousesConsistent(null, customer0);
-            AssertSpousesConsistent(null, customer1);
+            AssertSpousesConsistent(null!, customer0);
+            AssertSpousesConsistent(null!, customer1);
         }
     }
 
@@ -432,13 +430,13 @@ public abstract class MonsterFixupTestBase<TFixture> : IClassFixture<TFixture>, 
             var customer2 = context.Customers.Single(e => e.Name == "Sue Pandy");
             var customer3 = context.Customers.Single(e => e.Name == "Tarquin Tiger");
 
-            AssertSpousesConsistent(customer0, null);
-            AssertSpousesConsistent(customer1, null);
+            AssertSpousesConsistent(customer0, null!);
+            AssertSpousesConsistent(customer1, null!);
             AssertSpousesConsistent(customer2, customer0);
-            AssertSpousesConsistent(customer3, null);
-            AssertSpousesConsistent(null, customer1);
-            AssertSpousesConsistent(null, customer2);
-            AssertSpousesConsistent(null, customer3);
+            AssertSpousesConsistent(customer3, null!);
+            AssertSpousesConsistent(null!, customer1);
+            AssertSpousesConsistent(null!, customer2);
+            AssertSpousesConsistent(null!, customer3);
 
             // Set a dependent
             customer1.Husband = customer3;
@@ -448,28 +446,28 @@ public abstract class MonsterFixupTestBase<TFixture> : IClassFixture<TFixture>, 
                 context.ChangeTracker.DetectChanges();
             }
 
-            AssertSpousesConsistent(customer0, null);
+            AssertSpousesConsistent(customer0, null!);
             AssertSpousesConsistent(customer1, customer3);
             AssertSpousesConsistent(customer2, customer0);
-            AssertSpousesConsistent(customer3, null);
-            AssertSpousesConsistent(null, customer1);
-            AssertSpousesConsistent(null, customer2);
+            AssertSpousesConsistent(customer3, null!);
+            AssertSpousesConsistent(null!, customer1);
+            AssertSpousesConsistent(null!, customer2);
 
             // Remove a dependent
-            customer2.Husband = null;
+            customer2.Husband = null!;
 
             if (UseDetectChanges)
             {
                 context.ChangeTracker.DetectChanges();
             }
 
-            AssertSpousesConsistent(customer0, null);
+            AssertSpousesConsistent(customer0, null!);
             AssertSpousesConsistent(customer1, customer3);
-            AssertSpousesConsistent(customer2, null);
-            AssertSpousesConsistent(customer3, null);
-            AssertSpousesConsistent(null, customer0);
-            AssertSpousesConsistent(null, customer1);
-            AssertSpousesConsistent(null, customer2);
+            AssertSpousesConsistent(customer2, null!);
+            AssertSpousesConsistent(customer3, null!);
+            AssertSpousesConsistent(null!, customer0);
+            AssertSpousesConsistent(null!, customer1);
+            AssertSpousesConsistent(null!, customer2);
 
             // Set a principal
             customer0.Wife = customer3;
@@ -479,28 +477,28 @@ public abstract class MonsterFixupTestBase<TFixture> : IClassFixture<TFixture>, 
                 context.ChangeTracker.DetectChanges();
             }
 
-            AssertSpousesConsistent(customer0, null);
+            AssertSpousesConsistent(customer0, null!);
             AssertSpousesConsistent(customer1, customer3);
-            AssertSpousesConsistent(customer2, null);
+            AssertSpousesConsistent(customer2, null!);
             AssertSpousesConsistent(customer3, customer0);
-            AssertSpousesConsistent(null, customer1);
-            AssertSpousesConsistent(null, customer2);
+            AssertSpousesConsistent(null!, customer1);
+            AssertSpousesConsistent(null!, customer2);
 
             // Remove a principal
-            customer0.Wife = null;
+            customer0.Wife = null!;
 
             if (UseDetectChanges)
             {
                 context.ChangeTracker.DetectChanges();
             }
 
-            AssertSpousesConsistent(customer0, null);
+            AssertSpousesConsistent(customer0, null!);
             AssertSpousesConsistent(customer1, customer3);
-            AssertSpousesConsistent(customer2, null);
-            AssertSpousesConsistent(customer3, null);
-            AssertSpousesConsistent(null, customer0);
-            AssertSpousesConsistent(null, customer1);
-            AssertSpousesConsistent(null, customer2);
+            AssertSpousesConsistent(customer2, null!);
+            AssertSpousesConsistent(customer3, null!);
+            AssertSpousesConsistent(null!, customer0);
+            AssertSpousesConsistent(null!, customer1);
+            AssertSpousesConsistent(null!, customer2);
         }
     }
 
@@ -538,7 +536,7 @@ public abstract class MonsterFixupTestBase<TFixture> : IClassFixture<TFixture>, 
             AssertPhotosConsistent(productPhoto1, productWebFeature1);
             AssertPhotosConsistent(productPhoto2);
             AssertPhotosConsistent(productPhoto3);
-            AssertPhotosConsistent(null, productWebFeature2);
+            AssertPhotosConsistent(null!, productWebFeature2);
 
             AssertReviewsConsistent(productReview1, productWebFeature1);
             AssertReviewsConsistent(productReview2);
@@ -555,7 +553,7 @@ public abstract class MonsterFixupTestBase<TFixture> : IClassFixture<TFixture>, 
             AssertPhotosConsistent(productPhoto1);
             AssertPhotosConsistent(productPhoto2);
             AssertPhotosConsistent(productPhoto3);
-            AssertPhotosConsistent(null, productWebFeature2);
+            AssertPhotosConsistent(null!, productWebFeature2);
             Assert.Equal(product3.ProductId, productWebFeature1.ProductId);
             Assert.Equal(productPhoto1.PhotoId, productWebFeature1.PhotoId);
             Assert.Null(productWebFeature1.Photo);
@@ -578,7 +576,7 @@ public abstract class MonsterFixupTestBase<TFixture> : IClassFixture<TFixture>, 
             AssertPhotosConsistent(productPhoto1);
             AssertPhotosConsistent(productPhoto2);
             AssertPhotosConsistent(productPhoto3);
-            AssertPhotosConsistent(null, productWebFeature2);
+            AssertPhotosConsistent(null!, productWebFeature2);
             Assert.Equal(product3.ProductId, productWebFeature1.ProductId);
             Assert.Equal(productPhoto1.PhotoId, productWebFeature1.PhotoId);
             Assert.Null(productWebFeature1.Photo);
@@ -599,7 +597,7 @@ public abstract class MonsterFixupTestBase<TFixture> : IClassFixture<TFixture>, 
             AssertPhotosConsistent(productPhoto1, productWebFeature1);
             AssertPhotosConsistent(productPhoto2);
             AssertPhotosConsistent(productPhoto3);
-            AssertPhotosConsistent(null, productWebFeature2);
+            AssertPhotosConsistent(null!, productWebFeature2);
 
             AssertReviewsConsistent(productReview1, productWebFeature1);
             AssertReviewsConsistent(productReview2);
@@ -634,7 +632,7 @@ public abstract class MonsterFixupTestBase<TFixture> : IClassFixture<TFixture>, 
 
             AssertBarcodeDetailsConsistent(barcode1, barcodeDetails1);
             AssertBarcodeDetailsConsistent(barcode2, barcodeDetails2);
-            AssertBarcodeDetailsConsistent(barcode3, null);
+            AssertBarcodeDetailsConsistent(barcode3, null!);
 
             // Binary FK change
             incorrectScan1.ExpectedCode = barcode3.Code.ToArray();
@@ -654,7 +652,7 @@ public abstract class MonsterFixupTestBase<TFixture> : IClassFixture<TFixture>, 
 
             AssertBarcodeDetailsConsistent(barcode1, barcodeDetails1);
             AssertBarcodeDetailsConsistent(barcode2, barcodeDetails2);
-            AssertBarcodeDetailsConsistent(barcode3, null);
+            AssertBarcodeDetailsConsistent(barcode3, null!);
 
             // Binary FK change
             incorrectScan2.ActualCode = barcode1.Code.ToArray();
@@ -674,7 +672,7 @@ public abstract class MonsterFixupTestBase<TFixture> : IClassFixture<TFixture>, 
 
             AssertBarcodeDetailsConsistent(barcode1, barcodeDetails1);
             AssertBarcodeDetailsConsistent(barcode2, barcodeDetails2);
-            AssertBarcodeDetailsConsistent(barcode3, null);
+            AssertBarcodeDetailsConsistent(barcode3, null!);
 
             // Change both back
             incorrectScan1.ExpectedCode = barcode2.Code.ToArray();
@@ -695,13 +693,13 @@ public abstract class MonsterFixupTestBase<TFixture> : IClassFixture<TFixture>, 
 
             AssertBarcodeDetailsConsistent(barcode1, barcodeDetails1);
             AssertBarcodeDetailsConsistent(barcode2, barcodeDetails2);
-            AssertBarcodeDetailsConsistent(barcode3, null);
+            AssertBarcodeDetailsConsistent(barcode3, null!);
 
             // Change FK objects without changing values
-            incorrectScan1.ExpectedCode = incorrectScan1.ExpectedCode.ToArray();
-            incorrectScan2.ExpectedCode = incorrectScan2.ExpectedCode.ToArray();
-            incorrectScan1.ActualCode = incorrectScan1.ActualCode.ToArray();
-            incorrectScan2.ActualCode = incorrectScan2.ActualCode.ToArray();
+            incorrectScan1.ExpectedCode = incorrectScan1.ExpectedCode!.ToArray();
+            incorrectScan2.ExpectedCode = incorrectScan2.ExpectedCode!.ToArray();
+            incorrectScan1.ActualCode = incorrectScan1.ActualCode!.ToArray();
+            incorrectScan2.ActualCode = incorrectScan2.ActualCode!.ToArray();
 
             // Collection navigation changes
             barcode1.BadScans.Remove(incorrectScan2);
@@ -722,7 +720,7 @@ public abstract class MonsterFixupTestBase<TFixture> : IClassFixture<TFixture>, 
 
             AssertBarcodeDetailsConsistent(barcode1, barcodeDetails1);
             AssertBarcodeDetailsConsistent(barcode2, barcodeDetails2);
-            AssertBarcodeDetailsConsistent(barcode3, null);
+            AssertBarcodeDetailsConsistent(barcode3, null!);
 
             // Reference navigation changes
             incorrectScan1.ExpectedBarcode = barcode1;
@@ -745,7 +743,7 @@ public abstract class MonsterFixupTestBase<TFixture> : IClassFixture<TFixture>, 
 
             AssertBarcodeDetailsConsistent(barcode1, barcodeDetails1);
             AssertBarcodeDetailsConsistent(barcode2, barcodeDetails2);
-            AssertBarcodeDetailsConsistent(barcode3, null);
+            AssertBarcodeDetailsConsistent(barcode3, null!);
         }
     }
 
@@ -1516,18 +1514,18 @@ public abstract class MonsterFixupTestBase<TFixture> : IClassFixture<TFixture>, 
             expectedPrincipal,
             expectedDependents,
             e => e.BadScans.NullChecked().OrderBy(m => m.Details),
-            e => e.ExpectedBarcode,
+            e => e.ExpectedBarcode!,
             e => e.Code,
-            e => e.ExpectedCode);
+            e => e.ExpectedCode!);
 
     private static void AssertActualBarcodeConsistent(IBarcode expectedPrincipal, params IIncorrectScan[] expectedDependents)
         => AssertConsistent(
             expectedPrincipal,
             expectedDependents,
-            null,
-            e => e.ActualBarcode,
+            null!,
+            e => e.ActualBarcode!,
             e => e.Code,
-            e => e.ActualCode);
+            e => e.ActualCode!);
 
     private static void AssertPhotosConsistent(IProductPhoto expectedPrincipal, params IProductWebFeature[] expectedDependents)
         => AssertConsistent(
@@ -1536,7 +1534,7 @@ public abstract class MonsterFixupTestBase<TFixture> : IClassFixture<TFixture>, 
             e => e.Features.NullChecked().OrderBy(f => f.Heading),
             e => e.Photo,
             e => Tuple.Create(e.PhotoId, e.ProductId),
-            e => e.ProductId == null || e.PhotoId == null ? null : Tuple.Create(e.PhotoId.Value, e.ProductId.Value));
+                e => e.ProductId == null || e.PhotoId == null ? null! : Tuple.Create(e.PhotoId.Value, e.ProductId.Value));
 
     private static void AssertReviewsConsistent(IProductReview expectedPrincipal, params IProductWebFeature[] expectedDependents)
         => AssertConsistent(
@@ -1545,16 +1543,16 @@ public abstract class MonsterFixupTestBase<TFixture> : IClassFixture<TFixture>, 
             e => e.Features.NullChecked().OrderBy(f => f.Heading),
             e => e.Review,
             e => Tuple.Create(e.ReviewId, e.ProductId),
-            e => e.ProductId == null ? null : Tuple.Create(e.ReviewId, e.ProductId.Value));
+                e => e.ProductId == null ? null! : Tuple.Create(e.ReviewId, e.ProductId.Value));
 
     private static void AssertReceivedMessagesConsistent(ILogin expectedPrincipal, params IMessage[] expectedDependents)
         => AssertConsistent(
             expectedPrincipal,
             expectedDependents,
             e => e.ReceivedMessages.NullChecked().OrderBy(m => m.Body),
-            e => e.Recipient,
+            e => e.Recipient!,
             e => e.Username,
-            e => e.ToUsername);
+            e => e.ToUsername!);
 
     private static void AssertSentMessagesConsistent(ILogin expectedPrincipal, params IMessage[] expectedDependents)
         => AssertConsistent(
@@ -1590,14 +1588,14 @@ public abstract class MonsterFixupTestBase<TFixture> : IClassFixture<TFixture>, 
 
             if (getDependents != null)
             {
-                Assert.Equal(expectedDependents.Length, dependents.Length);
+                Assert.Equal(expectedDependents.Length, dependents!.Length);
             }
 
             for (var i = 0; i < expectedDependents.Length; i++)
             {
                 if (getDependents != null)
                 {
-                    Assert.Same(expectedDependents[i], dependents[i]);
+                    Assert.Same(expectedDependents[i], dependents![i]);
                 }
 
                 if (getPrincipal != null)
@@ -1617,14 +1615,14 @@ public abstract class MonsterFixupTestBase<TFixture> : IClassFixture<TFixture>, 
             e => e.Wife,
             e => e.Husband,
             e => e.CustomerId,
-            e => e.HusbandId);
+                e => e.HusbandId!);
 
     private static void AssertBarcodeDetailsConsistent(IBarcode principal, IBarcodeDetail dependent)
         => AssertConsistent(
             principal,
             dependent,
             e => e.Detail,
-            null,
+            null!,
             e => e.Code,
             e => e.Code);
 

--- a/test/EFCore.Specification.Tests/MusicStoreTestBase.cs
+++ b/test/EFCore.Specification.Tests/MusicStoreTestBase.cs
@@ -6,8 +6,6 @@ using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.EntityFrameworkCore;
 
-#nullable disable
-
 public abstract class MusicStoreTestBase<TFixture> : IClassFixture<TFixture>
     where TFixture : MusicStoreTestBase<TFixture>.MusicStoreFixtureBase, new()
 {
@@ -32,7 +30,7 @@ public abstract class MusicStoreTestBase<TFixture> : IClassFixture<TFixture>
 
                 var result = await controller.Browse(genreName);
 
-                Assert.Equal(genreName, result.Name);
+                Assert.Equal(genreName, result!.Name);
                 Assert.NotNull(result.Albums);
                 Assert.Equal(3, result.Albums.Count);
             }
@@ -73,7 +71,7 @@ public abstract class MusicStoreTestBase<TFixture> : IClassFixture<TFixture>
 
                 var result = await controller.Details(albumId);
 
-                Assert.NotNull(result.Genre);
+                Assert.NotNull(result!.Genre);
                 var genre = genres.SingleOrDefault(g => g.GenreId == result.GenreId);
                 Assert.NotNull(genre);
                 Assert.NotNull(genre.Albums.SingleOrDefault(a => a.AlbumId == albumId));
@@ -521,7 +519,7 @@ public abstract class MusicStoreTestBase<TFixture> : IClassFixture<TFixture>
     protected class CartSummaryViewBag
     {
         public int CartCount { get; set; }
-        public string CartSummary { get; set; }
+        public string CartSummary { get; set; } = null!;
     }
 
     protected class ShoppingCartController(MusicStoreContext context, string cartId)
@@ -588,12 +586,12 @@ public abstract class MusicStoreTestBase<TFixture> : IClassFixture<TFixture>
         }
     }
 
-    public class CheckoutController(Dictionary<string, StringValues> formCollection = null)
+    public class CheckoutController(Dictionary<string, StringValues>? formCollection = null)
     {
         private readonly Dictionary<string, StringValues> _formCollection = formCollection ?? [];
         private const string PromoCode = "FREE";
 
-        public async Task<object> AddressAndPayment(MusicStoreContext context, string cartId, Order order)
+        public async Task<object?> AddressAndPayment(MusicStoreContext context, string cartId, Order order)
         {
             try
             {
@@ -670,7 +668,7 @@ public abstract class MusicStoreTestBase<TFixture> : IClassFixture<TFixture>
             return genres;
         }
 
-        public async Task<Genre> Browse(string genre)
+        public async Task<Genre?> Browse(string genre)
         {
             var genreModel = await _context.Genres
                 .Include(g => g.Albums)
@@ -680,7 +678,7 @@ public abstract class MusicStoreTestBase<TFixture> : IClassFixture<TFixture>
             return genreModel;
         }
 
-        public async Task<Album> Details(int id)
+        public async Task<Album?> Details(int id)
         {
             var album = await _context.Albums
                 .Where(a => a.AlbumId == id)

--- a/test/EFCore.Specification.Tests/NotificationEntitiesTestBase.cs
+++ b/test/EFCore.Specification.Tests/NotificationEntitiesTestBase.cs
@@ -8,8 +8,6 @@ using System.Runtime.CompilerServices;
 // ReSharper disable InconsistentNaming
 namespace Microsoft.EntityFrameworkCore;
 
-#nullable disable
-
 public abstract class NotificationEntitiesTestBase<TFixture>(TFixture fixture) : IClassFixture<TFixture>
     where TFixture : NotificationEntitiesTestBase<TFixture>.NotificationEntitiesFixtureBase, new()
 {
@@ -54,7 +52,7 @@ public abstract class NotificationEntitiesTestBase<TFixture>(TFixture fixture) :
         {
             get;
             set => SetWithNotify(value, ref field);
-        }
+        } = null!;
     }
 
     protected class Post : NotificationEntity
@@ -75,12 +73,12 @@ public abstract class NotificationEntitiesTestBase<TFixture>(TFixture fixture) :
         {
             get;
             set => SetWithNotify(value, ref field);
-        }
+        } = null!;
     }
 
     protected class NotificationEntity : INotifyPropertyChanged
     {
-        public event PropertyChangedEventHandler PropertyChanged;
+        public event PropertyChangedEventHandler? PropertyChanged;
 
         private void NotifyChanged(string propertyName)
             => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));

--- a/test/EFCore.Specification.Tests/OptimisticConcurrencyTestBase.cs
+++ b/test/EFCore.Specification.Tests/OptimisticConcurrencyTestBase.cs
@@ -7,8 +7,6 @@ using Microsoft.EntityFrameworkCore.TestModels.ConcurrencyModel;
 // ReSharper disable InconsistentNaming
 namespace Microsoft.EntityFrameworkCore;
 
-#nullable disable
-
 public abstract class OptimisticConcurrencyTestBase<TFixture, TRowVersion> : IClassFixture<TFixture>
     where TFixture : F1FixtureBase<TRowVersion>, new()
 {
@@ -71,7 +69,7 @@ public abstract class OptimisticConcurrencyTestBase<TFixture, TRowVersion> : ICl
             ClientPodiums, async (_, ex) =>
             {
                 var driverEntry = ex.Entries.Single();
-                driverEntry.OriginalValues.SetValues(await driverEntry.GetDatabaseValuesAsync());
+                driverEntry.OriginalValues.SetValues((await driverEntry.GetDatabaseValuesAsync())!);
                 ResolveConcurrencyTokens(driverEntry);
             });
 
@@ -82,8 +80,8 @@ public abstract class OptimisticConcurrencyTestBase<TFixture, TRowVersion> : ICl
             {
                 var driverEntry = ex.Entries.Single();
                 var storeValues = await driverEntry.GetDatabaseValuesAsync();
-                driverEntry.CurrentValues.SetValues(storeValues);
-                driverEntry.OriginalValues.SetValues(storeValues);
+                driverEntry.CurrentValues.SetValues(storeValues!);
+                driverEntry.OriginalValues.SetValues(storeValues!);
                 ResolveConcurrencyTokens(driverEntry);
             });
 
@@ -93,7 +91,7 @@ public abstract class OptimisticConcurrencyTestBase<TFixture, TRowVersion> : ICl
             10, async (_, ex) =>
             {
                 var driverEntry = ex.Entries.Single();
-                driverEntry.OriginalValues.SetValues(await driverEntry.GetDatabaseValuesAsync());
+                driverEntry.OriginalValues.SetValues((await driverEntry.GetDatabaseValuesAsync())!);
                 ResolveConcurrencyTokens(driverEntry);
                 ((Driver)driverEntry.Entity).Podiums = 10;
             });
@@ -105,8 +103,8 @@ public abstract class OptimisticConcurrencyTestBase<TFixture, TRowVersion> : ICl
             {
                 var driverEntry = ex.Entries.Single();
                 var storeValues = await driverEntry.GetDatabaseValuesAsync();
-                driverEntry.CurrentValues.SetValues(storeValues);
-                driverEntry.OriginalValues.SetValues(storeValues);
+                driverEntry.CurrentValues.SetValues(storeValues!);
+                driverEntry.OriginalValues.SetValues(storeValues!);
                 driverEntry.State = EntityState.Unchanged;
             });
 
@@ -239,7 +237,7 @@ public abstract class OptimisticConcurrencyTestBase<TFixture, TRowVersion> : ICl
                 Assert.IsAssignableFrom<Team>(entry.Entity);
                 return Task.CompletedTask;
             },
-            null);
+            null!);
 
     [Fact]
     public virtual Task
@@ -254,7 +252,7 @@ public abstract class OptimisticConcurrencyTestBase<TFixture, TRowVersion> : ICl
                 Assert.IsAssignableFrom<Team>(entry.Entity);
                 return Task.CompletedTask;
             },
-            null);
+            null!);
 
     [Fact]
     public virtual Task Attempting_to_delete_same_relationship_twice_for_many_to_many_results_in_independent_association_exception()
@@ -271,7 +269,7 @@ public abstract class OptimisticConcurrencyTestBase<TFixture, TRowVersion> : ICl
                 Assert.IsAssignableFrom<TeamSponsor>(entry.Entity);
                 return Task.CompletedTask;
             },
-            null);
+            null!);
 
     [Fact]
     public virtual Task Attempting_to_add_same_relationship_twice_for_many_to_many_results_in_independent_association_exception()
@@ -285,7 +283,7 @@ public abstract class OptimisticConcurrencyTestBase<TFixture, TRowVersion> : ICl
                 Assert.IsAssignableFrom<TeamSponsor>(entry.Entity);
                 return Task.CompletedTask;
             },
-            null);
+            null!);
 
         static async Task Change(F1Context c)
         {
@@ -303,7 +301,7 @@ public abstract class OptimisticConcurrencyTestBase<TFixture, TRowVersion> : ICl
     [Fact(Skip = "Issue#13890")]
     public virtual Task Concurrency_issue_where_a_complex_type_nested_member_is_the_concurrency_token_can_be_handled()
         => ConcurrencyTestAsync(
-            async c => (await c.Engines.SingleAsync(s => s.Name == "CA2010")).StorageLocation.Latitude = 47.642576,
+            async c => (await c.Engines.SingleAsync(s => s.Name == "CA2010")).StorageLocation!.Latitude = 47.642576,
             (_, ex) =>
             {
                 var entry = ex.Entries.Single();
@@ -311,7 +309,7 @@ public abstract class OptimisticConcurrencyTestBase<TFixture, TRowVersion> : ICl
                 entry.Reload();
                 return Task.CompletedTask;
             }, async c =>
-                Assert.Equal(47.642576, (await c.Engines.SingleAsync(s => s.Name == "CA2010")).StorageLocation.Latitude));
+                Assert.Equal(47.642576, (await c.Engines.SingleAsync(s => s.Name == "CA2010")).StorageLocation!.Latitude));
 
     #endregion
 
@@ -386,8 +384,8 @@ public abstract class OptimisticConcurrencyTestBase<TFixture, TRowVersion> : ICl
 
                 entry.State = EntityState.Unchanged;
                 var storeValues = await entry.GetDatabaseValuesAsync();
-                entry.OriginalValues.SetValues(storeValues);
-                entry.CurrentValues.SetValues(storeValues);
+                entry.OriginalValues.SetValues(storeValues!);
+                entry.CurrentValues.SetValues(storeValues!);
                 ResolveConcurrencyTokens(entry);
             },
             async c => Assert.Equal(1, (await c.Drivers.SingleAsync(d => d.Name == "Fernando Alonso")).Wins));
@@ -576,9 +574,9 @@ public abstract class OptimisticConcurrencyTestBase<TFixture, TRowVersion> : ICl
                 await innerContext.SaveChangesAsync();
 
                 var databaseValues = async
-                    ? await ownedEntry.GetDatabaseValuesAsync()
-                    : ownedEntry.GetDatabaseValues();
-                Assert.Equal(5, databaseValues.GetValue<int>("Days"));
+                    ? await ownedEntry!.GetDatabaseValuesAsync()
+                    : ownedEntry!.GetDatabaseValues();
+                Assert.Equal(5, databaseValues!.GetValue<int>("Days"));
             });
     }
 
@@ -607,11 +605,11 @@ public abstract class OptimisticConcurrencyTestBase<TFixture, TRowVersion> : ICl
 
                 if (async)
                 {
-                    await ownedEntry.ReloadAsync();
+                    await ownedEntry!.ReloadAsync();
                 }
                 else
                 {
-                    ownedEntry.Reload();
+                    ownedEntry!.Reload();
                 }
 
                 Assert.Equal(5, ownedEntry.Property(e => e.Days).CurrentValue);

--- a/test/EFCore.Specification.Tests/OverzealousInitializationTestBase.cs
+++ b/test/EFCore.Specification.Tests/OverzealousInitializationTestBase.cs
@@ -5,8 +5,6 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace Microsoft.EntityFrameworkCore;
 
-#nullable disable
-
 public abstract class OverzealousInitializationTestBase<TFixture>(TFixture fixture) : IClassFixture<TFixture>
     where TFixture : OverzealousInitializationTestBase<TFixture>.OverzealousInitializationFixtureBase, new()
 {
@@ -58,7 +56,7 @@ public abstract class OverzealousInitializationTestBase<TFixture>(TFixture fixtu
         [DatabaseGenerated(DatabaseGeneratedOption.None)]
         public int Id { get; set; }
 
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
     }
 
     public class Track

--- a/test/EFCore.Specification.Tests/Query/AdHocAdvancedMappingsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/AdHocAdvancedMappingsQueryTestBase.cs
@@ -7,8 +7,6 @@ using System.Globalization;
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
-#nullable disable
-
 public abstract class AdHocAdvancedMappingsQueryTestBase(NonSharedFixture fixture)
     : NonSharedModelTestBase(fixture), IClassFixture<NonSharedFixture>
 {
@@ -48,7 +46,7 @@ public abstract class AdHocAdvancedMappingsQueryTestBase(NonSharedFixture fixtur
         public class TipoServicio
         {
             public int Id { get; set; }
-            public string Nombre { get; set; }
+            public string Nombre { get; set; } = null!;
         }
     }
 
@@ -76,7 +74,7 @@ public abstract class AdHocAdvancedMappingsQueryTestBase(NonSharedFixture fixtur
             {
                 e.Id,
                 e.Title,
-                FirstPostName = e.Posts.OrderBy(i => i.Id).FirstOrDefault().Name
+                FirstPostName = e.Posts.OrderBy(i => i.Id).FirstOrDefault()!.Name
             }).ToList();
         }
     }
@@ -84,8 +82,11 @@ public abstract class AdHocAdvancedMappingsQueryTestBase(NonSharedFixture fixtur
     // Protected so that it can be used by inheriting tests, and so that things like unused setters are not removed.
     protected class Context11835(DbContextOptions options) : DbContext(options)
     {
-        public DbSet<Blog> Blogs { get; set; }
-        public DbSet<Post> Posts { get; set; }
+        public DbSet<Blog> Blogs
+            => Set<Blog>();
+
+        public DbSet<Post> Posts
+            => Set<Post>();
 
         public Task SeedAsync()
         {
@@ -107,17 +108,17 @@ public abstract class AdHocAdvancedMappingsQueryTestBase(NonSharedFixture fixtur
             public int Id { get; set; }
 
             [NotMapped]
-            public string Title { get; set; }
+            public string Title { get; set; } = null!;
 
-            public List<Post> Posts { get; set; }
+            public List<Post> Posts { get; set; } = [];
         }
 
         public class Post
         {
             public int Id { get; set; }
             public int BlogId { get; set; }
-            public Blog Blog { get; set; }
-            public string Name { get; set; }
+            public Blog Blog { get; set; } = null!;
+            public string Name { get; set; } = null!;
         }
     }
 
@@ -147,8 +148,11 @@ public abstract class AdHocAdvancedMappingsQueryTestBase(NonSharedFixture fixtur
     // Protected so that it can be used by inheriting tests, and so that things like unused setters are not removed.
     protected class Context15684(DbContextOptions options) : DbContext(options)
     {
-        public DbSet<Category> Categories { get; set; }
-        public DbSet<Product> Products { get; set; }
+        public DbSet<Category> Categories
+            => Set<Category>();
+
+        public DbSet<Product> Products
+            => Set<Product>();
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
             => modelBuilder
@@ -172,11 +176,11 @@ public abstract class AdHocAdvancedMappingsQueryTestBase(NonSharedFixture fixtur
             public int Id { get; set; }
 
             [Required]
-            public string Name { get; set; }
+            public string Name { get; set; } = null!;
 
             public int? CategoryId { get; set; }
 
-            public Category Category { get; set; }
+            public Category? Category { get; set; }
         }
 
         public class Category
@@ -185,17 +189,17 @@ public abstract class AdHocAdvancedMappingsQueryTestBase(NonSharedFixture fixtur
             public int Id { get; set; }
 
             [Required]
-            public string Name { get; set; }
+            public string Name { get; set; } = null!;
 
             public CategoryStatus Status { get; set; }
         }
 
         public class ProductDto
         {
-            public string CategoryName { get; set; }
+            public string CategoryName { get; set; } = null!;
             public CategoryStatus CategoryStatus { get; set; }
             public int Id { get; set; }
-            public string Name { get; set; }
+            public string Name { get; set; } = null!;
         }
 
         public enum CategoryStatus
@@ -243,10 +247,12 @@ public abstract class AdHocAdvancedMappingsQueryTestBase(NonSharedFixture fixtur
     protected class Context17276(DbContextOptions options) : DbContext(options)
     {
         // ReSharper disable once UnusedAutoPropertyAccessor.Local
-        public DbSet<RemovableEntity> RemovableEntities { get; set; }
+        public DbSet<RemovableEntity> RemovableEntities
+            => Set<RemovableEntity>();
 
         // ReSharper disable once UnusedAutoPropertyAccessor.Local
-        public DbSet<Parent> Parents { get; set; }
+        public DbSet<Parent> Parents
+            => Set<Parent>();
 
         public static List<T> List<T>(IQueryable<T> query)
             where T : IRemovable
@@ -256,7 +262,7 @@ public abstract class AdHocAdvancedMappingsQueryTestBase(NonSharedFixture fixtur
         {
             bool IsRemoved { get; set; }
 
-            string RemovedByUser { get; set; }
+            string? RemovedByUser { get; set; }
 
             DateTime? Removed { get; set; }
         }
@@ -265,21 +271,21 @@ public abstract class AdHocAdvancedMappingsQueryTestBase(NonSharedFixture fixtur
         {
             public int Id { get; set; }
             public bool IsRemoved { get; set; }
-            public string RemovedByUser { get; set; }
+            public string? RemovedByUser { get; set; }
             public DateTime? Removed { get; set; }
-            public OwnedEntity OwnedEntity { get; set; }
+            public OwnedEntity? OwnedEntity { get; set; }
         }
 
         public class Parent : IHasId<int>
         {
             public int Id { get; set; }
-            public RemovableEntity RemovableEntity { get; set; }
+            public RemovableEntity? RemovableEntity { get; set; }
         }
 
         [Owned]
         public class OwnedEntity : IOwned
         {
-            public string OwnedValue { get; set; }
+            public string? OwnedValue { get; set; }
             public int Exists { get; set; }
         }
 
@@ -290,7 +296,7 @@ public abstract class AdHocAdvancedMappingsQueryTestBase(NonSharedFixture fixtur
 
         public interface IOwned
         {
-            string OwnedValue { get; }
+            string? OwnedValue { get; }
             int Exists { get; }
         }
 
@@ -319,8 +325,11 @@ public abstract class AdHocAdvancedMappingsQueryTestBase(NonSharedFixture fixtur
     // Protected so that it can be used by inheriting tests, and so that things like unused setters are not removed.
     protected class Context17794(DbContextOptions options) : DbContext(options)
     {
-        public DbSet<Offer> Offers { get; set; }
-        public DbSet<OfferAction> OfferActions { get; set; }
+        public DbSet<Offer> Offers
+            => Set<Offer>();
+
+        public DbSet<OfferAction> OfferActions
+            => Set<OfferAction>();
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
@@ -349,7 +358,7 @@ public abstract class AdHocAdvancedMappingsQueryTestBase(NonSharedFixture fixtur
         {
             public int Id { get; set; }
 
-            public ICollection<OfferAction> OfferActions { get; set; }
+            public ICollection<OfferAction> OfferActions { get; set; } = [];
         }
 
         public enum Actions
@@ -363,7 +372,7 @@ public abstract class AdHocAdvancedMappingsQueryTestBase(NonSharedFixture fixtur
             public int Id { get; set; }
 
             [Required]
-            public Offer Offer { get; set; }
+            public Offer Offer { get; set; } = null!;
 
             public int OfferId { get; set; }
 
@@ -387,7 +396,7 @@ public abstract class AdHocAdvancedMappingsQueryTestBase(NonSharedFixture fixtur
             var id = 1;
             var query = queryBase.Cast<Context18087.IDomainEntity>().FirstOrDefault(x => x.Id == id);
 
-            Assert.Equal(1, query.Id);
+            Assert.Equal(1, query!.Id);
         }
 
         using (var context = contextFactory.CreateDbContext())
@@ -417,7 +426,8 @@ public abstract class AdHocAdvancedMappingsQueryTestBase(NonSharedFixture fixtur
     // Protected so that it can be used by inheriting tests, and so that things like unused setters are not removed.
     protected class Context18087(DbContextOptions options) : DbContext(options)
     {
-        public DbSet<MockEntity> MockEntities { get; set; }
+        public DbSet<MockEntity> MockEntities
+            => Set<MockEntity>();
 
         public Task SeedAsync()
         {
@@ -442,9 +452,9 @@ public abstract class AdHocAdvancedMappingsQueryTestBase(NonSharedFixture fixtur
         public class MockEntity : IDomainEntity
         {
             public int Id { get; set; }
-            public string Name { get; set; }
+            public string Name { get; set; } = null!;
 
-            public MockEntity NavigationEntity { get; set; }
+            public MockEntity? NavigationEntity { get; set; }
         }
     }
 
@@ -464,7 +474,8 @@ public abstract class AdHocAdvancedMappingsQueryTestBase(NonSharedFixture fixtur
     // Protected so that it can be used by inheriting tests, and so that things like unused setters are not removed.
     protected class Context18346(DbContextOptions options) : DbContext(options)
     {
-        public DbSet<Business> Businesses { get; set; }
+        public DbSet<Business> Businesses
+            => Set<Business>();
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
             => modelBuilder.Entity<Business>()
@@ -484,7 +495,7 @@ public abstract class AdHocAdvancedMappingsQueryTestBase(NonSharedFixture fixtur
         public abstract class Business
         {
             public int Id { get; set; }
-            public string Name { get; set; }
+            public string Name { get; set; } = null!;
             public BusinessType Type { get; set; }
         }
 
@@ -566,7 +577,8 @@ public abstract class AdHocAdvancedMappingsQueryTestBase(NonSharedFixture fixtur
     // Protected so that it can be used by inheriting tests, and so that things like unused setters are not removed.
     protected class Context26742(DbContextOptions options) : DbContext(options)
     {
-        public DbSet<Entity> Entities { get; set; }
+        public DbSet<Entity> Entities
+            => Set<Entity>();
 
         public class Entity
         {
@@ -585,7 +597,7 @@ public abstract class AdHocAdvancedMappingsQueryTestBase(NonSharedFixture fixtur
     public virtual Task Hierarchy_query_with_abstract_type_sibling(bool async)
         => Hierarchy_query_with_abstract_type_sibling_helper(async, null);
 
-    public virtual async Task Hierarchy_query_with_abstract_type_sibling_helper(bool async, Action<ModelBuilder> onModelCreating)
+    public virtual async Task Hierarchy_query_with_abstract_type_sibling_helper(bool async, Action<ModelBuilder>? onModelCreating)
     {
         var contextFactory = await InitializeNonSharedTest<Context28196>(onModelCreating: onModelCreating, seed: c => c.SeedAsync());
         using var context = contextFactory.CreateDbContext();
@@ -597,7 +609,8 @@ public abstract class AdHocAdvancedMappingsQueryTestBase(NonSharedFixture fixtur
 
     protected class Context28196(DbContextOptions options) : DbContext(options)
     {
-        public DbSet<Animal> Animals { get; set; }
+        public DbSet<Animal> Animals
+            => Set<Animal>();
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
@@ -645,7 +658,7 @@ public abstract class AdHocAdvancedMappingsQueryTestBase(NonSharedFixture fixtur
         public abstract class Animal
         {
             public int Id { get; set; }
-            public string Species { get; set; }
+            public string Species { get; set; } = null!;
         }
 
         public class FarmAnimal : Animal
@@ -655,17 +668,17 @@ public abstract class AdHocAdvancedMappingsQueryTestBase(NonSharedFixture fixtur
 
         public abstract class Pet : Animal
         {
-            public string Name { get; set; }
+            public string Name { get; set; } = null!;
         }
 
         public class Cat : Pet
         {
-            public string EdcuationLevel { get; set; }
+            public string EdcuationLevel { get; set; } = null!;
         }
 
         public class Dog : Pet
         {
-            public string FavoriteToy { get; set; }
+            public string FavoriteToy { get; set; } = null!;
         }
     }
 
@@ -715,7 +728,8 @@ public abstract class AdHocAdvancedMappingsQueryTestBase(NonSharedFixture fixtur
 
     protected class Context34760(DbContextOptions options) : DbContext(options)
     {
-        public DbSet<Book> Books { get; set; }
+        public DbSet<Book> Books
+            => Set<Book>();
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
@@ -749,7 +763,7 @@ public abstract class AdHocAdvancedMappingsQueryTestBase(NonSharedFixture fixtur
         public class Book
         {
             public int Id { get; set; }
-            public string Name { get; set; }
+            public string Name { get; set; } = null!;
 
             public virtual DateTime PublishDate { get; set; }
             public virtual DateTime AudiobookDate { get; set; }

--- a/test/EFCore.Specification.Tests/Query/AdHocMiscellaneousQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/AdHocMiscellaneousQueryTestBase.cs
@@ -7,8 +7,6 @@ using Microsoft.Extensions.Caching.Memory;
 
 namespace Microsoft.EntityFrameworkCore;
 
-#nullable disable
-
 public abstract class AdHocMiscellaneousQueryTestBase(NonSharedFixture fixture)
     : NonSharedModelTestBase(fixture), IClassFixture<NonSharedFixture>
 {
@@ -37,7 +35,7 @@ public abstract class AdHocMiscellaneousQueryTestBase(NonSharedFixture fixture)
         using (var context = contextFactory.CreateDbContext())
         {
             var product = await context.Products.OrderBy(p => p.Id).FirstOrDefaultAsync();
-            context.Products.Remove(product);
+            context.Products.Remove(product!);
             await context.SaveChangesAsync();
         }
     }
@@ -45,7 +43,7 @@ public abstract class AdHocMiscellaneousQueryTestBase(NonSharedFixture fixture)
     // Protected so that it can be used by inheriting tests, and so that things like unused setters are not removed.
     protected class Context603(DbContextOptions options) : DbContext(options)
     {
-        public DbSet<Product> Products { get; set; }
+        public DbSet<Product> Products { get; set; } = null!;
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
             => modelBuilder.Entity<Product>()
@@ -55,7 +53,7 @@ public abstract class AdHocMiscellaneousQueryTestBase(NonSharedFixture fixture)
         {
             public int Id { get; set; }
 
-            public string Name { get; set; }
+            public string? Name { get; set; }
         }
     }
 
@@ -160,21 +158,21 @@ public abstract class AdHocMiscellaneousQueryTestBase(NonSharedFixture fixture)
             });
         }
 
-        public DbSet<Customer> Customers { get; set; }
-        public DbSet<Postcode> Postcodes { get; set; }
+        public DbSet<Customer> Customers { get; set; } = null!;
+        public DbSet<Postcode> Postcodes { get; set; } = null!;
 
         public class Customer
         {
             public int CustomerID { get; set; }
-            public string CustomerName { get; set; }
+            public string CustomerName { get; set; } = null!;
             public int? PostcodeID { get; set; }
         }
 
         public class Postcode
         {
             public int PostcodeID { get; set; }
-            public string PostcodeValue { get; set; }
-            public string TownName { get; set; }
+            public string PostcodeValue { get; set; } = null!;
+            public string TownName { get; set; } = null!;
         }
     }
 
@@ -221,11 +219,11 @@ public abstract class AdHocMiscellaneousQueryTestBase(NonSharedFixture fixture)
     // Protected so that it can be used by inheriting tests, and so that things like unused setters are not removed.
     protected class Context6986(DbContextOptions options) : DbContext(options)
     {
-        public DbSet<Contact> Contacts { get; set; }
-        public DbSet<EmployerContact> EmployerContacts { get; set; }
-        public DbSet<Employer> Employers { get; set; }
-        public DbSet<ServiceOperatorContact> ServiceOperatorContacts { get; set; }
-        public DbSet<ServiceOperator> ServiceOperators { get; set; }
+        public DbSet<Contact> Contacts { get; set; } = null!;
+        public DbSet<EmployerContact> EmployerContacts { get; set; } = null!;
+        public DbSet<Employer> Employers { get; set; } = null!;
+        public DbSet<ServiceOperatorContact> ServiceOperatorContacts { get; set; } = null!;
+        public DbSet<ServiceOperator> ServiceOperators { get; set; } = null!;
 
         public async Task SeedAsync()
         {
@@ -260,33 +258,33 @@ public abstract class AdHocMiscellaneousQueryTestBase(NonSharedFixture fixture)
         public class EmployerContact : Contact
         {
             [Required]
-            public Employer Employer { get; set; }
+            public Employer Employer { get; set; } = null!;
         }
 
         public class ServiceOperatorContact : Contact
         {
             [Required]
-            public ServiceOperator ServiceOperator { get; set; }
+            public ServiceOperator ServiceOperator { get; set; } = null!;
         }
 
         public class Contact
         {
             public int Id { get; set; }
-            public string UserName { get; set; }
+            public string UserName { get; set; } = null!;
             public bool IsPrimary { get; set; }
         }
 
         public class Employer
         {
             public int Id { get; set; }
-            public string Name { get; set; }
-            public List<EmployerContact> Contacts { get; set; }
+            public string Name { get; set; } = null!;
+            public List<EmployerContact> Contacts { get; set; } = null!;
         }
 
         public class ServiceOperator
         {
             public int Id { get; set; }
-            public List<ServiceOperatorContact> Contacts { get; set; }
+            public List<ServiceOperatorContact> Contacts { get; set; } = null!;
         }
     }
 
@@ -312,7 +310,7 @@ public abstract class AdHocMiscellaneousQueryTestBase(NonSharedFixture fixture)
     // Protected so that it can be used by inheriting tests, and so that things like unused setters are not removed.
     protected class Context7222(DbContextOptions options) : DbContext(options)
     {
-        public DbSet<Blog> Blogs { get; set; }
+        public DbSet<Blog> Blogs { get; set; } = null!;
 
         public void RunQuery()
             => Blogs.Select(b => ClientMethod(b)).ToList();
@@ -353,7 +351,7 @@ public abstract class AdHocMiscellaneousQueryTestBase(NonSharedFixture fixture)
     // Protected so that it can be used by inheriting tests, and so that things like unused setters are not removed.
     protected class Context7359(DbContextOptions options) : DbContext(options)
     {
-        public DbSet<Product> Products { get; set; }
+        public DbSet<Product> Products { get; set; } = null!;
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
@@ -375,7 +373,7 @@ public abstract class AdHocMiscellaneousQueryTestBase(NonSharedFixture fixture)
         {
             public int Id { get; set; }
 
-            public string Name { get; set; }
+            public string Name { get; set; } = null!;
         }
 
         public class SpecialProduct : Product;
@@ -399,8 +397,8 @@ public abstract class AdHocMiscellaneousQueryTestBase(NonSharedFixture fixture)
     // Protected so that it can be used by inheriting tests, and so that things like unused setters are not removed.
     protected class Context7983(DbContextOptions options) : DbContext(options)
     {
-        public DbSet<Blog> Blogs { get; set; }
-        public DbSet<Post> Posts { get; set; }
+        public DbSet<Blog> Blogs { get; set; } = null!;
+        public DbSet<Post> Posts { get; set; } = null!;
 
         public Task SeedAsync()
         {
@@ -421,23 +419,23 @@ public abstract class AdHocMiscellaneousQueryTestBase(NonSharedFixture fixture)
         public class Blog
         {
             public int Id { get; set; }
-            public string Title { get; set; }
+            public string? Title { get; set; }
 
-            public ICollection<Post> Posts { get; set; }
+            public ICollection<Post> Posts { get; set; } = null!;
         }
 
         public class Post
         {
             public int Id { get; set; }
-            public string Title { get; set; }
+            public string Title { get; set; } = null!;
 
             public int? BlogId { get; set; }
-            public Blog Blog { get; set; }
+            public Blog? Blog { get; set; }
         }
 
         public class PostDTO
         {
-            public string Title { get; set; }
+            public string Title { get; set; } = null!;
 
             public PostDTO From(Post post)
             {
@@ -490,7 +488,7 @@ public abstract class AdHocMiscellaneousQueryTestBase(NonSharedFixture fixture)
     // Protected so that it can be used by inheriting tests, and so that things like unused setters are not removed.
     protected class Context8538(DbContextOptions options) : DbContext(options)
     {
-        public DbSet<Entity> Entities { get; set; }
+        public DbSet<Entity> Entities { get; set; } = null!;
 
         public Task SeedAsync()
         {
@@ -616,7 +614,7 @@ public abstract class AdHocMiscellaneousQueryTestBase(NonSharedFixture fixture)
         using var context = contextFactory.CreateDbContext();
         context.Cache.Compact(1);
 
-        var name = "A";
+        string? name = "A";
 
         context.Entities.Where(e => e.Name == name).ToList();
         Assert.Equal(2, context.Cache.Count);
@@ -635,9 +633,9 @@ public abstract class AdHocMiscellaneousQueryTestBase(NonSharedFixture fixture)
         Assert.Equal(0, context.Cache.Count);
 
         var entityParam = Expression.Parameter(typeof(Context8909.Entity), "e");
-        var idPropertyInfo = context.Model.FindEntityType(typeof(Context8909.Entity))
-            .FindProperty(nameof(Context8909.Entity.Id))
-            .PropertyInfo;
+        var idPropertyInfo = context.Model.FindEntityType(typeof(Context8909.Entity))!
+            .FindProperty(nameof(Context8909.Entity.Id))!
+            .PropertyInfo!;
         for (var i = 0; i < 1100; i++)
         {
             var conditionBody = Expression.Equal(
@@ -679,7 +677,7 @@ public abstract class AdHocMiscellaneousQueryTestBase(NonSharedFixture fixture)
     // Protected so that it can be used by inheriting tests, and so that things like unused setters are not removed.
     protected class Context8909(DbContextOptions options) : DbContext(options)
     {
-        public DbSet<Entity> Entities { get; set; }
+        public DbSet<Entity> Entities { get; set; } = null!;
 
         public MemoryCache Cache
         {
@@ -689,14 +687,14 @@ public abstract class AdHocMiscellaneousQueryTestBase(NonSharedFixture fixture)
 
                 return (MemoryCache)typeof(CompiledQueryCache)
                     .GetField("_memoryCache", BindingFlags.Instance | BindingFlags.NonPublic)
-                    ?.GetValue(compiledQueryCache);
+                    !.GetValue(compiledQueryCache)!;
             }
         }
 
         public class Entity
         {
             public int Id { get; set; }
-            public string Name { get; set; }
+            public string? Name { get; set; }
         }
     }
 
@@ -720,7 +718,7 @@ public abstract class AdHocMiscellaneousQueryTestBase(NonSharedFixture fixture)
     // Protected so that it can be used by inheriting tests, and so that things like unused setters are not removed.
     protected class Context9468(DbContextOptions options) : DbContext(options)
     {
-        public DbSet<Cart> Carts { get; set; }
+        public DbSet<Cart> Carts { get; set; } = null!;
 
         public Task SeedAsync()
         {
@@ -737,7 +735,7 @@ public abstract class AdHocMiscellaneousQueryTestBase(NonSharedFixture fixture)
         {
             public int Id { get; set; }
             public int? ConfigurationId { get; set; }
-            public Configuration Configuration { get; set; }
+            public Configuration Configuration { get; set; } = null!;
         }
 
         public class Configuration
@@ -765,7 +763,7 @@ public abstract class AdHocMiscellaneousQueryTestBase(NonSharedFixture fixture)
     // Protected so that it can be used by inheriting tests, and so that things like unused setters are not removed.
     protected class Context11104(DbContextOptions options) : DbContext(options)
     {
-        public DbSet<Base> Bases { get; set; }
+        public DbSet<Base> Bases { get; set; } = null!;
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
             => modelBuilder.Entity<Base>()
@@ -787,7 +785,7 @@ public abstract class AdHocMiscellaneousQueryTestBase(NonSharedFixture fixture)
 
         public class Derived1 : Base
         {
-            public Stuff MoreStuff { get; set; }
+            public Stuff? MoreStuff { get; set; }
         }
 
         public class Derived2 : Base;
@@ -825,7 +823,7 @@ public abstract class AdHocMiscellaneousQueryTestBase(NonSharedFixture fixture)
     // Protected so that it can be used by inheriting tests, and so that things like unused setters are not removed.
     protected class Context11885(DbContextOptions options) : DbContext(options)
     {
-        public DbSet<PriceEntity> Prices { get; set; }
+        public DbSet<PriceEntity> Prices { get; set; } = null!;
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
             => modelBuilder.Entity<PriceEntity>(b =>
@@ -922,7 +920,7 @@ public abstract class AdHocMiscellaneousQueryTestBase(NonSharedFixture fixture)
     // Protected so that it can be used by inheriting tests, and so that things like unused setters are not removed.
     protected class Context12274(DbContextOptions options) : DbContext(options)
     {
-        public DbSet<MyEntity> Entities { get; set; }
+        public DbSet<MyEntity> Entities { get; set; } = null!;
 
         public Task SeedAsync()
         {
@@ -938,14 +936,14 @@ public abstract class AdHocMiscellaneousQueryTestBase(NonSharedFixture fixture)
         public class MyEntity
         {
             public int Id { get; set; }
-            public string Name { get; set; }
+            public string Name { get; set; } = null!;
         }
 
         public class OuterDTO
         {
             public int Id { get; set; }
-            public string Name { get; set; }
-            public InnerDTO Inner { get; set; }
+            public string Name { get; set; } = null!;
+            public InnerDTO Inner { get; set; } = null!;
         }
 
         public class InnerDTO;
@@ -986,8 +984,8 @@ public abstract class AdHocMiscellaneousQueryTestBase(NonSharedFixture fixture)
     // Protected so that it can be used by inheriting tests, and so that things like unused setters are not removed.
     protected class Context12549(DbContextOptions options) : DbContext(options)
     {
-        public DbSet<Table1> Tables1 { get; set; }
-        public DbSet<Table2> Tables2 { get; set; }
+        public DbSet<Table1> Tables1 { get; set; } = null!;
+        public DbSet<Table2> Tables2 { get; set; } = null!;
 
         public class Table1
         {
@@ -1024,8 +1022,8 @@ public abstract class AdHocMiscellaneousQueryTestBase(NonSharedFixture fixture)
     // Protected so that it can be used by inheriting tests, and so that things like unused setters are not removed.
     protected class Context15215(DbContextOptions options) : DbContext(options)
     {
-        public DbSet<Auto> Autos { get; set; }
-        public DbSet<EqualAuto> EqualAutos { get; set; }
+        public DbSet<Auto> Autos { get; set; } = null!;
+        public DbSet<EqualAuto> EqualAutos { get; set; } = null!;
 
         public async Task SeedAsync()
         {
@@ -1037,8 +1035,8 @@ public abstract class AdHocMiscellaneousQueryTestBase(NonSharedFixture fixture)
             await SaveChangesAsync();
 
             AddRange(
-                new EqualAuto { Auto = await Autos.FindAsync(1), AnotherAuto = await Autos.FindAsync(2) },
-                new EqualAuto { Auto = await Autos.FindAsync(5), AnotherAuto = await Autos.FindAsync(4) });
+                new EqualAuto { Auto = (await Autos.FindAsync(1))!, AnotherAuto = (await Autos.FindAsync(2))! },
+                new EqualAuto { Auto = (await Autos.FindAsync(5))!, AnotherAuto = (await Autos.FindAsync(4))! });
 
             await SaveChangesAsync();
         }
@@ -1046,14 +1044,14 @@ public abstract class AdHocMiscellaneousQueryTestBase(NonSharedFixture fixture)
         public class Auto
         {
             public int Id { get; set; }
-            public string Name { get; set; }
+            public string? Name { get; set; }
         }
 
         public class EqualAuto
         {
             public int Id { get; set; }
-            public Auto Auto { get; set; }
-            public Auto AnotherAuto { get; set; }
+            public Auto? Auto { get; set; }
+            public Auto? AnotherAuto { get; set; }
         }
     }
 
@@ -1078,7 +1076,7 @@ public abstract class AdHocMiscellaneousQueryTestBase(NonSharedFixture fixture)
                     (left, rightg) => new { left, rightg })
                 .SelectMany(
                     r => r.rightg.DefaultIfEmpty(),
-                    (x, y) => new Context19253.JoinResult<Context19253.A, Context19253.B> { Left = x.left, Right = y })
+                    (x, y) => new Context19253.JoinResult<Context19253.A, Context19253.B> { Left = x.left, Right = y! })
                 .Concat(
                     context.Bs.GroupJoin(
                             context.As,
@@ -1087,7 +1085,7 @@ public abstract class AdHocMiscellaneousQueryTestBase(NonSharedFixture fixture)
                             (right, leftg) => new { leftg, right })
                         .SelectMany(
                             l => l.leftg.DefaultIfEmpty(),
-                            (x, y) => new Context19253.JoinResult<Context19253.A, Context19253.B> { Left = y, Right = x.right })
+                            (x, y) => new Context19253.JoinResult<Context19253.A, Context19253.B> { Left = y!, Right = x.right })
                         .Where(z => z.Left.Equals(null)))
                 .ToList();
 
@@ -1106,7 +1104,7 @@ public abstract class AdHocMiscellaneousQueryTestBase(NonSharedFixture fixture)
                     (left, rightg) => new { left, rightg })
                 .SelectMany(
                     r => r.rightg.DefaultIfEmpty(),
-                    (x, y) => new Context19253.JoinResult<Context19253.A, Context19253.B> { Left = x.left, Right = y })
+                    (x, y) => new Context19253.JoinResult<Context19253.A, Context19253.B> { Left = x.left, Right = y! })
                 .Union(
                     context.Bs.GroupJoin(
                             context.As,
@@ -1115,7 +1113,7 @@ public abstract class AdHocMiscellaneousQueryTestBase(NonSharedFixture fixture)
                             (right, leftg) => new { leftg, right })
                         .SelectMany(
                             l => l.leftg.DefaultIfEmpty(),
-                            (x, y) => new Context19253.JoinResult<Context19253.A, Context19253.B> { Left = y, Right = x.right })
+                            (x, y) => new Context19253.JoinResult<Context19253.A, Context19253.B> { Left = y!, Right = x.right })
                         .Where(z => z.Left.Equals(null)))
                 .ToList();
 
@@ -1134,7 +1132,7 @@ public abstract class AdHocMiscellaneousQueryTestBase(NonSharedFixture fixture)
                     (left, rightg) => new { left, rightg })
                 .SelectMany(
                     r => r.rightg.DefaultIfEmpty(),
-                    (x, y) => new Context19253.JoinResult<Context19253.A, Context19253.B> { Left = x.left, Right = y })
+                    (x, y) => new Context19253.JoinResult<Context19253.A, Context19253.B> { Left = x.left, Right = y! })
                 .Except(
                     context.Bs.GroupJoin(
                             context.As,
@@ -1143,7 +1141,7 @@ public abstract class AdHocMiscellaneousQueryTestBase(NonSharedFixture fixture)
                             (right, leftg) => new { leftg, right })
                         .SelectMany(
                             l => l.leftg.DefaultIfEmpty(),
-                            (x, y) => new Context19253.JoinResult<Context19253.A, Context19253.B> { Left = y, Right = x.right }))
+                            (x, y) => new Context19253.JoinResult<Context19253.A, Context19253.B> { Left = y!, Right = x.right }))
                 .ToList();
 
             Assert.Single(query);
@@ -1161,7 +1159,7 @@ public abstract class AdHocMiscellaneousQueryTestBase(NonSharedFixture fixture)
                     (left, rightg) => new { left, rightg })
                 .SelectMany(
                     r => r.rightg.DefaultIfEmpty(),
-                    (x, y) => new Context19253.JoinResult<Context19253.A, Context19253.B> { Left = x.left, Right = y })
+                    (x, y) => new Context19253.JoinResult<Context19253.A, Context19253.B> { Left = x.left, Right = y! })
                 .Intersect(
                     context.Bs.GroupJoin(
                             context.As,
@@ -1170,7 +1168,7 @@ public abstract class AdHocMiscellaneousQueryTestBase(NonSharedFixture fixture)
                             (right, leftg) => new { leftg, right })
                         .SelectMany(
                             l => l.leftg.DefaultIfEmpty(),
-                            (x, y) => new Context19253.JoinResult<Context19253.A, Context19253.B> { Left = y, Right = x.right }))
+                            (x, y) => new Context19253.JoinResult<Context19253.A, Context19253.B> { Left = y!, Right = x.right }))
                 .ToList();
 
             Assert.Single(query);
@@ -1180,8 +1178,8 @@ public abstract class AdHocMiscellaneousQueryTestBase(NonSharedFixture fixture)
     // Protected so that it can be used by inheriting tests, and so that things like unused setters are not removed.
     protected class Context19253(DbContextOptions options) : DbContext(options)
     {
-        public DbSet<A> As { get; set; }
-        public DbSet<B> Bs { get; set; }
+        public DbSet<A> As { get; set; } = null!;
+        public DbSet<B> Bs { get; set; } = null!;
 
         public Task SeedAsync()
         {
@@ -1222,25 +1220,25 @@ public abstract class AdHocMiscellaneousQueryTestBase(NonSharedFixture fixture)
 
         public class JoinResult<TLeft, TRight>
         {
-            public TLeft Left { get; set; }
+            public TLeft Left { get; set; } = default!;
 
-            public TRight Right { get; set; }
+            public TRight Right { get; set; } = default!;
         }
 
         public class A
         {
             public int Id { get; set; }
-            public string a { get; set; }
-            public string a1 { get; set; }
-            public string forkey { get; set; }
+            public string a { get; set; } = null!;
+            public string a1 { get; set; } = null!;
+            public string forkey { get; set; } = null!;
         }
 
         public class B
         {
             public int Id { get; set; }
-            public string b { get; set; }
-            public string b1 { get; set; }
-            public string forkey { get; set; }
+            public string b { get; set; } = null!;
+            public string b1 { get; set; } = null!;
+            public string forkey { get; set; } = null!;
         }
     }
 
@@ -1314,8 +1312,8 @@ public abstract class AdHocMiscellaneousQueryTestBase(NonSharedFixture fixture)
     // Protected so that it can be used by inheriting tests, and so that things like unused setters are not removed.
     protected class Context21770(DbContextOptions options) : DbContext(options)
     {
-        public DbSet<IceCream> IceCreams { get; set; }
-        public DbSet<Food> Foods { get; set; }
+        public DbSet<IceCream> IceCreams { get; set; } = null!;
+        public DbSet<Food> Foods { get; set; } = null!;
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
@@ -1351,7 +1349,7 @@ public abstract class AdHocMiscellaneousQueryTestBase(NonSharedFixture fixture)
         public class IceCream
         {
             public int IceCreamId { get; set; }
-            public string Name { get; set; }
+            public string Name { get; set; } = null!;
             public int Taste { get; set; }
         }
 
@@ -1411,7 +1409,7 @@ public abstract class AdHocMiscellaneousQueryTestBase(NonSharedFixture fixture)
                 .Property(o => o.Id)
                 .UsePropertyAccessMode(PropertyAccessMode.Property);
 
-        public DbSet<ObservableThing> ObservableThings { get; set; }
+        public DbSet<ObservableThing> ObservableThings { get; set; } = null!;
 
         public class ObservableThing
         {
@@ -1425,7 +1423,7 @@ public abstract class AdHocMiscellaneousQueryTestBase(NonSharedFixture fixture)
                 }
             }
 
-            public event Action Event;
+            public event Action Event = null!;
         }
     }
 
@@ -1451,7 +1449,7 @@ public abstract class AdHocMiscellaneousQueryTestBase(NonSharedFixture fixture)
     // Protected so that it can be used by inheriting tests, and so that things like unused setters are not removed.
     protected class Context24657(DbContextOptions options) : DbContext(options)
     {
-        public DbSet<Author> Authors { get; set; }
+        public DbSet<Author> Authors { get; set; } = null!;
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
             => modelBuilder.Entity<Blog>()
@@ -1470,14 +1468,14 @@ public abstract class AdHocMiscellaneousQueryTestBase(NonSharedFixture fixture)
         public class Author
         {
             public int Id { get; set; }
-            public Blog Blog { get; set; }
+            public Blog? Blog { get; set; }
         }
 
         public abstract class Blog
         {
             public int Id { get; set; }
             public bool IsPhotoBlog { get; set; }
-            public string Title { get; set; }
+            public string? Title { get; set; }
         }
 
         public class DevBlog : Blog
@@ -1574,9 +1572,9 @@ public abstract class AdHocMiscellaneousQueryTestBase(NonSharedFixture fixture)
     // Protected so that it can be used by inheriting tests, and so that things like unused setters are not removed.
     protected class Context26593(DbContextOptions options) : DbContext(options)
     {
-        public DbSet<User> Users { get; set; }
-        public DbSet<Group> Groups { get; set; }
-        public DbSet<Membership> Memberships { get; set; }
+        public DbSet<User> Users { get; set; } = null!;
+        public DbSet<Group> Groups { get; set; } = null!;
+        public DbSet<Membership> Memberships { get; set; } = null!;
 
         public Task SeedAsync()
         {
@@ -1592,22 +1590,22 @@ public abstract class AdHocMiscellaneousQueryTestBase(NonSharedFixture fixture)
         {
             public int Id { get; set; }
 
-            public ICollection<Membership> Memberships { get; set; }
+            public ICollection<Membership> Memberships { get; set; } = null!;
         }
 
         public class Group
         {
             public int Id { get; set; }
 
-            public ICollection<Membership> Memberships { get; set; }
+            public ICollection<Membership> Memberships { get; set; } = null!;
         }
 
         public class Membership
         {
             public int Id { get; set; }
-            public User User { get; set; }
+            public User User { get; set; } = null!;
             public int UserId { get; set; }
-            public Group Group { get; set; }
+            public Group Group { get; set; } = null!;
             public int GroupId { get; set; }
         }
     }
@@ -1647,7 +1645,7 @@ public abstract class AdHocMiscellaneousQueryTestBase(NonSharedFixture fixture)
     // Protected so that it can be used by inheriting tests, and so that things like unused setters are not removed.
     protected class Context26587(DbContextOptions options) : DbContext(options)
     {
-        public DbSet<OrderItem> OrderItems { get; set; }
+        public DbSet<OrderItem> OrderItems { get; set; } = null!;
 
         public class OrderItem
         {
@@ -1687,8 +1685,8 @@ public abstract class AdHocMiscellaneousQueryTestBase(NonSharedFixture fixture)
     // Protected so that it can be used by inheriting tests, and so that things like unused setters are not removed.
     protected class Context26472(DbContextOptions options) : DbContext(options)
     {
-        public virtual DbSet<Order> Orders { get; set; }
-        public virtual DbSet<OrderItem> OrderItems { get; set; }
+        public virtual DbSet<Order> Orders { get; set; } = null!;
+        public virtual DbSet<OrderItem> OrderItems { get; set; } = null!;
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
             => modelBuilder.Entity<OrderItem>().Property(x => x.Type).HasConversion<string>();
@@ -1697,7 +1695,7 @@ public abstract class AdHocMiscellaneousQueryTestBase(NonSharedFixture fixture)
         {
             public int Id { get; set; }
 
-            public virtual ICollection<OrderItem> Items { get; set; }
+            public virtual ICollection<OrderItem> Items { get; set; } = null!;
         }
 
         public class OrderItem
@@ -1790,8 +1788,8 @@ public abstract class AdHocMiscellaneousQueryTestBase(NonSharedFixture fixture)
     // Protected so that it can be used by inheriting tests, and so that things like unused setters are not removed.
     protected class Context27083(DbContextOptions options) : DbContext(options)
     {
-        public DbSet<TimeSheet> TimeSheets { get; set; }
-        public DbSet<Customer> Customers { get; set; }
+        public DbSet<TimeSheet> TimeSheets { get; set; } = null!;
+        public DbSet<Customer> Customers { get; set; } = null!;
 
         public Task SeedAsync()
         {
@@ -1834,19 +1832,19 @@ public abstract class AdHocMiscellaneousQueryTestBase(NonSharedFixture fixture)
         {
             public int Id { get; set; }
 
-            public string Name { get; set; }
+            public string? Name { get; set; }
 
-            public List<Project> Projects { get; set; }
-            public List<Order> Orders { get; set; }
+            public List<Project> Projects { get; set; } = null!;
+            public List<Order> Orders { get; set; } = null!;
         }
 
         public class Order
         {
             public int Id { get; set; }
-            public string Number { get; set; }
+            public string? Number { get; set; }
 
             public int CustomerId { get; set; }
-            public Customer Customer { get; set; }
+            public Customer Customer { get; set; } = null!;
 
             public int HourlyRate { get; set; }
         }
@@ -1856,7 +1854,7 @@ public abstract class AdHocMiscellaneousQueryTestBase(NonSharedFixture fixture)
             public int Id { get; set; }
             public int CustomerId { get; set; }
 
-            public Customer Customer { get; set; }
+            public Customer Customer { get; set; } = null!;
         }
 
         public class TimeSheet
@@ -1864,10 +1862,10 @@ public abstract class AdHocMiscellaneousQueryTestBase(NonSharedFixture fixture)
             public int Id { get; set; }
 
             public int ProjectId { get; set; }
-            public Project Project { get; set; }
+            public Project Project { get; set; } = null!;
 
             public int? OrderId { get; set; }
-            public Order Order { get; set; }
+            public Order Order { get; set; } = null!;
         }
     }
 
@@ -1923,7 +1921,7 @@ public abstract class AdHocMiscellaneousQueryTestBase(NonSharedFixture fixture)
     // Protected so that it can be used by inheriting tests, and so that things like unused setters are not removed.
     protected class Context27094(DbContextOptions options) : DbContext(options)
     {
-        public DbSet<Table> Tables { get; set; }
+        public DbSet<Table> Tables { get; set; } = null!;
 
         public class Table
         {
@@ -1983,7 +1981,7 @@ public abstract class AdHocMiscellaneousQueryTestBase(NonSharedFixture fixture)
     // Protected so that it can be used by inheriting tests, and so that things like unused setters are not removed.
     protected class Context26744(DbContextOptions options) : DbContext(options)
     {
-        public DbSet<Parent> Parents { get; set; }
+        public DbSet<Parent> Parents { get; set; } = null!;
 
         public Task SeedAsync()
         {
@@ -1995,7 +1993,7 @@ public abstract class AdHocMiscellaneousQueryTestBase(NonSharedFixture fixture)
         public class Parent
         {
             public int Id { get; set; }
-            public List<Child> Children { get; set; }
+            public List<Child> Children { get; set; } = null!;
         }
 
         public class Child
@@ -2004,7 +2002,7 @@ public abstract class AdHocMiscellaneousQueryTestBase(NonSharedFixture fixture)
             public int SomeInteger { get; set; }
             public DateTime? SomeNullableDateTime { get; set; }
             public DateTime? SomeOtherNullableDateTime { get; set; }
-            public Parent Parent { get; set; }
+            public Parent Parent { get; set; } = null!;
         }
     }
 
@@ -2034,7 +2032,7 @@ public abstract class AdHocMiscellaneousQueryTestBase(NonSharedFixture fixture)
     // Protected so that it can be used by inheriting tests, and so that things like unused setters are not removed.
     protected class Context27343(DbContextOptions options) : DbContext(options)
     {
-        public DbSet<Parent> Parents { get; set; }
+        public DbSet<Parent> Parents { get; set; } = null!;
 
         public Task SeedAsync()
             => SaveChangesAsync();
@@ -2047,7 +2045,7 @@ public abstract class AdHocMiscellaneousQueryTestBase(NonSharedFixture fixture)
         public class Parent : IDocumentType
         {
             public int Id { get; set; }
-            public List<Child> Children { get; set; }
+            public List<Child> Children { get; set; } = null!;
         }
 
         public class Child
@@ -2056,7 +2054,7 @@ public abstract class AdHocMiscellaneousQueryTestBase(NonSharedFixture fixture)
             public int SomeInteger { get; set; }
             public DateTime? SomeNullableDateTime { get; set; }
             public DateTime? SomeOtherNullableDateTime { get; set; }
-            public Parent Parent { get; set; }
+            public Parent Parent { get; set; } = null!;
         }
     }
 
@@ -2091,15 +2089,15 @@ public abstract class AdHocMiscellaneousQueryTestBase(NonSharedFixture fixture)
     // Protected so that it can be used by inheriting tests, and so that things like unused setters are not removed.
     protected class Context28039(DbContextOptions options) : DbContext(options)
     {
-        public DbSet<IndexData> IndexDatas { get; set; }
-        public DbSet<TableData> TableDatas { get; set; }
+        public DbSet<IndexData> IndexDatas { get; set; } = null!;
+        public DbSet<TableData> TableDatas { get; set; } = null!;
 
         public class TableData : EntityBase
         {
             public int TableId { get; set; }
-            public string ParcelNumber { get; set; }
+            public string ParcelNumber { get; set; } = null!;
             public short RowId { get; set; }
-            public string JSON { get; set; }
+            public string JSON { get; set; } = null!;
         }
 
         public abstract class EntityBase
@@ -2110,15 +2108,15 @@ public abstract class AdHocMiscellaneousQueryTestBase(NonSharedFixture fixture)
 
         public class IndexData : EntityBase
         {
-            public string Parcel { get; set; }
+            public string Parcel { get; set; } = null!;
             public int RowId { get; set; }
         }
 
         public class SearchResult
         {
-            public string ParcelNumber { get; set; }
+            public string ParcelNumber { get; set; } = null!;
             public int RowId { get; set; }
-            public string DistinctValue { get; set; }
+            public string DistinctValue { get; set; } = null!;
         }
     }
 
@@ -2145,13 +2143,13 @@ public abstract class AdHocMiscellaneousQueryTestBase(NonSharedFixture fixture)
                         CountryId = m.Company.CountryId,
                         Country = new Context31961.CountryDto
                         {
-                            Id = m.Company.Country.Id,
-                            CountryName = m.Company.Country.CountryName,
+                            Id = m.Company.Country!.Id,
+                            CountryName = m.Company.Country!.CountryName,
                         },
                     }
                     : null,
             })
-            .Where(m => m.Company.Country.CountryName == "COUNTRY");
+            .Where(m => m.Company!.Country!.CountryName == "COUNTRY");
 
         var result = async
             ? await query.ToListAsync()
@@ -2161,91 +2159,91 @@ public abstract class AdHocMiscellaneousQueryTestBase(NonSharedFixture fixture)
     // Protected so that it can be used by inheriting tests, and so that things like unused setters are not removed.
     protected class Context31961(DbContextOptions options) : DbContext(options)
     {
-        public DbSet<Customer> Customers { get; set; }
+        public DbSet<Customer> Customers { get; set; } = null!;
 
-        public DbSet<Company> Companies { get; set; }
+        public DbSet<Company> Companies { get; set; } = null!;
 
-        public DbSet<Country> Countries { get; set; }
+        public DbSet<Country> Countries { get; set; } = null!;
 
         public class Customer
         {
             public string Id { get; set; } = string.Empty;
 
-            public string CompanyId { get; set; }
+            public string? CompanyId { get; set; }
 
-            public Company Company { get; set; }
+            public Company? Company { get; set; }
         }
 
         public class Country
         {
             public string Id { get; set; } = string.Empty;
 
-            public string CountryName { get; set; } = string.Empty;
+            public string? CountryName { get; set; }
         }
 
         public class Company
         {
             public string Id { get; set; } = string.Empty;
 
-            public string CompanyName { get; set; } = string.Empty;
+            public string? CompanyName { get; set; }
 
-            public string CountryId { get; set; }
+            public string? CountryId { get; set; }
 
-            public Country Country { get; set; }
+            public Country? Country { get; set; }
         }
 
         public interface ICustomerDto
         {
             string Id { get; set; }
 
-            string CompanyId { get; set; }
+            string? CompanyId { get; set; }
 
-            ICompanyDto Company { get; set; }
+            ICompanyDto? Company { get; set; }
         }
 
         public interface ICountryDto
         {
             string Id { get; set; }
 
-            string CountryName { get; set; }
+            string? CountryName { get; set; }
         }
 
         public interface ICompanyDto
         {
             string Id { get; set; }
 
-            string CompanyName { get; set; }
+            string? CompanyName { get; set; }
 
-            string CountryId { get; set; }
+            string? CountryId { get; set; }
 
-            ICountryDto Country { get; set; }
+            ICountryDto? Country { get; set; }
         }
 
         public class CustomerDto : ICustomerDto
         {
             public string Id { get; set; } = string.Empty;
 
-            public string CompanyId { get; set; }
+            public string? CompanyId { get; set; }
 
-            public ICompanyDto Company { get; set; }
+            public ICompanyDto? Company { get; set; }
         }
 
         public class CountryDto : ICountryDto
         {
             public string Id { get; set; } = string.Empty;
 
-            public string CountryName { get; set; } = string.Empty;
+            public string? CountryName { get; set; }
         }
 
         public class CompanyDto : ICompanyDto
         {
             public string Id { get; set; } = string.Empty;
 
-            public string CompanyName { get; set; } = string.Empty;
+            public string? CompanyName { get; set; }
 
-            public string CountryId { get; set; }
+            public string? CountryId { get; set; }
 
-            public ICountryDto Country { get; set; }
+            public ICountryDto? Country { get; set; }
         }
     }
 

--- a/test/EFCore.Specification.Tests/Query/AdHocNavigationsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/AdHocNavigationsQueryTestBase.cs
@@ -8,8 +8,6 @@ using Microsoft.EntityFrameworkCore.Diagnostics.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
-#nullable disable
-
 public abstract class AdHocNavigationsQueryTestBase(NonSharedFixture fixture)
     : NonSharedModelTestBase(fixture), IClassFixture<NonSharedFixture>
 {
@@ -81,8 +79,8 @@ public abstract class AdHocNavigationsQueryTestBase(NonSharedFixture fixture)
     // Protected so that it can be used by inheriting tests, and so that things like unused setters are not removed.
     protected class Context3409(DbContextOptions options) : DbContext(options)
     {
-        public DbSet<Parent> Parents { get; set; }
-        public DbSet<Child> Children { get; set; }
+        public DbSet<Parent> Parents { get; set; } = null!;
+        public DbSet<Child> Children { get; set; } = null!;
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
@@ -135,7 +133,7 @@ public abstract class AdHocNavigationsQueryTestBase(NonSharedFixture fixture)
         {
             public int Id { get; set; }
 
-            public ICollection<IChild> ChildCollection { get; set; }
+            public ICollection<IChild> ChildCollection { get; set; } = null!;
         }
 
         public class Child : IChild
@@ -143,11 +141,11 @@ public abstract class AdHocNavigationsQueryTestBase(NonSharedFixture fixture)
             public int Id { get; set; }
 
             public int? ParentBackNavigationId { get; set; }
-            public IParent ParentBackNavigation { get; set; }
+            public IParent ParentBackNavigation { get; set; } = null!;
 
-            public ICollection<IChild> SelfReferenceCollection { get; set; }
+            public ICollection<IChild> SelfReferenceCollection { get; set; } = null!;
             public int? SelfReferenceBackNavigationId { get; set; }
-            public IChild SelfReferenceBackNavigation { get; set; }
+            public IChild SelfReferenceBackNavigation { get; set; } = null!;
         }
     }
 
@@ -197,8 +195,8 @@ public abstract class AdHocNavigationsQueryTestBase(NonSharedFixture fixture)
 
     protected class Context3758(DbContextOptions options) : DbContext(options)
     {
-        public DbSet<Customer> Customers { get; set; }
-        public DbSet<Order> Orders { get; set; }
+        public DbSet<Customer> Customers { get; set; } = null!;
+        public DbSet<Order> Orders { get; set; } = null!;
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
             => modelBuilder.Entity<Customer>(b =>
@@ -266,18 +264,18 @@ public abstract class AdHocNavigationsQueryTestBase(NonSharedFixture fixture)
         public class Customer
         {
             public int Id { get; set; }
-            public string Name { get; set; }
+            public string Name { get; set; } = null!;
 
-            public ICollection<Order> Orders1 { get; set; }
-            public MyGenericCollection<Order> Orders2 { get; set; }
-            public MyNonGenericCollection Orders3 { get; set; }
-            public MyInvalidCollection<Order> Orders4 { get; set; }
+            public ICollection<Order> Orders1 { get; set; } = null!;
+            public MyGenericCollection<Order> Orders2 { get; set; } = null!;
+            public MyNonGenericCollection Orders3 { get; set; } = null!;
+            public MyInvalidCollection<Order> Orders4 { get; set; } = null!;
         }
 
         public class Order
         {
             public int Id { get; set; }
-            public string Name { get; set; }
+            public string Name { get; set; } = null!;
         }
 
         public class MyGenericCollection<TElement> : List<TElement>;
@@ -313,9 +311,9 @@ public abstract class AdHocNavigationsQueryTestBase(NonSharedFixture fixture)
     // Protected so that it can be used by inheriting tests, and so that things like unused setters are not removed.
     protected class Context7312(DbContextOptions options) : DbContext(options)
     {
-        public DbSet<Proposal> Proposals { get; set; }
-        public DbSet<ProposalCustom> ProposalCustoms { get; set; }
-        public DbSet<ProposalLeave> ProposalLeaves { get; set; }
+        public DbSet<Proposal> Proposals { get; set; } = null!;
+        public DbSet<ProposalCustom> ProposalCustoms { get; set; } = null!;
+        public DbSet<ProposalLeave> ProposalLeaves { get; set; } = null!;
 
         public Task SeedAsync()
         {
@@ -334,19 +332,19 @@ public abstract class AdHocNavigationsQueryTestBase(NonSharedFixture fixture)
 
         public class ProposalCustom : Proposal
         {
-            public string Name { get; set; }
+            public string Name { get; set; } = null!;
         }
 
         public class ProposalLeave : Proposal
         {
             public DateTime LeaveStart { get; set; }
-            public virtual ProposalLeaveType LeaveType { get; set; }
+            public virtual ProposalLeaveType? LeaveType { get; set; }
         }
 
         public class ProposalLeaveType
         {
             public int Id { get; set; }
-            public ICollection<ProposalLeave> ProposalLeaves { get; set; }
+            public ICollection<ProposalLeave> ProposalLeaves { get; set; } = null!;
         }
     }
 
@@ -363,8 +361,8 @@ public abstract class AdHocNavigationsQueryTestBase(NonSharedFixture fixture)
         {
             var result = await context.People.OfType<Context9038.PersonTeacher9038>()
                 .Include(m => m.Students)
-                .ThenInclude(m => m.Family)
-                .ThenInclude(m => m.Members)
+                .ThenInclude(m => m.Family!)
+                .ThenInclude(m => m!.Members)
                 .ToListAsync();
 
             Assert.Equal(2, result.Count);
@@ -374,7 +372,7 @@ public abstract class AdHocNavigationsQueryTestBase(NonSharedFixture fixture)
         using (var context = contextFactory.CreateDbContext())
         {
             var result = await context.Set<Context9038.PersonTeacher9038>()
-                .Include(m => m.Family.Members)
+                .Include(m => m.Family!.Members)
                 .Include(m => m.Students)
                 .ToListAsync();
 
@@ -388,9 +386,9 @@ public abstract class AdHocNavigationsQueryTestBase(NonSharedFixture fixture)
     // Protected so that it can be used by inheriting tests, and so that things like unused setters are not removed.
     protected class Context9038(DbContextOptions options) : DbContext(options)
     {
-        public DbSet<Person9038> People { get; set; }
+        public DbSet<Person9038> People { get; set; } = null!;
 
-        public DbSet<PersonFamily9038> Families { get; set; }
+        public DbSet<PersonFamily9038> Families { get; set; } = null!;
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
@@ -443,32 +441,32 @@ public abstract class AdHocNavigationsQueryTestBase(NonSharedFixture fixture)
         {
             public int Id { get; set; }
 
-            public string Name { get; set; }
+            public string Name { get; set; } = null!;
 
             public int? TeacherId { get; set; }
 
-            public PersonFamily9038 Family { get; set; }
+            public PersonFamily9038? Family { get; set; }
         }
 
         public class PersonKid9038 : Person9038
         {
             public int Grade { get; set; }
 
-            public PersonTeacher9038 Teacher { get; set; }
+            public PersonTeacher9038 Teacher { get; set; } = null!;
         }
 
         public class PersonTeacher9038 : Person9038
         {
-            public ICollection<PersonKid9038> Students { get; set; }
+            public ICollection<PersonKid9038> Students { get; set; } = null!;
         }
 
         public class PersonFamily9038
         {
             public int Id { get; set; }
 
-            public string LastName { get; set; }
+            public string LastName { get; set; } = null!;
 
-            public ICollection<Person9038> Members { get; set; }
+            public ICollection<Person9038> Members { get; set; } = null!;
         }
     }
 
@@ -494,8 +492,8 @@ public abstract class AdHocNavigationsQueryTestBase(NonSharedFixture fixture)
     // Protected so that it can be used by inheriting tests, and so that things like unused setters are not removed.
     protected class Context10635(DbContextOptions options) : DbContext(options)
     {
-        public DbSet<Parent10635> Parents { get; set; }
-        public DbSet<Child10635> Children { get; set; }
+        public DbSet<Parent10635> Parents { get; set; } = null!;
+        public DbSet<Child10635> Children { get; set; } = null!;
 
         public Task SeedAsync()
         {
@@ -519,14 +517,14 @@ public abstract class AdHocNavigationsQueryTestBase(NonSharedFixture fixture)
         public class Parent10635 : IEntity10635
         {
             public int Id { get; set; }
-            public string Name { get; set; }
-            public virtual ICollection<Child10635> Children { get; set; }
+            public string Name { get; set; } = null!;
+            public virtual ICollection<Child10635> Children { get; set; } = null!;
         }
 
         public class Child10635 : IEntity10635
         {
             public int Id { get; set; }
-            public string Name { get; set; }
+            public string Name { get; set; } = null!;
             public int ParentId { get; set; }
         }
     }
@@ -568,9 +566,9 @@ public abstract class AdHocNavigationsQueryTestBase(NonSharedFixture fixture)
     // Protected so that it can be used by inheriting tests, and so that things like unused setters are not removed.
     protected class Context11923(DbContextOptions options) : DbContext(options)
     {
-        public DbSet<Blog> Blogs { get; set; }
-        public DbSet<Post> Posts { get; set; }
-        public DbSet<Comment> Comments { get; set; }
+        public DbSet<Blog> Blogs { get; set; } = null!;
+        public DbSet<Post> Posts { get; set; } = null!;
+        public DbSet<Comment> Comments { get; set; } = null!;
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
@@ -624,7 +622,7 @@ public abstract class AdHocNavigationsQueryTestBase(NonSharedFixture fixture)
             }
 
             public int Id { get; set; }
-            public string Name { get; set; }
+            public string Name { get; set; } = null!;
 
             public List<Post> Posts1 { get; } = posts1;
             public CustomCollection Posts2 { get; } = posts2;
@@ -634,9 +632,9 @@ public abstract class AdHocNavigationsQueryTestBase(NonSharedFixture fixture)
         public class Post
         {
             public int Id { get; set; }
-            public string Name { get; set; }
+            public string Name { get; set; } = null!;
 
-            public List<Comment> Comments { get; set; }
+            public List<Comment> Comments { get; set; } = null!;
         }
 
         public class Comment
@@ -677,9 +675,9 @@ public abstract class AdHocNavigationsQueryTestBase(NonSharedFixture fixture)
 
     protected class Context11944(DbContextOptions options) : DbContext(options)
     {
-        public DbSet<Student> Students { get; set; }
-        public DbSet<School> Schools { get; set; }
-        public DbSet<ElementarySchool> ElementarySchools { get; set; }
+        public DbSet<Student> Students { get; set; } = null!;
+        public DbSet<School> Schools { get; set; } = null!;
+        public DbSet<ElementarySchool> ElementarySchools { get; set; } = null!;
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
             => modelBuilder.Entity<ElementarySchool>().HasMany(s => s.Students).WithOne(s => s.School);
@@ -701,7 +699,7 @@ public abstract class AdHocNavigationsQueryTestBase(NonSharedFixture fixture)
         public class Student
         {
             public int Id { get; set; }
-            public ElementarySchool School { get; set; }
+            public ElementarySchool School { get; set; } = null!;
         }
 
         public class School
@@ -711,7 +709,7 @@ public abstract class AdHocNavigationsQueryTestBase(NonSharedFixture fixture)
 
         public abstract class PrimarySchool : School
         {
-            public List<Student> Students { get; set; }
+            public List<Student> Students { get; set; } = null!;
         }
 
         public class ElementarySchool : PrimarySchool;
@@ -756,28 +754,28 @@ public abstract class AdHocNavigationsQueryTestBase(NonSharedFixture fixture)
     // Protected so that it can be used by inheriting tests, and so that things like unused setters are not removed.
     protected class Context12456(DbContextOptions options) : DbContext(options)
     {
-        public DbSet<Activity> Activities { get; set; }
-        public DbSet<CompetitionSeason> CompetitionSeasons { get; set; }
+        public DbSet<Activity> Activities { get; set; } = null!;
+        public DbSet<CompetitionSeason> CompetitionSeasons { get; set; } = null!;
 
         public class CompetitionSeason
         {
             public int Id { get; set; }
             public DateTime StartDate { get; set; }
             public DateTime EndDate { get; set; }
-            public List<ActivityTypePoints> ActivityTypePoints { get; set; }
+            public List<ActivityTypePoints> ActivityTypePoints { get; set; } = null!;
         }
 
         public class Point
         {
             public int Id { get; set; }
-            public CompetitionSeason CompetitionSeason { get; set; }
+            public CompetitionSeason CompetitionSeason { get; set; } = null!;
             public int? Points { get; set; }
         }
 
         public class ActivityType
         {
             public int Id { get; set; }
-            public List<ActivityTypePoints> Points { get; set; }
+            public List<ActivityTypePoints> Points { get; set; } = null!;
         }
 
         public class ActivityTypePoints
@@ -787,8 +785,8 @@ public abstract class AdHocNavigationsQueryTestBase(NonSharedFixture fixture)
             public int CompetitionSeasonId { get; set; }
             public int Points { get; set; }
 
-            public ActivityType ActivityType { get; set; }
-            public CompetitionSeason CompetitionSeason { get; set; }
+            public ActivityType ActivityType { get; set; } = null!;
+            public CompetitionSeason CompetitionSeason { get; set; } = null!;
         }
 
         public class Activity
@@ -797,7 +795,7 @@ public abstract class AdHocNavigationsQueryTestBase(NonSharedFixture fixture)
             public int ActivityTypeId { get; set; }
             public DateTime DateTime { get; set; }
             public int? Points { get; set; }
-            public ActivityType ActivityType { get; set; }
+            public ActivityType ActivityType { get; set; } = null!;
         }
     }
 
@@ -838,8 +836,8 @@ public abstract class AdHocNavigationsQueryTestBase(NonSharedFixture fixture)
     // Protected so that it can be used by inheriting tests, and so that things like unused setters are not removed.
     protected class Context12582(DbContextOptions options) : DbContext(options)
     {
-        public DbSet<Employee> Employees { get; set; }
-        public DbSet<EmployeeDevice> Devices { get; set; }
+        public DbSet<Employee> Employees { get; set; } = null!;
+        public DbSet<EmployeeDevice> Devices { get; set; } = null!;
 
         public Task SeedAsync()
         {
@@ -860,21 +858,21 @@ public abstract class AdHocNavigationsQueryTestBase(NonSharedFixture fixture)
         public class Employee : IEmployee
         {
             public int Id { get; set; }
-            public string Name { get; set; }
-            public ICollection<EmployeeDevice> Devices { get; set; }
+            public string Name { get; set; } = null!;
+            public ICollection<EmployeeDevice> Devices { get; set; } = null!;
         }
 
         public interface IEmployeeDevice
         {
-            string Device { get; set; }
+            string? Device { get; set; }
         }
 
         public class EmployeeDevice : IEmployeeDevice
         {
             public int Id { get; set; }
             public int EmployeeId { get; set; }
-            public string Device { get; set; }
-            public Employee Employee { get; set; }
+            public string? Device { get; set; }
+            public Employee Employee { get; set; } = null!;
         }
     }
 
@@ -896,8 +894,8 @@ public abstract class AdHocNavigationsQueryTestBase(NonSharedFixture fixture)
     // Protected so that it can be used by inheriting tests, and so that things like unused setters are not removed.
     protected class Context12748(DbContextOptions options) : DbContext(options)
     {
-        public DbSet<Blog> Blogs { get; set; }
-        public DbSet<Comment> Comments { get; set; }
+        public DbSet<Blog> Blogs { get; set; } = null!;
+        public DbSet<Comment> Comments { get; set; } = null!;
 
         public Task SeedAsync()
         {
@@ -909,16 +907,16 @@ public abstract class AdHocNavigationsQueryTestBase(NonSharedFixture fixture)
         public class Blog
         {
             [Key]
-            public byte[] Name { get; set; }
+            public byte[] Name { get; set; } = null!;
 
-            public List<Comment> Comments { get; set; }
+            public List<Comment> Comments { get; set; } = null!;
         }
 
         public class Comment
         {
             public int Id { get; set; }
-            public byte[] BlogName { get; set; }
-            public Blog Blog { get; set; }
+            public byte[] BlogName { get; set; } = null!;
+            public Blog Blog { get; set; } = null!;
         }
     }
 
@@ -938,9 +936,9 @@ public abstract class AdHocNavigationsQueryTestBase(NonSharedFixture fixture)
 
     protected class Context20609(DbContextOptions options) : DbContext(options)
     {
-        public DbSet<BaseClass> BaseClasses { get; set; }
-        public DbSet<SubA> SubAs { get; set; }
-        public DbSet<SubB> SubBs { get; set; }
+        public DbSet<BaseClass> BaseClasses { get; set; } = null!;
+        public DbSet<SubA> SubAs { get; set; } = null!;
+        public DbSet<SubB> SubBs { get; set; } = null!;
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
@@ -950,17 +948,17 @@ public abstract class AdHocNavigationsQueryTestBase(NonSharedFixture fixture)
 
         public class BaseClass
         {
-            public string Id { get; set; }
+            public string Id { get; set; } = null!;
         }
 
         public class ClassA : BaseClass
         {
-            public SubA SubA { get; set; }
+            public SubA SubA { get; set; } = null!;
         }
 
         public class ClassB : BaseClass
         {
-            public SubB SubB { get; set; }
+            public SubB SubB { get; set; } = null!;
         }
 
         public class SubA
@@ -1002,17 +1000,17 @@ public abstract class AdHocNavigationsQueryTestBase(NonSharedFixture fixture)
     // Protected so that it can be used by inheriting tests, and so that things like unused setters are not removed.
     protected class Context20813(DbContextOptions options) : DbContext(options)
     {
-        public DbSet<Order> Orders { get; set; }
+        public DbSet<Order> Orders { get; set; } = null!;
 
         public class Order
         {
-            private ICollection<IdentityDocument> _identityDocuments;
+            private ICollection<IdentityDocument> _identityDocuments = null!;
 
             public Guid Id { get; set; }
 
             public Guid CustomerId { get; set; }
 
-            public string ExternalReferenceId { get; set; }
+            public string ExternalReferenceId { get; set; } = null!;
 
             public ICollection<IdentityDocument> IdentityDocuments
             {
@@ -1023,14 +1021,14 @@ public abstract class AdHocNavigationsQueryTestBase(NonSharedFixture fixture)
 
         public class IdentityDocument
         {
-            private ICollection<IdentityDocumentImage> _images;
+            private ICollection<IdentityDocumentImage> _images = null!;
 
             public Guid Id { get; set; }
 
             [ForeignKey(nameof(Order))]
             public Guid OrderId { get; set; }
 
-            public Order Order { get; set; }
+            public Order Order { get; set; } = null!;
 
             public ICollection<IdentityDocumentImage> Images
             {
@@ -1046,9 +1044,9 @@ public abstract class AdHocNavigationsQueryTestBase(NonSharedFixture fixture)
             [ForeignKey(nameof(IdentityDocument))]
             public Guid IdentityDocumentId { get; set; }
 
-            public byte[] Image { get; set; }
+            public byte[] Image { get; set; } = null!;
 
-            public IdentityDocument IdentityDocument { get; set; }
+            public IdentityDocument IdentityDocument { get; set; } = null!;
         }
     }
 
@@ -1069,7 +1067,7 @@ public abstract class AdHocNavigationsQueryTestBase(NonSharedFixture fixture)
                         ? new Context21768.PageViewModel
                         {
                             Uri = b.FrontCover.Illustrations
-                                .FirstOrDefault(i => i.State >= Context21768.IllustrationState.Approved).Uri
+                            .FirstOrDefault(i => i.State >= Context21768.IllustrationState.Approved)!.Uri
                         }
                         : null,
             };
@@ -1080,9 +1078,9 @@ public abstract class AdHocNavigationsQueryTestBase(NonSharedFixture fixture)
     // Protected so that it can be used by inheriting tests, and so that things like unused setters are not removed.
     protected class Context21768(DbContextOptions options) : DbContext(options)
     {
-        public DbSet<Book> Books { get; set; }
-        public DbSet<BookCover> BookCovers { get; set; }
-        public DbSet<CoverIllustration> CoverIllustrations { get; set; }
+        public DbSet<Book> Books { get; set; } = null!;
+        public DbSet<BookCover> BookCovers { get; set; } = null!;
+        public DbSet<CoverIllustration> CoverIllustrations { get; set; } = null!;
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
@@ -1094,12 +1092,12 @@ public abstract class AdHocNavigationsQueryTestBase(NonSharedFixture fixture)
 
         public class BookViewModel
         {
-            public PageViewModel FirstPage { get; set; }
+            public PageViewModel? FirstPage { get; set; }
         }
 
         public class PageViewModel
         {
-            public string Uri { get; set; }
+            public string Uri { get; set; } = null!;
         }
 
         public interface IBook
@@ -1132,10 +1130,10 @@ public abstract class AdHocNavigationsQueryTestBase(NonSharedFixture fixture)
         {
             public int Id { get; set; }
 
-            public BookCover FrontCover { get; set; }
+            public BookCover FrontCover { get; set; } = null!;
             public int FrontCoverId { get; set; }
 
-            public BookCover BackCover { get; set; }
+            public BookCover BackCover { get; set; } = null!;
             public int BackCoverId { get; set; }
 
             IBookCover IBook.FrontCover
@@ -1148,7 +1146,7 @@ public abstract class AdHocNavigationsQueryTestBase(NonSharedFixture fixture)
         public class BookCover : IBookCover
         {
             public int Id { get; set; }
-            public ICollection<CoverIllustration> Illustrations { get; set; }
+            public ICollection<CoverIllustration> Illustrations { get; set; } = null!;
 
             IEnumerable<ICoverIllustration> IBookCover.Illustrations
                 => Illustrations;
@@ -1157,9 +1155,9 @@ public abstract class AdHocNavigationsQueryTestBase(NonSharedFixture fixture)
         public class CoverIllustration : ICoverIllustration
         {
             public int Id { get; set; }
-            public BookCover Cover { get; set; }
+            public BookCover Cover { get; set; } = null!;
             public int CoverId { get; set; }
-            public string Uri { get; set; }
+            public string Uri { get; set; } = null!;
             public IllustrationState State { get; set; }
 
             IBookCover ICoverIllustration.Cover
@@ -1272,7 +1270,7 @@ public abstract class AdHocNavigationsQueryTestBase(NonSharedFixture fixture)
         public class PrincipalOneToOne
         {
             public int Id { get; set; }
-            public DependentOneToOne Dependent { get; set; }
+            public DependentOneToOne Dependent { get; set; } = null!;
         }
 
         public class DependentOneToOne
@@ -1282,13 +1280,13 @@ public abstract class AdHocNavigationsQueryTestBase(NonSharedFixture fixture)
             [ForeignKey("Principal")]
             public int PrincipalId { get; set; }
 
-            public PrincipalOneToOne Principal { get; set; }
+            public PrincipalOneToOne Principal { get; set; } = null!;
         }
 
         public class PrincipalOneToMany
         {
             public int Id { get; set; }
-            public List<DependentOneToMany> Dependents { get; set; }
+            public List<DependentOneToMany> Dependents { get; set; } = null!;
         }
 
         public class DependentOneToMany
@@ -1298,31 +1296,31 @@ public abstract class AdHocNavigationsQueryTestBase(NonSharedFixture fixture)
             [ForeignKey("Principal")]
             public int PrincipalId { get; set; }
 
-            public PrincipalOneToMany Principal { get; set; }
+            public PrincipalOneToMany Principal { get; set; } = null!;
         }
 
         public class PrincipalManyToMany
         {
             public int Id { get; set; }
-            public List<DependentManyToMany> Dependents { get; set; }
+            public List<DependentManyToMany> Dependents { get; set; } = null!;
         }
 
         public class DependentManyToMany
         {
             public int Id { get; set; }
-            public List<PrincipalManyToMany> Principals { get; set; }
+            public List<PrincipalManyToMany> Principals { get; set; } = null!;
         }
 
         public class CycleA
         {
             public int Id { get; set; }
-            public List<CycleB> Bs { get; set; }
+            public List<CycleB> Bs { get; set; } = null!;
         }
 
         public class CycleB
         {
             public int Id { get; set; }
-            public CycleC C { get; set; }
+            public CycleC C { get; set; } = null!;
         }
 
         public class CycleC
@@ -1332,8 +1330,8 @@ public abstract class AdHocNavigationsQueryTestBase(NonSharedFixture fixture)
             [ForeignKey("B")]
             public int BId { get; set; }
 
-            private CycleB B { get; set; }
-            public List<CycleA> As { get; set; }
+            private CycleB B { get; set; } = null!;
+            public List<CycleA> As { get; set; } = null!;
         }
     }
 
@@ -1350,7 +1348,7 @@ public abstract class AdHocNavigationsQueryTestBase(NonSharedFixture fixture)
         {
             var query = context.Set<Context23674.Principal>()
                 .Include(p => p.ManyDependents)
-                .ThenInclude(m => m.Principal.SingleDependent);
+                .ThenInclude(m => m.Principal!.SingleDependent);
 
             Assert.Equal(
                 CoreStrings.WarningAsErrorTemplate(
@@ -1369,7 +1367,7 @@ public abstract class AdHocNavigationsQueryTestBase(NonSharedFixture fixture)
 
         using (var context = contextFactory.CreateDbContext())
         {
-            var query = context.Set<Context23674.Principal>().Include(p => p.SingleDependent.Principal.ManyDependents);
+            var query = context.Set<Context23674.Principal>().Include(p => p.SingleDependent!.Principal.ManyDependents);
 
             Assert.Equal(
                 CoreStrings.WarningAsErrorTemplate(
@@ -1390,7 +1388,7 @@ public abstract class AdHocNavigationsQueryTestBase(NonSharedFixture fixture)
         {
             // This does not warn because after round-tripping from one-to-many from dependent side, the number of dependents could be larger.
             var query = context.Set<Context23674.ManyDependent>()
-                .Include(p => p.Principal.ManyDependents)
+                .Include(p => p.Principal!.ManyDependents)
                 .ThenInclude(m => m.SingleDependent)
                 .ToList();
         }
@@ -1403,7 +1401,7 @@ public abstract class AdHocNavigationsQueryTestBase(NonSharedFixture fixture)
 
         using (var context = contextFactory.CreateDbContext())
         {
-            var query = context.Set<Context23674.SingleDependent>().Include(p => p.ManyDependent.SingleDependent.Principal);
+            var query = context.Set<Context23674.SingleDependent>().Include(p => p.ManyDependent.SingleDependent!.Principal);
 
             Assert.Equal(
                 CoreStrings.WarningAsErrorTemplate(
@@ -1424,24 +1422,24 @@ public abstract class AdHocNavigationsQueryTestBase(NonSharedFixture fixture)
         public class Principal
         {
             public int Id { get; set; }
-            public List<ManyDependent> ManyDependents { get; set; }
-            public SingleDependent SingleDependent { get; set; }
+            public List<ManyDependent> ManyDependents { get; set; } = null!;
+            public SingleDependent? SingleDependent { get; set; }
         }
 
         public class ManyDependent
         {
             public int Id { get; set; }
-            public Principal Principal { get; set; }
-            public SingleDependent SingleDependent { get; set; }
+            public Principal? Principal { get; set; }
+            public SingleDependent? SingleDependent { get; set; }
         }
 
         public class SingleDependent
         {
             public int Id { get; set; }
-            public Principal Principal { get; set; }
+            public Principal Principal { get; set; } = null!;
             public int PrincipalId { get; set; }
             public int ManyDependentId { get; set; }
-            public ManyDependent ManyDependent { get; set; }
+            public ManyDependent ManyDependent { get; set; } = null!;
         }
     }
 
@@ -1500,37 +1498,37 @@ public abstract class AdHocNavigationsQueryTestBase(NonSharedFixture fixture)
     // Protected so that it can be used by inheriting tests, and so that things like unused setters are not removed.
     protected class Context23676(DbContextOptions options) : DbContext(options)
     {
-        public DbSet<PersonEntity> Persons { get; set; }
+        public DbSet<PersonEntity> Persons { get; set; } = null!;
 
         public class PersonEntity
         {
             public int Id { get; set; }
-            public string Name { get; set; }
-            public string Surname { get; set; }
+            public string Name { get; set; } = null!;
+            public string Surname { get; set; } = null!;
             public DateTime Birthday { get; set; }
-            public string Hometown { get; set; }
-            public string Bio { get; set; }
-            public string AvatarUrl { get; set; }
+            public string Hometown { get; set; } = null!;
+            public string Bio { get; set; } = null!;
+            public string AvatarUrl { get; set; } = null!;
 
-            public ActorEntity Actor { get; set; }
-            public DirectorEntity Director { get; set; }
+            public ActorEntity Actor { get; set; } = null!;
+            public DirectorEntity Director { get; set; } = null!;
             public IList<PersonImageEntity> Images { get; } = new List<PersonImageEntity>();
         }
 
         public class PersonImageEntity
         {
             public int Id { get; set; }
-            public string ImageUrl { get; set; }
+            public string ImageUrl { get; set; } = null!;
             public int Height { get; set; }
             public int Width { get; set; }
-            public PersonEntity Person { get; set; }
+            public PersonEntity Person { get; set; } = null!;
         }
 
         public class ActorEntity
         {
             public int Id { get; set; }
             public int PersonId { get; set; }
-            public PersonEntity Person { get; set; }
+            public PersonEntity Person { get; set; } = null!;
 
             public IList<MovieActorEntity> Movies { get; } = new List<MovieActorEntity>();
         }
@@ -1539,12 +1537,12 @@ public abstract class AdHocNavigationsQueryTestBase(NonSharedFixture fixture)
         {
             public int Id { get; set; }
             public int ActorId { get; set; }
-            public ActorEntity Actor { get; set; }
+            public ActorEntity Actor { get; set; } = null!;
 
             public int MovieId { get; set; }
-            public MovieEntity Movie { get; set; }
+            public MovieEntity Movie { get; set; } = null!;
 
-            public string RoleInFilm { get; set; }
+            public string RoleInFilm { get; set; } = null!;
 
             public int Order { get; set; }
         }
@@ -1553,7 +1551,7 @@ public abstract class AdHocNavigationsQueryTestBase(NonSharedFixture fixture)
         {
             public int Id { get; set; }
             public int PersonId { get; set; }
-            public PersonEntity Person { get; set; }
+            public PersonEntity Person { get; set; } = null!;
 
             public IList<MovieDirectorEntity> Movies { get; } = new List<MovieDirectorEntity>();
         }
@@ -1562,23 +1560,23 @@ public abstract class AdHocNavigationsQueryTestBase(NonSharedFixture fixture)
         {
             public int Id { get; set; }
             public int DirectorId { get; set; }
-            public DirectorEntity Director { get; set; }
+            public DirectorEntity Director { get; set; } = null!;
 
             public int MovieId { get; set; }
-            public MovieEntity Movie { get; set; }
+            public MovieEntity Movie { get; set; } = null!;
         }
 
         public class MovieEntity
         {
             public int Id { get; set; }
-            public string Name { get; set; }
+            public string Name { get; set; } = null!;
             public double Rating { get; set; }
-            public string Description { get; set; }
+            public string Description { get; set; } = null!;
             public DateTime ReleaseDate { get; set; }
             public int DurationInMins { get; set; }
             public int Budget { get; set; }
             public int Revenue { get; set; }
-            public string PosterUrl { get; set; }
+            public string PosterUrl { get; set; } = null!;
 
             public IList<MovieDirectorEntity> Directors { get; set; } = new List<MovieDirectorEntity>();
             public IList<MovieActorEntity> Actors { get; set; } = new List<MovieActorEntity>();
@@ -1607,8 +1605,8 @@ public abstract class AdHocNavigationsQueryTestBase(NonSharedFixture fixture)
 
     protected class Context26433(DbContextOptions options) : DbContext(options)
     {
-        public DbSet<Book> Books { get; set; }
-        public DbSet<Author> Authors { get; set; }
+        public DbSet<Book> Books { get; set; } = null!;
+        public DbSet<Author> Authors { get; set; } = null!;
 
         public Task SeedAsync()
         {
@@ -1633,9 +1631,9 @@ public abstract class AdHocNavigationsQueryTestBase(NonSharedFixture fixture)
             [Key]
             public int AuthorId { get; set; }
 
-            public string FirstName { get; set; }
-            public string LastName { get; set; }
-            public IReadOnlyCollection<Book> Books { get; set; }
+            public string FirstName { get; set; } = null!;
+            public string LastName { get; set; } = null!;
+            public IReadOnlyCollection<Book> Books { get; set; } = null!;
         }
 
         public class Book
@@ -1643,9 +1641,9 @@ public abstract class AdHocNavigationsQueryTestBase(NonSharedFixture fixture)
             [Key]
             public int BookId { get; set; }
 
-            public string Title { get; set; }
+            public string Title { get; set; } = null!;
             public int AuthorId { get; set; }
-            public Author Author { get; set; }
+            public Author Author { get; set; } = null!;
         }
     }
 
@@ -1686,8 +1684,8 @@ public abstract class AdHocNavigationsQueryTestBase(NonSharedFixture fixture)
 
     protected class Context35706(DbContextOptions options) : DbContext(options)
     {
-        public DbSet<Employer35706> Employers { get; set; }
-        public DbSet<Person35706> People { get; set; }
+        public DbSet<Employer35706> Employers { get; set; } = null!;
+        public DbSet<Person35706> People { get; set; } = null!;
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
@@ -1715,16 +1713,16 @@ public abstract class AdHocNavigationsQueryTestBase(NonSharedFixture fixture)
         public class Employer35706
         {
             public int EmployerId { get; set; }
-            public string Name { get; set; }
-            public IList<Person35706> Employees { get; set; }
+            public string Name { get; set; } = null!;
+            public IList<Person35706> Employees { get; set; } = null!;
         }
 
         public class Person35706
         {
             public int PersonId { get; set; }
-            public string Name { get; set; }
+            public string Name { get; set; } = null!;
             public int? EmployerId { get; set; }
-            public Employer35706 Employer { get; set; }
+            public Employer35706 Employer { get; set; } = null!;
         }
     }
 

--- a/test/EFCore.Specification.Tests/Query/AdHocQueryFiltersQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/AdHocQueryFiltersQueryTestBase.cs
@@ -3,8 +3,6 @@
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
-#nullable disable
-
 public abstract class AdHocQueryFiltersQueryTestBase(NonSharedFixture fixture)
     : NonSharedModelTestBase(fixture), IClassFixture<NonSharedFixture>
 {
@@ -128,7 +126,8 @@ public abstract class AdHocQueryFiltersQueryTestBase(NonSharedFixture fixture)
     {
         protected readonly List<int> _ids = [1, 7];
 
-        public DbSet<MyEntity8576> Entities { get; set; }
+        public DbSet<MyEntity8576> Entities
+            => Set<MyEntity8576>();
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
             => modelBuilder.Entity<MyEntity8576>().HasQueryFilter(x => !_ids.Contains(x.Id));
@@ -144,7 +143,7 @@ public abstract class AdHocQueryFiltersQueryTestBase(NonSharedFixture fixture)
         public class MyEntity8576
         {
             public int Id { get; set; }
-            public string Name { get; set; }
+            public string Name { get; set; } = null!;
             public bool IsDeleted { get; set; }
             public bool IsDraft { get; set; }
         }
@@ -201,7 +200,8 @@ public abstract class AdHocQueryFiltersQueryTestBase(NonSharedFixture fixture)
     {
         private readonly List<int> _ids = [1, 7];
 
-        public DbSet<MyEntity10295> Entities { get; set; }
+        public DbSet<MyEntity10295> Entities
+            => Set<MyEntity10295>();
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
             => modelBuilder.Entity<MyEntity10295>().HasQueryFilter(x => !_ids.Contains(x.Id));
@@ -217,7 +217,7 @@ public abstract class AdHocQueryFiltersQueryTestBase(NonSharedFixture fixture)
         public class MyEntity10295
         {
             public int Id { get; set; }
-            public string Name { get; set; }
+            public string Name { get; set; } = null!;
         }
     }
 
@@ -244,7 +244,8 @@ public abstract class AdHocQueryFiltersQueryTestBase(NonSharedFixture fixture)
     {
         public int Tenant { get; set; }
 
-        public DbSet<Blog10301> Blogs { get; set; }
+        public DbSet<Blog10301> Blogs
+            => Set<Blog10301>();
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
             => modelBuilder.Entity<Blog10301>().HasQueryFilter(e => e.SomeValue == Tenant);
@@ -285,8 +286,11 @@ public abstract class AdHocQueryFiltersQueryTestBase(NonSharedFixture fixture)
 
     protected class Context12170(DbContextOptions options) : DbContext(options)
     {
-        public virtual DbSet<Definition12170> Definitions { get; set; }
-        public virtual DbSet<DefinitionHistory12170> DefinitionHistories { get; set; }
+        public virtual DbSet<Definition12170> Definitions
+            => Set<Definition12170>();
+
+        public virtual DbSet<DefinitionHistory12170> DefinitionHistories
+            => Set<DefinitionHistory12170>();
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
@@ -308,24 +312,24 @@ public abstract class AdHocQueryFiltersQueryTestBase(NonSharedFixture fixture)
         public class MasterChangeInfo12170
         {
             public bool Exists { get; set; }
-            public virtual OptionalChangePoint12170 RemovedPoint { get; set; }
+            public virtual OptionalChangePoint12170 RemovedPoint { get; set; } = null!;
         }
 
         public class DefinitionHistory12170
         {
             public int Id { get; set; }
             public int MacGuffinDefinitionID { get; set; }
-            public virtual Definition12170 Definition { get; set; }
-            public OptionalChangePoint12170 EndedPoint { get; set; }
+            public virtual Definition12170? Definition { get; set; }
+            public OptionalChangePoint12170 EndedPoint { get; set; } = null!;
         }
 
         public class Definition12170
         {
             public int Id { get; set; }
-            public virtual MasterChangeInfo12170 ChangeInfo { get; set; }
+            public virtual MasterChangeInfo12170 ChangeInfo { get; set; } = null!;
 
-            public virtual ICollection<DefinitionHistory12170> HistoryEntries { get; set; }
-            public virtual DefinitionHistory12170 LatestHistoryEntry { get; set; }
+            public virtual ICollection<DefinitionHistory12170> HistoryEntries { get; set; } = null!;
+            public virtual DefinitionHistory12170? LatestHistoryEntry { get; set; }
             public int? LatestHistoryEntryID { get; set; }
         }
     }
@@ -352,8 +356,11 @@ public abstract class AdHocQueryFiltersQueryTestBase(NonSharedFixture fixture)
 
     protected class Context13517(DbContextOptions options) : DbContext(options)
     {
-        public DbSet<Entity13517> Entities { get; set; }
-        public DbSet<RefEntity13517> RefEntities { get; set; }
+        public DbSet<Entity13517> Entities
+            => Set<Entity13517>();
+
+        public DbSet<RefEntity13517> RefEntities
+            => Set<RefEntity13517>();
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
             => modelBuilder.Entity<RefEntity13517>().HasQueryFilter(f => f.Public);
@@ -370,7 +377,7 @@ public abstract class AdHocQueryFiltersQueryTestBase(NonSharedFixture fixture)
         {
             public int Id { get; set; }
             public int? RefEntityId { get; set; }
-            public RefEntity13517 RefEntity { get; set; }
+            public RefEntity13517? RefEntity { get; set; }
         }
 
         public class RefEntity13517
@@ -383,7 +390,7 @@ public abstract class AdHocQueryFiltersQueryTestBase(NonSharedFixture fixture)
         {
             public int Id { get; set; }
             public int? RefEntityId { get; set; }
-            public RefEntityDto13517 RefEntity { get; set; }
+            public RefEntityDto13517? RefEntity { get; set; }
         }
 
         public class RefEntityDto13517
@@ -417,17 +424,20 @@ public abstract class AdHocQueryFiltersQueryTestBase(NonSharedFixture fixture)
 
     protected class Context17253(DbContextOptions options) : DbContext(options)
     {
-        public DbSet<EntityWithQueryFilterSelfReference17253> EntitiesWithQueryFilterSelfReference { get; set; }
+        public DbSet<EntityWithQueryFilterSelfReference17253> EntitiesWithQueryFilterSelfReference
+            => Set<EntityWithQueryFilterSelfReference17253>();
 
         public DbSet<EntityReferencingEntityWithQueryFilterSelfReference17253> EntitiesReferencingEntityWithQueryFilterSelfReference
-        {
-            get;
-            set;
-        }
+            => Set<EntityReferencingEntityWithQueryFilterSelfReference17253>();
 
-        public DbSet<EntityWithQueryFilterCycle17253_1> EntitiesWithQueryFilterCycle1 { get; set; }
-        public DbSet<EntityWithQueryFilterCycle17253_2> EntitiesWithQueryFilterCycle2 { get; set; }
-        public DbSet<EntityWithQueryFilterCycle17253_3> EntitiesWithQueryFilterCycle3 { get; set; }
+        public DbSet<EntityWithQueryFilterCycle17253_1> EntitiesWithQueryFilterCycle1
+            => Set<EntityWithQueryFilterCycle17253_1>();
+
+        public DbSet<EntityWithQueryFilterCycle17253_2> EntitiesWithQueryFilterCycle2
+            => Set<EntityWithQueryFilterCycle17253_2>();
+
+        public DbSet<EntityWithQueryFilterCycle17253_3> EntitiesWithQueryFilterCycle3
+            => Set<EntityWithQueryFilterCycle17253_3>();
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
@@ -460,31 +470,31 @@ public abstract class AdHocQueryFiltersQueryTestBase(NonSharedFixture fixture)
         public class EntityWithQueryFilterSelfReference17253
         {
             public int Id { get; set; }
-            public string Name { get; set; }
+            public string? Name { get; set; }
         }
 
         public class EntityReferencingEntityWithQueryFilterSelfReference17253
         {
             public int Id { get; set; }
-            public string Name { get; set; }
+            public string? Name { get; set; }
         }
 
         public class EntityWithQueryFilterCycle17253_1
         {
             public int Id { get; set; }
-            public string Name { get; set; }
+            public string Name { get; set; } = null!;
         }
 
         public class EntityWithQueryFilterCycle17253_2
         {
             public int Id { get; set; }
-            public string Name { get; set; }
+            public string Name { get; set; } = null!;
         }
 
         public class EntityWithQueryFilterCycle17253_3
         {
             public int Id { get; set; }
-            public string Name { get; set; }
+            public string Name { get; set; } = null!;
         }
     }
 
@@ -509,7 +519,8 @@ public abstract class AdHocQueryFiltersQueryTestBase(NonSharedFixture fixture)
 
     protected class Context18510(DbContextOptions options) : DbContext(options)
     {
-        public DbSet<MyEntity18510> Entities { get; set; }
+        public DbSet<MyEntity18510> Entities
+            => Set<MyEntity18510>();
 
         public int TenantId { get; set; }
 
@@ -518,17 +529,17 @@ public abstract class AdHocQueryFiltersQueryTestBase(NonSharedFixture fixture)
             modelBuilder.Entity<MyEntity18510>().HasQueryFilter(x => x.Name != "Foo");
 
             var entityType = modelBuilder.Model.GetEntityTypes().Single(et => et.ClrType == typeof(MyEntity18510));
-            var queryFilter = entityType.GetDeclaredQueryFilters().FirstOrDefault();
+            var queryFilter = entityType.GetDeclaredQueryFilters().FirstOrDefault()!;
             Expression<Func<int>> tenantFunc = () => TenantId;
             var tenant = Expression.Invoke(tenantFunc);
 
-            var efPropertyMethod = typeof(EF).GetTypeInfo().GetDeclaredMethod(nameof(EF.Property)).MakeGenericMethod(typeof(int));
-            var prm = queryFilter.Expression.Parameters[0];
+            var efPropertyMethod = typeof(EF).GetTypeInfo().GetDeclaredMethod(nameof(EF.Property))!.MakeGenericMethod(typeof(int));
+            var prm = queryFilter.Expression!.Parameters[0];
             var efPropertyMethodCall = Expression.Call(efPropertyMethod, prm, Expression.Constant("TenantId"));
 
             var updatedQueryFilter = Expression.Lambda(
                 Expression.AndAlso(
-                    queryFilter.Expression.Body,
+                    queryFilter.Expression!.Body,
                     Expression.Equal(
                         efPropertyMethodCall,
                         tenant)),
@@ -558,7 +569,7 @@ public abstract class AdHocQueryFiltersQueryTestBase(NonSharedFixture fixture)
         public class MyEntity18510
         {
             public int Id { get; set; }
-            public string Name { get; set; }
+            public string? Name { get; set; }
 
             public int TenantId { get; set; }
         }
@@ -578,7 +589,8 @@ public abstract class AdHocQueryFiltersQueryTestBase(NonSharedFixture fixture)
 
     protected class Context18759(DbContextOptions options) : DbContext(options)
     {
-        public DbSet<Person18759> People { get; set; }
+        public DbSet<Person18759> People
+            => Set<Person18759>();
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
             => modelBuilder.Entity<Person18759>().HasQueryFilter(p => p.UserDelete != null);
@@ -586,7 +598,7 @@ public abstract class AdHocQueryFiltersQueryTestBase(NonSharedFixture fixture)
         public class Person18759
         {
             public int Id { get; set; }
-            public User18759 UserDelete { get; set; }
+            public User18759? UserDelete { get; set; }
         }
 
         public class User18759
@@ -598,8 +610,6 @@ public abstract class AdHocQueryFiltersQueryTestBase(NonSharedFixture fixture)
     #endregion
 
     #region 26428
-
-#nullable enable
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual async Task IsDeleted_query_filter_with_conversion_to_int_works(bool async)
@@ -676,8 +686,6 @@ public abstract class AdHocQueryFiltersQueryTestBase(NonSharedFixture fixture)
         public bool IsDeleted { get; set; }
     }
 
-#nullable disable
-
     #endregion
 
     #region 27163
@@ -693,11 +701,11 @@ public abstract class AdHocQueryFiltersQueryTestBase(NonSharedFixture fixture)
             .Select(g => new
             {
                 Test1 = g
-                    .Select(x => x.Child1.Value1)
+                    .Select(x => x.Child1!.Value1)
                     .Distinct()
                     .Count(),
                 Test2 = g
-                    .Select(x => x.Child2.Value2)
+                    .Select(x => x.Child2!.Value2)
                     .Distinct()
                     .Count()
             });
@@ -718,11 +726,11 @@ public abstract class AdHocQueryFiltersQueryTestBase(NonSharedFixture fixture)
             .Select(g => new
             {
                 Test1 = g
-                    .Select(x => x.ChildFilter1.Value1)
+                    .Select(x => x.ChildFilter1!.Value1)
                     .Distinct()
                     .Count(),
                 Test2 = g
-                    .Select(x => x.ChildFilter2.Value2)
+                    .Select(x => x.ChildFilter2!.Value2)
                     .Distinct()
                     .Count()
             });
@@ -734,7 +742,8 @@ public abstract class AdHocQueryFiltersQueryTestBase(NonSharedFixture fixture)
 
     protected class Context27163(DbContextOptions options) : DbContext(options)
     {
-        public DbSet<Parent> Parents { get; set; }
+        public DbSet<Parent> Parents
+            => Set<Parent>();
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
@@ -746,36 +755,36 @@ public abstract class AdHocQueryFiltersQueryTestBase(NonSharedFixture fixture)
     public class Parent
     {
         public int Id { get; set; }
-        public Child1 Child1 { get; set; }
-        public Child2 Child2 { get; set; }
-        public ChildFilter1 ChildFilter1 { get; set; }
-        public ChildFilter2 ChildFilter2 { get; set; }
+        public Child1? Child1 { get; set; }
+        public Child2? Child2 { get; set; }
+        public ChildFilter1? ChildFilter1 { get; set; }
+        public ChildFilter2? ChildFilter2 { get; set; }
     }
 
     public class Child1
     {
         public int Id { get; set; }
-        public string Value1 { get; set; }
+        public string Value1 { get; set; } = null!;
     }
 
     public class Child2
     {
         public int Id { get; set; }
-        public string Value2 { get; set; }
+        public string Value2 { get; set; } = null!;
     }
 
     public class ChildFilter1
     {
         public int Id { get; set; }
-        public string Filter1 { get; set; }
-        public string Value1 { get; set; }
+        public string Filter1 { get; set; } = null!;
+        public string Value1 { get; set; } = null!;
     }
 
     public class ChildFilter2
     {
         public int Id { get; set; }
-        public string Filter2 { get; set; }
-        public string Value2 { get; set; }
+        public string Filter2 { get; set; } = null!;
+        public string Value2 { get; set; } = null!;
     }
 
     #endregion
@@ -797,7 +806,7 @@ public abstract class AdHocQueryFiltersQueryTestBase(NonSharedFixture fixture)
     {
         public int Foo { get; set; }
         public long? Bar { get; set; }
-        public List<long> Baz { get; set; }
+        public List<long> Baz { get; set; } = null!;
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
             => modelBuilder.Entity<FooBar35111>()
@@ -845,7 +854,7 @@ public abstract class AdHocQueryFiltersQueryTestBase(NonSharedFixture fixture)
     public class Entity38132
     {
         public int Id { get; set; }
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
         public Guid TenantId { get; set; }
     }
 

--- a/test/EFCore.Specification.Tests/Query/Associations/AssociationsModel.cs
+++ b/test/EFCore.Specification.Tests/Query/Associations/AssociationsModel.cs
@@ -163,5 +163,5 @@ public class RootReferencingEntity
 {
     public int Id { get; set; }
 
-    public RootEntity? Root { get; set; } = null!;
+    public RootEntity? Root { get; set; }
 }

--- a/test/EFCore.Specification.Tests/Query/ComplexNavigationsCollectionsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/ComplexNavigationsCollectionsQueryTestBase.cs
@@ -5,8 +5,6 @@ using Microsoft.EntityFrameworkCore.TestModels.ComplexNavigationsModel;
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
-#nullable disable
-
 public abstract class ComplexNavigationsCollectionsQueryTestBase<TFixture>(TFixture fixture) : QueryTestBase<TFixture>(fixture)
     where TFixture : ComplexNavigationsQueryFixtureBase, new()
 {
@@ -14,7 +12,9 @@ public abstract class ComplexNavigationsCollectionsQueryTestBase<TFixture>(TFixt
         => Fixture.CreateContext();
 
     protected override Expression RewriteExpectedQueryExpression(Expression expectedQueryExpression)
-        => new ExpectedQueryRewritingVisitor(Fixture.GetShadowPropertyMappings()).Visit(expectedQueryExpression);
+        => new ExpectedQueryRewritingVisitor(
+            Fixture.GetShadowPropertyMappings().ToDictionary(e => e.Key, e => new Func<object, object>(o => e.Value(o)!)))
+            .Visit(expectedQueryExpression);
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Select_nav_prop_collection_one_to_many_required(bool async)
@@ -30,8 +30,8 @@ public abstract class ComplexNavigationsCollectionsQueryTestBase<TFixture>(TFixt
         => AssertQuery(
             async,
             ss => from l4 in ss.Set<Level1>()
-                      .SelectMany(l1 => l1.OneToOne_Required_FK1.OneToOne_Optional_FK2.OneToMany_Required3.DefaultIfEmpty())
-                  join l2 in ss.Set<Level4>().SelectMany(l4 => l4.OneToOne_Required_FK_Inverse4.OneToOne_Optional_FK_Inverse3
+                      .SelectMany(l1 => l1.OneToOne_Required_FK1.OneToOne_Optional_FK2!.OneToMany_Required3.DefaultIfEmpty())
+                  join l2 in ss.Set<Level4>().SelectMany(l4 => l4.OneToOne_Required_FK_Inverse4.OneToOne_Optional_FK_Inverse3!
                           .OneToMany_Required_Self2
                           .DefaultIfEmpty())
                       on l4.Id equals l2.Id
@@ -39,17 +39,17 @@ public abstract class ComplexNavigationsCollectionsQueryTestBase<TFixture>(TFixt
                           => l4.OneToOne_Required_FK_Inverse4.OneToOne_Required_FK_Inverse3.OneToMany_Required2.DefaultIfEmpty())
                       on l2.Id equals l3.Id into grouping
                   from l3 in grouping.DefaultIfEmpty()
-                  where l4.OneToMany_Optional_Inverse4.Name != "Foo"
-                  orderby l2.OneToOne_Optional_FK2.Id
+                  where l4.OneToMany_Optional_Inverse4!.Name != "Foo"
+                  orderby l2.OneToOne_Optional_FK2!.Id
                   select new
                   {
                       Entity = l4,
                       Collection = l2.OneToMany_Optional_Self2.Where(e => e.Id != 42).ToList(),
-                      Property = l3.OneToOne_Optional_FK_Inverse3.OneToOne_Required_FK2.Name
+                      Property = l3.OneToOne_Optional_FK_Inverse3!.OneToOne_Required_FK2.Name
                   },
             ss => from l4 in ss.Set<Level1>()
-                      .SelectMany(l1 => l1.OneToOne_Required_FK1.OneToOne_Optional_FK2.OneToMany_Required3.DefaultIfEmpty())
-                  join l2 in ss.Set<Level4>().SelectMany(l4 => l4.OneToOne_Required_FK_Inverse4.OneToOne_Optional_FK_Inverse3
+                      .SelectMany(l1 => l1.OneToOne_Required_FK1.OneToOne_Optional_FK2!.OneToMany_Required3.DefaultIfEmpty())
+                  join l2 in ss.Set<Level4>().SelectMany(l4 => l4.OneToOne_Required_FK_Inverse4.OneToOne_Optional_FK_Inverse3!
                           .OneToMany_Required_Self2
                           .DefaultIfEmpty())
                       on l4.Id equals l2.Id
@@ -57,13 +57,13 @@ public abstract class ComplexNavigationsCollectionsQueryTestBase<TFixture>(TFixt
                           => l4.OneToOne_Required_FK_Inverse4.OneToOne_Required_FK_Inverse3.OneToMany_Required2.DefaultIfEmpty())
                       on l2.Id equals l3.Id into grouping
                   from l3 in grouping.DefaultIfEmpty()
-                  where l4.OneToMany_Optional_Inverse4.Name != "Foo"
-                  orderby l2.OneToOne_Optional_FK2.MaybeScalar(x => x.Id)
+                  where l4.OneToMany_Optional_Inverse4!.Name != "Foo"
+                  orderby l2.OneToOne_Optional_FK2!.MaybeScalar(x => x.Id)
                   select new
                   {
                       Entity = l4,
                       Collection = l2.OneToMany_Optional_Self2.Where(e => e.Id != 42).ToList(),
-                      Property = l3.OneToOne_Optional_FK_Inverse3.OneToOne_Required_FK2.Name
+                      Property = l3.OneToOne_Optional_FK_Inverse3!.OneToOne_Required_FK2.Name
                   },
             elementSorter: e => e.Entity.Id,
             elementAsserter: (e, a) =>
@@ -87,9 +87,9 @@ public abstract class ComplexNavigationsCollectionsQueryTestBase<TFixture>(TFixt
         => AssertQuery(
             async,
             ss => from l1 in ss.Set<Level1>()
-                  select l1.OneToOne_Optional_FK1.OneToMany_Optional2,
+                  select l1.OneToOne_Optional_FK1!.OneToMany_Optional2,
             ss => from l1 in ss.Set<Level1>()
-                  select l1.OneToOne_Optional_FK1.OneToMany_Optional2 ?? new List<Level3>(),
+                  select l1.OneToOne_Optional_FK1!.OneToMany_Optional2 ?? new List<Level3>(),
             elementSorter: e => e.Count,
             elementAsserter: (e, a) => AssertCollection(e, a));
 
@@ -98,9 +98,9 @@ public abstract class ComplexNavigationsCollectionsQueryTestBase<TFixture>(TFixt
         => AssertQuery(
             async,
             ss => from l1 in ss.Set<Level1>()
-                  select l1.OneToOne_Optional_FK1.OneToMany_Optional2.Take(50),
+                  select l1.OneToOne_Optional_FK1!.OneToMany_Optional2.Take(50),
             ss => from l1 in ss.Set<Level1>()
-                  select (l1.OneToOne_Optional_FK1.OneToMany_Optional2 ?? new List<Level3>()).Take(50),
+                  select (l1.OneToOne_Optional_FK1!.OneToMany_Optional2 ?? new List<Level3>()).Take(50),
             elementSorter: e => e?.Count() ?? 0,
             elementAsserter: (e, a) => AssertCollection(e, a));
 
@@ -122,7 +122,7 @@ public abstract class ComplexNavigationsCollectionsQueryTestBase<TFixture>(TFixt
         => AssertQuery(
             async,
             ss => from l1 in ss.Set<Level1>()
-                  select new { l1.Id, l1.OneToOne_Optional_FK1.OneToMany_Optional2 },
+                  select new { l1.Id, l1.OneToOne_Optional_FK1!.OneToMany_Optional2 },
             elementSorter: e => e.Id,
             elementAsserter: (e, a) =>
             {
@@ -175,7 +175,7 @@ public abstract class ComplexNavigationsCollectionsQueryTestBase<TFixture>(TFixt
         => AssertQuery(
             async,
             ss => from l1 in ss.Set<Level1>()
-                  select new { l1.OneToOne_Optional_FK1, l1.OneToOne_Optional_FK1.OneToMany_Optional2 },
+                select new { l1.OneToOne_Optional_FK1, l1.OneToOne_Optional_FK1!.OneToMany_Optional2 },
             elementSorter: e => e.OneToOne_Optional_FK1?.Id,
             elementAsserter: (e, a) =>
             {
@@ -211,7 +211,7 @@ public abstract class ComplexNavigationsCollectionsQueryTestBase<TFixture>(TFixt
             elementAsserter: (e, a) => AssertCollection(
                 e.Level2s,
                 a.Level2s,
-                elementSorter: ee => ee?.Level3.Name));
+                elementSorter: ee => ee?.Level3!.Name));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Null_check_in_Dto_projection_should_not_be_removed(bool async)
@@ -223,7 +223,7 @@ public abstract class ComplexNavigationsCollectionsQueryTestBase<TFixture>(TFixt
                 {
                     Level3 = l2.OneToOne_Required_FK2 == null
                         ? null
-                        : new ProjectedDto<string> { Value = l2.OneToOne_Required_FK2.Name }
+                        : new ProjectedDto<string?> { Value = l2.OneToOne_Required_FK2.Name }
                 }).ToList()
             }),
             assertOrder: true,
@@ -235,7 +235,7 @@ public abstract class ComplexNavigationsCollectionsQueryTestBase<TFixture>(TFixt
 
     private class ProjectedDto<T>
     {
-        public T Value { get; set; }
+        public T Value { get; set; } = default!;
     }
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -318,7 +318,7 @@ public abstract class ComplexNavigationsCollectionsQueryTestBase<TFixture>(TFixt
                 }
                 else
                 {
-                    AssertCollection(e.Level2.Level3s, a.Level2.Level3s, ordered: true);
+                    AssertCollection(e.Level2.Level3s, a.Level2!.Level3s, ordered: true);
                 }
             });
 
@@ -348,7 +348,7 @@ public abstract class ComplexNavigationsCollectionsQueryTestBase<TFixture>(TFixt
                     }
                     else
                     {
-                        AssertCollection(e2.Level3.Level4s, a2.Level3.Level4s, ordered: true);
+                        AssertCollection(e2.Level3.Level4s, a2.Level3!.Level4s, ordered: true);
                     }
                 }));
 
@@ -408,8 +408,8 @@ public abstract class ComplexNavigationsCollectionsQueryTestBase<TFixture>(TFixt
         => AssertQuery(
             async,
             ss => from l4 in ss.Set<Level1>()
-                      .SelectMany(l1 => l1.OneToOne_Required_FK1.OneToOne_Optional_FK2.OneToMany_Required3.DefaultIfEmpty())
-                  join l2 in ss.Set<Level4>().SelectMany(l4 => l4.OneToOne_Required_FK_Inverse4.OneToOne_Optional_FK_Inverse3
+                      .SelectMany(l1 => l1.OneToOne_Required_FK1.OneToOne_Optional_FK2!.OneToMany_Required3.DefaultIfEmpty())
+                  join l2 in ss.Set<Level4>().SelectMany(l4 => l4.OneToOne_Required_FK_Inverse4.OneToOne_Optional_FK_Inverse3!
                           .OneToMany_Required_Self2
                           .DefaultIfEmpty()) on
                       l4.Id equals l2.Id
@@ -417,17 +417,17 @@ public abstract class ComplexNavigationsCollectionsQueryTestBase<TFixture>(TFixt
                           => l4.OneToOne_Required_FK_Inverse4.OneToOne_Required_FK_Inverse3.OneToMany_Required2.DefaultIfEmpty()) on
                       l2.Id equals l3.Id into grouping
                   from l3 in grouping.DefaultIfEmpty()
-                  where l4.OneToMany_Optional_Inverse4.Name != "Foo"
-                  orderby l2.OneToOne_Optional_FK2.Id
+                  where l4.OneToMany_Optional_Inverse4!.Name != "Foo"
+                  orderby l2.OneToOne_Optional_FK2!.Id
                   select new
                   {
                       Entity = l4,
                       Collection = l2.OneToMany_Optional_Self2.Where(e => e.Id != 42).ToList(),
-                      Property = l3.OneToOne_Optional_FK_Inverse3.OneToOne_Required_FK2.Name
+                      Property = l3.OneToOne_Optional_FK_Inverse3!.OneToOne_Required_FK2.Name
                   },
             ss => from l4 in ss.Set<Level1>()
-                      .SelectMany(l1 => l1.OneToOne_Required_FK1.OneToOne_Optional_FK2.OneToMany_Required3.DefaultIfEmpty())
-                  join l2 in ss.Set<Level4>().SelectMany(l4 => l4.OneToOne_Required_FK_Inverse4.OneToOne_Optional_FK_Inverse3
+                      .SelectMany(l1 => l1.OneToOne_Required_FK1.OneToOne_Optional_FK2!.OneToMany_Required3.DefaultIfEmpty())
+                  join l2 in ss.Set<Level4>().SelectMany(l4 => l4.OneToOne_Required_FK_Inverse4.OneToOne_Optional_FK_Inverse3!
                           .OneToMany_Required_Self2
                           .DefaultIfEmpty()) on
                       l4.Id equals l2.Id
@@ -435,13 +435,13 @@ public abstract class ComplexNavigationsCollectionsQueryTestBase<TFixture>(TFixt
                           => l4.OneToOne_Required_FK_Inverse4.OneToOne_Required_FK_Inverse3.OneToMany_Required2.DefaultIfEmpty()) on
                       l2.Id equals l3.Id into grouping
                   from l3 in grouping.DefaultIfEmpty()
-                  where l4.OneToMany_Optional_Inverse4.Name != "Foo"
-                  orderby l2.OneToOne_Optional_FK2.MaybeScalar(e => e.Id)
+                  where l4.OneToMany_Optional_Inverse4!.Name != "Foo"
+                  orderby l2.OneToOne_Optional_FK2!.MaybeScalar(e => e.Id)
                   select new
                   {
                       Entity = l4,
                       Collection = l2.OneToMany_Optional_Self2.Where(e => e.Id != 42).ToList(),
-                      Property = l3.OneToOne_Optional_FK_Inverse3.OneToOne_Required_FK2.Name
+                      Property = l3.OneToOne_Optional_FK_Inverse3!.OneToOne_Required_FK2.Name
                   },
             assertOrder: true,
             elementAsserter: (e, a) =>
@@ -554,15 +554,15 @@ public abstract class ComplexNavigationsCollectionsQueryTestBase<TFixture>(TFixt
             async,
             ss => ss.Set<Level1>()
                 .Include(e => e.OneToOne_Optional_FK1)
-                .ThenInclude(e => e.OneToMany_Optional2)
+                .ThenInclude(e => e!.OneToMany_Optional2)
                 .Include(e => e.OneToMany_Optional1)
                 .ThenInclude(e => e.OneToOne_Optional_FK2),
             elementAsserter: (e, a) => AssertInclude(
                 e, a,
-                new ExpectedInclude<Level1>(l1 => l1.OneToOne_Optional_FK1),
+                new ExpectedInclude<Level1>(l1 => l1.OneToOne_Optional_FK1!),
                 new ExpectedInclude<Level2>(l2 => l2.OneToMany_Optional2, "OneToOne_Optional_FK1"),
                 new ExpectedInclude<Level1>(l1 => l1.OneToMany_Optional1),
-                new ExpectedInclude<Level2>(l2 => l2.OneToOne_Optional_FK2, "OneToMany_Optional1")));
+                new ExpectedInclude<Level2>(l2 => l2.OneToOne_Optional_FK2!, "OneToMany_Optional1")));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Multiple_complex_includes_EF_Property(bool async)
@@ -575,10 +575,10 @@ public abstract class ComplexNavigationsCollectionsQueryTestBase<TFixture>(TFixt
                 .ThenInclude(e => EF.Property<Level3>(e, "OneToOne_Optional_FK2")),
             elementAsserter: (e, a) => AssertInclude(
                 e, a,
-                new ExpectedInclude<Level1>(l1 => l1.OneToOne_Optional_FK1),
+                new ExpectedInclude<Level1>(l1 => l1.OneToOne_Optional_FK1!),
                 new ExpectedInclude<Level2>(l2 => l2.OneToMany_Optional2, "OneToOne_Optional_FK1"),
                 new ExpectedInclude<Level1>(l1 => l1.OneToMany_Optional1),
-                new ExpectedInclude<Level2>(l2 => l2.OneToOne_Optional_FK2, "OneToMany_Optional1")));
+                new ExpectedInclude<Level2>(l2 => l2.OneToOne_Optional_FK2!, "OneToMany_Optional1")));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Multiple_complex_includes_self_ref(bool async)
@@ -586,14 +586,14 @@ public abstract class ComplexNavigationsCollectionsQueryTestBase<TFixture>(TFixt
             async,
             ss => ss.Set<Level1>()
                 .Include(e => e.OneToOne_Optional_Self1)
-                .ThenInclude(e => e.OneToMany_Optional_Self1)
+                .ThenInclude(e => e!.OneToMany_Optional_Self1)
                 .Include(e => e.OneToMany_Optional_Self1)
                 .ThenInclude(e => e.OneToOne_Optional_Self1),
             elementAsserter: (e, a) => AssertInclude(
-                e, a, new ExpectedInclude<Level1>(l1 => l1.OneToOne_Optional_Self1),
+                e, a, new ExpectedInclude<Level1>(l1 => l1.OneToOne_Optional_Self1!),
                 new ExpectedInclude<Level1>(l2 => l2.OneToMany_Optional_Self1, "OneToOne_Optional_Self1"),
                 new ExpectedInclude<Level1>(l1 => l1.OneToMany_Optional_Self1),
-                new ExpectedInclude<Level1>(l2 => l2.OneToOne_Optional_Self1, "OneToMany_Optional_Self1")));
+                new ExpectedInclude<Level1>(l2 => l2.OneToOne_Optional_Self1!, "OneToMany_Optional_Self1")));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Multiple_complex_includes_self_ref_EF_Property(bool async)
@@ -605,21 +605,21 @@ public abstract class ComplexNavigationsCollectionsQueryTestBase<TFixture>(TFixt
                 .Include(e => EF.Property<ICollection<Level1>>(e, "OneToMany_Optional_Self1"))
                 .ThenInclude(e => EF.Property<Level1>(e, "OneToOne_Optional_Self1")),
             elementAsserter: (e, a) => AssertInclude(
-                e, a, new ExpectedInclude<Level1>(l1 => l1.OneToOne_Optional_Self1),
+                e, a, new ExpectedInclude<Level1>(l1 => l1.OneToOne_Optional_Self1!),
                 new ExpectedInclude<Level1>(l2 => l2.OneToMany_Optional_Self1, "OneToOne_Optional_Self1"),
                 new ExpectedInclude<Level1>(l1 => l1.OneToMany_Optional_Self1),
-                new ExpectedInclude<Level1>(l2 => l2.OneToOne_Optional_Self1, "OneToMany_Optional_Self1")));
+                new ExpectedInclude<Level1>(l2 => l2.OneToOne_Optional_Self1!, "OneToMany_Optional_Self1")));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Include_reference_and_collection_order_by(bool async)
         => AssertQuery(
             async,
             ss => ss.Set<Level1>()
-                .Include(e => e.OneToOne_Optional_FK1.OneToMany_Optional2)
+                .Include(e => e.OneToOne_Optional_FK1!.OneToMany_Optional2)
                 .OrderBy(e => e.Name),
             assertOrder: true,
             elementAsserter: (e, a) => AssertInclude(
-                e, a, new ExpectedInclude<Level1>(l1 => l1.OneToOne_Optional_FK1),
+                e, a, new ExpectedInclude<Level1>(l1 => l1.OneToOne_Optional_FK1!),
                 new ExpectedInclude<Level2>(l2 => l2.OneToMany_Optional2, "OneToOne_Optional_FK1")));
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -628,11 +628,11 @@ public abstract class ComplexNavigationsCollectionsQueryTestBase<TFixture>(TFixt
             async,
             ss => ss.Set<Level1>()
                 .Include(e => e.OneToOne_Optional_FK1)
-                .ThenInclude(e => e.OneToMany_Optional2)
+                .ThenInclude(e => e!.OneToMany_Optional2)
                 .OrderBy(e => e.Name),
             assertOrder: true,
             elementAsserter: (e, a) => AssertInclude(
-                e, a, new ExpectedInclude<Level1>(l1 => l1.OneToOne_Optional_FK1),
+                e, a, new ExpectedInclude<Level1>(l1 => l1.OneToOne_Optional_FK1!),
                 new ExpectedInclude<Level2>(l2 => l2.OneToMany_Optional2, "OneToOne_Optional_FK1")));
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -644,7 +644,7 @@ public abstract class ComplexNavigationsCollectionsQueryTestBase<TFixture>(TFixt
                 .ThenInclude(e => e.OneToOne_Optional_FK2),
             elementAsserter: (e, a) => AssertInclude(
                 e, a, new ExpectedInclude<Level1>(l1 => l1.OneToMany_Optional1),
-                new ExpectedInclude<Level2>(l2 => l2.OneToOne_Optional_FK2, "OneToMany_Optional1")));
+                new ExpectedInclude<Level2>(l2 => l2.OneToOne_Optional_FK2!, "OneToMany_Optional1")));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Include_collection_with_conditional_order_by(bool async)
@@ -652,7 +652,7 @@ public abstract class ComplexNavigationsCollectionsQueryTestBase<TFixture>(TFixt
             async,
             ss => ss.Set<Level1>()
                 .Include(e => e.OneToMany_Optional1)
-                .OrderBy(e => e.Name.EndsWith("03") ? 1 : 2)
+                .OrderBy(e => e.Name!.EndsWith("03") ? 1 : 2)
                 .Select(e => e),
             elementSorter: e => e.Id,
             elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Level1>(ee => ee.OneToMany_Optional1)));
@@ -663,26 +663,26 @@ public abstract class ComplexNavigationsCollectionsQueryTestBase<TFixture>(TFixt
             async,
             ss => ss.Set<Level1>()
                 .Include(e => e.OneToOne_Optional_FK1)
-                .ThenInclude(e => e.OneToMany_Optional2)
+                .ThenInclude(e => e!.OneToMany_Optional2)
                 .Include(e => e.OneToMany_Optional1)
                 .ThenInclude(e => e.OneToOne_Optional_FK2),
             elementAsserter: (e, a) => AssertInclude(
-                e, a, new ExpectedInclude<Level1>(l1 => l1.OneToOne_Optional_FK1),
+                e, a, new ExpectedInclude<Level1>(l1 => l1.OneToOne_Optional_FK1!),
                 new ExpectedInclude<Level2>(l2 => l2.OneToMany_Optional2, "OneToOne_Optional_FK1"),
                 new ExpectedInclude<Level1>(l1 => l1.OneToMany_Optional1),
-                new ExpectedInclude<Level2>(l2 => l2.OneToOne_Optional_FK2, "OneToMany_Optional1")));
+                new ExpectedInclude<Level2>(l2 => l2.OneToOne_Optional_FK2!, "OneToMany_Optional1")));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Include_nested_with_optional_navigation(bool async)
         => AssertQuery(
             async,
             ss => from l1 in ss.Set<Level1>()
-                      .Include(e => e.OneToOne_Optional_FK1.OneToMany_Required2)
+                      .Include(e => e.OneToOne_Optional_FK1!.OneToMany_Required2)
                       .ThenInclude(e => e.OneToOne_Required_FK3)
-                  where l1.OneToOne_Optional_FK1.Name != "L2 09"
+                  where l1.OneToOne_Optional_FK1!.Name != "L2 09"
                   select l1,
             elementAsserter: (e, a) => AssertInclude(
-                e, a, new ExpectedInclude<Level1>(l1 => l1.OneToOne_Optional_FK1),
+                e, a, new ExpectedInclude<Level1>(l1 => l1.OneToOne_Optional_FK1!),
                 new ExpectedInclude<Level2>(l1 => l1.OneToMany_Required2, "OneToOne_Optional_FK1"),
                 new ExpectedInclude<Level3>(l1 => l1.OneToOne_Required_FK3, "OneToOne_Optional_FK1.OneToMany_Required2")));
 
@@ -705,12 +705,12 @@ public abstract class ComplexNavigationsCollectionsQueryTestBase<TFixture>(TFixt
         => AssertQuery(
             async,
             ss => ss.Set<Level1>()
-                .Include(e => e.OneToOne_Optional_FK1).ThenInclude(e => e.OneToMany_Optional2)
+                .Include(e => e.OneToOne_Optional_FK1).ThenInclude(e => e!.OneToMany_Optional2)
                 .Include(e => e.OneToOne_Required_FK1).ThenInclude(e => e.OneToMany_Required2)
                 .OrderBy(t => t.Name)
                 .Skip(0).Take(10),
             elementAsserter: (e, a) => AssertInclude(
-                e, a, new ExpectedInclude<Level1>(l1 => l1.OneToOne_Optional_FK1),
+                e, a, new ExpectedInclude<Level1>(l1 => l1.OneToOne_Optional_FK1!),
                 new ExpectedInclude<Level2>(l2 => l2.OneToMany_Optional2, "OneToOne_Optional_FK1"),
                 new ExpectedInclude<Level1>(l1 => l1.OneToOne_Required_FK1),
                 new ExpectedInclude<Level2>(l2 => l2.OneToMany_Required2, "OneToOne_Required_FK1")));
@@ -720,11 +720,11 @@ public abstract class ComplexNavigationsCollectionsQueryTestBase<TFixture>(TFixt
         => AssertQuery(
             async,
             ss => ss.Set<Level1>()
-                .Include(e => e.OneToOne_Optional_FK1.OneToOne_Required_FK2).ThenInclude(e => e.OneToMany_Optional3)
+                .Include(e => e.OneToOne_Optional_FK1!.OneToOne_Required_FK2).ThenInclude(e => e.OneToMany_Optional3)
                 .OrderBy(t => t.Name)
                 .Skip(0).Take(10),
             elementAsserter: (e, a) => AssertInclude(
-                e, a, new ExpectedInclude<Level1>(l1 => l1.OneToOne_Optional_FK1),
+                e, a, new ExpectedInclude<Level1>(l1 => l1.OneToOne_Optional_FK1!),
                 new ExpectedInclude<Level2>(l2 => l2.OneToOne_Required_FK2, "OneToOne_Optional_FK1"),
                 new ExpectedInclude<Level3>(l3 => l3.OneToMany_Optional3, "OneToOne_Optional_FK1.OneToOne_Required_FK2")));
 
@@ -735,15 +735,15 @@ public abstract class ComplexNavigationsCollectionsQueryTestBase<TFixture>(TFixt
             ss => ss.Set<Level1>()
                 .Include(e => e.OneToOne_Required_FK1).ThenInclude(e => e.OneToMany_Optional2)
                 .Include(e => e.OneToOne_Required_FK1).ThenInclude(e => e.OneToOne_Optional_FK2)
-                .Include(e => e.OneToOne_Optional_FK1).ThenInclude(e => e.OneToOne_Optional_FK2)
-                .Where(e => e.OneToOne_Required_FK1.OneToOne_Optional_PK2.Name != "Foo")
+                .Include(e => e.OneToOne_Optional_FK1).ThenInclude(e => e!.OneToOne_Optional_FK2)
+                .Where(e => e.OneToOne_Required_FK1.OneToOne_Optional_PK2!.Name != "Foo")
                 .OrderBy(e => e.Id),
             elementAsserter: (e, a) => AssertInclude(
                 e, a, new ExpectedInclude<Level1>(l1 => l1.OneToOne_Required_FK1),
                 new ExpectedInclude<Level2>(l2 => l2.OneToMany_Optional2, "OneToOne_Required_FK1"),
-                new ExpectedInclude<Level2>(l2 => l2.OneToOne_Optional_FK2, "OneToOne_Required_FK1"),
-                new ExpectedInclude<Level1>(l1 => l1.OneToOne_Optional_FK1),
-                new ExpectedInclude<Level2>(l2 => l2.OneToOne_Optional_FK2, "OneToOne_Optional_FK1")),
+                new ExpectedInclude<Level2>(l2 => l2.OneToOne_Optional_FK2!, "OneToOne_Required_FK1"),
+                new ExpectedInclude<Level1>(l1 => l1.OneToOne_Optional_FK1!),
+                new ExpectedInclude<Level2>(l2 => l2.OneToOne_Optional_FK2!, "OneToOne_Optional_FK1")),
             assertOrder: true);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -817,27 +817,27 @@ public abstract class ComplexNavigationsCollectionsQueryTestBase<TFixture>(TFixt
                 .Select(l4 => l4.OneToOne_Required_FK_Inverse4),
             elementAsserter: (e, a) => AssertInclude(
                 e, a, new ExpectedInclude<Level3>(l3 => l3.OneToMany_Required_Inverse3),
-                new ExpectedInclude<Level2>(l2 => l2.OneToMany_Optional_Inverse2, "OneToMany_Required_Inverse3")));
+                new ExpectedInclude<Level2>(l2 => l2.OneToMany_Optional_Inverse2!, "OneToMany_Required_Inverse3")));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Optional_navigation_with_Include_ThenInclude(bool async)
         => AssertQuery(
             async,
             ss => ss.Set<Level1>()
-                .Include(l1 => l1.OneToOne_Optional_FK1.OneToMany_Optional2)
+                .Include(l1 => l1.OneToOne_Optional_FK1!.OneToMany_Optional2)
                 .ThenInclude(l3 => l3.OneToOne_Optional_FK3)
                 .Select(l1 => l1.OneToOne_Optional_FK1),
             elementAsserter: (e, a) => AssertInclude(
                 e, a, new ExpectedInclude<Level2>(l2 => l2.OneToMany_Optional2),
-                new ExpectedInclude<Level3>(l3 => l3.OneToOne_Optional_FK3, "OneToMany_Optional2")));
+                new ExpectedInclude<Level3>(l3 => l3.OneToOne_Optional_FK3!, "OneToMany_Optional2")));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Multiple_optional_navigation_with_Include(bool async)
         => AssertQuery(
             async,
             ss => ss.Set<Level1>()
-                .Include(l1 => l1.OneToOne_Optional_FK1.OneToOne_Optional_PK2.OneToMany_Optional3)
-                .Select(l1 => l1.OneToOne_Optional_FK1.OneToOne_Optional_PK2),
+                .Include(l1 => l1.OneToOne_Optional_FK1!.OneToOne_Optional_PK2!.OneToMany_Optional3)
+                .Select(l1 => l1.OneToOne_Optional_FK1!.OneToOne_Optional_PK2),
             elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Level3>(l3 => l3.OneToMany_Optional3)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -847,7 +847,7 @@ public abstract class ComplexNavigationsCollectionsQueryTestBase<TFixture>(TFixt
             ss => ss.Set<Level1>()
                 .Include("OneToOne_Optional_FK1.OneToOne_Optional_PK2.OneToMany_Optional3")
                 .Select(l1 => l1.OneToOne_Optional_FK1)
-                .Select(l2 => l2.OneToOne_Optional_PK2),
+                .Select(l2 => l2!.OneToOne_Optional_PK2),
             elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Level3>(l3 => l3.OneToMany_Optional3)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -855,9 +855,9 @@ public abstract class ComplexNavigationsCollectionsQueryTestBase<TFixture>(TFixt
         => AssertQuery(
             async,
             ss => ss.Set<Level1>()
-                .Include(l1 => l1.OneToOne_Optional_FK1.OneToMany_Optional2)
+                .Include(l1 => l1.OneToOne_Optional_FK1!.OneToMany_Optional2)
                 .Select(l1 => l1.OneToOne_Optional_FK1)
-                .OrderBy(l2 => l2.Name),
+                .OrderBy(l2 => l2!.Name),
             elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Level2>(l2 => l2.OneToMany_Optional2)),
             assertOrder: true);
 
@@ -866,9 +866,9 @@ public abstract class ComplexNavigationsCollectionsQueryTestBase<TFixture>(TFixt
         => AssertQuery(
             async,
             ss => ss.Set<Level1>()
-                .Include(l1 => l1.OneToOne_Optional_FK1.OneToMany_Optional2)
+                .Include(l1 => l1.OneToOne_Optional_FK1!.OneToMany_Optional2)
                 .Select(l1 => l1.OneToOne_Optional_FK1)
-                .OrderBy(l2 => l2.Name),
+                .OrderBy(l2 => l2!.Name),
             elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Level2>(l2 => l2.OneToMany_Optional2)),
             assertOrder: true);
 
@@ -1026,11 +1026,11 @@ public abstract class ComplexNavigationsCollectionsQueryTestBase<TFixture>(TFixt
         => AssertQuery(
             async,
             ss => ss.Set<Level1>()
-                .Include(l1 => l1.OneToOne_Optional_FK1.OneToMany_Optional2)
-                .OrderBy(l1 => (int?)l1.OneToOne_Optional_FK1.Id),
+                .Include(l1 => l1.OneToOne_Optional_FK1!.OneToMany_Optional2)
+                .OrderBy(l1 => (int?)l1.OneToOne_Optional_FK1!.Id),
             elementAsserter: (e, a) => AssertInclude(
                 e, a,
-                new ExpectedInclude<Level1>(e => e.OneToOne_Optional_FK1),
+                new ExpectedInclude<Level1>(e => e.OneToOne_Optional_FK1!),
                 new ExpectedInclude<Level2>(e => e.OneToMany_Optional2, "OneToOne_Optional_FK1")),
             assertOrder: true);
 
@@ -1038,13 +1038,13 @@ public abstract class ComplexNavigationsCollectionsQueryTestBase<TFixture>(TFixt
     public virtual Task Include_after_Select(bool async)
         => AssertIncludeOnNonEntity(() => AssertQuery(
             async,
-            ss => ss.Set<Level1>().Select(l1 => l1.OneToOne_Optional_FK1).Include(l2 => l2.OneToMany_Optional2)));
+            ss => ss.Set<Level1>().Select(l1 => l1.OneToOne_Optional_FK1!).Include(l2 => l2.OneToMany_Optional2)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Include_after_SelectMany_and_reference_navigation(bool async)
         => AssertIncludeOnNonEntity(() => AssertQuery(
             async,
-            ss => ss.Set<Level1>().SelectMany(l1 => l1.OneToMany_Required1).Select(l2 => l2.OneToOne_Optional_FK2)
+            ss => ss.Set<Level1>().SelectMany(l1 => l1.OneToMany_Required1).Select(l2 => l2.OneToOne_Optional_FK2!)
                 .Include(l3 => l3.OneToMany_Optional3)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -1071,8 +1071,8 @@ public abstract class ComplexNavigationsCollectionsQueryTestBase<TFixture>(TFixt
             async,
             ss => ss.Set<Level1>()
                 .SelectMany(l1 => l1.OneToMany_Required1)
-                .Include(l2 => l2.OneToOne_Optional_FK2.OneToOne_Required_FK3.OneToMany_Optional_Self4)
-                .Select(l2 => l2.OneToOne_Optional_FK2)
+                .Include(l2 => l2.OneToOne_Optional_FK2!.OneToOne_Required_FK3.OneToMany_Optional_Self4)
+                .Select(l2 => l2.OneToOne_Optional_FK2!)
                 .Select(l3 => l3.OneToOne_Required_FK3),
             elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Level4>(l4 => l4.OneToMany_Optional_Self4)));
 
@@ -1090,15 +1090,15 @@ public abstract class ComplexNavigationsCollectionsQueryTestBase<TFixture>(TFixt
             ss => ss.Set<Level1>().Include(l1 => l1.OneToMany_Optional1).ThenInclude(l2 => l2.OneToOne_Optional_PK2),
             elementAsserter: (e, a) => AssertInclude(
                 e, a, new ExpectedInclude<Level1>(e1 => e1.OneToMany_Optional1),
-                new ExpectedInclude<Level2>(e2 => e2.OneToOne_Optional_PK2, "OneToMany_Optional1")));
+                new ExpectedInclude<Level2>(e2 => e2.OneToOne_Optional_PK2!, "OneToMany_Optional1")));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Include_reference_followed_by_include_collection(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<Level1>().Include(l1 => l1.OneToOne_Optional_FK1).ThenInclude(l2 => l2.OneToMany_Optional2),
+            ss => ss.Set<Level1>().Include(l1 => l1.OneToOne_Optional_FK1).ThenInclude(l2 => l2!.OneToMany_Optional2),
             elementAsserter: (e, a) => AssertInclude(
-                e, a, new ExpectedInclude<Level1>(e1 => e1.OneToOne_Optional_FK1),
+                e, a, new ExpectedInclude<Level1>(e1 => e1.OneToOne_Optional_FK1!),
                 new ExpectedInclude<Level2>(e2 => e2.OneToMany_Optional2, "OneToOne_Optional_FK1")));
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -1122,7 +1122,7 @@ public abstract class ComplexNavigationsCollectionsQueryTestBase<TFixture>(TFixt
             elementAsserter: (e, a) => AssertCollection(
                 e,
                 a,
-                elementAsserter: (ee, aa) => AssertInclude(ee, aa, new ExpectedInclude<Level2>(x => x.OneToOne_Optional_PK2))));
+                elementAsserter: (ee, aa) => AssertInclude(ee, aa, new ExpectedInclude<Level2>(x => x.OneToOne_Optional_PK2!))));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Include_collection_and_another_navigation_chain_followed_by_projecting_the_first_collection(bool async)
@@ -1132,15 +1132,15 @@ public abstract class ComplexNavigationsCollectionsQueryTestBase<TFixture>(TFixt
                 .OrderBy(l1 => l1.Id)
                 .Include(l1 => l1.OneToMany_Optional1)
                 .ThenInclude(l2 => l2.OneToOne_Optional_PK2)
-                .ThenInclude(l3 => l3.OneToOne_Optional_FK3)
+                .ThenInclude(l3 => l3!.OneToOne_Optional_FK3)
                 .Select(l1 => l1.OneToMany_Optional1),
             assertOrder: true,
             elementAsserter: (e, a) => AssertCollection(
                 e,
                 a,
                 elementAsserter: (ee, aa) => AssertInclude(
-                    ee, aa, new ExpectedInclude<Level2>(e1 => e1.OneToOne_Optional_PK2),
-                    new ExpectedInclude<Level3>(e2 => e2.OneToOne_Optional_FK3, "OneToOne_Optional_PK2"))));
+                    ee, aa, new ExpectedInclude<Level2>(e1 => e1.OneToOne_Optional_PK2!),
+                    new ExpectedInclude<Level3>(e2 => e2.OneToOne_Optional_FK3!, "OneToOne_Optional_PK2"))));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Include_collection_ThenInclude_two_references(bool async)
@@ -1149,11 +1149,11 @@ public abstract class ComplexNavigationsCollectionsQueryTestBase<TFixture>(TFixt
             ss => ss.Set<Level1>()
                 .Include(l1 => l1.OneToMany_Optional1)
                 .ThenInclude(l2 => l2.OneToOne_Optional_PK2)
-                .ThenInclude(l3 => l3.OneToOne_Optional_FK3),
+                .ThenInclude(l3 => l3!.OneToOne_Optional_FK3),
             elementAsserter: (e, a) => AssertInclude(
                 e, a, new ExpectedInclude<Level1>(e1 => e1.OneToMany_Optional1),
-                new ExpectedInclude<Level2>(e2 => e2.OneToOne_Optional_PK2, "OneToMany_Optional1"),
-                new ExpectedInclude<Level3>(e3 => e3.OneToOne_Optional_FK3, "OneToMany_Optional1.OneToOne_Optional_PK2")));
+                new ExpectedInclude<Level2>(e2 => e2.OneToOne_Optional_PK2!, "OneToMany_Optional1"),
+                new ExpectedInclude<Level3>(e3 => e3.OneToOne_Optional_FK3!, "OneToMany_Optional1.OneToOne_Optional_PK2")));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Include_collection_followed_by_complex_includes_and_projecting_the_included_collection(bool async)
@@ -1162,15 +1162,15 @@ public abstract class ComplexNavigationsCollectionsQueryTestBase<TFixture>(TFixt
             ss => ss.Set<Level1>()
                 .OrderBy(l1 => l1.Id)
                 .Include(l1 => l1.OneToMany_Optional1).ThenInclude(l2 => l2.OneToOne_Optional_PK2)
-                .ThenInclude(l3 => l3.OneToOne_Optional_FK3)
+                .ThenInclude(l3 => l3!.OneToOne_Optional_FK3)
                 .Include(l1 => l1.OneToMany_Optional1).ThenInclude(l2 => l2.OneToOne_Optional_FK2)
-                .ThenInclude(l3 => l3.OneToMany_Optional3)
+                .ThenInclude(l3 => l3!.OneToMany_Optional3)
                 .Select(l1 => l1.OneToMany_Optional1),
             assertOrder: true,
             elementAsserter: (e, a) => AssertInclude(
-                e, a, new ExpectedInclude<Level2>(e1 => e1.OneToOne_Optional_PK2),
-                new ExpectedInclude<Level3>(e2 => e2.OneToOne_Optional_FK3, "OneToOne_Optional_PK2"),
-                new ExpectedInclude<Level2>(e3 => e3.OneToOne_Optional_FK2),
+                e, a, new ExpectedInclude<Level2>(e1 => e1.OneToOne_Optional_PK2!),
+                new ExpectedInclude<Level3>(e2 => e2.OneToOne_Optional_FK3!, "OneToOne_Optional_PK2"),
+                new ExpectedInclude<Level2>(e3 => e3.OneToOne_Optional_FK2!),
                 new ExpectedInclude<Level3>(e4 => e4.OneToMany_Optional3, "OneToOne_Optional_FK2")));
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -1179,14 +1179,14 @@ public abstract class ComplexNavigationsCollectionsQueryTestBase<TFixture>(TFixt
             async,
             ss => ss.Set<Level1>()
                 .Include(l1 => l1.OneToMany_Optional1).ThenInclude(l2 => l2.OneToOne_Optional_PK2)
-                .ThenInclude(l3 => l3.OneToOne_Optional_FK3)
+                .ThenInclude(l3 => l3!.OneToOne_Optional_FK3)
                 .Include(l1 => l1.OneToMany_Optional1).ThenInclude(l2 => l2.OneToOne_Optional_FK2)
-                .ThenInclude(l3 => l3.OneToMany_Optional3),
+                .ThenInclude(l3 => l3!.OneToMany_Optional3),
             elementAsserter: (e, a) => AssertInclude(
                 e, a, new ExpectedInclude<Level1>(e1 => e1.OneToMany_Optional1),
-                new ExpectedInclude<Level2>(e2 => e2.OneToOne_Optional_PK2, "OneToMany_Optional1"),
-                new ExpectedInclude<Level3>(e3 => e3.OneToOne_Optional_FK3, "OneToMany_Optional1.OneToOne_Optional_PK2"),
-                new ExpectedInclude<Level2>(e4 => e4.OneToOne_Optional_FK2, "OneToMany_Optional1"),
+                new ExpectedInclude<Level2>(e2 => e2.OneToOne_Optional_PK2!, "OneToMany_Optional1"),
+                new ExpectedInclude<Level3>(e3 => e3.OneToOne_Optional_FK3!, "OneToMany_Optional1.OneToOne_Optional_PK2"),
+                new ExpectedInclude<Level2>(e4 => e4.OneToOne_Optional_FK2!, "OneToMany_Optional1"),
                 new ExpectedInclude<Level3>(e5 => e5.OneToMany_Optional3, "OneToMany_Optional1.OneToOne_Optional_FK2")));
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -1196,11 +1196,11 @@ public abstract class ComplexNavigationsCollectionsQueryTestBase<TFixture>(TFixt
             ss => ss.Set<Level1>()
                 .OrderBy(l1 => l1.Id)
                 .Include(l1 => l1.OneToMany_Optional1).ThenInclude(l2 => l2.OneToOne_Optional_PK2)
-                .ThenInclude(l3 => l3.OneToOne_Optional_FK3)
+                .ThenInclude(l3 => l3!.OneToOne_Optional_FK3)
                 .Select(l1 => l1.OneToMany_Optional1.Select(l2 => l2.OneToOne_Optional_PK2)),
             assertOrder: true,
             elementAsserter: (e, a) => AssertCollection(
-                e, a, elementAsserter: (ee, aa) => AssertInclude(ee, aa, new ExpectedInclude<Level3>(x => x.OneToOne_Optional_FK3))));
+                e, a, elementAsserter: (ee, aa) => AssertInclude(ee, aa, new ExpectedInclude<Level3>(x => x.OneToOne_Optional_FK3!))));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Include_collection_ThenInclude_reference_followed_by_projection_into_anonmous_type(bool async)
@@ -1215,11 +1215,11 @@ public abstract class ComplexNavigationsCollectionsQueryTestBase<TFixture>(TFixt
             {
                 AssertInclude(
                     e.l1, a.l1, new ExpectedInclude<Level1>(e1 => e1.OneToMany_Optional1),
-                    new ExpectedInclude<Level2>(e2 => e2.OneToOne_Optional_PK2, "OneToMany_Optional1"));
+                    new ExpectedInclude<Level2>(e2 => e2.OneToOne_Optional_PK2!, "OneToMany_Optional1"));
                 AssertCollection(
                     e.OneToMany_Optional1,
                     a.OneToMany_Optional1,
-                    elementAsserter: (ee, aa) => AssertInclude(ee, aa, new ExpectedInclude<Level2>(e => e.OneToOne_Optional_PK2)));
+                    elementAsserter: (ee, aa) => AssertInclude(ee, aa, new ExpectedInclude<Level2>(e => e.OneToOne_Optional_PK2!)));
             });
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -1229,12 +1229,12 @@ public abstract class ComplexNavigationsCollectionsQueryTestBase<TFixture>(TFixt
             ss => ss.Set<Level1>()
                 .Include(l1 => l1.OneToMany_Optional1)
                 .ThenInclude(l2 => l2.OneToOne_Optional_PK2)
-                .ThenInclude(l3 => l3.OneToOne_Optional_FK3)
-                .Where(l1 => l1.OneToMany_Optional1.Where(l2 => l2.OneToOne_Optional_PK2.Name != "Foo").Count() > 0),
+                .ThenInclude(l3 => l3!.OneToOne_Optional_FK3)
+                .Where(l1 => l1.OneToMany_Optional1.Where(l2 => l2.OneToOne_Optional_PK2!.Name != "Foo").Count() > 0),
             elementAsserter: (e, a) => AssertInclude(
                 e, a, new ExpectedInclude<Level1>(e1 => e1.OneToMany_Optional1),
-                new ExpectedInclude<Level2>(e2 => e2.OneToOne_Optional_PK2, "OneToMany_Optional1"),
-                new ExpectedInclude<Level3>(e3 => e3.OneToOne_Optional_FK3, "OneToMany_Optional1.OneToOne_Optional_PK2")));
+                new ExpectedInclude<Level2>(e2 => e2.OneToOne_Optional_PK2!, "OneToMany_Optional1"),
+                new ExpectedInclude<Level3>(e3 => e3.OneToOne_Optional_FK3!, "OneToMany_Optional1.OneToOne_Optional_PK2")));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Include_collection_multiple_with_filter_EF_Property(bool async)
@@ -1244,13 +1244,13 @@ public abstract class ComplexNavigationsCollectionsQueryTestBase<TFixture>(TFixt
                 .Include(l1 => EF.Property<ICollection<Level2>>(l1, "OneToMany_Optional1"))
                 .ThenInclude(l2 => EF.Property<Level3>(l2, "OneToOne_Optional_PK2"))
                 .ThenInclude(l3 => EF.Property<Level4>(l3, "OneToOne_Optional_FK3"))
-                .Where(l1 => EF.Property<ICollection<Level2>>(l1, "OneToMany_Optional1").Where(l2 => l2.OneToOne_Optional_PK2.Name != "Foo")
+                .Where(l1 => EF.Property<ICollection<Level2>>(l1, "OneToMany_Optional1").Where(l2 => l2.OneToOne_Optional_PK2!.Name != "Foo")
                         .Count()
                     > 0),
             elementAsserter: (e, a) => AssertInclude(
                 e, a, new ExpectedInclude<Level1>(e1 => e1.OneToMany_Optional1),
-                new ExpectedInclude<Level2>(e2 => e2.OneToOne_Optional_PK2, "OneToMany_Optional1"),
-                new ExpectedInclude<Level3>(e3 => e3.OneToOne_Optional_FK3, "OneToMany_Optional1.OneToOne_Optional_PK2")));
+                new ExpectedInclude<Level2>(e2 => e2.OneToOne_Optional_PK2!, "OneToMany_Optional1"),
+                new ExpectedInclude<Level3>(e3 => e3.OneToOne_Optional_FK3!, "OneToMany_Optional1.OneToOne_Optional_PK2")));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Including_reference_navigation_and_projecting_collection_navigation(bool async)
@@ -1269,7 +1269,7 @@ public abstract class ComplexNavigationsCollectionsQueryTestBase<TFixture>(TFixt
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task LeftJoin_with_Any_on_outer_source_and_projecting_collection_from_inner(bool async)
     {
-        var validIds = new List<string> { "L1 01", "L1 02" };
+        var validIds = new List<string?> { "L1 01", "L1 02" };
 
         return AssertQuery(
             async,
@@ -1277,7 +1277,7 @@ public abstract class ComplexNavigationsCollectionsQueryTestBase<TFixture>(TFixt
                   join l2 in ss.Set<Level2>()
                       on l1.Id equals l2.Level1_Required_Id into l2s
                   from l2 in l2s.DefaultIfEmpty()
-                  select new Level2 { Id = l2 == null ? 0 : l2.Id, OneToMany_Required2 = l2 == null ? null : l2.OneToMany_Required2 });
+                  select new Level2 { Id = l2 == null ? 0 : l2.Id, OneToMany_Required2 = l2 == null ? null! : l2.OneToMany_Required2 });
     }
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -1438,10 +1438,10 @@ public abstract class ComplexNavigationsCollectionsQueryTestBase<TFixture>(TFixt
             async,
             ss => ss.Set<Level1>()
                 .Include(l1 => l1.OneToOne_Optional_FK1)
-                .ThenInclude(l2 => l2.OneToMany_Optional2.Where(x => x.Name != "Foo").OrderBy(x => x.Name).Skip(1).Take(3)),
+                .ThenInclude(l2 => l2!.OneToMany_Optional2.Where(x => x.Name != "Foo").OrderBy(x => x.Name).Skip(1).Take(3)),
             elementAsserter: (e, a) => AssertInclude(
                 e, a,
-                new ExpectedInclude<Level1>(e => e.OneToOne_Optional_FK1),
+                new ExpectedInclude<Level1>(e => e.OneToOne_Optional_FK1!),
                 new ExpectedFilteredInclude<Level2, Level3>(
                     e => e.OneToMany_Optional2,
                     "OneToOne_Optional_FK1",
@@ -1458,7 +1458,7 @@ public abstract class ComplexNavigationsCollectionsQueryTestBase<TFixture>(TFixt
                     .Where(x => x.Name != "Foo").OrderBy(x => x.Name).Skip(1).Take(3)),
             elementAsserter: (e, a) => AssertInclude(
                 e, a,
-                new ExpectedInclude<Level1>(e => e.OneToOne_Optional_FK1),
+                new ExpectedInclude<Level1>(e => e.OneToOne_Optional_FK1!),
                 new ExpectedFilteredInclude<Level2, Level3>(
                     e => e.OneToMany_Optional2,
                     "OneToOne_Optional_FK1",
@@ -1470,11 +1470,11 @@ public abstract class ComplexNavigationsCollectionsQueryTestBase<TFixture>(TFixt
         => AssertQuery(
             async,
             ss => ss.Set<Level1>()
-                .Include(l1 => l1.OneToOne_Optional_FK1.OneToMany_Optional2.Where(x => x.Name != "Foo").OrderBy(x => x.Name).Skip(1)
+                .Include(l1 => l1.OneToOne_Optional_FK1!.OneToMany_Optional2.Where(x => x.Name != "Foo").OrderBy(x => x.Name).Skip(1)
                     .Take(3)),
             elementAsserter: (e, a) => AssertInclude(
                 e, a,
-                new ExpectedInclude<Level1>(e => e.OneToOne_Optional_FK1),
+                new ExpectedInclude<Level1>(e => e.OneToOne_Optional_FK1!),
                 new ExpectedFilteredInclude<Level2, Level3>(
                     e => e.OneToMany_Optional2,
                     "OneToOne_Optional_FK1",
@@ -1634,14 +1634,14 @@ public abstract class ComplexNavigationsCollectionsQueryTestBase<TFixture>(TFixt
             ss => ss.Set<Level1>()
                 .Include(l1 => l1.OneToMany_Optional1.Where(x => x.Name != "Foo").OrderBy(x => x.Id).Take(1))
                 .Include(l1 => l1.OneToMany_Optional1)
-                .ThenInclude(l2 => l2.OneToOne_Optional_PK2.OneToMany_Optional3.Where(x => x.Id > 1)),
+                .ThenInclude(l2 => l2.OneToOne_Optional_PK2!.OneToMany_Optional3.Where(x => x.Id > 1)),
             elementAsserter: (e, a) => AssertInclude(
                 e, a,
                 new ExpectedFilteredInclude<Level1, Level2>(
                     e => e.OneToMany_Optional1,
                     includeFilter: x => x.Where(x => x.Name != "Foo").OrderBy(x => x.Id).Take(1),
                     assertOrder: true),
-                new ExpectedInclude<Level2>(e => e.OneToOne_Optional_PK2, "OneToMany_Optional1"),
+                new ExpectedInclude<Level2>(e => e.OneToOne_Optional_PK2!, "OneToMany_Optional1"),
                 new ExpectedFilteredInclude<Level3, Level4>(
                     e => e.OneToMany_Optional3,
                     "OneToMany_Optional1.OneToOne_Optional_PK2",
@@ -1813,7 +1813,7 @@ public abstract class ComplexNavigationsCollectionsQueryTestBase<TFixture>(TFixt
                 new ExpectedFilteredInclude<Level1, Level2>(
                     x => x.OneToMany_Optional1,
                     includeFilter: x => x.OrderByDescending(xx => xx.Name).Take(4)),
-                new ExpectedInclude<Level2>(x => x.OneToOne_Optional_FK2, "OneToMany_Optional1")));
+                new ExpectedInclude<Level2>(x => x.OneToOne_Optional_FK2!, "OneToMany_Optional1")));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Filtered_include_Skip_Take_with_another_Skip_Take_on_top_level(bool async)
@@ -1832,7 +1832,7 @@ public abstract class ComplexNavigationsCollectionsQueryTestBase<TFixture>(TFixt
                 new ExpectedFilteredInclude<Level1, Level2>(
                     x => x.OneToMany_Optional1,
                     includeFilter: x => x.OrderByDescending(xx => xx.Name).Skip(2).Take(4)),
-                new ExpectedInclude<Level2>(x => x.OneToOne_Optional_FK2, "OneToMany_Optional1")));
+                new ExpectedInclude<Level2>(x => x.OneToOne_Optional_FK2!, "OneToMany_Optional1")));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Filtered_include_with_Take_without_order_by_followed_by_ThenInclude_and_FirstOrDefault_on_top_level(bool async)
@@ -1848,7 +1848,7 @@ public abstract class ComplexNavigationsCollectionsQueryTestBase<TFixture>(TFixt
                 new ExpectedFilteredInclude<Level1, Level2>(
                     x => x.OneToMany_Optional1,
                     includeFilter: x => x.Take(40)),
-                new ExpectedInclude<Level2>(x => x.OneToOne_Optional_FK2, "OneToMany_Optional1")));
+                new ExpectedInclude<Level2>(x => x.OneToOne_Optional_FK2!, "OneToMany_Optional1")));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Filtered_include_with_Take_without_order_by_followed_by_ThenInclude_and_unordered_Take_on_top_level(bool async)
@@ -1866,7 +1866,7 @@ public abstract class ComplexNavigationsCollectionsQueryTestBase<TFixture>(TFixt
                 new ExpectedFilteredInclude<Level1, Level2>(
                     x => x.OneToMany_Optional1,
                     includeFilter: x => x.Take(40)),
-                new ExpectedInclude<Level2>(x => x.OneToOne_Optional_FK2, "OneToMany_Optional1")));
+                new ExpectedInclude<Level2>(x => x.OneToOne_Optional_FK2!, "OneToMany_Optional1")));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Projecting_collection_with_FirstOrDefault(bool async)
@@ -1877,7 +1877,7 @@ public abstract class ComplexNavigationsCollectionsQueryTestBase<TFixture>(TFixt
             predicate: l => l.Id == 1,
             asserter: (e, a) =>
             {
-                Assert.Equal(e.Id, a.Id);
+                Assert.Equal(e!.Id, a!.Id);
                 AssertCollection(e.Level2s, a.Level2s);
             });
 
@@ -1996,7 +1996,7 @@ public abstract class ComplexNavigationsCollectionsQueryTestBase<TFixture>(TFixt
                 AssertEqual(e.Key, a.Key);
                 AssertCollection(
                     e.Level1s, a.Level1s,
-                    elementAsserter: (ee, aa) => AssertInclude(ee, aa, new ExpectedInclude<Level1>(l => l.OneToOne_Optional_FK1)));
+                    elementAsserter: (ee, aa) => AssertInclude(ee, aa, new ExpectedInclude<Level1>(l => l.OneToOne_Optional_FK1!)));
             });
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -2029,7 +2029,7 @@ public abstract class ComplexNavigationsCollectionsQueryTestBase<TFixture>(TFixt
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Collection_projection_over_GroupBy_over_parameter(bool async)
     {
-        var validIds = new List<string> { "L1 01", "L1 02" };
+        var validIds = new List<string?> { "L1 01", "L1 02" };
 
         return AssertQuery(
             async,
@@ -2052,7 +2052,7 @@ public abstract class ComplexNavigationsCollectionsQueryTestBase<TFixture>(TFixt
             ss => ss.Set<Level2>()
                 .SelectMany(l2 => l2.Id == 1
                     ? l2.OneToMany_Required_Inverse2.OneToMany_Optional1.Select(e => e.Id)
-                    : null)));
+                    : null!)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task SelectMany_over_conditional_empty_source(bool async)
@@ -2069,27 +2069,27 @@ public abstract class ComplexNavigationsCollectionsQueryTestBase<TFixture>(TFixt
             async,
             ss => ss.Set<Level1>()
                 .Include(l1 => l1.OneToOne_Optional_FK1)
-                .Where(l1 => l1.OneToOne_Optional_PK1.Id < 3 || l1.OneToOne_Optional_FK1.Id > 8)
-                .Include(l1 => l1.OneToOne_Optional_FK1.OneToMany_Optional2)
+                .Where(l1 => l1.OneToOne_Optional_PK1!.Id < 3 || l1.OneToOne_Optional_FK1!.Id > 8)
+                .Include(l1 => l1.OneToOne_Optional_FK1!.OneToMany_Optional2)
                 .ThenInclude(l3 => l3.OneToOne_Optional_FK3),
             elementAsserter: (e, a) => AssertInclude(
-                e, a, new ExpectedInclude<Level1>(l2 => l2.OneToOne_Optional_FK1),
+                e, a, new ExpectedInclude<Level1>(l2 => l2.OneToOne_Optional_FK1!),
                 new ExpectedInclude<Level2>(l2 => l2.OneToMany_Optional2, "OneToOne_Optional_FK1"),
-                new ExpectedInclude<Level3>(l3 => l3.OneToOne_Optional_FK3, "OneToOne_Optional_FK1.OneToMany_Optional2")));
+                new ExpectedInclude<Level3>(l3 => l3.OneToOne_Optional_FK3!, "OneToOne_Optional_FK1.OneToMany_Optional2")));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Include_partially_added_before_Where_and_then_build_upon_with_filtered_include(bool async)
         => AssertQuery(
             async,
             ss => ss.Set<Level1>()
-                .Include(l1 => l1.OneToOne_Optional_FK1.OneToMany_Optional2.OrderBy(x => x.Id).Take(3))
-                .Where(l1 => l1.OneToOne_Optional_PK1.Id < 3 || l1.OneToOne_Optional_FK1.Id > 8)
-                .Include(l1 => l1.OneToOne_Optional_FK1.OneToMany_Required2)
+                .Include(l1 => l1.OneToOne_Optional_FK1!.OneToMany_Optional2.OrderBy(x => x.Id).Take(3))
+                .Where(l1 => l1.OneToOne_Optional_PK1!.Id < 3 || l1.OneToOne_Optional_FK1!.Id > 8)
+                .Include(l1 => l1.OneToOne_Optional_FK1!.OneToMany_Required2)
                 .ThenInclude(l3 => l3.OneToOne_Optional_FK3),
             elementAsserter: (e, a) => AssertInclude(
-                e, a, new ExpectedInclude<Level1>(l2 => l2.OneToOne_Optional_FK1),
+                e, a, new ExpectedInclude<Level1>(l2 => l2.OneToOne_Optional_FK1!),
                 new ExpectedInclude<Level2>(l2 => l2.OneToMany_Optional2, "OneToOne_Optional_FK1"),
-                new ExpectedInclude<Level3>(l3 => l3.OneToOne_Optional_FK3, "OneToOne_Optional_FK1.OneToMany_Optional2")));
+                new ExpectedInclude<Level3>(l3 => l3.OneToOne_Optional_FK3!, "OneToOne_Optional_FK1.OneToMany_Optional2")));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Take_on_correlated_collection_in_projection(bool async)
@@ -2121,7 +2121,7 @@ public abstract class ComplexNavigationsCollectionsQueryTestBase<TFixture>(TFixt
         => AssertQuery(
             async,
             ss => from l1 in ss.Set<Level1>()
-                  from l2 in ss.Set<Level2>().Where(x => x.Level1_Required_Id == l1.Id * 2 || x.Name.Length == x.Id).DefaultIfEmpty()
+                  from l2 in ss.Set<Level2>().Where(x => x.Level1_Required_Id == l1.Id * 2 || x.Name!.Length == x.Id).DefaultIfEmpty()
                   select new
                   {
                       Root = l1,
@@ -2145,7 +2145,7 @@ public abstract class ComplexNavigationsCollectionsQueryTestBase<TFixture>(TFixt
                 .Select(l1 => new
                 {
                     Level1 = l1,
-                    Level2Name = l1.OneToOne_Optional_FK1.Name,
+                    Level2Name = l1.OneToOne_Optional_FK1!.Name,
                     ChildCount = l1.OneToMany_Optional_Self1.Count,
                     Level2Count = l1.OneToMany_Optional1.Count(),
                     IsLevel2There = l1.OneToMany_Optional1.Any(l2 => l2.Id == 2),
@@ -2157,7 +2157,7 @@ public abstract class ComplexNavigationsCollectionsQueryTestBase<TFixture>(TFixt
                         {
                             Level1 = lc1,
                             ChildCount = lc1.OneToMany_Optional_Self1.Count,
-                            Level2Name = lc1.OneToOne_Optional_FK1.Name,
+                            Level2Name = lc1.OneToOne_Optional_FK1!.Name,
                             Level2Count = lc1.OneToMany_Optional1.Count(),
                             IsLevel2There = lc1.OneToMany_Optional1.Any(l2 => l2.Id == 2)
                         })
@@ -2165,13 +2165,13 @@ public abstract class ComplexNavigationsCollectionsQueryTestBase<TFixture>(TFixt
             e => e.Level1.Id == 2,
             asserter: (e, a) =>
             {
-                AssertEqual(e.Level1, a.Level1);
+                AssertEqual(e!.Level1, a!.Level1);
                 AssertEqual(e.Level2Name, a.Level2Name);
                 AssertEqual(e.ChildCount, a.ChildCount);
                 AssertEqual(e.Level2Count, a.Level2Count);
                 AssertEqual(e.IsLevel2There, a.IsLevel2There);
                 AssertCollection(
-                    e.Children, a.Children, ordered: true,
+                    e.Children!, a.Children!, ordered: true,
                     elementAsserter: (ee, aa) =>
                     {
                         AssertEqual(ee.Level1, aa.Level1);
@@ -2189,14 +2189,14 @@ public abstract class ComplexNavigationsCollectionsQueryTestBase<TFixture>(TFixt
             ss => ss.Set<Level1>().Select(l1 => new
             {
                 l1.Id,
-                Collection = l1.OneToOne_Optional_FK1.OneToMany_Optional2.Select(l3
+                Collection = l1.OneToOne_Optional_FK1!.OneToMany_Optional2.Select(l3
                     => new { ChildId = l3.Id, ParentName = l1.OneToOne_Optional_FK1.Name })
             }),
             ss => ss.Set<Level1>().Select(l1 => new
             {
                 l1.Id,
-                Collection = l1.Maybe(x => x.OneToOne_Optional_FK1.Maybe(xx => xx.OneToMany_Optional2.Select(l3
-                    => new { ChildId = (int)l3.MaybeScalar(xxx => xxx.Id), ParentName = l1.OneToOne_Optional_FK1.Maybe(xxx => xxx.Name) })))
+                Collection = l1.Maybe(x => x.OneToOne_Optional_FK1.Maybe(xx => xx!.OneToMany_Optional2.Select(l3
+                    => new { ChildId = (int)l3.MaybeScalar(xxx => xxx.Id)!, ParentName = l1.OneToOne_Optional_FK1!.Maybe(xxx => xxx.Name) })))!
             }),
             elementSorter: e => e.Id,
             elementAsserter: (e, a) =>
@@ -2205,7 +2205,7 @@ public abstract class ComplexNavigationsCollectionsQueryTestBase<TFixture>(TFixt
 
                 if (!(e.Collection == null && a.Collection != null && a.Collection.Count() == 0))
                 {
-                    AssertCollection(e.Collection, a.Collection, elementSorter: ee => ee.ChildId);
+                    AssertCollection(e.Collection!, a.Collection!, elementSorter: ee => ee.ChildId);
                 }
             });
 
@@ -2216,17 +2216,17 @@ public abstract class ComplexNavigationsCollectionsQueryTestBase<TFixture>(TFixt
             ss => ss.Set<Level1>().Select(l1 => new
             {
                 l1.Id,
-                Entity = l1.OneToOne_Optional_FK1.OneToOne_Optional_FK2,
-                Collection = l1.OneToOne_Optional_FK1.OneToMany_Optional2.GroupBy(x => x.Name)
+                Entity = l1.OneToOne_Optional_FK1!.OneToOne_Optional_FK2,
+                Collection = l1.OneToOne_Optional_FK1!.OneToMany_Optional2.GroupBy(x => x.Name)
                     .Select(g => new { g.Key, Count = g.Count() })
             }),
             ss => ss.Set<Level1>().Select(l1 => new
             {
                 l1.Id,
-                Entity = l1.OneToOne_Optional_FK1.OneToOne_Optional_FK2,
+                Entity = l1.OneToOne_Optional_FK1!.OneToOne_Optional_FK2,
                 Collection = l1.Maybe(x
                     => x.OneToOne_Optional_FK1.Maybe(xx
-                        => xx.OneToMany_Optional2.GroupBy(x => x.Name).Select(g => new { g.Key, Count = g.Count() })))
+                        => xx!.OneToMany_Optional2.GroupBy(x => x.Name).Select(g => new { g.Key, Count = g.Count() })))!
             }),
             elementSorter: e => e.Id,
             elementAsserter: (e, a) =>
@@ -2273,7 +2273,7 @@ public abstract class ComplexNavigationsCollectionsQueryTestBase<TFixture>(TFixt
                 elementAsserter: (ee, aa) => AssertInclude(
                     ee, aa,
                     new ExpectedInclude<Level1>(i => i.OneToMany_Optional1),
-                    new ExpectedInclude<Level2>(l2 => l2.OneToOne_Optional_FK2, "OneToManyOptional1"))));
+                    new ExpectedInclude<Level2>(l2 => l2.OneToOne_Optional_FK2!, "OneToManyOptional1"))));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Final_GroupBy_property_entity_Include_collection_multiple(bool async)
@@ -2299,7 +2299,7 @@ public abstract class ComplexNavigationsCollectionsQueryTestBase<TFixture>(TFixt
                 elementAsserter: (ee, aa) => AssertInclude(
                     ee, aa,
                     new ExpectedInclude<Level1>(i => i.OneToMany_Optional1),
-                    new ExpectedInclude<Level1>(l2 => l2.OneToOne_Optional_FK1))));
+                    new ExpectedInclude<Level1>(l2 => l2.OneToOne_Optional_FK1!))));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Final_GroupBy_property_entity_Include_reference(bool async)
@@ -2311,7 +2311,7 @@ public abstract class ComplexNavigationsCollectionsQueryTestBase<TFixture>(TFixt
                 e, a,
                 elementAsserter: (ee, aa) => AssertInclude(
                     ee, aa,
-                    new ExpectedInclude<Level1>(l2 => l2.OneToOne_Optional_FK1))));
+                    new ExpectedInclude<Level1>(l2 => l2.OneToOne_Optional_FK1!))));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Final_GroupBy_property_entity_Include_reference_multiple(bool async)
@@ -2323,7 +2323,7 @@ public abstract class ComplexNavigationsCollectionsQueryTestBase<TFixture>(TFixt
                 e, a,
                 elementAsserter: (ee, aa) => AssertInclude(
                     ee, aa,
-                    new ExpectedInclude<Level1>(l2 => l2.OneToOne_Optional_FK1),
+                    new ExpectedInclude<Level1>(l2 => l2.OneToOne_Optional_FK1!),
                     new ExpectedInclude<Level1>(l2 => l2.OneToOne_Required_FK1))));
 
     [Theory, MemberData(nameof(IsAsyncData))]

--- a/test/EFCore.Specification.Tests/Query/ComplexNavigationsQueryFixtureBase.cs
+++ b/test/EFCore.Specification.Tests/Query/ComplexNavigationsQueryFixtureBase.cs
@@ -5,8 +5,6 @@ using Microsoft.EntityFrameworkCore.TestModels.ComplexNavigationsModel;
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
-#nullable disable
-
 public abstract class ComplexNavigationsQueryFixtureBase : QueryFixtureBase<ComplexNavigationsContext>
 {
     protected override string StoreName
@@ -15,7 +13,7 @@ public abstract class ComplexNavigationsQueryFixtureBase : QueryFixtureBase<Comp
     public override ISetSource GetExpectedData()
         => ComplexNavigationsDefaultData.Instance;
 
-    public virtual Dictionary<(Type, string), Func<object, object>> GetShadowPropertyMappings()
+    public virtual Dictionary<(Type, string), Func<object, object?>> GetShadowPropertyMappings()
     {
         var l1s = GetExpectedData().Set<Level1>().ToList();
         var l2s = GetExpectedData().Set<Level2>().ToList();
@@ -27,7 +25,7 @@ public abstract class ComplexNavigationsQueryFixtureBase : QueryFixtureBase<Comp
         var il1s = GetExpectedData().Set<InheritanceLeaf1>().ToList();
         var il2s = GetExpectedData().Set<InheritanceLeaf2>().ToList();
 
-        return new Dictionary<(Type, string), Func<object, object>>
+        return new Dictionary<(Type, string), Func<object, object?>>
         {
             {
                 (typeof(Level1), "OneToOne_Optional_Self1Id"),
@@ -147,18 +145,18 @@ public abstract class ComplexNavigationsQueryFixtureBase : QueryFixtureBase<Comp
         };
     }
 
-    public override IReadOnlyDictionary<Type, object> EntitySorters { get; } = new Dictionary<Type, Func<object, object>>
+    public override IReadOnlyDictionary<Type, object> EntitySorters { get; } = new Dictionary<Type, Func<object?, object?>>
     {
-        { typeof(Level1), e => ((Level1)e)?.Id },
-        { typeof(Level2), e => ((Level2)e)?.Id },
-        { typeof(Level3), e => ((Level3)e)?.Id },
-        { typeof(Level4), e => ((Level4)e)?.Id },
-        { typeof(InheritanceBase1), e => ((InheritanceBase1)e)?.Id },
-        { typeof(InheritanceBase2), e => ((InheritanceBase2)e)?.Id },
-        { typeof(InheritanceDerived1), e => ((InheritanceDerived1)e)?.Id },
-        { typeof(InheritanceDerived2), e => ((InheritanceDerived2)e)?.Id },
-        { typeof(InheritanceLeaf1), e => ((InheritanceLeaf1)e)?.Id },
-        { typeof(InheritanceLeaf2), e => ((InheritanceLeaf2)e)?.Id }
+        { typeof(Level1), e => ((Level1?)e)?.Id },
+        { typeof(Level2), e => ((Level2?)e)?.Id },
+        { typeof(Level3), e => ((Level3?)e)?.Id },
+        { typeof(Level4), e => ((Level4?)e)?.Id },
+        { typeof(InheritanceBase1), e => ((InheritanceBase1?)e)?.Id },
+        { typeof(InheritanceBase2), e => ((InheritanceBase2?)e)?.Id },
+        { typeof(InheritanceDerived1), e => ((InheritanceDerived1?)e)?.Id },
+        { typeof(InheritanceDerived2), e => ((InheritanceDerived2?)e)?.Id },
+        { typeof(InheritanceLeaf1), e => ((InheritanceLeaf1?)e)?.Id },
+        { typeof(InheritanceLeaf2), e => ((InheritanceLeaf2?)e)?.Id }
     }.ToDictionary(e => e.Key, e => (object)e.Value);
 
     public override IReadOnlyDictionary<Type, object> EntityAsserters { get; } = new Dictionary<Type, Action<object, object>>
@@ -170,7 +168,7 @@ public abstract class ComplexNavigationsQueryFixtureBase : QueryFixtureBase<Comp
 
                 if (a != null)
                 {
-                    var ee = (Level1)e;
+                    var ee = (Level1)e!;
                     var aa = (Level1)a;
 
                     Assert.Equal(ee.Id, aa.Id);
@@ -186,7 +184,7 @@ public abstract class ComplexNavigationsQueryFixtureBase : QueryFixtureBase<Comp
 
                 if (a != null)
                 {
-                    var ee = (Level2)e;
+                    var ee = (Level2)e!;
                     var aa = (Level2)a;
 
                     Assert.Equal(ee.Id, aa.Id);
@@ -204,7 +202,7 @@ public abstract class ComplexNavigationsQueryFixtureBase : QueryFixtureBase<Comp
 
                 if (a != null)
                 {
-                    var ee = (Level3)e;
+                    var ee = (Level3)e!;
                     var aa = (Level3)a;
 
                     Assert.Equal(ee.Id, aa.Id);
@@ -221,7 +219,7 @@ public abstract class ComplexNavigationsQueryFixtureBase : QueryFixtureBase<Comp
 
                 if (a != null)
                 {
-                    var ee = (Level4)e;
+                    var ee = (Level4)e!;
                     var aa = (Level4)a;
 
                     Assert.Equal(ee.Id, aa.Id);
@@ -238,7 +236,7 @@ public abstract class ComplexNavigationsQueryFixtureBase : QueryFixtureBase<Comp
 
                 if (a != null)
                 {
-                    var ee = (InheritanceBase1)e;
+                    var ee = (InheritanceBase1)e!;
                     var aa = (InheritanceBase1)a;
 
                     Assert.Equal(ee.Id, aa.Id);
@@ -253,7 +251,7 @@ public abstract class ComplexNavigationsQueryFixtureBase : QueryFixtureBase<Comp
 
                 if (a != null)
                 {
-                    var ee = (InheritanceBase2)e;
+                    var ee = (InheritanceBase2)e!;
                     var aa = (InheritanceBase2)a;
 
                     Assert.Equal(ee.Id, aa.Id);
@@ -268,7 +266,7 @@ public abstract class ComplexNavigationsQueryFixtureBase : QueryFixtureBase<Comp
 
                 if (a != null)
                 {
-                    var ee = (InheritanceDerived1)e;
+                    var ee = (InheritanceDerived1)e!;
                     var aa = (InheritanceDerived1)a;
 
                     Assert.Equal(ee.Id, aa.Id);
@@ -283,7 +281,7 @@ public abstract class ComplexNavigationsQueryFixtureBase : QueryFixtureBase<Comp
 
                 if (a != null)
                 {
-                    var ee = (InheritanceDerived2)e;
+                    var ee = (InheritanceDerived2)e!;
                     var aa = (InheritanceDerived2)a;
 
                     Assert.Equal(ee.Id, aa.Id);
@@ -298,7 +296,7 @@ public abstract class ComplexNavigationsQueryFixtureBase : QueryFixtureBase<Comp
 
                 if (a != null)
                 {
-                    var ee = (InheritanceLeaf1)e;
+                    var ee = (InheritanceLeaf1)e!;
                     var aa = (InheritanceLeaf1)a;
 
                     Assert.Equal(ee.Id, aa.Id);
@@ -313,7 +311,7 @@ public abstract class ComplexNavigationsQueryFixtureBase : QueryFixtureBase<Comp
 
                 if (a != null)
                 {
-                    var ee = (InheritanceLeaf2)e;
+                    var ee = (InheritanceLeaf2)e!;
                     var aa = (InheritanceLeaf2)a;
 
                     Assert.Equal(ee.Id, aa.Id);

--- a/test/EFCore.Specification.Tests/Query/ComplexNavigationsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/ComplexNavigationsQueryTestBase.cs
@@ -6,8 +6,6 @@ using Microsoft.EntityFrameworkCore.TestModels.ComplexNavigationsModel;
 #pragma warning disable RCS1155 // Use StringComparison when comparing strings.
 namespace Microsoft.EntityFrameworkCore.Query;
 
-#nullable disable
-
 public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture) : QueryTestBase<TFixture>(fixture)
     where TFixture : ComplexNavigationsQueryFixtureBase, new()
 {
@@ -15,7 +13,9 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
         => Fixture.CreateContext();
 
     protected override Expression RewriteExpectedQueryExpression(Expression expectedQueryExpression)
-        => new ExpectedQueryRewritingVisitor(Fixture.GetShadowPropertyMappings()).Visit(expectedQueryExpression);
+        => new ExpectedQueryRewritingVisitor(
+            Fixture.GetShadowPropertyMappings().ToDictionary(e => e.Key, e => new Func<object, object>(o => e.Value(o)!)))
+            .Visit(expectedQueryExpression);
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Entity_equality_empty(bool async)
@@ -28,7 +28,7 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
     public virtual Task Key_equality_when_sentinel_ef_property(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<Level1>().Where(l => EF.Property<int>(l.OneToOne_Optional_FK1, "Id") == 0),
+            ss => ss.Set<Level1>().Where(l => EF.Property<int>(l.OneToOne_Optional_FK1!, "Id") == 0),
             assertEmpty: true);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -104,9 +104,9 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
         using var context = CreateContext();
 
         var query = context.Fields
-            .Include(x => x.Label.Globalizations)
+            .Include(x => x.Label!.Globalizations)
             .ThenInclude(x => x.Language)
-            .Include(x => x.Placeholder.Globalizations)
+            .Include(x => x.Placeholder!.Globalizations)
             .ThenInclude(x => x.Language);
 
         var result = (async ? await query.ToListAsync() : query.ToList()).OrderBy(e => e.Name).ToList();
@@ -115,33 +115,33 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
         Assert.Equal("Field1", result[0].Name);
         Assert.Equal("Field2", result[1].Name);
 
-        Assert.Equal("MLS1", result[0].Label.DefaultText);
-        Assert.Equal("MLS3", result[1].Label.DefaultText);
+        Assert.Equal("MLS1", result[0].Label!.DefaultText);
+        Assert.Equal("MLS3", result[1].Label!.DefaultText);
         Assert.Null(result[0].Placeholder);
-        Assert.Equal("MLS4", result[1].Placeholder.DefaultText);
+        Assert.Equal("MLS4", result[1].Placeholder!.DefaultText);
 
-        var globalizations_0_label = result[0].Label.Globalizations.OrderBy(g => g.Text).ToList();
+        var globalizations_0_label = result[0].Label!.Globalizations.OrderBy(g => g.Text).ToList();
         Assert.Equal(3, globalizations_0_label.Count);
         Assert.Equal("Globalization0", globalizations_0_label[0].Text);
-        Assert.Equal("Language0", globalizations_0_label[0].Language.Name);
+        Assert.Equal("Language0", globalizations_0_label[0].Language!.Name);
         Assert.Equal("Globalization1", globalizations_0_label[1].Text);
-        Assert.Equal("Language1", globalizations_0_label[1].Language.Name);
+        Assert.Equal("Language1", globalizations_0_label[1].Language!.Name);
         Assert.Equal("Globalization2", globalizations_0_label[2].Text);
-        Assert.Equal("Language2", globalizations_0_label[2].Language.Name);
+        Assert.Equal("Language2", globalizations_0_label[2].Language!.Name);
 
-        var globalizations_1_label = result[1].Label.Globalizations.OrderBy(g => g.Text).ToList();
+        var globalizations_1_label = result[1].Label!.Globalizations.OrderBy(g => g.Text).ToList();
         Assert.Equal(3, globalizations_1_label.Count);
         Assert.Equal("Globalization6", globalizations_1_label[0].Text);
-        Assert.Equal("Language6", globalizations_1_label[0].Language.Name);
+        Assert.Equal("Language6", globalizations_1_label[0].Language!.Name);
         Assert.Equal("Globalization7", globalizations_1_label[1].Text);
-        Assert.Equal("Language7", globalizations_1_label[1].Language.Name);
+        Assert.Equal("Language7", globalizations_1_label[1].Language!.Name);
         Assert.Equal("Globalization8", globalizations_1_label[2].Text);
-        Assert.Equal("Language8", globalizations_1_label[2].Language.Name);
+        Assert.Equal("Language8", globalizations_1_label[2].Language!.Name);
 
-        var globalizations_1_placeholder = result[1].Placeholder.Globalizations.OrderBy(g => g.Text).ToList();
+        var globalizations_1_placeholder = result[1].Placeholder!.Globalizations.OrderBy(g => g.Text).ToList();
         Assert.Single(globalizations_1_placeholder);
         Assert.Equal("Globalization9", globalizations_1_placeholder[0].Text);
-        Assert.Equal("Language9", globalizations_1_placeholder[0].Language.Name);
+        Assert.Equal("Language9", globalizations_1_placeholder[0].Language!.Name);
     }
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -149,7 +149,7 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
         => AssertQuery(
             async,
             ss => from e1 in ss.Set<Level1>()
-                  join e2 in ss.Set<Level2>() on e1.Id equals e2.OneToOne_Optional_FK_Inverse2.Id
+                  join e2 in ss.Set<Level2>() on e1.Id equals e2.OneToOne_Optional_FK_Inverse2!.Id
                   select new { Id1 = e1.Id, Id2 = e2.Id },
             e => (e.Id1, e.Id2));
 
@@ -167,7 +167,7 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
         => AssertQueryScalar(
             async,
             ss => from e2 in ss.Set<Level2>()
-                  where e2.OneToOne_Optional_PK_Inverse2.Id > 5
+                  where e2.OneToOne_Optional_PK_Inverse2!.Id > 5
                   select e2.Id);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -224,10 +224,10 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
         => AssertQuery(
             async,
             ss => from e1 in ss.Set<Level1>()
-                  where e1.OneToOne_Required_FK1.Name.StartsWith("L")
+                  where e1.OneToOne_Required_FK1.Name!.StartsWith("L")
                   select e1,
             ss => from e1 in ss.Set<Level1>()
-                  where e1.OneToOne_Required_FK1.Name.MaybeScalar(x => x.StartsWith("L")) == true
+                  where e1.OneToOne_Required_FK1.Name.MaybeScalar(x => x!.StartsWith("L")) == true
                   select e1);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -235,7 +235,7 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
         => AssertQuery(
             async,
             ss => from e3 in ss.Set<Level3>()
-                  where e3.OneToOne_Required_FK_Inverse3.Name.StartsWith("L")
+                  where e3.OneToOne_Required_FK_Inverse3.Name!.StartsWith("L")
                   select e3);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -243,10 +243,10 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
         => AssertQuery(
             async,
             ss => from e1 in ss.Set<Level1>()
-                  where e1.OneToOne_Optional_FK1.Name.StartsWith("L")
+                  where e1.OneToOne_Optional_FK1!.Name!.StartsWith("L")
                   select e1,
             ss => from e1 in ss.Set<Level1>()
-                  where e1.OneToOne_Optional_FK1.Name.MaybeScalar(x => x.StartsWith("L")) == true
+                  where e1.OneToOne_Optional_FK1!.Name.MaybeScalar(x => x!.StartsWith("L")) == true
                   select e1);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -262,10 +262,10 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
         => AssertQuery(
             async,
             ss => from e1 in ss.Set<Level1>()
-                  where e1.OneToOne_Optional_FK1.Name.ToUpper().StartsWith("L")
+                  where e1.OneToOne_Optional_FK1!.Name!.ToUpper().StartsWith("L")
                   select e1,
             ss => from e1 in ss.Set<Level1>()
-                  where e1.OneToOne_Optional_FK1.Name.MaybeScalar(x => x.ToUpper().StartsWith("L"))
+                  where e1.OneToOne_Optional_FK1!.Name.MaybeScalar(x => x!.ToUpper().StartsWith("L"))
                       == true
                   select e1);
 
@@ -274,10 +274,10 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
         => AssertQuery(
             async,
             ss => from e1 in ss.Set<Level1>()
-                  where e1.OneToOne_Optional_FK1.Name.StartsWith(e1.OneToOne_Optional_FK1.Name)
+                  where e1.OneToOne_Optional_FK1!.Name!.StartsWith(e1.OneToOne_Optional_FK1.Name!)
                   select e1,
             ss => from e1 in ss.Set<Level1>()
-                  where e1.OneToOne_Optional_FK1.Name.MaybeScalar(x => x.StartsWith(e1.OneToOne_Optional_FK1.Name)) == true
+                  where e1.OneToOne_Optional_FK1!.Name.MaybeScalar(x => x!.StartsWith(e1.OneToOne_Optional_FK1.Name!)) == true
                   select e1);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -286,11 +286,11 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
             async,
             ss =>
                 from e1 in ss.Set<Level1>()
-                where e1.OneToOne_Optional_FK1.Date.AddDays(10) > new DateTime(2000, 2, 1)
+                where e1.OneToOne_Optional_FK1!.Date.AddDays(10) > new DateTime(2000, 2, 1)
                 select e1,
             ss =>
                 from e1 in ss.Set<Level1>()
-                where e1.OneToOne_Optional_FK1.MaybeScalar(x => x.Date.AddDays(10)) > new DateTime(2000, 2, 1)
+                where e1.OneToOne_Optional_FK1!.MaybeScalar(x => x.Date.AddDays(10)) > new DateTime(2000, 2, 1)
                 select e1);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -299,11 +299,11 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
             async,
             ss =>
                 from e1 in ss.Set<Level1>()
-                where e1.OneToOne_Optional_FK1.Date.AddDays(10).AddDays(15).AddMonths(2) > new DateTime(2002, 2, 1)
+                where e1.OneToOne_Optional_FK1!.Date.AddDays(10).AddDays(15).AddMonths(2) > new DateTime(2002, 2, 1)
                 select e1,
             ss =>
                 from e1 in ss.Set<Level1>()
-                where e1.OneToOne_Optional_FK1.MaybeScalar(x => x.Date.AddDays(10).AddDays(15).AddMonths(2)) > new DateTime(2000, 2, 1)
+                where e1.OneToOne_Optional_FK1!.MaybeScalar(x => x.Date.AddDays(10).AddDays(15).AddMonths(2)) > new DateTime(2000, 2, 1)
                 select e1);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -313,11 +313,11 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
             async,
             ss =>
                 from e1 in ss.Set<Level1>()
-                where e1.OneToOne_Optional_FK1.Date.AddDays(15).AddDays(e1.OneToOne_Optional_FK1.Id) > new DateTime(2002, 2, 1)
+                where e1.OneToOne_Optional_FK1!.Date.AddDays(15).AddDays(e1.OneToOne_Optional_FK1.Id) > new DateTime(2002, 2, 1)
                 select e1,
             ss =>
                 from e1 in ss.Set<Level1>()
-                where e1.OneToOne_Optional_FK1.MaybeScalar(x => x.Date.AddDays(15).AddDays(x.Id)) > new DateTime(2000, 2, 1)
+                where e1.OneToOne_Optional_FK1!.MaybeScalar(x => x.Date.AddDays(15).AddDays(x.Id)) > new DateTime(2000, 2, 1)
                 select e1);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -325,7 +325,7 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
         => AssertQuery(
             async,
             ss => from e1 in ss.Set<Level1>()
-                  join e2 in ss.Set<Level2>() on e1.OneToOne_Optional_FK1.Id equals e2.Id
+                  join e2 in ss.Set<Level2>() on e1.OneToOne_Optional_FK1!.Id equals e2.Id
                   select new { Id1 = e1.Id, Id2 = e2.Id },
             e => (e.Id1, e.Id2));
 
@@ -334,7 +334,7 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
         => AssertQuery(
             async,
             ss => from e1 in ss.Set<Level1>()
-                  join e3 in ss.Set<Level3>() on e1.OneToOne_Required_FK1.OneToOne_Optional_FK2.Id equals e3.Id
+                  join e3 in ss.Set<Level3>() on e1.OneToOne_Required_FK1.OneToOne_Optional_FK2!.Id equals e3.Id
                   select new { Id1 = e1.Id, Id3 = e3.Id },
             e => (e.Id1, e.Id3));
 
@@ -343,7 +343,7 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
         => AssertQuery(
             async,
             ss => from e3 in ss.Set<Level3>()
-                  join e1 in ss.Set<Level1>() on e3.OneToOne_Required_FK_Inverse3.OneToOne_Optional_FK_Inverse2.Id equals e1.Id
+                  join e1 in ss.Set<Level1>() on e3.OneToOne_Required_FK_Inverse3.OneToOne_Optional_FK_Inverse2!.Id equals e1.Id
                   select new { Id3 = e3.Id, Id1 = e1.Id },
             e => (e.Id1, e.Id3));
 
@@ -352,7 +352,7 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
         => AssertQuery(
             async,
             ss => from e2 in ss.Set<Level2>()
-                  join e1 in ss.Set<Level1>() on e2.Id equals e1.OneToOne_Optional_FK1.Id
+                  join e1 in ss.Set<Level1>() on e2.Id equals e1.OneToOne_Optional_FK1!.Id
                   select new { Id2 = e2.Id, Id1 = e1.Id },
             e => (e.Id2, e.Id1));
 
@@ -361,8 +361,8 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
         => AssertQuery(
             async,
             ss => from e2 in ss.Set<Level2>()
-                  join e1 in ss.Set<Level1>() on e2.Id equals e1.OneToOne_Optional_FK1.Id
-                  join e3 in ss.Set<Level3>() on e2.Id equals e3.OneToOne_Optional_FK_Inverse3.Id
+                  join e1 in ss.Set<Level1>() on e2.Id equals e1.OneToOne_Optional_FK1!.Id
+                  join e3 in ss.Set<Level3>() on e2.Id equals e3.OneToOne_Optional_FK_Inverse3!.Id
                   select new
                   {
                       Id2 = e2.Id,
@@ -377,7 +377,7 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
             async,
             ss =>
                 from e2 in ss.Set<Level2>()
-                join e1 in ss.Set<Level1>() on e2.Name equals e1.OneToOne_Optional_FK1.Name
+                join e1 in ss.Set<Level1>() on e2.Name equals e1.OneToOne_Optional_FK1!.Name
                 select new
                 {
                     Id2 = e2.Id,
@@ -393,7 +393,7 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
             async,
             ss =>
                 from e2 in ss.Set<Level2>()
-                join e1 in ss.Set<Level1>().OrderBy(l1 => l1.Id) on e2.Name equals e1.OneToOne_Optional_FK1.Name
+                join e1 in ss.Set<Level1>().OrderBy(l1 => l1.Id) on e2.Name equals e1.OneToOne_Optional_FK1!.Name
                 select new
                 {
                     Id2 = e2.Id,
@@ -408,7 +408,7 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
         => AssertQuery(
             async,
             ss => from e1 in ss.Set<Level1>()
-                  join e2 in ss.Set<Level1>() on e1.Id equals e2.OneToMany_Optional_Self_Inverse1.Id
+                  join e2 in ss.Set<Level1>() on e1.Id equals e2.OneToMany_Optional_Self_Inverse1!.Id
                   select new { Id1 = e1.Id, Id2 = e2.Id },
             e => (e.Id1, e.Id2));
 
@@ -417,7 +417,7 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
         => AssertQuery(
             async,
             ss => from e3 in ss.Set<Level3>()
-                  join e1 in ss.Set<Level1>() on e3.Id equals e1.OneToOne_Required_FK1.OneToOne_Optional_FK2.Id
+                  join e1 in ss.Set<Level1>() on e3.Id equals e1.OneToOne_Required_FK1.OneToOne_Optional_FK2!.Id
                   select new { Id3 = e3.Id, Id1 = e1.Id },
             e => (e.Id3, e.Id1));
 
@@ -426,7 +426,7 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
         => AssertQuery(
             async,
             ss => from e3 in ss.Set<Level3>()
-                  join e1 in ss.Set<Level1>().OrderBy(ll => ll.Id) on e3.Id equals e1.OneToOne_Required_FK1.OneToOne_Optional_FK2.Id
+                  join e1 in ss.Set<Level1>().OrderBy(ll => ll.Id) on e3.Id equals e1.OneToOne_Required_FK1.OneToOne_Optional_FK2!.Id
                   select new { Id3 = e3.Id, Id1 = e1.Id },
             e => (e.Id3, e.Id1));
 
@@ -436,7 +436,7 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
             async,
             ss =>
                 from e4 in ss.Set<Level4>()
-                join e1 in ss.Set<Level1>() on e4.Name equals e1.OneToOne_Required_FK1.OneToOne_Optional_FK2.OneToOne_Required_PK3.Name
+                join e1 in ss.Set<Level1>() on e4.Name equals e1.OneToOne_Required_FK1.OneToOne_Optional_FK2!.OneToOne_Required_PK3.Name
                 select new
                 {
                     Id4 = e4.Id,
@@ -471,7 +471,7 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
             elementSorter: e => e.Id,
             elementAsserter: (e, a) =>
             {
-                AssertInclude(e.entity, a.entity, new ExpectedInclude<Level1>(ee => ee.OneToOne_Optional_FK1));
+                AssertInclude(e.entity, a.entity, new ExpectedInclude<Level1>(ee => ee.OneToOne_Optional_FK1!));
                 AssertEqual(e.Id, a.Id);
             });
 
@@ -479,7 +479,7 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
     public virtual Task Select_nav_prop_reference_optional1(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<Level1>().Select(e => e.OneToOne_Optional_FK1.Name));
+            ss => ss.Set<Level1>().Select(e => e.OneToOne_Optional_FK1!.Name));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Select_nav_prop_reference_optional1_via_DefaultIfEmpty(bool async)
@@ -495,7 +495,7 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
     public virtual Task Select_nav_prop_reference_optional2(bool async)
         => AssertQueryScalar(
             async,
-            ss => ss.Set<Level1>().Select(e => (int?)e.OneToOne_Optional_FK1.Id));
+            ss => ss.Set<Level1>().Select(e => (int?)e.OneToOne_Optional_FK1!.Id));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Select_nav_prop_reference_optional2_via_DefaultIfEmpty(bool async)
@@ -510,14 +510,14 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
     public virtual Task Select_nav_prop_reference_optional3(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<Level2>().Select(e => e.OneToOne_Optional_FK_Inverse2.Name));
+            ss => ss.Set<Level2>().Select(e => e.OneToOne_Optional_FK_Inverse2!.Name));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Where_nav_prop_reference_optional1(bool async)
         => AssertQueryScalar(
             async,
             ss => ss.Set<Level1>()
-                .Where(e => e.OneToOne_Optional_FK1.Name == "L2 05" || e.OneToOne_Optional_FK1.Name == "L2 07")
+                .Where(e => e.OneToOne_Optional_FK1!.Name == "L2 05" || e.OneToOne_Optional_FK1!.Name == "L2 07")
                 .Select(e => e.Id));
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -537,7 +537,7 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
         => AssertQueryScalar(
             async,
             ss => ss.Set<Level1>()
-                .Where(e => e.OneToOne_Optional_FK1.Name == "L2 05" || e.OneToOne_Optional_FK1.Name != "L2 42")
+                .Where(e => e.OneToOne_Optional_FK1!.Name == "L2 05" || e.OneToOne_Optional_FK1!.Name != "L2 42")
                 .Select(e => e.Id));
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -556,7 +556,7 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
     public virtual Task Select_multiple_nav_prop_reference_optional(bool async)
         => AssertQueryScalar(
             async,
-            ss => ss.Set<Level1>().Select(e => (int?)e.OneToOne_Optional_FK1.OneToOne_Optional_FK2.Id));
+            ss => ss.Set<Level1>().Select(e => (int?)e.OneToOne_Optional_FK1!.OneToOne_Optional_FK2!.Id));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Where_multiple_nav_prop_reference_optional_member_compared_to_value(bool async)
@@ -564,7 +564,7 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
             async,
             ss =>
                 from l1 in ss.Set<Level1>()
-                where l1.OneToOne_Optional_FK1.OneToOne_Optional_FK2.Name != "L3 05"
+                where l1.OneToOne_Optional_FK1!.OneToOne_Optional_FK2!.Name != "L3 05"
                 select l1);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -573,7 +573,7 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
             async,
             ss =>
                 from l1 in ss.Set<Level1>()
-                where l1.OneToOne_Optional_FK1.OneToOne_Optional_FK2.Name != null
+                where l1.OneToOne_Optional_FK1!.OneToOne_Optional_FK2!.Name != null
                 select l1);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -582,7 +582,7 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
             async,
             ss =>
                 from l1 in ss.Set<Level1>()
-                where l1.OneToOne_Optional_FK1.OneToOne_Optional_FK2 == null
+                where l1.OneToOne_Optional_FK1!.OneToOne_Optional_FK2 == null
                 select l1);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -591,7 +591,7 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
             async,
             ss =>
                 from l3 in ss.Set<Level3>()
-                where l3.OneToOne_Optional_FK_Inverse3.OneToOne_Optional_FK_Inverse2 == null
+                where l3.OneToOne_Optional_FK_Inverse3!.OneToOne_Optional_FK_Inverse2 == null
                 select l3);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -600,7 +600,7 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
             async,
             ss =>
                 from l1 in ss.Set<Level1>()
-                where null != l1.OneToOne_Optional_FK1.OneToOne_Optional_FK2
+                where null != l1.OneToOne_Optional_FK1!.OneToOne_Optional_FK2
                 select l1);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -609,14 +609,14 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
             async,
             ss =>
                 from l3 in ss.Set<Level3>()
-                where null != l3.OneToOne_Optional_FK_Inverse3.OneToOne_Optional_FK_Inverse2
+                where null != l3.OneToOne_Optional_FK_Inverse3!.OneToOne_Optional_FK_Inverse2
                 select l3);
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Where_multiple_nav_prop_reference_optional_compared_to_null5(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<Level1>().Where(e => e.OneToOne_Optional_FK1.OneToOne_Required_FK2.OneToOne_Required_FK3 == null));
+            ss => ss.Set<Level1>().Where(e => e.OneToOne_Optional_FK1!.OneToOne_Required_FK2.OneToOne_Required_FK3 == null));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Select_multiple_nav_prop_reference_required(bool async)
@@ -635,7 +635,7 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
         => AssertQueryScalar(
             async,
             ss => from l1 in ss.Set<Level1>()
-                  select (int?)l1.OneToOne_Optional_FK1.OneToOne_Required_FK2.Id);
+                  select (int?)l1.OneToOne_Optional_FK1!.OneToOne_Required_FK2.Id);
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Where_multiple_nav_prop_optional_required(bool async)
@@ -643,7 +643,7 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
             async,
             ss =>
                 from l1 in ss.Set<Level1>()
-                where l1.OneToOne_Optional_FK1.OneToOne_Required_FK2.Name != "L3 05"
+                where l1.OneToOne_Optional_FK1!.OneToOne_Required_FK2.Name != "L3 05"
                 select l1);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -674,7 +674,7 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
             ss =>
                 from l1 in ss.Set<Level1>()
                 from l2 in ss.Set<Level2>()
-                where l1.Id == l2.OneToOne_Optional_FK_Inverse2.Id
+                where l1.Id == l2.OneToOne_Optional_FK_Inverse2!.Id
                 select new { Id1 = l1.Id, Id2 = l2.Id },
             e => (e.Id1, e.Id2));
 
@@ -690,7 +690,7 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
             ss =>
                 from l1 in ss.Set<Level1>()
                 from l2 in ss.Set<Level2>()
-                where l1.OneToOne_Optional_FK1.Id == l2.Id
+                where l1.OneToOne_Optional_FK1!.Id == l2.Id
                 select new { Id1 = l1.Id, Id2 = l2.Id },
             e => (e.Id1, e.Id2));
 
@@ -701,7 +701,7 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
             ss =>
                 from l1 in ss.Set<Level1>()
                 from l2 in ss.Set<Level2>()
-                where l1.OneToOne_Optional_FK1.Name == "L2 01" || l2.OneToOne_Required_FK_Inverse2.Name != "Bar"
+                where l1.OneToOne_Optional_FK1!.Name == "L2 01" || l2.OneToOne_Required_FK_Inverse2.Name != "Bar"
                 select new { Id1 = (int?)l1.Id, Id2 = (int?)l2.Id },
             e => (e.Id1, e.Id2));
 
@@ -710,7 +710,7 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
         => AssertQueryScalar(
             async,
             ss => from l1 in ss.Set<Level1>()
-                  where l1.OneToOne_Optional_FK1.OneToOne_Required_FK2.Name == "L3 05" || l1.OneToOne_Optional_FK1.Name != "L2 05"
+                  where l1.OneToOne_Optional_FK1!.OneToOne_Required_FK2.Name == "L3 05" || l1.OneToOne_Optional_FK1!.Name != "L2 05"
                   select l1.Id);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -718,7 +718,7 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
         => AssertQueryScalar(
             async,
             ss => from l1 in ss.Set<Level1>()
-                  where l1.OneToOne_Optional_FK1.Name != "L2 05" || l1.OneToOne_Required_FK1.OneToOne_Optional_FK2.Name == "L3 05"
+                  where l1.OneToOne_Optional_FK1!.Name != "L2 05" || l1.OneToOne_Required_FK1.OneToOne_Optional_FK2!.Name == "L3 05"
                   select l1.Id);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -726,8 +726,8 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
         => AssertQueryScalar(
             async,
             ss => from l3 in ss.Set<Level3>()
-                  where l3.OneToOne_Optional_FK_Inverse3.Name != "L2 05"
-                      || l3.OneToOne_Required_FK_Inverse3.OneToOne_Optional_FK_Inverse2.Name == "L1 05"
+                  where l3.OneToOne_Optional_FK_Inverse3!.Name != "L2 05"
+                      || l3.OneToOne_Required_FK_Inverse3.OneToOne_Optional_FK_Inverse2!.Name == "L1 05"
                   select l3.Id);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -737,7 +737,7 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
             ss => ss.Set<Level1>()
                 .Where(e => e.OneToOne_Required_FK1.OneToOne_Required_FK2 == e.OneToOne_Required_FK1.OneToOne_Optional_FK2
                     && e.OneToOne_Required_FK1.OneToOne_Optional_FK2.Id != 7)
-                .Select(e => new { e.Name, Id = (int?)e.OneToOne_Required_FK1.OneToOne_Optional_FK2.Id }),
+                .Select(e => new { e.Name, Id = (int?)e.OneToOne_Required_FK1.OneToOne_Optional_FK2!.Id }),
             elementSorter: e => (e.Name, e.Id));
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -747,8 +747,8 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
             ss => from e in ss.Set<Level3>()
                   where e.OneToOne_Required_FK_Inverse3.OneToOne_Required_FK_Inverse2
                       != e.OneToOne_Required_FK_Inverse3.OneToOne_Optional_FK_Inverse2
-                      && e.OneToOne_Required_FK_Inverse3.OneToOne_Optional_FK_Inverse2.Id != 7
-                  select new { e.Name, Id = (int?)e.OneToOne_Required_FK_Inverse3.OneToOne_Optional_FK_Inverse2.Id },
+                      && e.OneToOne_Required_FK_Inverse3.OneToOne_Optional_FK_Inverse2!.Id != 7
+                  select new { e.Name, Id = (int?)e.OneToOne_Required_FK_Inverse3.OneToOne_Optional_FK_Inverse2!.Id },
             e => (e.Name, e.Id));
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -775,22 +775,22 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
     public class MyOuterDto
     {
         public int Id { get; set; }
-        public string Name { get; set; }
+        public string? Name { get; set; }
 
-        public MyInnerDto Inner { get; set; }
+        public MyInnerDto? Inner { get; set; }
     }
 
     public class MyInnerDto
     {
         public int? Id { get; set; }
-        public string Name { get; set; }
+        public string? Name { get; set; }
     }
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task OrderBy_nav_prop_reference_optional(bool async)
         => AssertQueryScalar(
             async,
-            ss => ss.Set<Level1>().OrderBy(e => e.OneToOne_Optional_FK1.Name).ThenBy(e => e.Id).Select(e => e.Id),
+            ss => ss.Set<Level1>().OrderBy(e => e.OneToOne_Optional_FK1!.Name).ThenBy(e => e.Id).Select(e => e.Id),
             assertOrder: true);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -810,8 +810,8 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
             async,
             ss => ss.Set<Level1>(),
             ss => ss.Set<Level1>(),
-            actualSelector: e => e.OneToOne_Optional_FK1.Level1_Required_Id,
-            expectedSelector: e => e.OneToOne_Optional_FK1.MaybeScalar(x => x.Level1_Required_Id));
+            actualSelector: e => e.OneToOne_Optional_FK1!.Level1_Required_Id,
+            expectedSelector: e => e.OneToOne_Optional_FK1!.MaybeScalar(x => x.Level1_Required_Id));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Result_operator_nav_prop_reference_optional_Min(bool async)
@@ -819,8 +819,8 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
             async,
             ss => ss.Set<Level1>(),
             ss => ss.Set<Level1>(),
-            actualSelector: e => e.OneToOne_Optional_FK1.Level1_Required_Id,
-            expectedSelector: e => e.OneToOne_Optional_FK1.MaybeScalar(x => x.Level1_Required_Id));
+            actualSelector: e => e.OneToOne_Optional_FK1!.Level1_Required_Id,
+            expectedSelector: e => e.OneToOne_Optional_FK1!.MaybeScalar(x => x.Level1_Required_Id));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Result_operator_nav_prop_reference_optional_Max(bool async)
@@ -828,8 +828,8 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
             async,
             ss => ss.Set<Level1>(),
             ss => ss.Set<Level1>(),
-            actualSelector: e => e.OneToOne_Optional_FK1.Level1_Required_Id,
-            expectedSelector: e => e.OneToOne_Optional_FK1.MaybeScalar(x => x.Level1_Required_Id));
+            actualSelector: e => e.OneToOne_Optional_FK1!.Level1_Required_Id,
+            expectedSelector: e => e.OneToOne_Optional_FK1!.MaybeScalar(x => x.Level1_Required_Id));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Result_operator_nav_prop_reference_optional_Average(bool async)
@@ -837,21 +837,21 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
             async,
             ss => ss.Set<Level1>(),
             ss => ss.Set<Level1>(),
-            actualSelector: e => e.OneToOne_Optional_FK1.Level1_Required_Id,
-            expectedSelector: e => e.OneToOne_Optional_FK1.MaybeScalar(x => x.Level1_Required_Id));
+            actualSelector: e => e.OneToOne_Optional_FK1!.Level1_Required_Id,
+            expectedSelector: e => e.OneToOne_Optional_FK1!.MaybeScalar(x => x.Level1_Required_Id));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Result_operator_nav_prop_reference_optional_Average_with_identity_selector(bool async)
         => AssertAverage(
             async,
-            ss => ss.Set<Level1>().Select(e => (int?)e.OneToOne_Optional_FK1.Level1_Required_Id),
+            ss => ss.Set<Level1>().Select(e => (int?)e.OneToOne_Optional_FK1!.Level1_Required_Id),
             selector: e => e);
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Result_operator_nav_prop_reference_optional_Average_without_selector(bool async)
         => AssertAverage(
             async,
-            ss => ss.Set<Level1>().Select(e => (int?)e.OneToOne_Optional_FK1.Level1_Required_Id));
+            ss => ss.Set<Level1>().Select(e => (int?)e.OneToOne_Optional_FK1!.Level1_Required_Id));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Result_operator_nav_prop_reference_optional_via_DefaultIfEmpty(bool async)
@@ -868,9 +868,9 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
         => AssertQuery(
             async,
             ss => from l1 in ss.Set<Level1>().Include(e => e.OneToOne_Optional_FK1)
-                  where l1.OneToOne_Optional_FK1.Name != "L2 05"
+                  where l1.OneToOne_Optional_FK1!.Name != "L2 05"
                   select l1,
-            elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Level1>(l1 => l1.OneToOne_Optional_FK1)));
+            elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Level1>(l1 => l1.OneToOne_Optional_FK1!)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Join_flattening_bug_4539(bool async)
@@ -944,8 +944,8 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
     public virtual Task SelectMany_nested_navigation_property_optional_and_projection(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<Level1>().SelectMany(l1 => l1.OneToOne_Optional_FK1.OneToMany_Optional2).Select(e => e.Name),
-            ss => ss.Set<Level1>().SelectMany(l1 => l1.OneToOne_Optional_FK1.OneToMany_Optional2 ?? new List<Level3>())
+            ss => ss.Set<Level1>().SelectMany(l1 => l1.OneToOne_Optional_FK1!.OneToMany_Optional2).Select(e => e.Name),
+            ss => ss.Set<Level1>().SelectMany(l1 => l1.OneToOne_Optional_FK1!.OneToMany_Optional2 ?? new List<Level3>())
                 .Select(e => e.Name));
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -995,7 +995,7 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
         => AssertQuery(
             async,
             ss => from e1 in ss.Set<Level1>()
-                  join e2 in ss.Set<Level2>() on e1.Id equals e2.OneToOne_Optional_FK_Inverse2.Id
+                  join e2 in ss.Set<Level2>() on e1.Id equals e2.OneToOne_Optional_FK_Inverse2!.Id
                   where ss.Set<Level2>().Any(l2 => l2.Level1_Required_Id == e1.Id)
                   select new { Name1 = e1.Name, Id2 = e2.Id },
             e => (e.Name1, e.Id2));
@@ -1086,10 +1086,10 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
         => AssertQuery(
             async,
             ss => ss.Set<Level1>()
-                .Select(l1 => l1.OneToOne_Optional_FK1)
+                .Select(l1 => l1.OneToOne_Optional_FK1!)
                 .OrderBy(l2 => (int?)l2.Id)
                 .Take(10)
-                .Select(l2 => l2.OneToOne_Optional_FK2.Name),
+                .Select(l2 => l2.OneToOne_Optional_FK2!.Name),
             assertOrder: true);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -1196,7 +1196,7 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
             ss => ss.Set<Level4>()
                 .Select(l4 => l4.OneToOne_Required_FK_Inverse4.OneToOne_Required_FK_Inverse3)
                 .Include(l2 => l2.OneToOne_Optional_FK2),
-            elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Level2>(l2 => l2.OneToOne_Optional_FK2))));
+            elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Level2>(l2 => l2.OneToOne_Optional_FK2!))));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Multiple_required_navigation_using_multiple_selects_with_Include(bool async)
@@ -1207,7 +1207,7 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
                 .Select(l4 => l4.OneToOne_Required_FK_Inverse4)
                 .Select(l3 => l3.OneToOne_Required_FK_Inverse3)
                 .Include(l2 => l2.OneToOne_Optional_FK2),
-            elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Level2>(l2 => l2.OneToOne_Optional_FK2))));
+            elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Level2>(l2 => l2.OneToOne_Optional_FK2!))));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Multiple_required_navigation_with_string_based_Include(bool async)
@@ -1217,7 +1217,7 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
             ss => ss.Set<Level4>()
                 .Select(l4 => l4.OneToOne_Required_FK_Inverse4.OneToOne_Required_FK_Inverse3)
                 .Include("OneToOne_Optional_FK2"),
-            elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Level2>(l2 => l2.OneToOne_Optional_FK2))));
+            elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Level2>(l2 => l2.OneToOne_Optional_FK2!))));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Multiple_required_navigation_with_EF_Property_Include(bool async)
@@ -1227,7 +1227,7 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
             ss => ss.Set<Level4>()
                 .Select(l4 => l4.OneToOne_Required_FK_Inverse4.OneToOne_Required_FK_Inverse3)
                 .Include(l2 => EF.Property<Level2>(l2, "OneToOne_Optional_FK2")),
-            elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Level2>(l2 => l2.OneToOne_Optional_FK2))));
+            elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Level2>(l2 => l2.OneToOne_Optional_FK2!))));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Multiple_required_navigation_using_multiple_selects_with_string_based_Include(bool async)
@@ -1238,7 +1238,7 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
                 .Select(l4 => l4.OneToOne_Required_FK_Inverse4)
                 .Select(l3 => l3.OneToOne_Required_FK_Inverse3)
                 .Include("OneToOne_Optional_FK2"),
-            elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Level2>(l2 => l2.OneToOne_Optional_FK2))));
+            elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Level2>(l2 => l2.OneToOne_Optional_FK2!))));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Multiple_required_navigation_using_multiple_selects_with_EF_Property_Include(bool async)
@@ -1249,7 +1249,7 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
                 .Select(l4 => l4.OneToOne_Required_FK_Inverse4)
                 .Select(l3 => l3.OneToOne_Required_FK_Inverse3)
                 .Include(l2 => EF.Property<Level2>(l2, "OneToOne_Optional_FK2")),
-            elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Level2>(l2 => l2.OneToOne_Optional_FK2))));
+            elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Level2>(l2 => l2.OneToOne_Optional_FK2!))));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Optional_navigation_with_Include(bool async)
@@ -1257,9 +1257,9 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
         => AssertIncludeOnNonEntity(() => AssertQuery(
             async,
             ss => ss.Set<Level1>()
-                .Select(l1 => l1.OneToOne_Optional_FK1)
+                .Select(l1 => l1.OneToOne_Optional_FK1!)
                 .Include(l2 => l2.OneToOne_Optional_FK2),
-            elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Level2>(l2 => l2.OneToOne_Optional_FK2))));
+            elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Level2>(l2 => l2.OneToOne_Optional_FK2!))));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task SelectMany_with_navigation_and_explicit_DefaultIfEmpty(bool async)
@@ -1298,11 +1298,11 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
         => AssertQuery(
             async,
             ss => from l1 in ss.Set<Level1>()
-                  from l3 in l1.OneToOne_Optional_FK1.OneToMany_Optional2.Where(l => l.Id > 5).DefaultIfEmpty()
+                  from l3 in l1.OneToOne_Optional_FK1!.OneToMany_Optional2.Where(l => l.Id > 5).DefaultIfEmpty()
                   where l3 != null
                   select l1,
             ss => from l1 in ss.Set<Level1>().Where(l => l.OneToOne_Optional_FK1 != null)
-                  from l3 in l1.OneToOne_Optional_FK1.OneToMany_Optional2.Where(l => l.Id > 5).DefaultIfEmpty()
+                  from l3 in l1.OneToOne_Optional_FK1!.OneToMany_Optional2.Where(l => l.Id > 5).DefaultIfEmpty()
                   where l3 != null
                   select l1);
 
@@ -1325,12 +1325,12 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
             async,
             ss => from l1 in ss.Set<Level1>()
                   join l2 in ss.Set<Level4>().SelectMany(l4
-                          => l4.OneToOne_Required_FK_Inverse4.OneToOne_Optional_FK_Inverse3.OneToMany_Required_Self2) on l1.Id
+                          => l4.OneToOne_Required_FK_Inverse4.OneToOne_Optional_FK_Inverse3!.OneToMany_Required_Self2) on l1.Id
                       equals l2.Level1_Optional_Id
                   select new { l1, l2 },
             ss => from l1 in ss.Set<Level1>()
                   join l2 in ss.Set<Level4>().SelectMany(l4
-                          => l4.OneToOne_Required_FK_Inverse4.OneToOne_Optional_FK_Inverse3.OneToMany_Required_Self2
+                          => l4.OneToOne_Required_FK_Inverse4.OneToOne_Optional_FK_Inverse3!.OneToMany_Required_Self2
                           ?? new List<Level2>()) on l1.Id
                       equals l2.Level1_Optional_Id
                   select new { l1, l2 },
@@ -1347,7 +1347,7 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
         => AssertQuery(
             async,
             ss => from l1 in ss.Set<Level1>()
-                  join l2 in ss.Set<Level4>().SelectMany(l4 => l4.OneToOne_Required_FK_Inverse4.OneToOne_Optional_FK_Inverse3
+                  join l2 in ss.Set<Level4>().SelectMany(l4 => l4.OneToOne_Required_FK_Inverse4.OneToOne_Optional_FK_Inverse3!
                           .OneToMany_Required_Self2
                           .DefaultIfEmpty())
                       on l1.Id equals l2.Level1_Optional_Id
@@ -1365,7 +1365,7 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
         => AssertQuery(
             async,
             ss => from l2 in ss.Set<Level4>().SelectMany(l4
-                      => l4.OneToOne_Required_FK_Inverse4.OneToOne_Optional_FK_Inverse3.OneToMany_Required_Self2.DefaultIfEmpty())
+                      => l4.OneToOne_Required_FK_Inverse4.OneToOne_Optional_FK_Inverse3!.OneToMany_Required_Self2.DefaultIfEmpty())
                   join l1 in ss.Set<Level1>() on l2.Level1_Optional_Id equals l1.Id
                   select new { l2, l1 },
             elementSorter: e => (e.l2?.Id, e.l1?.Id),
@@ -1381,7 +1381,7 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
         => AssertQuery(
             async,
             ss => from l4 in ss.Set<Level1>()
-                      .SelectMany(l1 => l1.OneToOne_Required_FK1.OneToOne_Optional_FK2.OneToMany_Required3.DefaultIfEmpty())
+                      .SelectMany(l1 => l1.OneToOne_Required_FK1.OneToOne_Optional_FK2!.OneToMany_Required3.DefaultIfEmpty())
                   join l2 in ss.Set<Level2>() on l4.Id equals l2.Id
                   select new { l4, l2 },
             elementSorter: e => (e.l4?.Id, e.l2?.Id),
@@ -1397,7 +1397,7 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
         => AssertQuery(
             async,
             ss => from l4 in ss.Set<Level1>()
-                      .SelectMany(l1 => l1.OneToOne_Required_FK1.OneToOne_Optional_FK2.OneToMany_Required3.DefaultIfEmpty())
+                      .SelectMany(l1 => l1.OneToOne_Required_FK1.OneToOne_Optional_FK2!.OneToMany_Required3.DefaultIfEmpty())
                   join l2 in ss.Set<Level2>() on l4.Id equals l2.Id into grouping
                   from l2 in grouping.DefaultIfEmpty()
                   select new { l4, l2 },
@@ -1413,8 +1413,8 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
         => AssertQuery(
             async,
             ss => from l4 in ss.Set<Level1>()
-                      .SelectMany(l1 => l1.OneToOne_Required_FK1.OneToOne_Optional_FK2.OneToMany_Required3.DefaultIfEmpty())
-                  join l2 in ss.Set<Level4>().SelectMany(l4 => l4.OneToOne_Required_FK_Inverse4.OneToOne_Optional_FK_Inverse3
+                      .SelectMany(l1 => l1.OneToOne_Required_FK1.OneToOne_Optional_FK2!.OneToMany_Required3.DefaultIfEmpty())
+                  join l2 in ss.Set<Level4>().SelectMany(l4 => l4.OneToOne_Required_FK_Inverse4.OneToOne_Optional_FK_Inverse3!
                           .OneToMany_Required_Self2
                           .DefaultIfEmpty())
                       on l4.Id equals l2.Id
@@ -1442,7 +1442,7 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
             bool async)
         => AssertQuery(
             async,
-            ss => from l3 in ss.Set<Level1>().SelectMany(l1 => l1.OneToOne_Optional_FK1.OneToMany_Optional2.DefaultIfEmpty())
+            ss => from l3 in ss.Set<Level1>().SelectMany(l1 => l1.OneToOne_Optional_FK1!.OneToMany_Optional2.DefaultIfEmpty())
                   select l3.OneToOne_Required_FK_Inverse3.OneToOne_Required_PK_Inverse2);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -1497,9 +1497,9 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
     public virtual Task Contains_with_subquery_optional_navigation_and_constant_item(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<Level1>().Where(l1 => l1.OneToOne_Optional_FK1.OneToMany_Optional2.Distinct().Select(l3 => l3.Id).Contains(6)),
+            ss => ss.Set<Level1>().Where(l1 => l1.OneToOne_Optional_FK1!.OneToMany_Optional2.Distinct().Select(l3 => l3.Id).Contains(6)),
             ss => ss.Set<Level1>().Where(l1
-                => l1.OneToOne_Optional_FK1.OneToMany_Optional2.MaybeScalar(x => x.Distinct().Select(l3 => l3.Id).Contains(6))
+                => l1.OneToOne_Optional_FK1!.OneToMany_Optional2.MaybeScalar(x => x.Distinct().Select(l3 => l3.Id).Contains(6))
                 == true));
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -1507,9 +1507,9 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
         => AssertQuery(
             async,
             ss => ss.Set<Level1>().Where(l1
-                => l1.OneToOne_Optional_FK1.OneToMany_Optional2.Select(l3 => l3.Name.Length).Distinct().Contains(5)),
+                => l1.OneToOne_Optional_FK1!.OneToMany_Optional2.Select(l3 => l3.Name!.Length).Distinct().Contains(5)),
             ss => ss.Set<Level1>().Where(l1
-                => l1.OneToOne_Optional_FK1.OneToMany_Optional2.MaybeScalar(x => x.Select(l3 => l3.Name.Length).Distinct().Contains(5))
+                => l1.OneToOne_Optional_FK1!.OneToMany_Optional2.MaybeScalar(x => x.Select(l3 => l3.Name!.Length).Distinct().Contains(5))
                 == true));
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -1517,10 +1517,10 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
         => AssertQuery(
             async,
             ss => ss.Set<Level1>().Where(l1 => l1.Id < 3
-                && !l1.OneToMany_Optional1.Select(l2 => l2.OneToOne_Optional_FK2.OneToOne_Optional_FK3.Id)
+                && !l1.OneToMany_Optional1.Select(l2 => l2.OneToOne_Optional_FK2!.OneToOne_Optional_FK3!.Id)
                     .All(l4 => ClientMethod(l4))),
             ss => ss.Set<Level1>().Where(l1 => l1.Id < 3
-                && !l1.OneToMany_Optional1.Select(l2 => l2.OneToOne_Optional_FK2.OneToOne_Optional_FK3.MaybeScalar(x => x.Id))
+                && !l1.OneToMany_Optional1.Select(l2 => l2.OneToOne_Optional_FK2!.OneToOne_Optional_FK3!.MaybeScalar(x => x.Id))
                     .All(a => true)),
             assertEmpty: true);
 
@@ -1586,7 +1586,7 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
                   join l2 in ss.Set<Level2>() on l2_nav.Level1_Required_Id equals l2.Id into grouping
                   from l2 in grouping.DefaultIfEmpty()
                   select new { Id1 = (int?)l2_nav.Id, Id2 = (int?)l2.Id },
-            elementSorter: e => e.Id1);
+            elementSorter: e => e.Id1!);
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Optional_navigation_propagates_nullability_to_manually_created_left_join2(bool async)
@@ -1769,10 +1769,10 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
     public virtual Task GroupJoin_on_left_side_being_a_subquery(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<Level1>().OrderBy(l1 => l1.OneToOne_Optional_FK1.Name)
+            ss => ss.Set<Level1>().OrderBy(l1 => l1.OneToOne_Optional_FK1!.Name)
                 .ThenBy(l1 => l1.Id)
                 .Take(2)
-                .Select(x => new { x.Id, Brand = x.OneToOne_Optional_FK1.Name }),
+                .Select(x => new { x.Id, Brand = x.OneToOne_Optional_FK1!.Name }),
             e => e.Id);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -1781,7 +1781,7 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
             async,
             ss =>
                 from l2 in ss.Set<Level2>()
-                join l1 in ss.Set<Level1>().OrderBy(x => x.OneToOne_Optional_FK1.Name).Take(2) on l2.Level1_Optional_Id equals l1.Id
+                join l1 in ss.Set<Level1>().OrderBy(x => x.OneToOne_Optional_FK1!.Name).Take(2) on l2.Level1_Optional_Id equals l1.Id
                     into grouping
                 from l1 in grouping.DefaultIfEmpty()
                 select new { l2.Id, Name = l1 != null ? l1.Name : null },
@@ -1856,7 +1856,7 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
                 where l1_outer.Id < 2
                 select l1_outer.Name);
 
-    private static string ClientStringMethod(string argument)
+    private static string? ClientStringMethod(string? argument)
         => argument;
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -1915,7 +1915,7 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
     public virtual Task Optional_navigation_in_subquery_with_unrelated_projection(bool async)
         => AssertQueryScalar(
             async,
-            ss => ss.Set<Level1>().Where(l1 => l1.OneToOne_Optional_FK1.Name != "Foo")
+            ss => ss.Set<Level1>().Where(l1 => l1.OneToOne_Optional_FK1!.Name != "Foo")
                 .OrderBy(l1 => l1.Id)
                 .Take(15)
                 .Select(l1 => l1.Id));
@@ -2063,7 +2063,7 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
         => AssertQueryScalar(
             async,
             ss => from l3 in ss.Set<Level3>()
-                  where l3.OneToMany_Optional_Inverse3.OneToOne_Required_FK_Inverse2 != null
+                  where l3.OneToMany_Optional_Inverse3!.OneToOne_Required_FK_Inverse2 != null
                   select l3.Id);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -2071,8 +2071,8 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
         => AssertQueryScalar(
             async,
             ss => from l3 in ss.Set<Level3>()
-                  where l3.OneToMany_Optional_Inverse3.OneToOne_Required_FK_Inverse2.Name != "L1 07"
-                  where l3.OneToMany_Optional_Inverse3.OneToOne_Required_FK_Inverse2 != null
+                  where l3.OneToMany_Optional_Inverse3!.OneToOne_Required_FK_Inverse2.Name != "L1 07"
+                  where l3.OneToMany_Optional_Inverse3!.OneToOne_Required_FK_Inverse2 != null
                   select l3.Id);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -2140,14 +2140,14 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
                 .Where(t => t != null)
                 .Select(l4 => l4.OneToOne_Required_FK_Inverse4.OneToOne_Required_FK_Inverse3)
                 .Include(l2 => l2.OneToOne_Optional_FK2),
-            elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Level2>(l2 => l2.OneToOne_Optional_FK2)),
+            elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Level2>(l2 => l2.OneToOne_Optional_FK2!)),
             elementSorter: e => e.Id));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Comparing_collection_navigation_on_optional_reference_to_null(bool async)
         => AssertQueryScalar(
             async,
-            ss => ss.Set<Level1>().Where(l1 => l1.OneToOne_Optional_FK1.OneToMany_Optional2 == null).Select(l1 => l1.Id));
+            ss => ss.Set<Level1>().Where(l1 => l1.OneToOne_Optional_FK1!.OneToMany_Optional2 == null).Select(l1 => l1.Id));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Select_subquery_with_client_eval_and_navigation1(bool async)
@@ -2176,7 +2176,7 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
                 from l1 in ss.Set<Level1>()
                 where l1.Id < 3
                 select (from l3 in ss.Set<Level3>()
-                        select l3).Distinct().OrderBy(l => l.Id).Skip(1).FirstOrDefault().Name);
+                    select l3).Distinct().OrderBy(l => l.Id).Skip(1).FirstOrDefault()!.Name);
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Subquery_with_Distinct_Skip_FirstOrDefault_without_OrderBy(bool async)
@@ -2189,7 +2189,7 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
                       Key = l1.Id,
                       Subquery = (from l3 in ss.Set<Level3>()
                                   orderby l3.Id
-                                  select l3).Distinct().Skip(1).FirstOrDefault().Name
+                                  select l3).Distinct().Skip(1).FirstOrDefault()!.Name
                   },
             elementSorter: e => e.Key,
             elementAsserter: (e, a) => Assert.Equal(e.Key, a.Key));
@@ -2199,9 +2199,9 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
         => AssertQuery(
             async,
             ss => from l1 in ss.Set<Level1>()
-                  select new { l1.Id, l1.OneToOne_Optional_FK1.OneToMany_Optional2.Count },
+                  select new { l1.Id, l1.OneToOne_Optional_FK1!.OneToMany_Optional2.Count },
             ss => from l1 in ss.Set<Level1>()
-                  select new { l1.Id, Count = l1.OneToOne_Optional_FK1.OneToMany_Optional2.MaybeScalar(x => x.Count) ?? 0 },
+                  select new { l1.Id, Count = l1.OneToOne_Optional_FK1!.OneToMany_Optional2.MaybeScalar(x => x.Count) ?? 0 },
             elementSorter: e => e.Id);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -2238,18 +2238,18 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
                 .Include(l1 => l1.OneToOne_Optional_FK1)
                 .GroupBy(g => g.Name)
                 .Select(g => g.OrderBy(e => e.Id).FirstOrDefault()),
-            elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Level1>(e => e.OneToOne_Optional_FK1)));
+            elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Level1>(e => e.OneToOne_Optional_FK1!)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Multi_include_with_groupby_in_subquery(bool async)
         => AssertQuery(
             async,
             ss => ss.Set<Level1>()
-                .Include(l1 => l1.OneToOne_Optional_FK1.OneToMany_Optional2)
+                .Include(l1 => l1.OneToOne_Optional_FK1!.OneToMany_Optional2)
                 .GroupBy(g => g.Name)
                 .Select(g => g.OrderBy(e => e.Id).FirstOrDefault()),
             elementAsserter: (e, a) => AssertInclude(
-                e, a, new ExpectedInclude<Level1>(e1 => e1.OneToOne_Optional_FK1),
+                e, a, new ExpectedInclude<Level1>(e1 => e1.OneToOne_Optional_FK1!),
                 new ExpectedInclude<Level2>(e2 => e2.OneToMany_Optional2, "OneToOne_Optional_FK1")));
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -2258,8 +2258,8 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
             async,
             ss => ss.Set<InheritanceBase1>().Include("ReferenceSameType"),
             elementAsserter: (e, a) => AssertInclude(
-                e, a, new ExpectedInclude<InheritanceDerived1>(e1 => e1.ReferenceSameType),
-                new ExpectedInclude<InheritanceDerived2>(e2 => e2.ReferenceSameType)));
+                e, a, new ExpectedInclude<InheritanceDerived1>(e1 => e1.ReferenceSameType!),
+                new ExpectedInclude<InheritanceDerived2>(e2 => e2.ReferenceSameType!)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task String_include_multiple_derived_navigation_with_same_name_and_different_type(bool async)
@@ -2267,8 +2267,8 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
             async,
             ss => ss.Set<InheritanceBase1>().Include("ReferenceDifferentType"),
             elementAsserter: (e, a) => AssertInclude(
-                e, a, new ExpectedInclude<InheritanceDerived1>(e1 => e1.ReferenceDifferentType),
-                new ExpectedInclude<InheritanceDerived2>(e2 => e2.ReferenceDifferentType)));
+                e, a, new ExpectedInclude<InheritanceDerived1>(e1 => e1.ReferenceDifferentType!),
+                new ExpectedInclude<InheritanceDerived2>(e2 => e2.ReferenceDifferentType!)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task
@@ -2278,8 +2278,8 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
             async,
             ss => ss.Set<InheritanceBase1>().Include("ReferenceDifferentType.BaseCollection"),
             elementAsserter: (e, a) => AssertInclude(
-                e, a, new ExpectedInclude<InheritanceDerived1>(e1 => e1.ReferenceDifferentType),
-                new ExpectedInclude<InheritanceDerived2>(e2 => e2.ReferenceDifferentType),
+                e, a, new ExpectedInclude<InheritanceDerived1>(e1 => e1.ReferenceDifferentType!),
+                new ExpectedInclude<InheritanceDerived2>(e2 => e2.ReferenceDifferentType!),
                 new ExpectedInclude<InheritanceLeaf2>(e3 => e3.BaseCollection, "ReferenceDifferentType")));
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -2318,19 +2318,19 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
             async,
             ss => ss.Set<InheritanceBase2>().Include("Reference.CollectionDifferentType").Include("Collection.ReferenceSameType"),
             elementAsserter: (e, a) => AssertInclude(
-                e, a, new ExpectedInclude<InheritanceBase2>(e1 => e1.Reference),
+                e, a, new ExpectedInclude<InheritanceBase2>(e1 => e1.Reference!),
                 new ExpectedInclude<InheritanceDerived1>(e2 => e2.CollectionDifferentType, "Reference"),
                 new ExpectedInclude<InheritanceDerived2>(e3 => e3.CollectionDifferentType, "Reference"),
                 new ExpectedInclude<InheritanceBase2>(e4 => e4.Collection),
-                new ExpectedInclude<InheritanceDerived1>(e5 => e5.ReferenceSameType, "Collection"),
-                new ExpectedInclude<InheritanceDerived2>(e6 => e6.ReferenceSameType, "Collection")));
+                new ExpectedInclude<InheritanceDerived1>(e5 => e5.ReferenceSameType!, "Collection"),
+                new ExpectedInclude<InheritanceDerived2>(e6 => e6.ReferenceSameType!, "Collection")));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Nav_rewrite_doesnt_apply_null_protection_for_function_arguments(bool async)
         => AssertQueryScalar(
             async,
             ss => ss.Set<Level1>().Where(l1 => l1.OneToOne_Optional_PK1 != null)
-                .Select(l1 => Math.Max(l1.OneToOne_Optional_PK1.Level1_Required_Id, 7)));
+                .Select(l1 => Math.Max(l1.OneToOne_Optional_PK1!.Level1_Required_Id, 7)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Accessing_optional_property_inside_result_operator_subquery(bool async)
@@ -2339,7 +2339,7 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
 
         return AssertQuery(
             async,
-            ss => ss.Set<Level1>().Where(l1 => names.All(n => l1.OneToOne_Optional_FK1.Name != n)));
+            ss => ss.Set<Level1>().Where(l1 => names.All(n => l1.OneToOne_Optional_FK1!.Name != n)));
     }
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -2353,7 +2353,7 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
         => AssertQuery(
             async,
             ss => ss.Set<Level1>().Include(l1 => l1.OneToOne_Optional_FK1),
-            elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Level1>(l1 => l1.OneToOne_Optional_FK1)));
+            elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Level1>(l1 => l1.OneToOne_Optional_FK1!)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Include2(bool async)
@@ -2361,8 +2361,8 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
             async,
             ss => ss.Set<Level1>().Include(l1 => l1.OneToOne_Optional_FK1).Include(l1 => l1.OneToOne_Optional_FK1),
             elementAsserter: (e, a) => AssertInclude(
-                e, a, new ExpectedInclude<Level1>(l1 => l1.OneToOne_Optional_FK1),
-                new ExpectedInclude<Level1>(l1 => l1.OneToOne_Optional_FK1)));
+                e, a, new ExpectedInclude<Level1>(l1 => l1.OneToOne_Optional_FK1!),
+                new ExpectedInclude<Level1>(l1 => l1.OneToOne_Optional_FK1!)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Include3(bool async)
@@ -2370,39 +2370,39 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
             async,
             ss => ss.Set<Level1>().Include(l1 => l1.OneToOne_Optional_FK1).Include(l1 => l1.OneToOne_Optional_PK1),
             elementAsserter: (e, a) => AssertInclude(
-                e, a, new ExpectedInclude<Level1>(l1 => l1.OneToOne_Optional_FK1),
-                new ExpectedInclude<Level1>(l1 => l1.OneToOne_Optional_PK1)));
+                e, a, new ExpectedInclude<Level1>(l1 => l1.OneToOne_Optional_FK1!),
+                new ExpectedInclude<Level1>(l1 => l1.OneToOne_Optional_PK1!)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Include4(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<Level1>().Include(l1 => l1.OneToOne_Optional_FK1).ThenInclude(l1 => l1.OneToOne_Optional_PK2),
+            ss => ss.Set<Level1>().Include(l1 => l1.OneToOne_Optional_FK1).ThenInclude(l1 => l1!.OneToOne_Optional_PK2),
             elementAsserter: (e, a) => AssertInclude(
-                e, a, new ExpectedInclude<Level1>(l1 => l1.OneToOne_Optional_FK1),
-                new ExpectedInclude<Level2>(l2 => l2.OneToOne_Optional_PK2, "OneToOne_Optional_FK1")));
+                e, a, new ExpectedInclude<Level1>(l1 => l1.OneToOne_Optional_FK1!),
+                new ExpectedInclude<Level2>(l2 => l2.OneToOne_Optional_PK2!, "OneToOne_Optional_FK1")));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Include5(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<Level1>().Include(l1 => l1.OneToOne_Optional_FK1.OneToOne_Optional_PK2),
+            ss => ss.Set<Level1>().Include(l1 => l1.OneToOne_Optional_FK1!.OneToOne_Optional_PK2),
             elementAsserter: (e, a) => AssertInclude(
-                e, a, new ExpectedInclude<Level1>(l1 => l1.OneToOne_Optional_FK1),
-                new ExpectedInclude<Level2>(l2 => l2.OneToOne_Optional_PK2, "OneToOne_Optional_FK1")));
+                e, a, new ExpectedInclude<Level1>(l1 => l1.OneToOne_Optional_FK1!),
+                new ExpectedInclude<Level2>(l2 => l2.OneToOne_Optional_PK2!, "OneToOne_Optional_FK1")));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Include6(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<Level1>().Include(l1 => l1.OneToOne_Optional_FK1.OneToOne_Optional_PK2).Select(l1 => l1.OneToOne_Optional_FK1),
-            elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Level2>(l2 => l2.OneToOne_Optional_PK2)));
+            ss => ss.Set<Level1>().Include(l1 => l1.OneToOne_Optional_FK1!.OneToOne_Optional_PK2).Select(l1 => l1.OneToOne_Optional_FK1),
+            elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Level2>(l2 => l2.OneToOne_Optional_PK2!)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Include7(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<Level1>().Include(l1 => l1.OneToOne_Optional_FK1.OneToOne_Optional_PK2)
+            ss => ss.Set<Level1>().Include(l1 => l1.OneToOne_Optional_FK1!.OneToOne_Optional_PK2)
                 .Select(l1 => l1.OneToOne_Optional_PK1));
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -2410,9 +2410,9 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
         => AssertQuery(
             async,
             ss => ss.Set<Level2>()
-                .Where(l2 => l2.OneToOne_Optional_FK_Inverse2.Name != "Fubar")
+                .Where(l2 => l2.OneToOne_Optional_FK_Inverse2!.Name != "Fubar")
                 .Include(l2 => l2.OneToOne_Optional_FK_Inverse2),
-            elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Level2>(l2 => l2.OneToOne_Optional_FK_Inverse2)));
+            elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Level2>(l2 => l2.OneToOne_Optional_FK_Inverse2!)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Include9(bool async)
@@ -2420,58 +2420,58 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
             async,
             ss => ss.Set<Level2>()
                 .Include(l2 => l2.OneToOne_Optional_FK_Inverse2)
-                .Where(l2 => l2.OneToOne_Optional_FK_Inverse2.Name != "Fubar"),
-            elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Level2>(l2 => l2.OneToOne_Optional_FK_Inverse2)));
+                .Where(l2 => l2.OneToOne_Optional_FK_Inverse2!.Name != "Fubar"),
+            elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Level2>(l2 => l2.OneToOne_Optional_FK_Inverse2!)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Include10(bool async)
         => AssertQuery(
             async,
             ss => ss.Set<Level1>()
-                .Include(l1 => l1.OneToOne_Optional_FK1.OneToOne_Optional_PK2)
-                .Include(l1 => l1.OneToOne_Optional_PK1.OneToOne_Optional_FK2.OneToOne_Optional_PK3),
+                .Include(l1 => l1.OneToOne_Optional_FK1!.OneToOne_Optional_PK2)
+                .Include(l1 => l1.OneToOne_Optional_PK1!.OneToOne_Optional_FK2!.OneToOne_Optional_PK3),
             elementAsserter: (e, a) => AssertInclude(
-                e, a, new ExpectedInclude<Level1>(l1 => l1.OneToOne_Optional_FK1),
-                new ExpectedInclude<Level2>(l2 => l2.OneToOne_Optional_PK2, "OneToOne_Optional_FK1"),
-                new ExpectedInclude<Level1>(l1 => l1.OneToOne_Optional_PK1),
-                new ExpectedInclude<Level2>(l2 => l2.OneToOne_Optional_FK2, "OneToOne_Optional_PK1"),
-                new ExpectedInclude<Level3>(l3 => l3.OneToOne_Optional_PK3, "OneToOne_Optional_FK1.OneToOne_Optional_FK2")));
+                e, a, new ExpectedInclude<Level1>(l1 => l1.OneToOne_Optional_FK1!),
+                new ExpectedInclude<Level2>(l2 => l2.OneToOne_Optional_PK2!, "OneToOne_Optional_FK1"),
+                new ExpectedInclude<Level1>(l1 => l1.OneToOne_Optional_PK1!),
+                new ExpectedInclude<Level2>(l2 => l2.OneToOne_Optional_FK2!, "OneToOne_Optional_PK1"),
+                new ExpectedInclude<Level3>(l3 => l3.OneToOne_Optional_PK3!, "OneToOne_Optional_FK1.OneToOne_Optional_FK2")));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Include11(bool async)
         => AssertQuery(
             async,
             ss => ss.Set<Level1>()
-                .Include(l1 => l1.OneToOne_Optional_FK1.OneToOne_Optional_FK2)
-                .Include(l1 => l1.OneToOne_Optional_FK1.OneToOne_Optional_PK2)
-                .Include(l1 => l1.OneToOne_Optional_PK1.OneToOne_Optional_FK2.OneToOne_Optional_FK3)
-                .Include(l1 => l1.OneToOne_Optional_PK1.OneToOne_Optional_FK2.OneToOne_Optional_PK3)
-                .Include(l1 => l1.OneToOne_Optional_PK1.OneToOne_Optional_PK2),
+                .Include(l1 => l1.OneToOne_Optional_FK1!.OneToOne_Optional_FK2)
+                .Include(l1 => l1.OneToOne_Optional_FK1!.OneToOne_Optional_PK2)
+                .Include(l1 => l1.OneToOne_Optional_PK1!.OneToOne_Optional_FK2!.OneToOne_Optional_FK3)
+                .Include(l1 => l1.OneToOne_Optional_PK1!.OneToOne_Optional_FK2!.OneToOne_Optional_PK3)
+                .Include(l1 => l1.OneToOne_Optional_PK1!.OneToOne_Optional_PK2),
             elementAsserter: (e, a) => AssertInclude(
-                e, a, new ExpectedInclude<Level1>(l1 => l1.OneToOne_Optional_FK1),
-                new ExpectedInclude<Level2>(l2 => l2.OneToOne_Optional_FK2, "OneToOne_Optional_FK1"),
-                new ExpectedInclude<Level2>(l2 => l2.OneToOne_Optional_PK2, "OneToOne_Optional_FK1"),
-                new ExpectedInclude<Level1>(l1 => l1.OneToOne_Optional_PK1),
-                new ExpectedInclude<Level2>(l2 => l2.OneToOne_Optional_FK2, "OneToOne_Optional_PK1"),
-                new ExpectedInclude<Level3>(l3 => l3.OneToOne_Optional_FK3, "OneToOne_Optional_PK1.OneToOne_Optional_FK2"),
-                new ExpectedInclude<Level1>(l1 => l1.OneToOne_Optional_PK1),
-                new ExpectedInclude<Level2>(l2 => l2.OneToOne_Optional_FK2, "OneToOne_Optional_PK1"),
-                new ExpectedInclude<Level3>(l3 => l3.OneToOne_Optional_PK3, "OneToOne_Optional_PK1.OneToOne_Optional_FK2"),
-                new ExpectedInclude<Level2>(l2 => l2.OneToOne_Optional_PK2, "OneToOne_Optional_PK1")));
+                e, a, new ExpectedInclude<Level1>(l1 => l1.OneToOne_Optional_FK1!),
+                new ExpectedInclude<Level2>(l2 => l2.OneToOne_Optional_FK2!, "OneToOne_Optional_FK1"),
+                new ExpectedInclude<Level2>(l2 => l2.OneToOne_Optional_PK2!, "OneToOne_Optional_FK1"),
+                new ExpectedInclude<Level1>(l1 => l1.OneToOne_Optional_PK1!),
+                new ExpectedInclude<Level2>(l2 => l2.OneToOne_Optional_FK2!, "OneToOne_Optional_PK1"),
+                new ExpectedInclude<Level3>(l3 => l3.OneToOne_Optional_FK3!, "OneToOne_Optional_PK1.OneToOne_Optional_FK2"),
+                new ExpectedInclude<Level1>(l1 => l1.OneToOne_Optional_PK1!),
+                new ExpectedInclude<Level2>(l2 => l2.OneToOne_Optional_FK2!, "OneToOne_Optional_PK1"),
+                new ExpectedInclude<Level3>(l3 => l3.OneToOne_Optional_PK3!, "OneToOne_Optional_PK1.OneToOne_Optional_FK2"),
+                new ExpectedInclude<Level2>(l2 => l2.OneToOne_Optional_PK2!, "OneToOne_Optional_PK1")));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Include12(bool async)
         => AssertQuery(
             async,
             ss => ss.Set<Level1>()
-                .Include(l1 => l1.OneToOne_Optional_FK1.OneToOne_Optional_FK2)
+                .Include(l1 => l1.OneToOne_Optional_FK1!.OneToOne_Optional_FK2)
                 .Select(l1 => l1.OneToOne_Optional_FK1),
-            elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Level2>(l2 => l2.OneToOne_Optional_FK2)));
+            elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Level2>(l2 => l2.OneToOne_Optional_FK2!)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Include13(bool async)
     {
-        var expectedIncludes = new IExpectedInclude[] { new ExpectedInclude<Level1>(l1 => l1.OneToOne_Optional_FK1) };
+        var expectedIncludes = new IExpectedInclude[] { new ExpectedInclude<Level1>(l1 => l1.OneToOne_Optional_FK1!) };
 
         return AssertQuery(
             async,
@@ -2491,7 +2491,7 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
         => AssertQuery(
             async,
             ss => ss.Set<Level1>()
-                .Include(l1 => l1.OneToOne_Optional_FK1).ThenInclude(l2 => l2.OneToOne_Optional_FK2)
+                .Include(l1 => l1.OneToOne_Optional_FK1).ThenInclude(l2 => l2!.OneToOne_Optional_FK2)
                 .Select(l1 => new
                 {
                     one = l1,
@@ -2501,9 +2501,9 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
             elementAsserter: (e, a) =>
             {
                 AssertInclude(
-                    e.one, a.one, new ExpectedInclude<Level1>(l1 => l1.OneToOne_Optional_FK1),
-                    new ExpectedInclude<Level2>(l2 => l2.OneToOne_Optional_FK2, "OneToOne_Optional_FK1"));
-                AssertInclude(e.two, a.two, new ExpectedInclude<Level2>(l2 => l2.OneToOne_Optional_FK2));
+                    e.one, a.one, new ExpectedInclude<Level1>(l1 => l1.OneToOne_Optional_FK1!),
+                    new ExpectedInclude<Level2>(l2 => l2.OneToOne_Optional_FK2!, "OneToOne_Optional_FK1"));
+                AssertInclude(e.two, a.two, new ExpectedInclude<Level2>(l2 => l2.OneToOne_Optional_FK2!));
                 AssertEqual(e.three, a.three);
             },
             elementSorter: e => e.one.Id);
@@ -2513,7 +2513,7 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
     {
         using var ctx = CreateContext();
         var query = ctx.LevelOne.Select(l1 => new { foo = l1.OneToOne_Optional_FK1, bar = l1.OneToOne_Optional_PK1 })
-            .Include(x => x.foo.OneToOne_Optional_FK2).Distinct();
+            .Include(x => x.foo!.OneToOne_Optional_FK2).Distinct();
 
         // Include after select. Issue #16752.
         return AssertIncludeOnNonEntity(() =>
@@ -2533,21 +2533,21 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
         => AssertQuery(
             async,
             ss => ss.Set<Level1>().Include(x => x.OneToOne_Optional_FK1).Distinct(),
-            elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Level1>(l1 => l1.OneToOne_Optional_FK1)));
+            elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Level1>(l1 => l1.OneToOne_Optional_FK1!)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Include18_1_1(bool async)
         => AssertQuery(
             async,
             ss => ss.Set<Level1>().OrderBy(x => x.OneToOne_Required_FK1.Name).Include(x => x.OneToOne_Optional_FK1).Take(10),
-            elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Level1>(l1 => l1.OneToOne_Optional_FK1)));
+            elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Level1>(l1 => l1.OneToOne_Optional_FK1!)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Include18_2(bool async)
         => AssertQuery(
             async,
             ss => ss.Set<Level1>().Where(x => x.OneToOne_Required_FK1.Name != "Foo").Include(x => x.OneToOne_Optional_FK1).Distinct(),
-            elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Level1>(l1 => l1.OneToOne_Optional_FK1)));
+            elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Level1>(l1 => l1.OneToOne_Optional_FK1!)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual async Task Include18_3(bool async)
@@ -2596,10 +2596,10 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
         => AssertQuery(
             async,
             ss => ss.Set<Level1>()
-                .Include(x => x.OneToOne_Optional_FK1.OneToOne_Optional_FK2)
-                .Select(l1 => l1.OneToOne_Optional_FK1)
+                .Include(x => x.OneToOne_Optional_FK1!.OneToOne_Optional_FK2)
+                .Select(l1 => l1.OneToOne_Optional_FK1!)
                 .Distinct(),
-            elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Level2>(l1 => l1.OneToOne_Optional_FK2)));
+            elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Level2>(l1 => l1.OneToOne_Optional_FK2!)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual async Task Include18_4(bool async)
@@ -2684,7 +2684,7 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
                             .FirstOrDefault())
                         .FirstOrDefault())
                     .FirstOrDefault()
-                    .Name
+                    !.Name
                 != "Foo");
 #pragma warning restore CS9236
 
@@ -2727,7 +2727,7 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
                             select l2.OneToMany_Optional2.Select(l3 => (from l4 in ctx.LevelFour
                                                                         where l4.Level3_Required_Id == l3.Id
                                                                         orderby l4.Id
-                                                                        select l4).FirstOrDefault()).FirstOrDefault()).FirstOrDefault()
+                                                                        select l4).FirstOrDefault()!).FirstOrDefault()!).FirstOrDefault()!
                         .Name;
 
         _ = async ? await query.ToListAsync() : query.ToList();
@@ -2737,12 +2737,12 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
     public virtual Task Member_pushdown_with_multiple_collections(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<Level1>().Select(l1 => l1.OneToMany_Optional1.OrderBy(l2 => l2.Id).FirstOrDefault().OneToMany_Optional2
+            ss => ss.Set<Level1>().Select(l1 => l1.OneToMany_Optional1.OrderBy(l2 => l2.Id).FirstOrDefault()!.OneToMany_Optional2
                 .OrderBy(l3 => l3.Id)
-                .FirstOrDefault().Name),
-            ss => ss.Set<Level1>().Select(l1 => l1.OneToMany_Optional1.OrderBy(l2 => l2.Id).FirstOrDefault().Maybe(x => x
+                .FirstOrDefault()!.Name),
+            ss => ss.Set<Level1>().Select(l1 => l1.OneToMany_Optional1.OrderBy(l2 => l2.Id).FirstOrDefault().Maybe(x => x!
                 .OneToMany_Optional2.OrderBy(l3 => l3.Id)
-                .FirstOrDefault().Maybe(xx => xx.Name))));
+                .FirstOrDefault().Maybe(xx => xx!.Name))));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Include_multiple_collections_on_same_level(bool async)
@@ -2765,10 +2765,10 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
                             : l1.OneToOne_Optional_FK1.OneToOne_Optional_FK2)
                         == null
                             ? null
-                            : l1.OneToOne_Optional_FK1.OneToOne_Optional_FK2.OneToOne_Optional_PK3)
+                            : l1.OneToOne_Optional_FK1!.OneToOne_Optional_FK2!.OneToOne_Optional_PK3)
                     == null
                         ? null
-                        : l1.OneToOne_Optional_FK1.OneToOne_Optional_FK2.OneToOne_Optional_PK3.Name)
+                        : l1.OneToOne_Optional_FK1!.OneToOne_Optional_FK2!.OneToOne_Optional_PK3!.Name)
                 == "L4 01"));
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -2785,6 +2785,7 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
                             : l1.OneToOne_Optional_FK1.OneToOne_Optional_FK2.OneToOne_Optional_PK3.Name)
                 == "L4 01"));
 
+#pragma warning disable CS8620 // Argument cannot be used for parameter due to differences in the nullability of reference types
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Union_over_entities_with_different_nullability(bool async)
         => AssertQueryScalar(
@@ -2795,8 +2796,8 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
                 .Concat(
                     ss.Set<Level2>().GroupJoin(ss.Set<Level1>(), l2 => l2.Level1_Optional_Id, l1 => l1.Id, (l2, l1s) => new { l2, l1s })
                         .SelectMany(g => g.l1s.DefaultIfEmpty(), (g, l1) => new { l1, g.l2 })
-                        .Where(e => e.l1.Equals(null)))
-                .Select(e => (int?)e.l1.Id),
+                        .Where(e => e.l1!.Equals(null)))
+                .Select(e => (int?)e.l1!.Id),
             ss => ss.Set<Level1>()
                 .GroupJoin(ss.Set<Level2>(), l1 => l1.Id, l2 => l2.Level1_Optional_Id, (l1, l2s) => new { l1, l2s })
                 .SelectMany(g => g.l2s.DefaultIfEmpty(), (g, l2) => new { g.l1, l2 })
@@ -2805,6 +2806,7 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
                         .SelectMany(g => g.l1s.DefaultIfEmpty(), (g, l1) => new { l1, g.l2 })
                         .Where(e => e.l1 == null))
                 .Select(e => e.l1.MaybeScalar(x => x.Id)));
+            #pragma warning restore CS8620
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Including_reference_navigation_and_projecting_collection_navigation_2(bool async)
@@ -2849,7 +2851,7 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
     public virtual Task Select_with_joined_where_clause_cast_using_as(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<Level1>().Where(w => (w.Id + 7) == (w.OneToOne_Optional_FK1.Id as int?)));
+            ss => ss.Set<Level1>().Where(w => (w.Id + 7) == (w.OneToOne_Optional_FK1!.Id as int?)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task SelectMany_with_outside_reference_to_joined_table_correctly_translated_to_apply(bool async)
@@ -2866,13 +2868,13 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
     public virtual Task Nested_SelectMany_correlated_with_join_table_correctly_translated_to_apply(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<Level1>().SelectMany(l1 => l1.OneToMany_Optional1.DefaultIfEmpty().SelectMany(l2 => l2.OneToOne_Required_PK2
+            ss => ss.Set<Level1>().SelectMany(l1 => l1.OneToMany_Optional1.DefaultIfEmpty().SelectMany(l2 => l2!.OneToOne_Required_PK2
                 .OneToMany_Optional3.DefaultIfEmpty()
                 .Select(l4 => new
                 {
                     l1Name = l1.Name,
                     l2Name = l2.OneToOne_Required_PK2.Name,
-                    l3Name = l4.OneToOne_Optional_PK_Inverse4.Name
+                    l3Name = l4!.OneToOne_Optional_PK_Inverse4!.Name
                 }))));
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -2901,8 +2903,8 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
             ss => ss.Set<Level1>().Select(l1 => new
             {
                 l1.Name,
-                OptionalName = l1.OneToOne_Optional_FK1.Name,
-                Contains = ss.Set<Level1>().Select(x => x.OneToOne_Optional_FK1.Name).Contains(l1.OneToOne_Optional_FK1.Name)
+                OptionalName = l1.OneToOne_Optional_FK1!.Name,
+                Contains = ss.Set<Level1>().Select(x => x.OneToOne_Optional_FK1!.Name).Contains(l1.OneToOne_Optional_FK1!.Name)
             }),
             elementSorter: e => (e.Name, e.OptionalName, e.Contains));
 
@@ -2913,7 +2915,7 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
             ss => ss.Set<Level1>().Select(l1 => new
             {
                 l1.Name,
-                OptionalName = l1.OneToOne_Optional_FK1.Name,
+                OptionalName = l1.OneToOne_Optional_FK1!.Name,
                 Contains = ss.Set<Level1>().Select(x => x.OneToOne_Optional_FK1).Contains(l1.OneToOne_Optional_PK1)
             }),
             elementSorter: e => (e.Name, e.OptionalName, e.Contains));
@@ -2939,10 +2941,10 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
                     l1.Id,
                     l1.Date,
                     l1.Name,
-                    InnerId = l1.OneToOne_Optional_FK1.Id,
-                    InnerDate = l1.OneToOne_Optional_FK1.Date,
-                    InnerOptionalId = l1.OneToOne_Optional_FK1.Level1_Optional_Id,
-                    InnerRequiredId = l1.OneToOne_Optional_FK1.Level1_Required_Id,
+                    InnerId = l1.OneToOne_Optional_FK1!.Id,
+                    InnerDate = l1.OneToOne_Optional_FK1!.Date,
+                    InnerOptionalId = l1.OneToOne_Optional_FK1!.Level1_Optional_Id,
+                    InnerRequiredId = l1.OneToOne_Optional_FK1!.Level1_Required_Id,
                     InnerName = l1.OneToOne_Required_FK1.Name
                 })
                 .Select(g => new
@@ -2961,7 +2963,7 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
                             Level1_Required_Id = g.Key.InnerRequiredId
                         }
                     },
-                    Aggregate = g.Sum(x => x.Name.Length)
+                    Aggregate = g.Sum(x => x.Name!.Length)
                 }));
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -2999,7 +3001,7 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
                             Name = l1.OneToOne_Optional_FK1.Name,
                         }
                 })
-                .OrderBy(e => e.Level2.Name)
+                .OrderBy(e => e.Level2!.Name)
                 .ThenBy(e => e.Id),
             assertOrder: true,
             elementAsserter: (e, a) =>
@@ -3013,7 +3015,7 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
                 else
                 {
                     Assert.NotNull(a.Level2);
-                    Assert.Equal(e.Level2.Id, a.Level2.Id);
+                    Assert.Equal(e.Level2.Id, a.Level2!.Id);
                     Assert.Equal(e.Level2.Name, a.Level2.Name);
                 }
             });
@@ -3021,14 +3023,14 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
     private class Level1Dto
     {
         public int Id { get; set; }
-        public string Name { get; set; }
-        public Level2Dto Level2 { get; set; }
+        public string? Name { get; set; }
+        public Level2Dto? Level2 { get; set; }
     }
 
     private class Level2Dto
     {
         public int Id { get; set; }
-        public string Name { get; set; }
+        public string? Name { get; set; }
     }
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -3055,7 +3057,7 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
                                 }
                         }
                 })
-                .Where(e => e.Level2.Level3.Name != "L"),
+                .Where(e => e.Level2!.Level3!.Name != "L"),
             elementSorter: e => e.Id,
             elementAsserter: (e, a) =>
             {
@@ -3068,7 +3070,7 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
                 else
                 {
                     Assert.NotNull(a.Level2);
-                    Assert.Equal(e.Level2.Id, a.Level2.Id);
+                    Assert.Equal(e.Level2.Id, a.Level2!.Id);
                     Assert.Equal(e.Level2.Name, a.Level2.Name);
                 }
             });
@@ -3113,7 +3115,7 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
                 }
                 else
                 {
-                    AssertEqual(e.Level2.Id, a.Level2.Id);
+                    AssertEqual(e.Level2.Id, a.Level2!.Id);
                     AssertEqual(e.Level2.Name, a.Level2.Name);
                 }
             });
@@ -3176,7 +3178,7 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
             ss => ss.Set<Level1>()
                 .Include(x => x.OneToMany_Optional1).ThenInclude(x => x.OneToMany_Optional2)
                 .Where(l1 => l1.Id < 3)
-                .Select(l1 => new { l1.Id, Pushdown = l1.OneToMany_Optional1.Where(x => x.Name == "L2 02").FirstOrDefault().Name }));
+                .Select(l1 => new { l1.Id, Pushdown = l1.OneToMany_Optional1.Where(x => x.Name == "L2 02").FirstOrDefault()!.Name }));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Collection_FirstOrDefault_entity_reference_accesses_in_projection(bool async)
@@ -3190,7 +3192,7 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
                     l1.Id,
                     Pushdown = l1.OneToMany_Optional1
                         .Where(x => x.Name == "L2 02")
-                        .FirstOrDefault().OneToOne_Optional_FK2
+                        .FirstOrDefault()!.OneToOne_Optional_FK2
                 }));
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -3204,7 +3206,7 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
                     l1.Id,
                     Pushdown = l1.OneToMany_Optional1
                         .Where(x => x.Name == "L2 02")
-                        .FirstOrDefault().OneToMany_Optional2.ToList()
+                        .FirstOrDefault()!.OneToMany_Optional2.ToList()
                 }),
             elementSorter: e => e.Id,
             elementAsserter: (e, a) =>
@@ -3224,9 +3226,9 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
                     l1.Id,
                     Pushdown = l1.OneToMany_Optional1
                         .Where(x => x.Name == "L2 02")
-                        .FirstOrDefault().OneToMany_Optional2
+                        .FirstOrDefault()!.OneToMany_Optional2
                         .OrderBy(x => x.Id)
-                        .FirstOrDefault().Name
+                        .FirstOrDefault()!.Name
                 }));
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -3258,7 +3260,7 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
             () => AssertQuery(
                 async,
                 ss => from l1 in ss.Set<Level1>()
-                      where l1.Name.StartsWith("L1 0")
+                      where l1.Name!.StartsWith("L1 0")
                       let inner = from i in ss.Set<Level1>()
                                   where i.Id == l1.Id && i.Id > 5
                                   select i
@@ -3622,19 +3624,19 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
         => AssertCount(
             async,
             ss => ss.Set<Level2>().Where(x => (x.OneToMany_Optional_Inverse2 != null
-                    && x.OneToMany_Optional_Inverse2.Name.Contains("L1 01"))
+                    && x.OneToMany_Optional_Inverse2.Name!.Contains("L1 01"))
                 || (x.OneToOne_Optional_FK_Inverse2 != null
-                    && x.OneToOne_Optional_FK_Inverse2.Name.Contains("L1 01"))));
+                    && x.OneToOne_Optional_FK_Inverse2.Name!.Contains("L1 01"))));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Null_check_removal_applied_recursively_complex(bool async)
     {
         var userParam = Expression.Parameter(typeof(Level3), "l3");
         var builderProperty = Expression.MakeMemberAccess(
-            userParam, typeof(Level3).GetProperty(nameof(Level3.OneToMany_Required_Inverse3)));
+            userParam, typeof(Level3).GetProperty(nameof(Level3.OneToMany_Required_Inverse3))!);
         var cityProperty = Expression.MakeMemberAccess(
-            builderProperty, typeof(Level2).GetProperty(nameof(Level2.OneToMany_Required_Inverse2)));
-        var nameProperty = Expression.MakeMemberAccess(cityProperty, typeof(Level1).GetProperty(nameof(Level1.Name)));
+            builderProperty, typeof(Level2).GetProperty(nameof(Level2.OneToMany_Required_Inverse2))!);
+        var nameProperty = Expression.MakeMemberAccess(cityProperty, typeof(Level1).GetProperty(nameof(Level1.Name))!);
 
         //{s => (IIF((IIF((l3.Inverse3 == null), null, s.Inverse3.Inverse2) == null), null, s.Inverse3.Inverse2.Name) == "L1 01")}
         var selection = Expression.Lambda<Func<Level3, bool>>(
@@ -3738,7 +3740,7 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
                 Collection = x.OneToMany_Optional1
                     .SelectMany(xx => xx.OneToMany_Optional2)
                     .OrderBy(xx => xx.Id).Take(12)
-                    .Select(xx => new { xx.Id, RefId = xx.OneToOne_Optional_FK3.Id }).ToList(),
+                    .Select(xx => new { xx.Id, RefId = xx.OneToOne_Optional_FK3!.Id }).ToList(),
                 Count = x.OneToMany_Optional1
                     .SelectMany(xx => xx.OneToMany_Optional2).Count(xx => xx.Name != "")
             }),
@@ -3768,7 +3770,7 @@ public abstract class ComplexNavigationsQueryTestBase<TFixture>(TFixture fixture
                 Collection = x.OneToMany_Optional1
                     .SelectMany(xx => xx.OneToMany_Optional2)
                     .OrderBy(xx => xx.Id).Take(12)
-                    .Select(xx => new { xx.Id, RefId = xx.OneToOne_Optional_FK3.Id }).ToList(),
+                    .Select(xx => new { xx.Id, RefId = xx.OneToOne_Optional_FK3!.Id }).ToList(),
             }),
             elementSorter: e => e.Id,
             elementAsserter: (e, a) =>

--- a/test/EFCore.Specification.Tests/Query/ComplexNavigationsSharedTypeQueryFixtureBase.cs
+++ b/test/EFCore.Specification.Tests/Query/ComplexNavigationsSharedTypeQueryFixtureBase.cs
@@ -6,8 +6,6 @@ using Microsoft.EntityFrameworkCore.TestModels.ComplexNavigationsModel;
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
-#nullable disable
-
 public abstract class ComplexNavigationsSharedTypeQueryFixtureBase : ComplexNavigationsQueryFixtureBase
 {
     protected override string StoreName
@@ -40,12 +38,14 @@ public abstract class ComplexNavigationsSharedTypeQueryFixtureBase : ComplexNavi
         var level2 = level1.Model.AddEntityType("Level1.OneToOne_Required_PK1#Level2", typeof(Level2));
         using (var batch = ((Model)modelBuilder.Model).ConventionDispatcher.DelayConventions())
         {
-            level2Fk = (ForeignKey)level2.AddForeignKey(level2.FindProperty(nameof(Level2.Id)), level1.FindPrimaryKey(), level1);
+            level2Fk = (ForeignKey)level2.AddForeignKey(
+                level2.FindProperty(nameof(Level2.Id))!, level1.FindPrimaryKey()!, level1);
             level2Fk.IsUnique = true;
             level2Fk.SetPrincipalToDependent(nameof(Level1.OneToOne_Required_PK1), ConfigurationSource.Explicit);
             level2Fk.SetDependentToPrincipal(nameof(Level2.OneToOne_Required_PK_Inverse2), ConfigurationSource.Explicit);
+            level2Fk.IsRequiredDependent = false;
             level2Fk.DeleteBehavior = DeleteBehavior.Restrict;
-            level2Fk = (ForeignKey)batch.Run(level2Fk);
+            level2Fk = (ForeignKey)batch.Run(level2Fk)!;
         }
 
         Configure(new OwnedNavigationBuilder<Level1, Level2>(level2Fk));
@@ -127,6 +127,7 @@ public abstract class ComplexNavigationsSharedTypeQueryFixtureBase : ComplexNavi
             .IsRequired()
             .OnDelete(DeleteBehavior.Restrict);
 
+        l2.Property<int?>("OneToMany_Optional_Inverse2Id");
         l2.HasOne(e => e.OneToMany_Optional_Inverse2)
             .WithMany(e => e.OneToMany_Optional1)
             .IsRequired(false);
@@ -135,12 +136,14 @@ public abstract class ComplexNavigationsSharedTypeQueryFixtureBase : ComplexNavi
         var level3 = level2.Model.AddEntityType("Level1.OneToOne_Required_PK1#Level2.OneToOne_Required_PK2#Level3", typeof(Level3));
         using (var batch = ((Model)level2.Model).ConventionDispatcher.DelayConventions())
         {
-            level3Fk = (ForeignKey)level3.AddForeignKey(level3.FindProperty(nameof(Level3.Id)), level2.FindPrimaryKey(), level2);
+            level3Fk = (ForeignKey)level3.AddForeignKey(
+                level3.FindProperty(nameof(Level3.Id))!, level2.FindPrimaryKey()!, level2);
             level3Fk.IsUnique = true;
             level3Fk.SetPrincipalToDependent(nameof(Level2.OneToOne_Required_PK2), ConfigurationSource.Explicit);
             level3Fk.SetDependentToPrincipal(nameof(Level3.OneToOne_Required_PK_Inverse3), ConfigurationSource.Explicit);
+            level3Fk.IsRequiredDependent = false;
             level3Fk.DeleteBehavior = DeleteBehavior.Restrict;
-            level3Fk = (ForeignKey)batch.Run(level3Fk);
+            level3Fk = (ForeignKey)batch.Run(level3Fk)!;
         }
 
         Configure(new OwnedNavigationBuilder<Level2, Level3>(level3Fk));
@@ -188,12 +191,14 @@ public abstract class ComplexNavigationsSharedTypeQueryFixtureBase : ComplexNavi
             typeof(Level4));
         using (var batch = ((Model)level3.Model).ConventionDispatcher.DelayConventions())
         {
-            level4Fk = (ForeignKey)level4.AddForeignKey(level4.FindProperty(nameof(Level4.Id)), level3.FindPrimaryKey(), level3);
+            level4Fk = (ForeignKey)level4.AddForeignKey(
+                level4.FindProperty(nameof(Level4.Id))!, level3.FindPrimaryKey()!, level3);
             level4Fk.IsUnique = true;
             level4Fk.SetPrincipalToDependent(nameof(Level3.OneToOne_Required_PK3), ConfigurationSource.Explicit);
             level4Fk.SetDependentToPrincipal(nameof(Level4.OneToOne_Required_PK_Inverse4), ConfigurationSource.Explicit);
+            level4Fk.IsRequiredDependent = false;
             level4Fk.DeleteBehavior = DeleteBehavior.Restrict;
-            level4Fk = (ForeignKey)batch.Run(level4Fk);
+            level4Fk = (ForeignKey)batch.Run(level4Fk)!;
         }
 
         Configure(new OwnedNavigationBuilder<Level3, Level4>(level4Fk));

--- a/test/EFCore.Specification.Tests/Query/CompositeKeysQueryFixtureBase.cs
+++ b/test/EFCore.Specification.Tests/Query/CompositeKeysQueryFixtureBase.cs
@@ -5,8 +5,6 @@ using Microsoft.EntityFrameworkCore.TestModels.CompositeKeysModel;
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
-#nullable disable
-
 public abstract class CompositeKeysQueryFixtureBase : QueryFixtureBase<CompositeKeysContext>
 {
     protected override string StoreName
@@ -15,14 +13,14 @@ public abstract class CompositeKeysQueryFixtureBase : QueryFixtureBase<Composite
     public override ISetSource GetExpectedData()
         => CompositeKeysDefaultData.Instance;
 
-    public virtual Dictionary<(Type, string), Func<object, object>> GetShadowPropertyMappings()
+    public virtual Dictionary<(Type, string), Func<object, object?>> GetShadowPropertyMappings()
     {
         var l1s = GetExpectedData().Set<CompositeOne>().ToList();
         var l2s = GetExpectedData().Set<CompositeTwo>().ToList();
         var l3s = GetExpectedData().Set<CompositeThree>().ToList();
         var l4s = GetExpectedData().Set<CompositeFour>().ToList();
 
-        return new Dictionary<(Type, string), Func<object, object>>
+        return new Dictionary<(Type, string), Func<object, object?>>
         {
             {
                 (typeof(CompositeOne), "OneToOne_Optional_Self1Id1"),
@@ -197,10 +195,10 @@ public abstract class CompositeKeysQueryFixtureBase : QueryFixtureBase<Composite
 
     public override IReadOnlyDictionary<Type, object> EntitySorters { get; } = new Dictionary<Type, Func<object, object>>
     {
-        { typeof(CompositeOne), e => (((CompositeOne)e)?.Id1, ((CompositeOne)e)?.Id2) },
-        { typeof(CompositeTwo), e => (((CompositeTwo)e)?.Id1, ((CompositeTwo)e)?.Id2) },
-        { typeof(CompositeThree), e => (((CompositeThree)e)?.Id1, ((CompositeThree)e)?.Id2) },
-        { typeof(CompositeFour), e => (((CompositeFour)e)?.Id1, ((CompositeFour)e)?.Id2) },
+        { typeof(CompositeOne), e => (((CompositeOne)e).Id1, ((CompositeOne)e).Id2) },
+        { typeof(CompositeTwo), e => (((CompositeTwo)e).Id1, ((CompositeTwo)e).Id2) },
+        { typeof(CompositeThree), e => (((CompositeThree)e).Id1, ((CompositeThree)e).Id2) },
+        { typeof(CompositeFour), e => (((CompositeFour)e).Id1, ((CompositeFour)e).Id2) },
     }.ToDictionary(e => e.Key, e => (object)e.Value);
 
     public override IReadOnlyDictionary<Type, object> EntityAsserters { get; } = new Dictionary<Type, Action<object, object>>
@@ -212,7 +210,7 @@ public abstract class CompositeKeysQueryFixtureBase : QueryFixtureBase<Composite
 
                 if (a != null)
                 {
-                    var ee = (CompositeOne)e;
+                    var ee = (CompositeOne)e!;
                     var aa = (CompositeOne)a;
 
                     Assert.Equal(ee.Id1, aa.Id1);
@@ -229,7 +227,7 @@ public abstract class CompositeKeysQueryFixtureBase : QueryFixtureBase<Composite
 
                 if (a != null)
                 {
-                    var ee = (CompositeTwo)e;
+                    var ee = (CompositeTwo)e!;
                     var aa = (CompositeTwo)a;
 
                     Assert.Equal(ee.Id1, aa.Id1);
@@ -250,7 +248,7 @@ public abstract class CompositeKeysQueryFixtureBase : QueryFixtureBase<Composite
 
                 if (a != null)
                 {
-                    var ee = (CompositeThree)e;
+                    var ee = (CompositeThree)e!;
                     var aa = (CompositeThree)a;
 
                     Assert.Equal(ee.Id1, aa.Id1);
@@ -270,7 +268,7 @@ public abstract class CompositeKeysQueryFixtureBase : QueryFixtureBase<Composite
 
                 if (a != null)
                 {
-                    var ee = (CompositeFour)e;
+                    var ee = (CompositeFour)e!;
                     var aa = (CompositeFour)a;
 
                     Assert.Equal(ee.Id1, aa.Id1);

--- a/test/EFCore.Specification.Tests/Query/CompositeKeysQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/CompositeKeysQueryTestBase.cs
@@ -12,7 +12,9 @@ public abstract class CompositeKeysQueryTestBase<TFixture>(TFixture fixture) : Q
         => Fixture.CreateContext();
 
     protected override Expression RewriteExpectedQueryExpression(Expression expectedQueryExpression)
-        => new ExpectedQueryRewritingVisitor(Fixture.GetShadowPropertyMappings()).Visit(expectedQueryExpression);
+        => new ExpectedQueryRewritingVisitor(
+            Fixture.GetShadowPropertyMappings().ToDictionary(e => e.Key, e => new Func<object, object>(o => e.Value(o)!)))
+            .Visit(expectedQueryExpression);
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Projecting_multiple_collections_same_level_top_level_ordering(bool async)

--- a/test/EFCore.Specification.Tests/Query/Ef6GroupByTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/Ef6GroupByTestBase.cs
@@ -3,8 +3,6 @@
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
-#nullable disable
-
 public abstract class Ef6GroupByTestBase<TFixture>(TFixture fixture) : QueryTestBase<TFixture>(fixture)
     where TFixture : Ef6GroupByTestBase<TFixture>.Ef6GroupByFixtureBase, new()
 {
@@ -380,7 +378,7 @@ public abstract class Ef6GroupByTestBase<TFixture>(TFixture fixture) : QueryTest
                   from o in ps
                   select new { Customer = c, o.Id },
             ss => from c in ss.Set<CustomerForLinq>()
-                  join o in ss.Set<OrderForLinq>() on c.Id equals o.Customer.Id into ps
+                join o in ss.Set<OrderForLinq>() on c.Id equals o.Customer!.Id into ps
                   from o in ps
                   select new { Customer = c, o.Id },
             r => (r.Id, r.Customer.Id),
@@ -401,7 +399,7 @@ public abstract class Ef6GroupByTestBase<TFixture>(TFixture fixture) : QueryTest
                   from o in ps.DefaultIfEmpty()
                   select new { Customer = c, OrderId = o == null ? -1 : o.Id },
             ss => from c in ss.Set<CustomerForLinq>()
-                  join o in ss.Set<OrderForLinq>() on c.Id equals o.Customer.Id into ps
+                join o in ss.Set<OrderForLinq>() on c.Id equals o.Customer!.Id into ps
                   from o in ps.DefaultIfEmpty()
                   select new { Customer = c, OrderId = o == null ? -1 : o.Id },
             r => (r.OrderId, r.Customer.Id),
@@ -440,7 +438,7 @@ public abstract class Ef6GroupByTestBase<TFixture>(TFixture fixture) : QueryTest
                 .Where(e => e.MiddleInitial == "Q" && e.Age == 20)
                 .GroupBy(e => e.LastName)
                 .Select(g => g.First().LastName)
-                .OrderBy(e => e.Length),
+                .OrderBy(e => e!.Length),
             assertOrder: true);
 
     [Theory, MemberData(nameof(IsAsyncData))] // From #18037
@@ -487,15 +485,15 @@ public abstract class Ef6GroupByTestBase<TFixture>(TFixture fixture) : QueryTest
         return AssertQuery(
             async,
             ss => ss.Set<Person>()
-                .Where(p => p.Feet.Size == size
+                .Where(p => p.Feet!.Size == size
                     && p.MiddleInitial != null
                     && p.Feet.Id != 1)
-                .GroupBy(p => new { p.Feet.Size, p.Feet.Person.LastName })
+                .GroupBy(p => new { p.Feet!.Size, p.Feet.Person!.LastName })
                 .Select(g => new
                 {
                     g.Key.LastName,
                     g.Key.Size,
-                    Min = g.Min(p => p.Feet.Size),
+                    Min = g.Min(p => p.Feet!.Size),
                 }));
     }
 
@@ -506,14 +504,14 @@ public abstract class Ef6GroupByTestBase<TFixture>(TFixture fixture) : QueryTest
             ss => ss.Set<Person>()
                 .Include(x => x.Shoes)
                 .Include(x => x.Feet)
-                .GroupBy(x => new { x.Feet.Id, x.Feet.Size })
+                .GroupBy(x => new { x.Feet!.Id, x.Feet.Size })
                 .Select(x => new
                 {
                     Key = x.Key.Id + x.Key.Size,
                     Count = x.Count(),
                     Sum = x.Sum(el => el.Id),
                     SumOver60 = x.Sum(el => el.Id) / (decimal)60,
-                    TotalCallOutCharges = x.Sum(el => el.Feet.Size == 11 ? 1 : 0)
+                    TotalCallOutCharges = x.Sum(el => el.Feet!.Size == 11 ? 1 : 0)
                 }));
 
     [Theory, MemberData(nameof(IsAsyncData))] // From #24591
@@ -522,7 +520,7 @@ public abstract class Ef6GroupByTestBase<TFixture>(TFixture fixture) : QueryTest
             async,
             ss => ss.Set<Person>()
                 .GroupBy(n => n.FirstName)
-                .Select(g => new { Feet = g.Key, Total = g.Sum(n => n.Feet.Size) }));
+                .Select(g => new { Feet = g.Key, Total = g.Sum(n => n.Feet!.Size) }));
 
     [Theory, MemberData(nameof(IsAsyncData))] // From #24695
     public virtual Task Whats_new_2021_sample_10(bool async)
@@ -584,7 +582,7 @@ public abstract class Ef6GroupByTestBase<TFixture>(TFixture fixture) : QueryTest
                 })
                 .OrderByDescending(e => e.LastName)
                 .Select(e => e),
-            r => (r.First.FirstName, r.First.MiddleInitial, r.First.LastName),
+            r => (r.First!.FirstName, r.First.MiddleInitial, r.First.LastName),
             (l, r) =>
             {
                 Assert.Equal(l.LastName, r.LastName);
@@ -677,7 +675,7 @@ public abstract class Ef6GroupByTestBase<TFixture>(TFixture fixture) : QueryTest
 
     public abstract class Ef6GroupByFixtureBase : QueryFixtureBase<ArubaContext>
     {
-        private ArubaData _expectedData;
+        private ArubaData _expectedData = null!;
 
         protected override string StoreName
             => "Ef6GroupByTest";
@@ -731,11 +729,11 @@ public abstract class Ef6GroupByTestBase<TFixture>(TFixture fixture) : QueryTest
 
         public override IReadOnlyDictionary<Type, object> EntitySorters { get; } = new Dictionary<Type, Func<object, object>>
         {
-            { typeof(CustomerForLinq), e => ((CustomerForLinq)e)?.Id },
-            { typeof(OrderForLinq), e => ((OrderForLinq)e)?.Id },
-            { typeof(Person), e => ((Person)e)?.Id },
-            { typeof(Shoes), e => ((Shoes)e)?.Id },
-            { typeof(Feet), e => ((Feet)e)?.Id }
+            { typeof(CustomerForLinq), e => ((CustomerForLinq)e).Id },
+            { typeof(OrderForLinq), e => ((OrderForLinq)e).Id },
+            { typeof(Person), e => ((Person)e).Id },
+            { typeof(Shoes), e => ((Shoes)e).Id },
+            { typeof(Feet), e => ((Feet)e).Id }
         }.ToDictionary(e => e.Key, e => (object)e.Value);
 
         public override IReadOnlyDictionary<Type, object> EntityAsserters { get; } = new Dictionary<Type, Action<object, object>>
@@ -747,7 +745,7 @@ public abstract class Ef6GroupByTestBase<TFixture>(TFixture fixture) : QueryTest
 
                     if (a != null)
                     {
-                        var ee = (CustomerForLinq)e;
+                        var ee = (CustomerForLinq)e!;
                         var aa = (CustomerForLinq)a;
 
                         Assert.Equal(ee.Id, aa.Id);
@@ -763,7 +761,7 @@ public abstract class Ef6GroupByTestBase<TFixture>(TFixture fixture) : QueryTest
 
                     if (a != null)
                     {
-                        var ee = (OrderForLinq)e;
+                        var ee = (OrderForLinq)e!;
                         var aa = (OrderForLinq)a;
 
                         Assert.Equal(ee.Id, aa.Id);
@@ -779,7 +777,7 @@ public abstract class Ef6GroupByTestBase<TFixture>(TFixture fixture) : QueryTest
 
                     if (a != null)
                     {
-                        var ee = (Person)e;
+                        var ee = (Person)e!;
                         var aa = (Person)a;
 
                         Assert.Equal(ee.Id, aa.Id);
@@ -797,7 +795,7 @@ public abstract class Ef6GroupByTestBase<TFixture>(TFixture fixture) : QueryTest
 
                     if (a != null)
                     {
-                        var ee = (Shoes)e;
+                        var ee = (Shoes)e!;
                         var aa = (Shoes)a;
 
                         Assert.Equal(ee.Id, aa.Id);
@@ -813,7 +811,7 @@ public abstract class Ef6GroupByTestBase<TFixture>(TFixture fixture) : QueryTest
 
                     if (a != null)
                     {
-                        var ee = (Feet)e;
+                        var ee = (Feet)e!;
                         var aa = (Feet)a;
 
                         Assert.Equal(ee.Id, aa.Id);
@@ -829,9 +827,9 @@ public abstract class Ef6GroupByTestBase<TFixture>(TFixture fixture) : QueryTest
     public class ArubaOwner
     {
         public int Id { get; set; }
-        public string FirstName { get; set; }
-        public string LastName { get; set; }
-        public string Alias { get; set; }
+        public string? FirstName { get; set; }
+        public string? LastName { get; set; }
+        public string? Alias { get; set; }
     }
 
     public class NumberForLinq(int value, string name)
@@ -844,8 +842,8 @@ public abstract class Ef6GroupByTestBase<TFixture>(TFixture fixture) : QueryTest
     public class ProductForLinq
     {
         public int Id { get; set; }
-        public string ProductName { get; set; }
-        public string Category { get; set; }
+        public string? ProductName { get; set; }
+        public string? Category { get; set; }
         public decimal UnitPrice { get; set; }
         public int UnitsInStock { get; set; }
     }
@@ -855,8 +853,8 @@ public abstract class Ef6GroupByTestBase<TFixture>(TFixture fixture) : QueryTest
     public class CustomerForLinq
     {
         public int Id { get; set; }
-        public string Region { get; set; }
-        public string CompanyName { get; set; }
+        public string? Region { get; set; }
+        public string? CompanyName { get; set; }
         public ICollection<OrderForLinq> Orders { get; } = [];
     }
 
@@ -865,17 +863,17 @@ public abstract class Ef6GroupByTestBase<TFixture>(TFixture fixture) : QueryTest
         public int Id { get; set; }
         public decimal Total { get; set; }
         public DateTime OrderDate { get; set; }
-        public CustomerForLinq Customer { get; set; }
+        public CustomerForLinq? Customer { get; set; }
     }
 
     public class Person
     {
         public int Id { get; set; }
         public int Age { get; set; }
-        public string FirstName { get; set; }
-        public string LastName { get; set; }
-        public string MiddleInitial { get; set; }
-        public Feet Feet { get; set; }
+        public string? FirstName { get; set; }
+        public string? LastName { get; set; }
+        public string? MiddleInitial { get; set; }
+        public Feet? Feet { get; set; }
         public ICollection<Shoes> Shoes { get; } = [];
     }
 
@@ -883,15 +881,15 @@ public abstract class Ef6GroupByTestBase<TFixture>(TFixture fixture) : QueryTest
     {
         public int Id { get; set; }
         public int Age { get; set; }
-        public string Style { get; set; }
-        public Person Person { get; set; }
+        public string? Style { get; set; }
+        public Person? Person { get; set; }
     }
 
     public class Feet
     {
         public int Id { get; set; }
         public int Size { get; set; }
-        public Person Person { get; set; }
+        public Person? Person { get; set; }
     }
 
     public class ArubaData : ISetSource
@@ -1210,7 +1208,7 @@ public abstract class Ef6GroupByTestBase<TFixture>(TFixture fixture) : QueryTest
 
             foreach (var order in orders)
             {
-                order.Customer.Orders.Add(order);
+                order.Customer!.Orders.Add(order);
             }
 
             return orders;
@@ -1530,7 +1528,7 @@ public abstract class Ef6GroupByTestBase<TFixture>(TFixture fixture) : QueryTest
 
             foreach (var person in people)
             {
-                person.Feet.Person = person;
+                person.Feet!.Person = person;
 
                 foreach (var shoes in person.Shoes)
                 {
@@ -1542,7 +1540,7 @@ public abstract class Ef6GroupByTestBase<TFixture>(TFixture fixture) : QueryTest
         }
 
         private static IReadOnlyList<Feet> CreateFeet(IReadOnlyList<Person> people)
-            => people.Select(e => e.Feet).ToList();
+            => people.Select(e => e.Feet!).ToList();
 
         private static IReadOnlyList<Shoes> CreateShoes(IReadOnlyList<Person> people)
             => people.SelectMany(e => e.Shoes).ToList();

--- a/test/EFCore.Specification.Tests/Query/FilteredQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/FilteredQueryTestBase.cs
@@ -5,19 +5,17 @@ using System.Runtime.CompilerServices;
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
-#nullable disable
-
 public abstract class FilteredQueryTestBase<TFixture>(TFixture fixture) : QueryTestBase<TFixture>(fixture)
     where TFixture : class, IQueryFixtureBase, new()
 {
     public Task AssertFilteredQuery<TResult>(
         bool async,
         Func<ISetSource, IQueryable<TResult>> query,
-        Func<TResult, object> elementSorter = null,
-        Action<TResult, TResult> elementAsserter = null,
+        Func<TResult, object>? elementSorter = null,
+        Action<TResult, TResult>? elementAsserter = null,
         bool assertOrder = false,
         bool assertEmpty = false,
-        [CallerMemberName] string testMethodName = null)
+        [CallerMemberName] string? testMethodName = null)
         where TResult : class
         => AssertFilteredQuery(async, query, query, elementSorter, elementAsserter, assertOrder, assertEmpty, testMethodName);
 
@@ -25,24 +23,24 @@ public abstract class FilteredQueryTestBase<TFixture>(TFixture fixture) : QueryT
         bool async,
         Func<ISetSource, IQueryable<TResult>> actualQuery,
         Func<ISetSource, IQueryable<TResult>> expectedQuery,
-        Func<TResult, object> elementSorter = null,
-        Action<TResult, TResult> elementAsserter = null,
+        Func<TResult, object>? elementSorter = null,
+        Action<TResult, TResult>? elementAsserter = null,
         bool assertOrder = false,
         bool assertEmpty = false,
-        [CallerMemberName] string testMethodName = null)
+        [CallerMemberName] string? testMethodName = null)
         where TResult : class
         => QueryAsserter.AssertQuery(
             actualQuery, expectedQuery, elementSorter, elementAsserter, assertOrder, assertEmpty, async, queryTrackingBehavior: null,
-            testMethodName,
+            testMethodName!,
             filteredQuery: true);
 
     public Task AssertFilteredQueryScalar<TResult>(
         bool async,
         Func<ISetSource, IQueryable<TResult>> query,
-        Action<TResult, TResult> asserter = null,
+        Action<TResult, TResult>? asserter = null,
         bool assertOrder = false,
         bool assertEmpty = false,
-        [CallerMemberName] string testMethodName = null)
+        [CallerMemberName] string? testMethodName = null)
         where TResult : struct
         => AssertFilteredQueryScalar(async, query, query, asserter, assertOrder, assertEmpty, testMethodName);
 
@@ -50,13 +48,13 @@ public abstract class FilteredQueryTestBase<TFixture>(TFixture fixture) : QueryT
         bool async,
         Func<ISetSource, IQueryable<TResult>> actualQuery,
         Func<ISetSource, IQueryable<TResult>> expectedQuery,
-        Action<TResult, TResult> asserter = null,
+        Action<TResult, TResult>? asserter = null,
         bool assertOrder = false,
         bool assertEmpty = false,
-        [CallerMemberName] string testMethodName = null)
+        [CallerMemberName] string? testMethodName = null)
         where TResult : struct
         => QueryAsserter.AssertQueryScalar(
-            actualQuery, expectedQuery, asserter, assertOrder, assertEmpty, async, testMethodName, filteredQuery: true);
+            actualQuery, expectedQuery, asserter, assertOrder, assertEmpty, async, testMethodName!, filteredQuery: true);
 
     protected Task AssertFilteredCount<TResult>(
         bool async,

--- a/test/EFCore.Specification.Tests/Query/FunkyDataQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/FunkyDataQueryTestBase.cs
@@ -9,8 +9,6 @@ using Microsoft.EntityFrameworkCore.TestModels.FunkyDataModel;
 // ReSharper disable InconsistentNaming
 namespace Microsoft.EntityFrameworkCore.Query;
 
-#nullable disable
-
 public abstract class FunkyDataQueryTestBase<TFixture>(TFixture fixture) : QueryTestBase<TFixture>(fixture)
     where TFixture : FunkyDataQueryTestBase<TFixture>.FunkyDataQueryFixtureBase, new()
 {
@@ -19,44 +17,44 @@ public abstract class FunkyDataQueryTestBase<TFixture>(TFixture fixture) : Query
     {
         await AssertQuery(
             async,
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.Contains("%B")).Select(c => c.FirstName),
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.Contains("%B")) == true).Select(c => c.FirstName));
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName!.Contains("%B")).Select(c => c.FirstName),
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName!.MaybeScalar(x => x.Contains("%B")) == true).Select(c => c.FirstName));
 
         await AssertQuery(
             async,
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.Contains("a_")).Select(c => c.FirstName),
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.Contains("a_")) == true).Select(c => c.FirstName));
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName!.Contains("a_")).Select(c => c.FirstName),
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName!.MaybeScalar(x => x.Contains("a_")) == true).Select(c => c.FirstName));
 
         await AssertQuery(
             async,
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.Contains(null)).Select(c => c.FirstName),
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName!.Contains(null!)).Select(c => c.FirstName),
             ss => ss.Set<FunkyCustomer>().Where(c => false).Select(c => c.FirstName),
             assertEmpty: true);
 
         await AssertQuery(
             async,
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.Contains("")).Select(c => c.FirstName),
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName!.Contains("")).Select(c => c.FirstName),
             ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName != null).Select(c => c.FirstName));
 
         await AssertQuery(
             async,
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.Contains("_Ba_")).Select(c => c.FirstName),
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.Contains("_Ba_")) == true).Select(c => c.FirstName));
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName!.Contains("_Ba_")).Select(c => c.FirstName),
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName!.MaybeScalar(x => x.Contains("_Ba_")) == true).Select(c => c.FirstName));
 
         await AssertQuery(
             async,
-            ss => ss.Set<FunkyCustomer>().Where(c => !c.FirstName.Contains("%B%a%r")).Select(c => c.FirstName),
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.Contains("%B%a%r")) != true)
+            ss => ss.Set<FunkyCustomer>().Where(c => !c.FirstName!.Contains("%B%a%r")).Select(c => c.FirstName),
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName!.MaybeScalar(x => x.Contains("%B%a%r")) != true)
                 .Select(c => c.FirstName));
 
         await AssertQuery(
             async,
-            ss => ss.Set<FunkyCustomer>().Where(c => !c.FirstName.Contains("")).Select(c => c.FirstName),
+            ss => ss.Set<FunkyCustomer>().Where(c => !c.FirstName!.Contains("")).Select(c => c.FirstName),
             ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName == null).Select(c => c.FirstName));
 
         await AssertQuery(
             async,
-            ss => ss.Set<FunkyCustomer>().Where(c => !c.FirstName.Contains(null)).Select(c => c.FirstName),
+            ss => ss.Set<FunkyCustomer>().Where(c => !c.FirstName!.Contains(null!)).Select(c => c.FirstName),
             ss => ss.Set<FunkyCustomer>().Where(c => true).Select(c => c.FirstName));
     }
 
@@ -66,51 +64,51 @@ public abstract class FunkyDataQueryTestBase<TFixture>(TFixture fixture) : Query
         var prm1 = "%B";
         await AssertQuery(
             async,
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.Contains(prm1)).Select(c => c.FirstName),
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.Contains(prm1)) == true).Select(c => c.FirstName));
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName!.Contains(prm1)).Select(c => c.FirstName),
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName!.MaybeScalar(x => x.Contains(prm1)) == true).Select(c => c.FirstName));
 
         var prm2 = "a_";
         await AssertQuery(
             async,
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.Contains(prm2)).Select(c => c.FirstName),
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.Contains(prm2)) == true).Select(c => c.FirstName));
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName!.Contains(prm2)).Select(c => c.FirstName),
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName!.MaybeScalar(x => x.Contains(prm2)) == true).Select(c => c.FirstName));
 
-        var prm3 = (string)null;
+        string? prm3 = null;
         await AssertQuery(
             async,
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.Contains(prm3)).Select(c => c.FirstName),
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName!.Contains(prm3!)).Select(c => c.FirstName),
             ss => ss.Set<FunkyCustomer>().Where(c => false).Select(c => c.FirstName),
             assertEmpty: true);
 
         var prm4 = "";
         await AssertQuery(
             async,
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.Contains(prm4)).Select(c => c.FirstName),
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName!.Contains(prm4)).Select(c => c.FirstName),
             ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName != null).Select(c => c.FirstName));
 
         var prm5 = "_Ba_";
         await AssertQuery(
             async,
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.Contains(prm5)).Select(c => c.FirstName),
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.Contains(prm5)) == true).Select(c => c.FirstName));
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName!.Contains(prm5)).Select(c => c.FirstName),
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName!.MaybeScalar(x => x.Contains(prm5)) == true).Select(c => c.FirstName));
 
         var prm6 = "%B%a%r";
         await AssertQuery(
             async,
-            ss => ss.Set<FunkyCustomer>().Where(c => !c.FirstName.Contains(prm6)).Select(c => c.FirstName),
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.Contains(prm6)) != true)
+            ss => ss.Set<FunkyCustomer>().Where(c => !c.FirstName!.Contains(prm6)).Select(c => c.FirstName),
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName!.MaybeScalar(x => x.Contains(prm6)) != true)
                 .Select(c => c.FirstName));
 
         var prm7 = "";
         await AssertQuery(
             async,
-            ss => ss.Set<FunkyCustomer>().Where(c => !c.FirstName.Contains(prm7)).Select(c => c.FirstName),
+            ss => ss.Set<FunkyCustomer>().Where(c => !c.FirstName!.Contains(prm7)).Select(c => c.FirstName),
             ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName == null).Select(c => c.FirstName));
 
-        var prm8 = (string)null;
+        string? prm8 = null;
         await AssertQuery(
             async,
-            ss => ss.Set<FunkyCustomer>().Where(c => !c.FirstName.Contains(prm8)).Select(c => c.FirstName),
+            ss => ss.Set<FunkyCustomer>().Where(c => !c.FirstName!.Contains(prm8!)).Select(c => c.FirstName),
             ss => ss.Set<FunkyCustomer>().Where(c => true).Select(c => c.FirstName));
     }
 
@@ -120,10 +118,10 @@ public abstract class FunkyDataQueryTestBase<TFixture>(TFixture fixture) : Query
             async,
             ss => ss.Set<FunkyCustomer>().Select(c => c.FirstName)
                 .SelectMany(c => ss.Set<FunkyCustomer>().Select(c2 => c2.LastName), (fn, ln) => new { fn, ln })
-                .Where(r => r.fn.Contains(r.ln)),
+                .Where(r => r.fn!.Contains(r.ln!)),
             ss => ss.Set<FunkyCustomer>().Select(c => c.FirstName)
                 .SelectMany(c => ss.Set<FunkyCustomer>().Select(c2 => c2.LastName), (fn, ln) => new { fn, ln })
-                .Where(r => r.fn.MaybeScalar(x => r.ln.MaybeScalar(xx => x.Contains(xx))) == true),
+                .Where(r => r.fn!.MaybeScalar(x => r.ln!.MaybeScalar(xx => x.Contains(xx!))) == true),
             elementSorter: e => (e.fn, e.ln),
             elementAsserter: (e, a) =>
             {
@@ -137,10 +135,10 @@ public abstract class FunkyDataQueryTestBase<TFixture>(TFixture fixture) : Query
             async,
             ss => ss.Set<FunkyCustomer>().Select(c => c.FirstName)
                 .SelectMany(c => ss.Set<FunkyCustomer>().Select(c2 => c2.LastName), (fn, ln) => new { fn, ln })
-                .Where(r => !r.fn.Contains(r.ln)),
+                .Where(r => !r.fn!.Contains(r.ln!)),
             ss => ss.Set<FunkyCustomer>().Select(c => c.FirstName)
                 .SelectMany(c => ss.Set<FunkyCustomer>().Select(c2 => c2.LastName), (fn, ln) => new { fn, ln })
-                .Where(r => r.fn.MaybeScalar(x => r.ln.MaybeScalar(xx => x.Contains(xx))) != true));
+                .Where(r => r.fn!.MaybeScalar(x => r.ln!.MaybeScalar(xx => x.Contains(xx!))) != true));
     // .Where(r => r.ln != "" && !r.fn.MaybeScalar(x => r.ln.MaybeScalar(xx => x.Contains(xx))) == true));
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -148,45 +146,45 @@ public abstract class FunkyDataQueryTestBase<TFixture>(TFixture fixture) : Query
     {
         await AssertQuery(
             async,
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.StartsWith("%B")).Select(c => c.FirstName),
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.StartsWith("%B")) == true).Select(c => c.FirstName));
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName!.StartsWith("%B")).Select(c => c.FirstName),
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName!.MaybeScalar(x => x.StartsWith("%B")) == true).Select(c => c.FirstName));
 
         await AssertQuery(
             async,
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.StartsWith("_B")).Select(c => c.FirstName),
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.StartsWith("_B")) == true).Select(c => c.FirstName));
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName!.StartsWith("_B")).Select(c => c.FirstName),
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName!.MaybeScalar(x => x.StartsWith("_B")) == true).Select(c => c.FirstName));
 
         await AssertQuery(
             async,
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.StartsWith(null)).Select(c => c.FirstName),
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName!.StartsWith(null!)).Select(c => c.FirstName),
             ss => ss.Set<FunkyCustomer>().Where(c => false).Select(c => c.FirstName),
             assertEmpty: true);
 
         await AssertQuery(
             async,
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.StartsWith("")).Select(c => c.FirstName),
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName!.StartsWith("")).Select(c => c.FirstName),
             ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName != null).Select(c => c.FirstName));
 
         await AssertQuery(
             async,
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.StartsWith("_Ba_")).Select(c => c.FirstName),
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.StartsWith("_Ba_")) == true).Select(c => c.FirstName));
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName!.StartsWith("_Ba_")).Select(c => c.FirstName),
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName!.MaybeScalar(x => x.StartsWith("_Ba_")) == true).Select(c => c.FirstName));
 
         await AssertQuery(
             async,
-            ss => ss.Set<FunkyCustomer>().Where(c => !c.FirstName.StartsWith("%B%a%r")).Select(c => c.FirstName),
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.StartsWith("%B%a%r")) != true)
+            ss => ss.Set<FunkyCustomer>().Where(c => !c.FirstName!.StartsWith("%B%a%r")).Select(c => c.FirstName),
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName!.MaybeScalar(x => x.StartsWith("%B%a%r")) != true)
                 .Select(c => c.FirstName));
 
         await AssertQuery(
             async,
-            ss => ss.Set<FunkyCustomer>().Where(c => !c.FirstName.StartsWith("")).Select(c => c.FirstName),
+            ss => ss.Set<FunkyCustomer>().Where(c => !c.FirstName!.StartsWith("")).Select(c => c.FirstName),
             ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName == null)
                 .Select(c => c.FirstName));
 
         await AssertQuery(
             async,
-            ss => ss.Set<FunkyCustomer>().Where(c => !c.FirstName.StartsWith(null)).Select(c => c.FirstName),
+            ss => ss.Set<FunkyCustomer>().Where(c => !c.FirstName!.StartsWith(null!)).Select(c => c.FirstName),
             ss => ss.Set<FunkyCustomer>().Where(c => true).Select(c => c.FirstName));
     }
 
@@ -196,51 +194,51 @@ public abstract class FunkyDataQueryTestBase<TFixture>(TFixture fixture) : Query
         var prm1 = "%B";
         await AssertQuery(
             async,
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.StartsWith(prm1)).Select(c => c.FirstName),
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.StartsWith(prm1)) == true).Select(c => c.FirstName));
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName!.StartsWith(prm1)).Select(c => c.FirstName),
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName!.MaybeScalar(x => x.StartsWith(prm1)) == true).Select(c => c.FirstName));
 
         var prm2 = "_B";
         await AssertQuery(
             async,
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.StartsWith(prm2)).Select(c => c.FirstName),
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.StartsWith(prm2)) == true).Select(c => c.FirstName));
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName!.StartsWith(prm2)).Select(c => c.FirstName),
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName!.MaybeScalar(x => x.StartsWith(prm2)) == true).Select(c => c.FirstName));
 
-        var prm3 = (string)null;
+        string? prm3 = null;
         await AssertQuery(
             async,
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.StartsWith(prm3)).Select(c => c.FirstName),
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName!.StartsWith(prm3!)).Select(c => c.FirstName),
             ss => ss.Set<FunkyCustomer>().Where(c => false).Select(c => c.FirstName),
             assertEmpty: true);
 
         var prm4 = "";
         await AssertQuery(
             async,
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.StartsWith(prm4)).Select(c => c.FirstName),
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName!.StartsWith(prm4)).Select(c => c.FirstName),
             ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName != null).Select(c => c.FirstName));
 
         var prm5 = "_Ba_";
         await AssertQuery(
             async,
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.StartsWith(prm5)).Select(c => c.FirstName),
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.StartsWith(prm5)) == true).Select(c => c.FirstName));
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName!.StartsWith(prm5)).Select(c => c.FirstName),
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName!.MaybeScalar(x => x.StartsWith(prm5)) == true).Select(c => c.FirstName));
 
         var prm6 = "%B%a%r";
         await AssertQuery(
             async,
-            ss => ss.Set<FunkyCustomer>().Where(c => !c.FirstName.StartsWith(prm6)).Select(c => c.FirstName),
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.StartsWith(prm6)) != true)
+            ss => ss.Set<FunkyCustomer>().Where(c => !c.FirstName!.StartsWith(prm6)).Select(c => c.FirstName),
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName!.MaybeScalar(x => x.StartsWith(prm6)) != true)
                 .Select(c => c.FirstName));
 
         var prm7 = "";
         await AssertQuery(
             async,
-            ss => ss.Set<FunkyCustomer>().Where(c => !c.FirstName.StartsWith(prm7)).Select(c => c.FirstName),
+            ss => ss.Set<FunkyCustomer>().Where(c => !c.FirstName!.StartsWith(prm7)).Select(c => c.FirstName),
             ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName == null).Select(c => c.FirstName));
 
-        var prm8 = (string)null;
+        string? prm8 = null;
         await AssertQuery(
             async,
-            ss => ss.Set<FunkyCustomer>().Where(c => !c.FirstName.StartsWith(prm8)).Select(c => c.FirstName),
+            ss => ss.Set<FunkyCustomer>().Where(c => !c.FirstName!.StartsWith(prm8!)).Select(c => c.FirstName),
             ss => ss.Set<FunkyCustomer>().Where(c => true).Select(c => c.FirstName));
     }
 
@@ -249,41 +247,41 @@ public abstract class FunkyDataQueryTestBase<TFixture>(TFixture fixture) : Query
     {
         await AssertQuery(
             async,
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.StartsWith("[")),
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.StartsWith("[")) == true));
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName!.StartsWith("[")),
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName!.MaybeScalar(x => x.StartsWith("[")) == true));
 
         await AssertQuery(
             async,
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.StartsWith("B[")),
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.StartsWith("B[")) == true));
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName!.StartsWith("B[")),
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName!.MaybeScalar(x => x.StartsWith("B[")) == true));
 
         await AssertQuery(
             async,
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.StartsWith("B[[a^")),
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.StartsWith("B[[a^")) == true));
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName!.StartsWith("B[[a^")),
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName!.MaybeScalar(x => x.StartsWith("B[[a^")) == true));
 
         var prm1 = "[";
         await AssertQuery(
             async,
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.StartsWith(prm1)),
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.StartsWith(prm1)) == true));
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName!.StartsWith(prm1)),
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName!.MaybeScalar(x => x.StartsWith(prm1)) == true));
 
         var prm2 = "B[";
         await AssertQuery(
             async,
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.StartsWith(prm2)),
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.StartsWith(prm2)) == true));
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName!.StartsWith(prm2)),
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName!.MaybeScalar(x => x.StartsWith(prm2)) == true));
 
         var prm3 = "B[[a^";
         await AssertQuery(
             async,
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.StartsWith(prm3)),
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.StartsWith(prm3)) == true));
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName!.StartsWith(prm3)),
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName!.MaybeScalar(x => x.StartsWith(prm3)) == true));
 
         await AssertQuery(
             async,
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.StartsWith(c.LastName)),
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => c.LastName.MaybeScalar(xx => x.StartsWith(xx))) == true));
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName!.StartsWith(c.LastName!)),
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName!.MaybeScalar(x => c.LastName!.MaybeScalar(xx => x.StartsWith(xx!))) == true));
     }
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -292,10 +290,10 @@ public abstract class FunkyDataQueryTestBase<TFixture>(TFixture fixture) : Query
             async,
             ss => ss.Set<FunkyCustomer>().Select(c => c.FirstName)
                 .SelectMany(c => ss.Set<FunkyCustomer>().Select(c2 => c2.LastName), (fn, ln) => new { fn, ln })
-                .Where(r => r.fn.StartsWith(r.ln)),
+                .Where(r => r.fn!.StartsWith(r.ln!)),
             ss => ss.Set<FunkyCustomer>().Select(c => c.FirstName)
                 .SelectMany(c => ss.Set<FunkyCustomer>().Select(c2 => c2.LastName), (fn, ln) => new { fn, ln })
-                .Where(r => r.fn.MaybeScalar(x => r.ln.MaybeScalar(xx => x.StartsWith(xx))) == true),
+                .Where(r => r.fn!.MaybeScalar(x => r.ln!.MaybeScalar(xx => x.StartsWith(xx!))) == true),
             elementSorter: e => (e.fn, e.ln),
             elementAsserter: (e, a) =>
             {
@@ -309,53 +307,53 @@ public abstract class FunkyDataQueryTestBase<TFixture>(TFixture fixture) : Query
             async,
             ss => ss.Set<FunkyCustomer>().Select(c => c.FirstName)
                 .SelectMany(c => ss.Set<FunkyCustomer>().Select(c2 => c2.LastName), (fn, ln) => new { fn, ln })
-                .Where(r => !r.fn.StartsWith(r.ln)),
+                .Where(r => !r.fn!.StartsWith(r.ln!)),
             ss => ss.Set<FunkyCustomer>().Select(c => c.FirstName)
                 .SelectMany(c => ss.Set<FunkyCustomer>().Select(c2 => c2.LastName), (fn, ln) => new { fn, ln })
-                .Where(r => !(r.fn.MaybeScalar(x => r.ln.MaybeScalar(xx => x.StartsWith(xx))) == true)));
+                .Where(r => !(r.fn!.MaybeScalar(x => r.ln!.MaybeScalar(xx => x.StartsWith(xx!))) == true)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual async Task String_ends_with_on_argument_with_wildcard_constant(bool async)
     {
         await AssertQuery(
             async,
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.EndsWith("%r")).Select(c => c.FirstName),
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.EndsWith("%r")) == true).Select(c => c.FirstName));
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName!.EndsWith("%r")).Select(c => c.FirstName),
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName!.MaybeScalar(x => x.EndsWith("%r")) == true).Select(c => c.FirstName));
 
         await AssertQuery(
             async,
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.EndsWith("r_")).Select(c => c.FirstName),
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.EndsWith("r_")) == true).Select(c => c.FirstName));
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName!.EndsWith("r_")).Select(c => c.FirstName),
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName!.MaybeScalar(x => x.EndsWith("r_")) == true).Select(c => c.FirstName));
 
         await AssertQuery(
             async,
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.EndsWith(null)).Select(c => c.FirstName),
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName!.EndsWith(null!)).Select(c => c.FirstName),
             ss => ss.Set<FunkyCustomer>().Where(c => false).Select(c => c.FirstName),
             assertEmpty: true);
 
         await AssertQuery(
             async,
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.EndsWith("")).Select(c => c.FirstName),
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName!.EndsWith("")).Select(c => c.FirstName),
             ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName != null).Select(c => c.FirstName));
 
         await AssertQuery(
             async,
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.EndsWith("_r_")).Select(c => c.FirstName),
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.EndsWith("_r_")) == true).Select(c => c.FirstName));
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName!.EndsWith("_r_")).Select(c => c.FirstName),
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName!.MaybeScalar(x => x.EndsWith("_r_")) == true).Select(c => c.FirstName));
 
         await AssertQuery(
             async,
-            ss => ss.Set<FunkyCustomer>().Where(c => !c.FirstName.EndsWith("a%r%")).Select(c => c.FirstName),
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.EndsWith("a%r%")) != true).Select(c => c.FirstName));
+            ss => ss.Set<FunkyCustomer>().Where(c => !c.FirstName!.EndsWith("a%r%")).Select(c => c.FirstName),
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName!.MaybeScalar(x => x.EndsWith("a%r%")) != true).Select(c => c.FirstName));
 
         await AssertQuery(
             async,
-            ss => ss.Set<FunkyCustomer>().Where(c => !c.FirstName.EndsWith("")).Select(c => c.FirstName),
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.EndsWith("")) != true).Select(c => c.FirstName));
+            ss => ss.Set<FunkyCustomer>().Where(c => !c.FirstName!.EndsWith("")).Select(c => c.FirstName),
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName!.MaybeScalar(x => x.EndsWith("")) != true).Select(c => c.FirstName));
 
         await AssertQuery(
             async,
-            ss => ss.Set<FunkyCustomer>().Where(c => !c.FirstName.EndsWith(null)).Select(c => c.FirstName),
+            ss => ss.Set<FunkyCustomer>().Where(c => !c.FirstName!.EndsWith(null!)).Select(c => c.FirstName),
             ss => ss.Set<FunkyCustomer>().Where(c => true).Select(c => c.FirstName));
     }
 
@@ -365,50 +363,50 @@ public abstract class FunkyDataQueryTestBase<TFixture>(TFixture fixture) : Query
         var prm1 = "%r";
         await AssertQuery(
             async,
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.EndsWith(prm1)).Select(c => c.FirstName),
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.EndsWith(prm1)) == true).Select(c => c.FirstName));
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName!.EndsWith(prm1)).Select(c => c.FirstName),
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName!.MaybeScalar(x => x.EndsWith(prm1)) == true).Select(c => c.FirstName));
 
         var prm2 = "r_";
         await AssertQuery(
             async,
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.EndsWith(prm2)).Select(c => c.FirstName),
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.EndsWith(prm2)) == true).Select(c => c.FirstName));
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName!.EndsWith(prm2)).Select(c => c.FirstName),
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName!.MaybeScalar(x => x.EndsWith(prm2)) == true).Select(c => c.FirstName));
 
-        var prm3 = (string)null;
+        string? prm3 = null;
         await AssertQuery(
             async,
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.EndsWith(prm3)).Select(c => c.FirstName),
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName!.EndsWith(prm3!)).Select(c => c.FirstName),
             ss => ss.Set<FunkyCustomer>().Where(c => false).Select(c => c.FirstName),
             assertEmpty: true);
 
         var prm4 = "";
         await AssertQuery(
             async,
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.EndsWith(prm4)).Select(c => c.FirstName),
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.EndsWith(prm4)) == true).Select(c => c.FirstName));
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName!.EndsWith(prm4)).Select(c => c.FirstName),
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName!.MaybeScalar(x => x.EndsWith(prm4)) == true).Select(c => c.FirstName));
 
         var prm5 = "_r_";
         await AssertQuery(
             async,
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.EndsWith(prm5)).Select(c => c.FirstName),
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.EndsWith(prm5)) == true).Select(c => c.FirstName));
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName!.EndsWith(prm5)).Select(c => c.FirstName),
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName!.MaybeScalar(x => x.EndsWith(prm5)) == true).Select(c => c.FirstName));
 
         var prm6 = "a%r%";
         await AssertQuery(
             async,
-            ss => ss.Set<FunkyCustomer>().Where(c => !c.FirstName.EndsWith(prm6)).Select(c => c.FirstName),
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.MaybeScalar(x => x.EndsWith(prm6)) != true).Select(c => c.FirstName));
+            ss => ss.Set<FunkyCustomer>().Where(c => !c.FirstName!.EndsWith(prm6)).Select(c => c.FirstName),
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName!.MaybeScalar(x => x.EndsWith(prm6)) != true).Select(c => c.FirstName));
 
         var prm7 = "";
         await AssertQuery(
             async,
-            ss => ss.Set<FunkyCustomer>().Where(c => !c.FirstName.EndsWith(prm7)).Select(c => c.FirstName),
+            ss => ss.Set<FunkyCustomer>().Where(c => !c.FirstName!.EndsWith(prm7)).Select(c => c.FirstName),
             ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName == null).Select(c => c.FirstName));
 
-        var prm8 = (string)null;
+        string? prm8 = null;
         await AssertQuery(
             async,
-            ss => ss.Set<FunkyCustomer>().Where(c => !c.FirstName.EndsWith(prm8)).Select(c => c.FirstName),
+            ss => ss.Set<FunkyCustomer>().Where(c => !c.FirstName!.EndsWith(prm8!)).Select(c => c.FirstName),
             ss => ss.Set<FunkyCustomer>().Where(c => true).Select(c => c.FirstName));
     }
 
@@ -418,10 +416,10 @@ public abstract class FunkyDataQueryTestBase<TFixture>(TFixture fixture) : Query
             async,
             ss => ss.Set<FunkyCustomer>().Select(c => c.FirstName)
                 .SelectMany(c => ss.Set<FunkyCustomer>().Select(c2 => c2.LastName), (fn, ln) => new { fn, ln })
-                .Where(r => r.fn.EndsWith(r.ln)),
+                .Where(r => r.fn!.EndsWith(r.ln!)),
             ss => ss.Set<FunkyCustomer>().Select(c => c.FirstName)
                 .SelectMany(c => ss.Set<FunkyCustomer>().Select(c2 => c2.LastName), (fn, ln) => new { fn, ln })
-                .Where(r => r.fn.MaybeScalar(x => r.ln.MaybeScalar(xx => x.EndsWith(xx))) == true),
+                .Where(r => r.fn!.MaybeScalar(x => r.ln!.MaybeScalar(xx => x.EndsWith(xx!))) == true),
             elementSorter: e => (e.fn, e.ln),
             elementAsserter: (e, a) =>
             {
@@ -435,10 +433,10 @@ public abstract class FunkyDataQueryTestBase<TFixture>(TFixture fixture) : Query
             async,
             ss => ss.Set<FunkyCustomer>().Select(c => c.FirstName)
                 .SelectMany(c => ss.Set<FunkyCustomer>().Select(c2 => c2.LastName), (fn, ln) => new { fn, ln })
-                .Where(r => !r.fn.EndsWith(r.ln)),
+                .Where(r => !r.fn!.EndsWith(r.ln!)),
             ss => ss.Set<FunkyCustomer>().Select(c => c.FirstName)
                 .SelectMany(c => ss.Set<FunkyCustomer>().Select(c2 => c2.LastName), (fn, ln) => new { fn, ln })
-                .Where(r => !(r.fn.MaybeScalar(x => r.ln.MaybeScalar(xx => x.EndsWith(xx))) == true)));
+                .Where(r => !(r.fn!.MaybeScalar(x => r.ln!.MaybeScalar(xx => x.EndsWith(xx!))) == true)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task String_ends_with_inside_conditional(bool async)
@@ -446,10 +444,10 @@ public abstract class FunkyDataQueryTestBase<TFixture>(TFixture fixture) : Query
             async,
             ss => ss.Set<FunkyCustomer>().Select(c => c.FirstName)
                 .SelectMany(c => ss.Set<FunkyCustomer>().Select(c2 => c2.LastName), (fn, ln) => new { fn, ln })
-                .Where(r => r.fn.EndsWith(r.ln) ? true : false),
+                .Where(r => r.fn!.EndsWith(r.ln!) ? true : false),
             ss => ss.Set<FunkyCustomer>().Select(c => c.FirstName)
                 .SelectMany(c => ss.Set<FunkyCustomer>().Select(c2 => c2.LastName), (fn, ln) => new { fn, ln })
-                .Where(r => r.fn.MaybeScalar(x => r.ln.MaybeScalar(xx => x.EndsWith(xx))) == true),
+                .Where(r => r.fn!.MaybeScalar(x => r.ln!.MaybeScalar(xx => x.EndsWith(xx!))) == true),
             elementSorter: e => (e.fn, e.ln),
             elementAsserter: (e, a) =>
             {
@@ -463,10 +461,10 @@ public abstract class FunkyDataQueryTestBase<TFixture>(TFixture fixture) : Query
             async,
             ss => ss.Set<FunkyCustomer>().Select(c => c.FirstName)
                 .SelectMany(c => ss.Set<FunkyCustomer>().Select(c2 => c2.LastName), (fn, ln) => new { fn, ln })
-                .Where(r => !r.fn.EndsWith(r.ln) ? true : false),
+                .Where(r => !r.fn!.EndsWith(r.ln!) ? true : false),
             ss => ss.Set<FunkyCustomer>().Select(c => c.FirstName)
                 .SelectMany(c => ss.Set<FunkyCustomer>().Select(c2 => c2.LastName), (fn, ln) => new { fn, ln })
-                .Where(r => !(r.fn.MaybeScalar(x => r.ln.MaybeScalar(xx => x.EndsWith(xx))) == true)
+                .Where(r => !(r.fn!.MaybeScalar(x => r.ln!.MaybeScalar(xx => x.EndsWith(xx!))) == true)
                     ? true
                     : false));
 
@@ -475,7 +473,7 @@ public abstract class FunkyDataQueryTestBase<TFixture>(TFixture fixture) : Query
         => AssertQuery(
             async,
             ss => ss.Set<FunkyCustomer>().SelectMany(c => ss.Set<FunkyCustomer>(), (c1, c2) => new { c1, c2 })
-                .Where(r => r.c1.FirstName.EndsWith(r.c2.LastName) == r.c1.NullableBool.Value),
+                .Where(r => r.c1.FirstName!.EndsWith(r.c2.LastName!) == r.c1.NullableBool!.Value),
             ss => ss.Set<FunkyCustomer>().SelectMany(c => ss.Set<FunkyCustomer>(), (c1, c2) => new { c1, c2 })
                 .Where(r => (r.c1.FirstName != null && r.c2.LastName != null && r.c1.FirstName.EndsWith(r.c2.LastName))
                     == r.c1.NullableBool),
@@ -491,7 +489,7 @@ public abstract class FunkyDataQueryTestBase<TFixture>(TFixture fixture) : Query
         => AssertQuery(
             async,
             ss => ss.Set<FunkyCustomer>().SelectMany(c => ss.Set<FunkyCustomer>(), (c1, c2) => new { c1, c2 })
-                .Where(r => r.c1.FirstName.EndsWith(r.c2.LastName) != r.c1.NullableBool.Value),
+                .Where(r => r.c1.FirstName!.EndsWith(r.c2.LastName!) != r.c1.NullableBool!.Value),
             ss => ss.Set<FunkyCustomer>().SelectMany(c => ss.Set<FunkyCustomer>(), (c1, c2) => new { c1, c2 })
                 .Where(r => (r.c1.FirstName != null && r.c2.LastName != null && r.c1.FirstName.EndsWith(r.c2.LastName))
                     != r.c1.NullableBool),
@@ -507,11 +505,11 @@ public abstract class FunkyDataQueryTestBase<TFixture>(TFixture fixture) : Query
         => AssertQuery(
             async,
             ss => ss.Set<FunkyCustomer>().OrderBy(e => e.Id).Select(e
-                => new { first = (char?)e.FirstName.FirstOrDefault(), last = (char?)e.FirstName.LastOrDefault() }),
+                => new { first = (char?)e.FirstName!.FirstOrDefault(), last = (char?)e.FirstName!.LastOrDefault() }),
             ss => ss.Set<FunkyCustomer>().OrderBy(e => e.Id).Select(e => new
             {
-                first = e.FirstName.MaybeScalar(x => x.FirstOrDefault()),
-                last = e.FirstName.MaybeScalar(x => x.LastOrDefault())
+                first = e.FirstName!.MaybeScalar(x => x.FirstOrDefault()),
+                last = e.FirstName!.MaybeScalar(x => x.LastOrDefault())
             }),
             assertOrder: true,
             elementAsserter: (e, a) =>
@@ -527,9 +525,9 @@ public abstract class FunkyDataQueryTestBase<TFixture>(TFixture fixture) : Query
 
         return AssertQuery(
             async,
-            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName.Contains(s) || c.LastName.StartsWith(s)),
+            ss => ss.Set<FunkyCustomer>().Where(c => c.FirstName!.Contains(s) || c.LastName!.StartsWith(s)),
             ss => ss.Set<FunkyCustomer>().Where(c
-                => c.FirstName.MaybeScalar(f => f.Contains(s)) == true || c.LastName.MaybeScalar(l => l.StartsWith(s)) == true));
+                => c.FirstName!.MaybeScalar(f => f.Contains(s)) == true || c.LastName!.MaybeScalar(l => l.StartsWith(s)) == true));
     }
 
     protected FunkyDataContext CreateContext()
@@ -545,7 +543,7 @@ public abstract class FunkyDataQueryTestBase<TFixture>(TFixture fixture) : Query
             => FunkyDataData.Instance;
 
         public override IReadOnlyDictionary<Type, object> EntitySorters { get; } =
-            new Dictionary<Type, Func<object, object>> { { typeof(FunkyCustomer), e => ((FunkyCustomer)e)?.Id } }
+            new Dictionary<Type, Func<object, object>> { { typeof(FunkyCustomer), e => ((FunkyCustomer)e).Id } }
                 .ToDictionary(e => e.Key, e => (object)e.Value);
 
         public override IReadOnlyDictionary<Type, object> EntityAsserters { get; } = new Dictionary<Type, Action<object, object>>
@@ -556,7 +554,7 @@ public abstract class FunkyDataQueryTestBase<TFixture>(TFixture fixture) : Query
                     Assert.Equal(e == null, a == null);
                     if (a != null)
                     {
-                        var ee = (FunkyCustomer)e;
+                        var ee = (FunkyCustomer)e!;
                         var aa = (FunkyCustomer)a;
 
                         Assert.Equal(ee.Id, aa.Id);

--- a/test/EFCore.Specification.Tests/Query/GearsOfWarQueryFixtureBase.cs
+++ b/test/EFCore.Specification.Tests/Query/GearsOfWarQueryFixtureBase.cs
@@ -5,8 +5,6 @@ using Microsoft.EntityFrameworkCore.TestModels.GearsOfWarModel;
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
-#nullable disable
-
 public abstract class GearsOfWarQueryFixtureBase : QueryFixtureBase<GearsOfWarContext>
 {
     protected override string StoreName
@@ -15,7 +13,7 @@ public abstract class GearsOfWarQueryFixtureBase : QueryFixtureBase<GearsOfWarCo
     public override ISetSource GetExpectedData()
         => GearsOfWarData.Instance;
 
-    public virtual Dictionary<(Type, string), Func<object, object>> GetShadowPropertyMappings()
+    public virtual Dictionary<(Type, string), Func<object, object?>> GetShadowPropertyMappings()
         => new()
         {
             {
@@ -25,21 +23,21 @@ public abstract class GearsOfWarQueryFixtureBase : QueryFixtureBase<GearsOfWarCo
             },
         };
 
-    public override IReadOnlyDictionary<Type, object> EntitySorters { get; } = new Dictionary<Type, Func<object, object>>
+    public override IReadOnlyDictionary<Type, object> EntitySorters { get; } = new Dictionary<Type, Func<object?, object?>>
     {
-        { typeof(City), e => ((City)e)?.Name },
-        { typeof(CogTag), e => ((CogTag)e)?.Id },
-        { typeof(Faction), e => ((Faction)e)?.Id },
-        { typeof(LocustHorde), e => ((LocustHorde)e)?.Id },
-        { typeof(Gear), e => (((Gear)e)?.SquadId, ((Gear)e)?.Nickname) },
-        { typeof(Officer), e => (((Officer)e)?.SquadId, ((Officer)e)?.Nickname) },
-        { typeof(LocustLeader), e => ((LocustLeader)e)?.Name },
-        { typeof(LocustCommander), e => ((LocustCommander)e)?.Name },
-        { typeof(Mission), e => ((Mission)e)?.Id },
-        { typeof(Squad), e => ((Squad)e)?.Id },
-        { typeof(SquadMission), e => (((SquadMission)e)?.SquadId, ((SquadMission)e)?.MissionId) },
-        { typeof(Weapon), e => ((Weapon)e)?.Id },
-        { typeof(LocustHighCommand), e => ((LocustHighCommand)e)?.Id }
+        { typeof(City), e => ((City?)e)?.Name },
+        { typeof(CogTag), e => ((CogTag?)e)?.Id },
+        { typeof(Faction), e => ((Faction?)e)?.Id },
+        { typeof(LocustHorde), e => ((LocustHorde?)e)?.Id },
+        { typeof(Gear), e => e is Gear gear ? (gear.SquadId, gear.Nickname) : null },
+        { typeof(Officer), e => e is Officer officer ? (officer.SquadId, officer.Nickname) : null },
+        { typeof(LocustLeader), e => ((LocustLeader?)e)?.Name },
+        { typeof(LocustCommander), e => ((LocustCommander?)e)?.Name },
+        { typeof(Mission), e => ((Mission?)e)?.Id },
+        { typeof(Squad), e => ((Squad?)e)?.Id },
+        { typeof(SquadMission), e => e is SquadMission squadMission ? (squadMission.SquadId, squadMission.MissionId) : null },
+        { typeof(Weapon), e => ((Weapon?)e)?.Id },
+        { typeof(LocustHighCommand), e => ((LocustHighCommand?)e)?.Id }
     }.ToDictionary(e => e.Key, e => (object)e.Value);
 
     public override IReadOnlyDictionary<Type, object> EntityAsserters { get; } = new Dictionary<Type, Action<object, object>>
@@ -51,7 +49,7 @@ public abstract class GearsOfWarQueryFixtureBase : QueryFixtureBase<GearsOfWarCo
 
                 if (a != null)
                 {
-                    var ee = (City)e;
+                    var ee = (City)e!;
                     var aa = (City)a;
 
                     Assert.Equal(ee.Name, aa.Name);
@@ -67,7 +65,7 @@ public abstract class GearsOfWarQueryFixtureBase : QueryFixtureBase<GearsOfWarCo
 
                 if (a != null)
                 {
-                    var ee = (CogTag)e;
+                    var ee = (CogTag)e!;
                     var aa = (CogTag)a;
 
                     Assert.Equal(ee.Id, aa.Id);
@@ -84,7 +82,7 @@ public abstract class GearsOfWarQueryFixtureBase : QueryFixtureBase<GearsOfWarCo
 
                 if (a != null)
                 {
-                    var ee = (Faction)e;
+                    var ee = (Faction)e!;
                     var aa = (Faction)a;
 
                     Assert.Equal(ee.Id, aa.Id);
@@ -106,7 +104,7 @@ public abstract class GearsOfWarQueryFixtureBase : QueryFixtureBase<GearsOfWarCo
 
                 if (a != null)
                 {
-                    var ee = (LocustHorde)e;
+                    var ee = (LocustHorde)e!;
                     var aa = (LocustHorde)a;
 
                     Assert.Equal(ee.Id, aa.Id);
@@ -124,7 +122,7 @@ public abstract class GearsOfWarQueryFixtureBase : QueryFixtureBase<GearsOfWarCo
 
                 if (a != null)
                 {
-                    var ee = (Gear)e;
+                    var ee = (Gear)e!;
                     var aa = (Gear)a;
 
                     Assert.Equal(ee.Nickname, aa.Nickname);
@@ -145,7 +143,7 @@ public abstract class GearsOfWarQueryFixtureBase : QueryFixtureBase<GearsOfWarCo
 
                 if (a != null)
                 {
-                    var ee = (Officer)e;
+                    var ee = (Officer)e!;
                     var aa = (Officer)a;
 
                     Assert.Equal(ee.Nickname, aa.Nickname);
@@ -166,7 +164,7 @@ public abstract class GearsOfWarQueryFixtureBase : QueryFixtureBase<GearsOfWarCo
 
                 if (a != null)
                 {
-                    var ee = (LocustLeader)e;
+                    var ee = (LocustLeader)e!;
                     var aa = (LocustLeader)a;
 
                     Assert.Equal(ee.Name, aa.Name);
@@ -190,7 +188,7 @@ public abstract class GearsOfWarQueryFixtureBase : QueryFixtureBase<GearsOfWarCo
 
                 if (a != null)
                 {
-                    var ee = (LocustCommander)e;
+                    var ee = (LocustCommander)e!;
                     var aa = (LocustCommander)a;
 
                     Assert.Equal(ee.Name, aa.Name);
@@ -209,7 +207,7 @@ public abstract class GearsOfWarQueryFixtureBase : QueryFixtureBase<GearsOfWarCo
 
                 if (a != null)
                 {
-                    var ee = (Mission)e;
+                    var ee = (Mission)e!;
                     var aa = (Mission)a;
 
                     Assert.Equal(ee.Id, aa.Id);
@@ -226,7 +224,7 @@ public abstract class GearsOfWarQueryFixtureBase : QueryFixtureBase<GearsOfWarCo
 
                 if (a != null)
                 {
-                    var ee = (Squad)e;
+                    var ee = (Squad)e!;
                     var aa = (Squad)a;
 
                     Assert.Equal(ee.Id, aa.Id);
@@ -252,7 +250,7 @@ public abstract class GearsOfWarQueryFixtureBase : QueryFixtureBase<GearsOfWarCo
 
                 if (a != null)
                 {
-                    var ee = (SquadMission)e;
+                    var ee = (SquadMission)e!;
                     var aa = (SquadMission)a;
 
                     Assert.Equal(ee.SquadId, aa.SquadId);
@@ -267,7 +265,7 @@ public abstract class GearsOfWarQueryFixtureBase : QueryFixtureBase<GearsOfWarCo
 
                 if (a != null)
                 {
-                    var ee = (Weapon)e;
+                    var ee = (Weapon)e!;
                     var aa = (Weapon)a;
 
                     Assert.Equal(ee.Id, aa.Id);
@@ -285,7 +283,7 @@ public abstract class GearsOfWarQueryFixtureBase : QueryFixtureBase<GearsOfWarCo
 
                 if (a != null)
                 {
-                    var ee = (LocustHighCommand)e;
+                    var ee = (LocustHighCommand)e!;
                     var aa = (LocustHighCommand)a;
 
                     Assert.Equal(ee.Id, aa.Id);
@@ -322,6 +320,7 @@ public abstract class GearsOfWarQueryFixtureBase : QueryFixtureBase<GearsOfWarCo
         modelBuilder.Entity<Weapon>(b =>
         {
             b.Property(w => w.Id).ValueGeneratedNever();
+            b.Property(w => w.Name).IsRequired(false);
             b.HasOne(w => w.SynergyWith).WithOne().HasForeignKey<Weapon>(w => w.SynergyWithId);
             b.HasOne(w => w.Owner).WithMany(g => g.Weapons).HasForeignKey(w => w.OwnerFullName).HasPrincipalKey(g => g.FullName);
         });
@@ -345,7 +344,9 @@ public abstract class GearsOfWarQueryFixtureBase : QueryFixtureBase<GearsOfWarCo
         modelBuilder.Entity<LocustHorde>().HasBaseType<Faction>();
         modelBuilder.Entity<LocustHorde>().HasMany(h => h.Leaders).WithOne();
 
-        modelBuilder.Entity<LocustHorde>().HasOne(h => h.Commander).WithOne(c => c.CommandingFaction);
+        modelBuilder.Entity<LocustHorde>().HasOne(h => h.Commander).WithOne(c => c.CommandingFaction)
+            .HasForeignKey<LocustHorde>(h => h.CommanderName)
+            .IsRequired(false);
 
         modelBuilder.Entity<LocustLeader>().HasKey(l => l.Name);
         modelBuilder.Entity<LocustCommander>().HasBaseType<LocustLeader>();

--- a/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -22,13 +22,14 @@ using Xunit.Sdk;
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
-#nullable disable
-
 public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : QueryTestBase<TFixture>(fixture)
     where TFixture : GearsOfWarQueryFixtureBase, new()
 {
     protected override Expression RewriteExpectedQueryExpression(Expression expectedQueryExpression)
-        => new ExpectedQueryRewritingVisitor(Fixture.GetShadowPropertyMappings())
+        => new ExpectedQueryRewritingVisitor(
+                Fixture.GetShadowPropertyMappings().ToDictionary(
+                    entry => entry.Key,
+                    entry => (Func<object, object>)(value => entry.Value(value)!)))
             .Visit(expectedQueryExpression);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -42,10 +43,10 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
     public virtual Task Include_multiple_one_to_one_and_one_to_many(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<CogTag>().Include(t => t.Gear.Weapons),
+            ss => ss.Set<CogTag>().Include(t => t.Gear!.Weapons),
             elementAsserter: (e, a) => AssertInclude(
                 e, a,
-                new ExpectedInclude<CogTag>(t => t.Gear),
+                new ExpectedInclude<CogTag>(t => t.Gear!),
                 new ExpectedInclude<Gear>(g => g.Weapons, "Gear"),
                 new ExpectedInclude<Officer>(o => o.Weapons, "Gear")));
 
@@ -55,7 +56,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
     public virtual Task ToString_string_property_projection(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<Weapon>().Select(w => w.Name.ToString()));
+            ss => ss.Set<Weapon>().Select(w => w.Name!.ToString()));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task ToString_boolean_property_non_nullable(bool async)
@@ -97,27 +98,27 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
     public virtual Task ToString_nullable_enum_contains(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<Weapon>().Where(w => w.AmmunitionType.ToString().Contains("Cart")).Select(g => g.Name));
+            ss => ss.Set<Weapon>().Where(w => w.AmmunitionType.ToString()!.Contains("Cart")).Select(g => g.Name));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Include_multiple_one_to_one_and_one_to_many_self_reference(bool async)
-        => Assert.ThrowsAsync<InvalidOperationException>(() => AssertQuery(async, ss => ss.Set<Weapon>().Include(w => w.Owner.Weapons)));
+        => Assert.ThrowsAsync<InvalidOperationException>(() => AssertQuery(async, ss => ss.Set<Weapon>().Include(w => w.Owner!.Weapons)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Include_multiple_one_to_one_optional_and_one_to_one_required(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<CogTag>().Include(t => t.Gear.Squad),
+            ss => ss.Set<CogTag>().Include(t => t.Gear!.Squad),
             elementAsserter: (e, a) => AssertInclude(
                 e, a,
-                new ExpectedInclude<CogTag>(t => t.Gear),
+                new ExpectedInclude<CogTag>(t => t.Gear!),
                 new ExpectedInclude<Gear>(g => g.Squad, "Gear"),
                 new ExpectedInclude<Officer>(o => o.Squad, "Gear")));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Include_multiple_one_to_one_and_one_to_one_and_one_to_many(bool async)
         => Assert.ThrowsAsync<InvalidOperationException>(() => AssertQuery(
-            async, ss => ss.Set<CogTag>().Include(t => t.Gear.Squad.Members)));
+            async, ss => ss.Set<CogTag>().Include(t => t.Gear!.Squad.Members)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Include_multiple_circular(bool async)
@@ -156,8 +157,8 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
         => Assert.ThrowsAsync<InvalidOperationException>(() => AssertQuery(
             async,
             ss => ss.Set<Gear>()
-                .Include(g => g.AssignedCity.BornGears).ThenInclude(g => g.Tag)
-                .Include(g => g.AssignedCity.StationedGears).ThenInclude(g => g.Tag)
+                .Include(g => g.AssignedCity!.BornGears).ThenInclude(g => g.Tag)
+                .Include(g => g.AssignedCity!.StationedGears).ThenInclude(g => g.Tag)
                 .Include(g => g.CityOfBirth.BornGears).ThenInclude(g => g.Tag)
                 .Include(g => g.CityOfBirth.StationedGears).ThenInclude(g => g.Tag)
                 .OrderBy(g => g.Nickname)));
@@ -188,9 +189,9 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
         => AssertQuery(
             async,
             ss => from t in ss.Set<CogTag>().Include(o => o.Gear)
-                  where t.Gear.Nickname == "Marcus"
+                where t.Gear!.Nickname == "Marcus"
                   select t,
-            elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<CogTag>(t => t.Gear)));
+            elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<CogTag>(t => t.Gear!)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Include_with_join_reference1(bool async)
@@ -199,7 +200,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
             ss => ss.Set<Gear>().Join(
                 ss.Set<CogTag>(),
                 g => new { SquadId = (int?)g.SquadId, g.Nickname },
-                t => new { SquadId = t.GearSquadId, Nickname = t.GearNickName },
+                t => new { SquadId = t.GearSquadId, Nickname = t.GearNickName! },
                 (g, t) => g).Include(g => g.CityOfBirth),
             elementAsserter: (e, a) => AssertInclude(
                 e, a,
@@ -212,7 +213,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
             async,
             ss => ss.Set<CogTag>().Join(
                 ss.Set<Gear>(),
-                t => new { SquadId = t.GearSquadId, Nickname = t.GearNickName },
+                t => new { SquadId = t.GearSquadId, Nickname = t.GearNickName! },
                 g => new { SquadId = (int?)g.SquadId, g.Nickname },
                 (t, g) => g).Include(g => g.CityOfBirth),
             elementAsserter: (e, a) => AssertInclude(
@@ -227,7 +228,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
             ss => ss.Set<Gear>().Join(
                 ss.Set<CogTag>(),
                 g => new { SquadId = (int?)g.SquadId, g.Nickname },
-                t => new { SquadId = t.GearSquadId, Nickname = t.GearNickName },
+                t => new { SquadId = t.GearSquadId, Nickname = t.GearNickName! },
                 (g, t) => g).Include(g => g.Weapons),
             elementAsserter: (e, a) => AssertInclude(
                 e, a,
@@ -240,7 +241,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
             async,
             ss => ss.Set<CogTag>().Join(
                 ss.Set<Gear>(),
-                t => new { SquadId = t.GearSquadId, Nickname = t.GearNickName },
+                t => new { SquadId = t.GearSquadId, Nickname = t.GearNickName! },
                 g => new { SquadId = (int?)g.SquadId, g.Nickname },
                 (t, g) => g).Include(g => g.Weapons),
             elementAsserter: (e, a) => AssertInclude(
@@ -317,7 +318,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
             ss => ss.Set<Gear>().Join(
                 ss.Set<CogTag>(),
                 g => new { SquadId = (int?)g.SquadId, g.Nickname },
-                t => new { SquadId = t.GearSquadId, Nickname = t.GearNickName },
+                t => new { SquadId = t.GearSquadId, Nickname = t.GearNickName! },
                 (g, t) => g).Include(g => g.CityOfBirth.StationedGears),
             elementAsserter: (e, a) => AssertInclude(
                 e, a,
@@ -331,7 +332,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
             async,
             ss => ss.Set<CogTag>().Join(
                 ss.Set<Gear>().OfType<Officer>(),
-                t => new { SquadId = t.GearSquadId, Nickname = t.GearNickName },
+                t => new { SquadId = t.GearSquadId, Nickname = t.GearNickName! },
                 o => new { SquadId = (int?)o.SquadId, o.Nickname },
                 (t, o) => o).Include(o => o.CityOfBirth),
             elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Officer>(o => o.CityOfBirth)));
@@ -342,7 +343,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
             async,
             ss => ss.Set<CogTag>().Join(
                     ss.Set<Gear>().OfType<Officer>().OrderBy(ee => ee.SquadId),
-                    t => new { SquadId = t.GearSquadId, Nickname = t.GearNickName },
+                    t => new { SquadId = t.GearSquadId, Nickname = t.GearNickName! },
                     o => new { SquadId = (int?)o.SquadId, o.Nickname },
                     (t, o) => o).OrderBy(ee => ee.FullName).Include(o => o.Reports).OrderBy(oo => oo.HasSoulPatch)
                 .ThenByDescending(oo => oo.Nickname),
@@ -356,7 +357,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
             ss => ss.Set<Gear>().OfType<Officer>().Join(
                 ss.Set<CogTag>(),
                 o => new { SquadId = (int?)o.SquadId, o.Nickname },
-                t => new { SquadId = t.GearSquadId, Nickname = t.GearNickName },
+                t => new { SquadId = t.GearSquadId, Nickname = t.GearNickName! },
                 (o, t) => o).Include(g => g.Weapons),
             elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Officer>(o => o.Weapons)));
 
@@ -366,7 +367,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
             async,
             ss => ss.Set<CogTag>().Join(
                 ss.Set<Gear>().OfType<Officer>(),
-                t => new { SquadId = t.GearSquadId, Nickname = t.GearNickName },
+                t => new { SquadId = t.GearSquadId, Nickname = t.GearNickName! },
                 g => new { SquadId = (int?)g.SquadId, g.Nickname },
                 (t, o) => o).Include(o => o.Reports),
             elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Officer>(o => o.Reports)));
@@ -377,9 +378,9 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
             async,
             ss => ss.Set<Weapon>()
                 .Include(w => w.Owner)
-                .Where(w => w.Owner.Nickname != "Paduk")
-                .OrderBy(e => e.Owner.CityOfBirth.Name).ThenBy(e => e.Id),
-            elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Weapon>(w => w.Owner)),
+                .Where(w => w.Owner!.Nickname != "Paduk")
+                .OrderBy(e => e.Owner!.CityOfBirth.Name).ThenBy(e => e.Id),
+            elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Weapon>(w => w.Owner!)),
             assertOrder: true);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -553,7 +554,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
         => AssertQuery(
             async,
             ss => ss.Set<Gear>().Where(g
-                => (null == EF.Property<string>(g, "LeaderNickname") ? null : g.LeaderNickname.Length) == 5 == (bool?)true));
+                => (null == EF.Property<string>(g, "LeaderNickname") ? null : g.LeaderNickname!.Length) == 5 == (bool?)true));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Null_propagation_optimization5(bool async)
@@ -656,7 +657,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
     public virtual Task Select_null_propagation_negative8(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<CogTag>().Select(t => t.Gear.Squad != null ? t.Gear.AssignedCity.Name : null));
+            ss => ss.Set<CogTag>().Select(t => t.Gear!.Squad != null ? t.Gear.AssignedCity!.Name : null));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Select_null_propagation_negative9(bool async)
@@ -680,8 +681,8 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
         => AssertQuery(
             async,
             ss => from t in ss.Set<CogTag>()
-                  select EF.Property<City>(EF.Property<CogTag>(t.Gear, "Tag").Gear, "AssignedCity") != null
-                      ? EF.Property<string>(EF.Property<Gear>(t.Gear.Tag, "Gear").AssignedCity, "Name")
+                  select EF.Property<City>(EF.Property<CogTag>(t.Gear!, "Tag").Gear!, "AssignedCity") != null
+                      ? EF.Property<string>(EF.Property<Gear>(t.Gear!.Tag!, "Gear").AssignedCity!, "Name")
                       : null);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -751,7 +752,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
             async,
             ss => from g in ss.Set<Gear>()
                   orderby g.Nickname
-                  select new { Name = g.LeaderNickname } ?? new { Name = g.FullName },
+                  select new { Name = g.LeaderNickname! } ?? new { Name = g.FullName },
             assertOrder: true);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -759,7 +760,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
         => AssertQuery(
             async,
             ss => from g in ss.Set<Gear>()
-                  where (new { Name = g.LeaderNickname } ?? new { Name = g.FullName }) != null
+                  where (new { Name = g.LeaderNickname! } ?? new { Name = g.FullName }) != null
                   select g.Nickname);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -809,7 +810,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
         => AssertQuery(
             async,
             ss => from t in ss.Set<CogTag>()
-                  where t.Gear.Nickname == "Marcus"
+                  where t.Gear!.Nickname == "Marcus"
                   select t);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -818,7 +819,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
             async,
             ss => from t1 in ss.Set<CogTag>()
                   from t2 in ss.Set<CogTag>()
-                  where t1.Gear.Nickname == t2.Gear.Nickname
+                  where t1.Gear!.Nickname == t2.Gear!.Nickname
                   select new { Tag1 = t1, Tag2 = t2 },
             elementSorter: e => (e.Tag1.Id, e.Tag2.Id),
             elementAsserter: (e, a) =>
@@ -833,7 +834,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
             async,
             ss => from t1 in ss.Set<CogTag>()
                   from t2 in ss.Set<CogTag>()
-                  where t1.Gear.Nickname == t2.Gear.Nickname
+                  where t1.Gear!.Nickname == t2.Gear!.Nickname
                   select new { Id1 = t1.Id, Id2 = t2.Id },
             elementSorter: e => (e.Id1, e.Id2));
 
@@ -841,7 +842,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
     public virtual Task Optional_Navigation_Null_Coalesce_To_Clr_Type(bool async)
         => AssertFirst(
             async,
-            ss => ss.Set<Weapon>().OrderBy(w => w.Id).Select(w => new Weapon { IsAutomatic = (bool?)w.SynergyWith.IsAutomatic ?? false }));
+            ss => ss.Set<Weapon>().OrderBy(w => w.Id).Select(w => new Weapon { IsAutomatic = (bool?)w.SynergyWith!.IsAutomatic ?? false }));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Where_subquery_boolean(bool async)
@@ -853,7 +854,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
     public virtual Task Where_subquery_boolean_with_pushdown(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<Gear>().Where(g => g.Weapons.OrderBy(w => w.Id).FirstOrDefault().IsAutomatic));
+            ss => ss.Set<Gear>().Where(g => g.Weapons.OrderBy(w => w.Id).FirstOrDefault()!.IsAutomatic));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Where_subquery_distinct_firstordefault_boolean(bool async)
@@ -866,7 +867,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
     public virtual Task Where_subquery_distinct_firstordefault_boolean_with_pushdown(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<Gear>().Where(g => g.HasSoulPatch && g.Weapons.Distinct().OrderBy(w => w.Id).FirstOrDefault().IsAutomatic));
+            ss => ss.Set<Gear>().Where(g => g.HasSoulPatch && g.Weapons.Distinct().OrderBy(w => w.Id).FirstOrDefault()!.IsAutomatic));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Where_subquery_distinct_first_boolean(bool async)
@@ -881,7 +882,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
         => AssertQuery(
             async,
             ss => ss.Set<Gear>().OrderBy(g => g.Nickname).Where(g => g.HasSoulPatch
-                && g.Weapons.Where(w => w.Name.Contains("Lancer")).Distinct().Select(w => w.IsAutomatic)
+                && g.Weapons.Where(w => w.Name!.Contains("Lancer")).Distinct().Select(w => w.IsAutomatic)
                     .SingleOrDefault()),
             assertOrder: true);
 
@@ -890,7 +891,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
         => AssertQuery(
             async,
             ss => ss.Set<Gear>().OrderBy(g => g.Nickname).Where(g => g.HasSoulPatch
-                && g.Weapons.Where(w => w.Name.Contains("Lancer")).Select(w => w.IsAutomatic).Distinct()
+                && g.Weapons.Where(w => w.Name!.Contains("Lancer")).Select(w => w.IsAutomatic).Distinct()
                     .SingleOrDefault()),
             assertOrder: true);
 
@@ -899,7 +900,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
         => AssertQuery(
             async,
             ss => ss.Set<Gear>().OrderBy(g => g.Nickname).Where(g
-                => g.HasSoulPatch && g.Weapons.Where(w => w.Name.Contains("Lancer")).Distinct().SingleOrDefault().IsAutomatic),
+                => g.HasSoulPatch && g.Weapons.Where(w => w.Name!.Contains("Lancer")).Distinct().SingleOrDefault()!.IsAutomatic),
             assertOrder: true);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -908,7 +909,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
             async,
             ss => ss.Set<Gear>()
                 .OrderBy(g => g.Nickname)
-                .Where(g => !g.Weapons.Distinct().OrderBy(w => w.Id).LastOrDefault().IsAutomatic),
+                .Where(g => !g.Weapons.Distinct().OrderBy(w => w.Id).LastOrDefault()!.IsAutomatic),
             assertOrder: true);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -931,20 +932,20 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
     public virtual Task Where_subquery_distinct_orderby_firstordefault_boolean_with_pushdown(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<Gear>().Where(g => g.HasSoulPatch && g.Weapons.Distinct().OrderBy(w => w.Id).FirstOrDefault().IsAutomatic));
+            ss => ss.Set<Gear>().Where(g => g.HasSoulPatch && g.Weapons.Distinct().OrderBy(w => w.Id).FirstOrDefault()!.IsAutomatic));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Where_subquery_union_firstordefault_boolean(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<Gear>().Where(g => g.HasSoulPatch && g.Weapons.Union(g.Weapons).OrderBy(w => w.Id).FirstOrDefault().IsAutomatic));
+            ss => ss.Set<Gear>().Where(g => g.HasSoulPatch && g.Weapons.Union(g.Weapons).OrderBy(w => w.Id).FirstOrDefault()!.IsAutomatic));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Where_subquery_join_firstordefault_boolean(bool async)
         => AssertQuery(
             async,
             ss => ss.Set<Gear>().Where(g => g.HasSoulPatch
-                && g.Weapons.Join(g.Weapons, e => e.Id, e => e.Id, (e1, e2) => e1).OrderBy(w => w.Id).FirstOrDefault()
+                && g.Weapons.Join(g.Weapons, e => e.Id, e => e.Id, (e1, e2) => e1).OrderBy(w => w.Id).FirstOrDefault()!
                     .IsAutomatic));
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -955,13 +956,13 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
                 && (from o in g.Weapons
                     join i in g.Weapons on o.Id equals i.Id into grouping
                     from i in grouping.DefaultIfEmpty()
-                    select o).OrderBy(w => w.Id).FirstOrDefault().IsAutomatic));
+                    select o).OrderBy(w => w.Id).FirstOrDefault()!.IsAutomatic));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Where_subquery_concat_firstordefault_boolean(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<Gear>().Where(g => g.HasSoulPatch && g.Weapons.Concat(g.Weapons).OrderBy(w => w.Id).FirstOrDefault().IsAutomatic));
+            ss => ss.Set<Gear>().Where(g => g.HasSoulPatch && g.Weapons.Concat(g.Weapons).OrderBy(w => w.Id).FirstOrDefault()!.IsAutomatic));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Concat_with_count(bool async)
@@ -1012,7 +1013,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
     public virtual Task Select_subquery_distinct_firstordefault(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<Gear>().Where(g => g.HasSoulPatch).Select(g => g.Weapons.Distinct().OrderBy(w => w.Id).FirstOrDefault().Name));
+            ss => ss.Set<Gear>().Where(g => g.HasSoulPatch).Select(g => g.Weapons.Distinct().OrderBy(w => w.Id).FirstOrDefault()!.Name));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Select_Where_Navigation_Client(bool async)
@@ -1078,7 +1079,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
         => AssertQuery(
             async,
             ss => ss.Set<LocustHorde>()
-                .Where(g => (g.DeputyCommander != null ? g.DeputyCommander : g.Commander).ThreatLevel == 4)
+                .Where(g => (g.DeputyCommander != null ? g.DeputyCommander : g.Commander!).ThreatLevel == 4)
                 .Select(g => new { g.Name }),
             elementSorter: e => e.Name);
 
@@ -1087,9 +1088,9 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
         => AssertQuery(
             async,
             ss => from ct in ss.Set<CogTag>()
-                  where ct.Gear.Nickname == "Marcus"
-                  where ct.Gear.CityOfBirthName != "Ephyra"
-                  select new { B = ct.Gear.CityOfBirthName },
+                  where ct.Gear!.Nickname == "Marcus"
+                  where ct.Gear!.CityOfBirthName != "Ephyra"
+                  select new { B = ct.Gear!.CityOfBirthName },
             elementSorter: e => e.B);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -1097,9 +1098,9 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
         => AssertQuery(
             async,
             ss => from ct in ss.Set<CogTag>()
-                  where ct.Gear.Nickname == "Marcus"
-                  where ct.Gear.CityOfBirthName != "Ephyra"
-                  select new { A = ct.Gear, B = ct.Gear.CityOfBirthName },
+                  where ct.Gear!.Nickname == "Marcus"
+                  where ct.Gear!.CityOfBirthName != "Ephyra"
+                  select new { A = ct.Gear!, B = ct.Gear!.CityOfBirthName },
             elementSorter: e => e.A.Nickname,
             elementAsserter: (e, a) =>
             {
@@ -1124,7 +1125,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
         => AssertQuery(
             async,
             ss => from g in ss.Set<Gear>()
-                  join t in ss.Set<CogTag>() on g.FullName equals t.Gear.FullName
+                  join t in ss.Set<CogTag>() on g.FullName equals t.Gear!.FullName
                   select new { g.FullName, t.Note },
             elementSorter: e => e.FullName);
 
@@ -1133,7 +1134,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
         => AssertQuery(
             async,
             ss => from g in ss.Set<Gear>()
-                  join t in ss.Set<CogTag>().OrderBy(tt => tt.Id) on g.FullName equals t.Gear.FullName
+                  join t in ss.Set<CogTag>().OrderBy(tt => tt.Id) on g.FullName equals t.Gear!.FullName
                   select new { g.FullName, t.Note },
             elementSorter: e => e.FullName);
 
@@ -1207,7 +1208,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Non_unicode_string_literals_in_contains_is_used_for_non_unicode_column(bool async)
     {
-        var cities = new List<string>
+        var cities = new List<string?>
         {
             "Unknown",
             "Jacinto's location",
@@ -1242,7 +1243,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
         => AssertQuery(
             async,
             ss => from c in ss.Set<City>()
-                  where c.Location.Contains("Jacinto")
+                  where c.Location!.Contains("Jacinto")
                   select c);
 
     [Theory, MemberData(nameof(IsAsyncData))] // Issue #32325
@@ -1397,58 +1398,58 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
     public virtual Task Coalesce_operator_in_predicate(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<CogTag>().Where(x => (bool?)x.Gear.HasSoulPatch ?? false));
+            ss => ss.Set<CogTag>().Where(x => (bool?)x.Gear!.HasSoulPatch ?? false));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Coalesce_operator_in_predicate_with_other_conditions(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<CogTag>().Where(x => x.Note != "K.I.A." && ((bool?)x.Gear.HasSoulPatch ?? false)));
+            ss => ss.Set<CogTag>().Where(x => x.Note != "K.I.A." && ((bool?)x.Gear!.HasSoulPatch ?? false)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Coalesce_operator_in_projection_with_other_conditions(bool async)
         => AssertQueryScalar(
             async,
-            ss => ss.Set<CogTag>().Select(x => x.Note != "K.I.A." && ((bool?)x.Gear.HasSoulPatch ?? false)));
+            ss => ss.Set<CogTag>().Select(x => x.Note != "K.I.A." && ((bool?)x.Gear!.HasSoulPatch ?? false)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Optional_navigation_type_compensation_works_with_predicate(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<CogTag>().Where(t => t.Note != "K.I.A." && t.Gear.HasSoulPatch));
+            ss => ss.Set<CogTag>().Where(t => t.Note != "K.I.A." && t.Gear!.HasSoulPatch));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Optional_navigation_type_compensation_works_with_predicate2(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<CogTag>().Where(t => t.Gear.HasSoulPatch),
-            ss => ss.Set<CogTag>().Where(t => t.Gear.MaybeScalar(x => x.HasSoulPatch) == true));
+            ss => ss.Set<CogTag>().Where(t => t.Gear!.HasSoulPatch),
+            ss => ss.Set<CogTag>().Where(t => t.Gear!.MaybeScalar(x => x.HasSoulPatch) == true));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Optional_navigation_type_compensation_works_with_predicate_negated(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<CogTag>().Where(t => !t.Gear.HasSoulPatch),
-            ss => ss.Set<CogTag>().Where(t => !t.Gear.MaybeScalar(x => x.HasSoulPatch) == true));
+            ss => ss.Set<CogTag>().Where(t => !t.Gear!.HasSoulPatch),
+            ss => ss.Set<CogTag>().Where(t => !t.Gear!.MaybeScalar(x => x.HasSoulPatch) == true));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Optional_navigation_type_compensation_works_with_predicate_negated_complex1(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<CogTag>().Where(t => !(t.Gear.HasSoulPatch ? true : t.Gear.HasSoulPatch)),
-            ss => ss.Set<CogTag>().Where(t => !(t.Gear.MaybeScalar(x => x.HasSoulPatch) == true
+                ss => ss.Set<CogTag>().Where(t => !(t.Gear!.HasSoulPatch ? true : t.Gear!.HasSoulPatch)),
+                ss => ss.Set<CogTag>().Where(t => !(t.Gear!.MaybeScalar(x => x.HasSoulPatch) == true
                     ? true
-                    : t.Gear.MaybeScalar(x => x.HasSoulPatch))
+                    : t.Gear!.MaybeScalar(x => x.HasSoulPatch))
                 == true));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Optional_navigation_type_compensation_works_with_predicate_negated_complex2(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<CogTag>().Where(t => !(!t.Gear.HasSoulPatch ? false : t.Gear.HasSoulPatch)),
-            ss => ss.Set<CogTag>().Where(t => !(t.Gear.MaybeScalar(x => x.HasSoulPatch) == false
+                ss => ss.Set<CogTag>().Where(t => !(!t.Gear!.HasSoulPatch ? false : t.Gear!.HasSoulPatch)),
+                ss => ss.Set<CogTag>().Where(t => !(t.Gear!.MaybeScalar(x => x.HasSoulPatch) == false
                     ? false
-                    : t.Gear.MaybeScalar(x => x.HasSoulPatch))
+                    : t.Gear!.MaybeScalar(x => x.HasSoulPatch))
                 == true));
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -1456,38 +1457,38 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
         => AssertQuery(
             async,
             // ReSharper disable once RedundantTernaryExpression
-            ss => ss.Set<CogTag>().Where(t => t.Gear.HasSoulPatch ? true : false));
+            ss => ss.Set<CogTag>().Where(t => t.Gear!.HasSoulPatch ? true : false));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Optional_navigation_type_compensation_works_with_binary_expression(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<CogTag>().Where(t => t.Gear.HasSoulPatch || t.Note.Contains("Cole")));
+            ss => ss.Set<CogTag>().Where(t => t.Gear!.HasSoulPatch || t.Note!.Contains("Cole")));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Optional_navigation_type_compensation_works_with_binary_and_expression(bool async)
         => AssertQueryScalar(
             async,
-            ss => ss.Set<CogTag>().Select(t => t.Gear.HasSoulPatch && t.Note.Contains("Cole")));
+            ss => ss.Set<CogTag>().Select(t => t.Gear!.HasSoulPatch && t.Note!.Contains("Cole")));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Optional_navigation_type_compensation_works_with_projection(bool async)
         => AssertQueryScalar(
             async,
-            ss => ss.Set<CogTag>().Where(t => t.Note != "K.I.A.").Select(t => t.Gear.SquadId));
+            ss => ss.Set<CogTag>().Where(t => t.Note != "K.I.A.").Select(t => t.Gear!.SquadId));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Optional_navigation_type_compensation_works_with_projection_into_anonymous_type(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<CogTag>().Where(t => t.Note != "K.I.A.").Select(t => new { t.Gear.SquadId }),
+            ss => ss.Set<CogTag>().Where(t => t.Note != "K.I.A.").Select(t => new { t.Gear!.SquadId }),
             elementSorter: e => e.SquadId);
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Optional_navigation_type_compensation_works_with_DTOs(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<CogTag>().Where(t => t.Note != "K.I.A.").Select(t => new Squad { Id = t.Gear.SquadId }));
+            ss => ss.Set<CogTag>().Where(t => t.Note != "K.I.A.").Select(t => new Squad { Id = t.Gear!.SquadId }));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Optional_navigation_type_compensation_works_with_list_initializers(bool async)
@@ -1496,8 +1497,8 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
             ss => ss.Set<CogTag>().Where(t => t.Note != "K.I.A.").OrderBy(t => t.Note)
                 .Select(t => new List<int>
                 {
-                    t.Gear.SquadId,
-                    t.Gear.SquadId + 1,
+                    t.Gear!.SquadId,
+                    t.Gear!.SquadId + 1,
                     42
                 }),
             assertOrder: true);
@@ -1506,33 +1507,33 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
     public virtual Task Optional_navigation_type_compensation_works_with_array_initializers(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<CogTag>().Where(t => t.Note != "K.I.A.").Select(t => new[] { t.Gear.SquadId }),
+            ss => ss.Set<CogTag>().Where(t => t.Note != "K.I.A.").Select(t => new[] { t.Gear!.SquadId }),
             elementSorter: e => e[0]);
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Optional_navigation_type_compensation_works_with_orderby(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<CogTag>().Where(t => t.Note != "K.I.A.").OrderBy(t => t.Gear.SquadId).Select(t => t));
+            ss => ss.Set<CogTag>().Where(t => t.Note != "K.I.A.").OrderBy(t => t.Gear!.SquadId).Select(t => t));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Optional_navigation_type_compensation_works_with_all(bool async)
         => AssertAll(
             async,
             ss => ss.Set<CogTag>().Where(t => t.Note != "K.I.A."),
-            predicate: t => t.Gear.HasSoulPatch);
+            predicate: t => t.Gear!.HasSoulPatch);
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Optional_navigation_type_compensation_works_with_negated_predicate(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<CogTag>().Where(t => t.Note != "K.I.A.").Where(t => !t.Gear.HasSoulPatch));
+            ss => ss.Set<CogTag>().Where(t => t.Note != "K.I.A.").Where(t => !t.Gear!.HasSoulPatch));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Optional_navigation_type_compensation_works_with_contains(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<CogTag>().Where(t => t.Note != "K.I.A." && ss.Set<Gear>().Select(g => g.SquadId).Contains(t.Gear.SquadId)));
+            ss => ss.Set<CogTag>().Where(t => t.Note != "K.I.A." && ss.Set<Gear>().Select(g => g.SquadId).Contains(t.Gear!.SquadId)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Optional_navigation_type_compensation_works_with_skip(bool async)
@@ -1540,7 +1541,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
             () => AssertQuery(
                 async,
                 ss => ss.Set<CogTag>().Where(t => t.Note != "K.I.A.").OrderBy(t => t.Note)
-                    .Select(t => ss.Set<Gear>().OrderBy(g => g.Nickname).Skip(t.Gear.SquadId)),
+                    .Select(t => ss.Set<Gear>().OrderBy(g => g.Nickname).Skip(t.Gear!.SquadId)),
                 assertOrder: true,
                 elementAsserter: (e, a) => AssertCollection(e, a, ordered: true)),
             "IEnumerable<T>");
@@ -1551,7 +1552,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
             () => AssertQuery(
                 async,
                 ss => ss.Set<CogTag>().Where(t => t.Note != "K.I.A.").OrderBy(t => t.Note)
-                    .Select(t => ss.Set<Gear>().OrderBy(g => g.Nickname).Take(t.Gear.SquadId)),
+                    .Select(t => ss.Set<Gear>().OrderBy(g => g.Nickname).Take(t.Gear!.SquadId)),
                 assertOrder: true,
                 elementAsserter: (e, a) => AssertCollection(e, a, ordered: true)),
             "IEnumerable<T>");
@@ -1675,7 +1676,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
 
     private static IEnumerable<TElement> ClientDefaultIfEmpty<TElement>(IEnumerable<TElement> source)
         // ReSharper disable PossibleMultipleEnumeration
-        => source?.Count() == 0 ? [default] : source;
+        => source.Count() == 0 ? [default!] : source;
     // ReSharper restore PossibleMultipleEnumeration
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -1683,10 +1684,10 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
         => AssertQuery(
             async,
             ss => from w in ss.Set<Weapon>()
-                  where w.Id != 50 && !w.Owner.HasSoulPatch
+                  where w.Id != 50 && !w.Owner!.HasSoulPatch
                   select w,
             ss => from w in ss.Set<Weapon>()
-                  where w.Id != 50 && w.Owner.MaybeScalar(x => x.HasSoulPatch) == false
+                  where w.Id != 50 && w.Owner!.MaybeScalar(x => x.HasSoulPatch) == false
                   select w);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -1749,7 +1750,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
             ss => ss.Set<Gear>().Where(g => ClientEquals(g.Tag.Note, prm)));
     }
 
-    private static bool ClientEquals(string first, string second)
+    private static bool ClientEquals(string? first, string? second)
         => first == second;
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -1956,7 +1957,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
         => AssertQuery(
             async,
             ss => from w in ss.Set<Weapon>()
-                  select new { w.Name, w.Name.Length },
+                select new { w.Name, w.Name!.Length },
             elementSorter: e => e.Name);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -2007,7 +2008,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
     }
 
     private static Weapon FavoriteWeapon(IEnumerable<Weapon> weapons)
-        => weapons.OrderBy(w => w.Id).FirstOrDefault();
+        => weapons.OrderBy(w => w.Id).FirstOrDefault()!;
 
     private static IEnumerable<Gear> Veterans(IEnumerable<Gear> gears)
         => gears.Where(g => g.Nickname is "Marcus" or "Dom" or "Cole Train" or "Baird");
@@ -2066,7 +2067,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
             ss => from f in ss.Set<Faction>()
                   where f is LocustHorde
                   orderby f.Name
-                  select new { f.Name, Threat = ((LocustHorde)f).Commander.ThreatLevel },
+                  select new { f.Name, Threat = ((LocustHorde)f).Commander!.ThreatLevel },
             assertOrder: true);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -2080,7 +2081,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
                   {
                       f,
                       f.Name,
-                      Threat = ((LocustHorde)f).Commander.ThreatLevel
+                      Threat = ((LocustHorde)f).Commander!.ThreatLevel
                   },
             assertOrder: true,
             elementAsserter: (e, a) =>
@@ -2107,7 +2108,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
             ss => from f in ss.Set<Faction>()
                   where f is LocustHorde
                   orderby f.Name
-                  select new { f.Name, CommanderName = ((LocustHorde)f).Commander.Name },
+                  select new { f.Name, CommanderName = ((LocustHorde)f).Commander!.Name },
             assertOrder: true);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -2139,7 +2140,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
                   select lh,
             elementAsserter: (e, a) => AssertInclude(
                 e, a,
-                new ExpectedInclude<LocustHorde>(e1 => e1.Commander),
+                new ExpectedInclude<LocustHorde>(e1 => e1.Commander!),
                 new ExpectedInclude<LocustHorde>(e2 => e2.Leaders)),
             assertOrder: true);
 
@@ -2152,7 +2153,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
                    where f is LocustHorde
                    orderby f.Id
                    select f).Include(f => f.Capital),
-            elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Faction>(e1 => e1.Capital)),
+            elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Faction>(e1 => e1.Capital!)),
             assertOrder: true);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -2191,7 +2192,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
                   from o in ss.Set<Gear>().OfType<Officer>()
                   where f is LocustHorde && o.HasSoulPatch
                   // ReSharper disable once PossibleUnintendedReferenceComparison
-                  where ((LocustHorde)f).Commander.DefeatedBy.Weapons == o.Weapons
+                  where ((LocustHorde)f).Commander!.DefeatedBy!.Weapons == o.Weapons
                   select new { f.Name, o.Nickname },
             elementSorter: e => (e.Name, e.Nickname));
 
@@ -2213,7 +2214,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
 
         return AssertQuery(
             async,
-            ss => ss.Set<Gear>().Where(g => g.SquadId < 2 && cities.Contains(g.AssignedCity.Name)));
+            ss => ss.Set<Gear>().Where(g => g.SquadId < 2 && cities.Contains(g.AssignedCity!.Name)));
     }
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -2243,7 +2244,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
         => AssertQuery(
             async,
             ss => ss.Set<Faction>().OfType<LocustHorde>()
-                .Select(h => new { h.Id, Leaders = EF.Property<ICollection<LocustLeader>>(h.Commander.CommandingFaction, "Leaders") }),
+                .Select(h => new { h.Id, Leaders = EF.Property<ICollection<LocustLeader>>(h.Commander!.CommandingFaction, "Leaders") }),
             elementSorter: e => e.Id,
             elementAsserter: (e, a) =>
             {
@@ -2256,7 +2257,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
         => AssertQuery(
             async,
             ss => ss.Set<Faction>().OfType<LocustHorde>()
-                .Select(h => new { h.Id, Gears = EF.Property<ICollection<Gear>>((Officer)h.Commander.DefeatedBy, "Reports") }),
+                .Select(h => new { h.Id, Gears = EF.Property<ICollection<Gear>>((Officer)h.Commander!.DefeatedBy!, "Reports") }),
             elementSorter: e => e.Id,
             elementAsserter: (e, a) =>
             {
@@ -2273,7 +2274,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
                 .Select(f => new
                 {
                     f.Id,
-                    Gears = EF.Property<ICollection<Gear>>((Officer)((LocustHorde)f).Commander.DefeatedBy, "Reports")
+                    Gears = EF.Property<ICollection<Gear>>((Officer)((LocustHorde)f).Commander!.DefeatedBy!, "Reports")
                 }),
             elementSorter: e => e.Id,
             elementAsserter: (e, a) =>
@@ -2287,14 +2288,14 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
         => AssertQuery(
             async,
             ss => ss.Set<LocustLeader>().Include("DefeatedBy"),
-            elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<LocustCommander>(lc => lc.DefeatedBy)));
+            elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<LocustCommander>(lc => lc.DefeatedBy!)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Include_reference_on_derived_type_using_EF_Property(bool async)
         => AssertQuery(
             async,
             ss => ss.Set<LocustLeader>().Include(lc => EF.Property<Gear>((LocustCommander)lc, "DefeatedBy")),
-            elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<LocustCommander>(lc => lc.DefeatedBy)));
+            elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<LocustCommander>(lc => lc.DefeatedBy!)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Include_reference_on_derived_type_using_string_nested1(bool async)
@@ -2303,7 +2304,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
             ss => ss.Set<LocustLeader>().Include("DefeatedBy.Squad"),
             elementAsserter: (e, a) => AssertInclude(
                 e, a,
-                new ExpectedInclude<LocustCommander>(lc => lc.DefeatedBy),
+                new ExpectedInclude<LocustCommander>(lc => lc.DefeatedBy!),
                 new ExpectedInclude<Gear>(g => g.Squad, "DefeatedBy")));
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -2313,7 +2314,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
             ss => ss.Set<LocustLeader>().Include("DefeatedBy.Reports.CityOfBirth"),
             elementAsserter: (e, a) => AssertInclude(
                 e, a,
-                new ExpectedInclude<LocustCommander>(lc => lc.DefeatedBy),
+                new ExpectedInclude<LocustCommander>(lc => lc.DefeatedBy!),
                 new ExpectedInclude<Officer>(o => o.Reports, "DefeatedBy"),
                 new ExpectedInclude<Gear>(g => g.CityOfBirth, "DefeatedBy.Reports")));
 
@@ -2322,21 +2323,21 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
         => AssertQuery(
             async,
             ss => ss.Set<LocustLeader>().Include(ll => ((LocustCommander)ll).DefeatedBy),
-            elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<LocustCommander>(lc => lc.DefeatedBy)));
+            elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<LocustCommander>(lc => lc.DefeatedBy!)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Include_reference_on_derived_type_using_lambda_with_soft_cast(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<LocustLeader>().Include(ll => (ll as LocustCommander).DefeatedBy),
-            elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<LocustCommander>(lc => lc.DefeatedBy)));
+            ss => ss.Set<LocustLeader>().Include(ll => (ll as LocustCommander)!.DefeatedBy),
+            elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<LocustCommander>(lc => lc.DefeatedBy!)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Include_reference_on_derived_type_using_lambda_with_tracking(bool async)
         => AssertQuery(
             async,
             ss => ss.Set<LocustLeader>().AsTracking().Include(ll => ((LocustCommander)ll).DefeatedBy),
-            elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<LocustCommander>(lc => lc.DefeatedBy)));
+            elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<LocustCommander>(lc => lc.DefeatedBy!)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Include_collection_on_derived_type_using_string(bool async)
@@ -2363,7 +2364,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
     public virtual Task Include_collection_on_derived_type_using_lambda_with_soft_cast(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<Gear>().Include(g => (g as Officer).Reports),
+            ss => ss.Set<Gear>().Include(g => (g as Officer)!.Reports),
             elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Officer>(o => o.Reports)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -2380,21 +2381,21 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
     public virtual Task ThenInclude_collection_on_derived_after_base_reference(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<CogTag>().Include(t => t.Gear).ThenInclude(g => (g as Officer).Weapons),
+            ss => ss.Set<CogTag>().Include(t => t.Gear).ThenInclude(g => (g as Officer)!.Weapons),
             elementAsserter: (e, a) => AssertInclude(
                 e, a,
-                new ExpectedInclude<CogTag>(e1 => e1.Gear),
+                new ExpectedInclude<CogTag>(e1 => e1.Gear!),
                 new ExpectedInclude<Officer>(e2 => e2.Weapons, "Gear")));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task ThenInclude_collection_on_derived_after_derived_reference(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<Faction>().Include(f => (f as LocustHorde).Commander).ThenInclude(c => (c.DefeatedBy as Officer).Reports),
+            ss => ss.Set<Faction>().Include(f => (f as LocustHorde)!.Commander!).ThenInclude(c => (c.DefeatedBy as Officer)!.Reports),
             elementAsserter: (e, a) => AssertInclude(
                 e, a,
-                new ExpectedInclude<LocustHorde>(e1 => e1.Commander),
-                new ExpectedInclude<LocustCommander>(e2 => e2.DefeatedBy, "Commander"),
+                new ExpectedInclude<LocustHorde>(e1 => e1.Commander!),
+                new ExpectedInclude<LocustCommander>(e2 => e2.DefeatedBy!, "Commander"),
                 new ExpectedInclude<Officer>(e3 => e3.Reports, "Commander.DefeatedBy")));
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -2415,17 +2416,17 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
             elementAsserter: (e, a) => AssertInclude(
                 e, a,
                 new ExpectedInclude<LocustHorde>(e1 => e1.Leaders),
-                new ExpectedInclude<LocustCommander>(e2 => e2.DefeatedBy, "Leaders")));
+                new ExpectedInclude<LocustCommander>(e2 => e2.DefeatedBy!, "Leaders")));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Multiple_derived_included_on_one_method(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<Faction>().Include(f => (((LocustHorde)f).Commander.DefeatedBy as Officer).Reports),
+            ss => ss.Set<Faction>().Include(f => (((LocustHorde)f).Commander!.DefeatedBy as Officer)!.Reports),
             elementAsserter: (e, a) => AssertInclude(
                 e, a,
-                new ExpectedInclude<LocustHorde>(e1 => e1.Commander),
-                new ExpectedInclude<LocustCommander>(e2 => e2.DefeatedBy, "Commander"),
+                new ExpectedInclude<LocustHorde>(e1 => e1.Commander!),
+                new ExpectedInclude<LocustCommander>(e2 => e2.DefeatedBy!, "Commander"),
                 new ExpectedInclude<Officer>(e3 => e3.Reports, "Commander.DefeatedBy")));
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -2814,8 +2815,8 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
                 select new
                 {
                     o.FullName,
-                    OuterCollection2 = (from www in o.Tag.Gear.Weapons
-                                        orderby www.IsAutomatic, www.Owner.Nickname descending
+                    OuterCollection2 = (from www in o.Tag!.Gear!.Weapons
+                                        orderby www.IsAutomatic, www.Owner!.Nickname descending
                                         select www).ToList()
                 },
             elementSorter: e => e.FullName,
@@ -2837,9 +2838,9 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
                 select new
                 {
                     o.FullName,
-                    OuterCollection2 = (from www in o.Tag.Gear.Weapons
-                                        orderby www.IsAutomatic, www.Owner.Nickname descending
-                                        orderby www.IsAutomatic, www.Owner.Nickname descending
+                    OuterCollection2 = (from www in o.Tag!.Gear!.Weapons
+                                        orderby www.IsAutomatic, www.Owner!.Nickname descending
+                                        orderby www.IsAutomatic, www.Owner!.Nickname descending
                                         select www).ToList()
                 },
             elementSorter: e => e.FullName,
@@ -2861,8 +2862,8 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
                 select new
                 {
                     o.FullName,
-                    OuterCollection2 = (from www in o.Tag.Gear.Weapons
-                                        orderby www.Id descending, www.Owner.Weapons.Count
+                    OuterCollection2 = (from www in o.Tag!.Gear!.Weapons
+                                        orderby www.Id descending, www.Owner!.Weapons.Count
                                         select www).ToList()
                 },
             elementSorter: e => e.FullName,
@@ -2896,15 +2897,15 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
                                                               {
                                                                   w.Id,
                                                                   InnerFirst =
-                                                                      w.Owner.Weapons.Select(ww => new { ww.Name, ww.IsAutomatic })
+                                                                      w.Owner!.Weapons.Select(ww => new { ww.Name, ww.IsAutomatic })
                                                                           .ToList(),
                                                                   InnerSecond =
-                                                                      w.Owner.Squad.Members.OrderBy(mm => mm.Nickname)
+                                                                      w.Owner!.Squad.Members.OrderBy(mm => mm.Nickname)
                                                                           .Select(mm => new { mm.Nickname, mm.HasSoulPatch }).ToList()
                                                               }).ToList()
                                        }).ToList(),
-                    OuterCollection2 = (from www in o.Tag.Gear.Weapons
-                                        orderby www.IsAutomatic, www.Owner.Nickname descending
+                    OuterCollection2 = (from www in o.Tag!.Gear!.Weapons
+                                        orderby www.IsAutomatic, www.Owner!.Nickname descending
                                         select www).ToList()
                 },
             elementSorter: e => e.FullName,
@@ -3138,8 +3139,8 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
                     g => g.Nickname,
                     t => t.GearNickName,
                     (g, c) => new { g, c })
-                .Where(t => !t.g.HasSoulPatch)
-                .Select(t => new { t.g.Nickname, WeaponNames = t.g.Weapons.Select(w => w.Name).ToList() }),
+                .Where(t => !t.g!.HasSoulPatch)
+                .Select(t => new { t.g!.Nickname, WeaponNames = t.g.Weapons.Select(w => w.Name).ToList() }),
             ss => ss.Set<Gear>()
                 .RightJoin(
                     ss.Set<CogTag>(),
@@ -3147,7 +3148,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
                     t => t.GearNickName,
                     (g, c) => new { g, c })
                 .Where(t => t.g != null && !t.g.HasSoulPatch)
-                .Select(t => new { t.g.Nickname, WeaponNames = t.g.Weapons.Select(w => w.Name).ToList() }),
+                .Select(t => new { t.g!.Nickname, WeaponNames = t.g.Weapons.Select(w => w.Name).ToList() }),
             elementSorter: e => e.Nickname,
             elementAsserter: (e, a) =>
             {
@@ -3163,13 +3164,13 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
                   join g in ss.Set<Gear>() on t.GearNickName equals g.Nickname into grouping
                   from g in grouping.DefaultIfEmpty()
                   orderby t.Note
-                  select g.Weapons.Select(w => w.Name).ToList(),
+                  select g!.Weapons.Select(w => w.Name).ToList(),
             ss =>
                 from t in ss.Set<CogTag>()
                 join g in ss.Set<Gear>() on t.GearNickName equals g.Nickname into grouping
                 from g in grouping.DefaultIfEmpty()
                 orderby t.Note
-                select g != null ? g.Weapons.Select(w => w.Name).ToList() : new List<string>(),
+                select g != null ? g.Weapons.Select(w => w.Name).ToList() : new List<string?>(),
             assertOrder: true,
             elementAsserter: (e, a) => AssertCollection(e, a));
 
@@ -3181,7 +3182,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
                 from t in ss.Set<CogTag>()
                 join o in ss.Set<Gear>().OfType<Officer>() on t.GearNickName equals o.Nickname into grouping
                 from o in grouping.DefaultIfEmpty()
-                select new { t.Note, ReportNames = o.Reports.Select(r => r.FullName).ToList() },
+                select new { t.Note, ReportNames = o!.Reports.Select(r => r.FullName).ToList() },
             ss =>
                 from t in ss.Set<CogTag>()
                 join o in ss.Set<Gear>().OfType<Officer>() on t.GearNickName equals o.Nickname into grouping
@@ -3203,7 +3204,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
                 join g in ss.Set<Gear>() on t.GearNickName equals g.Nickname into grouping
                 from g in grouping.DefaultIfEmpty()
                 orderby t.Note, g.Nickname descending
-                select g.Squad.Members.Where(m => m.HasSoulPatch)
+                select g!.Squad.Members.Where(m => m.HasSoulPatch)
                     .Select(m => new { m.Nickname, AutomaticWeapons = m.Weapons.Where(w => w.IsAutomatic).ToList() }).ToList(),
             ss =>
                 from t in ss.Set<CogTag>()
@@ -3214,7 +3215,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
                     g != null
                         ? g.Squad.Members.Where(m => m.HasSoulPatch).OrderBy(m => m.Nickname)
                             .Select(m => new { m.Nickname, AutomaticWeapons = m.Weapons.Where(w => w.IsAutomatic).ToList() }).ToList()
-                        : Enumerable.Empty<int>().Select(x => new { Nickname = (string)null, AutomaticWeapons = new List<Weapon>() })
+                        : Enumerable.Empty<int>().Select(x => new { Nickname = (string)null!, AutomaticWeapons = new List<Weapon>() })
                             .ToList(),
             assertOrder: true,
             elementAsserter: (e, a) => AssertCollection(
@@ -3232,7 +3233,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
         => AssertQuery(
             async,
             ss => ss.Set<Weapon>().OrderBy(w => w.Name).Select(w
-                => w.Owner.Squad.Members.OrderByDescending(m => m.FullName).Select(m
+                => w.Owner!.Squad.Members.OrderByDescending(m => m.FullName).Select(m
                     => new { Weapons = m.Weapons.Where(ww => !ww.IsAutomatic).OrderBy(ww => ww.Id).ToList(), m.Rank }).ToList()),
             ss => ss.Set<Weapon>().OrderBy(w => w.Name).Select(w => w.Owner != null
                 ? w.Owner.Squad.Members.OrderByDescending(m => m.FullName).Select(m
@@ -3260,7 +3261,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
                                        {
                                            w.Id,
                                            InnerCollection =
-                                               w.Owner.Squad.Members.OrderBy(mm => mm.Nickname)
+                                               w.Owner!.Squad.Members.OrderBy(mm => mm.Nickname)
                                                    .Select(mm => new { mm.Nickname, mm.HasSoulPatch }).ToList()
                                        }).ToList()
                 },
@@ -3296,7 +3297,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
                                                               select new
                                                               {
                                                                   w.Id,
-                                                                  InnerSecond = w.Owner.Squad.Members.OrderBy(mm => mm.Nickname)
+                                                                  InnerSecond = w.Owner!.Squad.Members.OrderBy(mm => mm.Nickname)
                                                                       .Select(mm => new { mm.Nickname, mm.HasSoulPatch }).ToList()
                                                               }).ToList()
                                        }).ToList()
@@ -3339,7 +3340,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
                                        {
                                            w.Id,
                                            InnerCollection =
-                                               w.Owner.Squad.Members.OrderBy(mm => mm.Nickname)
+                                               w.Owner!.Squad.Members.OrderBy(mm => mm.Nickname)
                                                    .Select(mm => new { mm.Nickname, mm.HasSoulPatch }).ToList()
                                        }).ToList()
                 },
@@ -3379,7 +3380,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
                                                               select new
                                                               {
                                                                   w.Id,
-                                                                  InnerSecond = w.Owner.Squad.Members.OrderBy(mm => mm.Nickname)
+                                                                  InnerSecond = w.Owner!.Squad.Members.OrderBy(mm => mm.Nickname)
                                                                       .Select(mm => new { mm.Nickname, mm.HasSoulPatch }).ToList()
                                                               }).ToList()
                                        }).ToList()
@@ -3460,12 +3461,12 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
     public virtual Task Include_on_derived_type_with_order_by_and_paging(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<LocustLeader>().Include(ll => ((LocustCommander)ll).DefeatedBy).ThenInclude(g => g.Weapons)
-                .OrderBy(ll => ((LocustCommander)ll).DefeatedBy.Tag.Note).Take(10),
+            ss => ss.Set<LocustLeader>().Include(ll => ((LocustCommander)ll).DefeatedBy!).ThenInclude(g => g.Weapons)
+                .OrderBy(ll => ((LocustCommander)ll).DefeatedBy!.Tag.Note).Take(10),
             ss => ss.Set<LocustLeader>().Take(10),
             elementAsserter: (e, a) => AssertInclude(
                 e, a,
-                new ExpectedInclude<LocustCommander>(e1 => e1.DefeatedBy),
+                new ExpectedInclude<LocustCommander>(e1 => e1.DefeatedBy!),
                 new ExpectedInclude<Gear>(e2 => e2.Weapons, "DefeatedBy")));
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -3554,10 +3555,10 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
     public virtual Task Negated_bool_ternary_inside_anonymous_type_in_projection(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<CogTag>().Select(t => new { c = !(t.Gear.HasSoulPatch ? true : ((bool?)t.Gear.HasSoulPatch ?? true)) }),
+            ss => ss.Set<CogTag>().Select(t => new { c = !(t.Gear!.HasSoulPatch ? true : ((bool?)t.Gear!.HasSoulPatch ?? true)) }),
             ss => ss.Set<CogTag>().Select(t => new
             {
-                c = !((t.Gear.MaybeScalar(x => x.HasSoulPatch) ?? false) || (t.Gear.MaybeScalar(x => x.HasSoulPatch) ?? true))
+                c = !((t.Gear!.MaybeScalar(x => x.HasSoulPatch) ?? false) || (t.Gear!.MaybeScalar(x => x.HasSoulPatch) ?? true))
             }),
             elementSorter: e => e.c);
 
@@ -3566,7 +3567,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
         => AssertQuery(
             async,
             ss => ss.Set<Gear>().OrderBy(g => g.AssignedCity).ThenByDescending(g => g.Nickname).Select(f => f.FullName),
-            ss => ss.Set<Gear>().OrderBy(g => g.AssignedCity.Name).ThenByDescending(g => g.Nickname).Select(f => f.FullName),
+            ss => ss.Set<Gear>().OrderBy(g => g.AssignedCity!.Name).ThenByDescending(g => g.Nickname).Select(f => f.FullName),
             assertOrder: true);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -3582,8 +3583,8 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
         => AssertQuery(
             async,
             ss => ss.Set<Weapon>().OrderBy(w => w.Owner).ThenBy(w => w.Id).Select(w => w.Name),
-            ss => ss.Set<Weapon>().OrderBy(w => w.Owner.Nickname)
-                .ThenBy(w => w.Owner.MaybeScalar(x => x.SquadId))
+            ss => ss.Set<Weapon>().OrderBy(w => w.Owner!.Nickname)
+                .ThenBy(w => w.Owner!.MaybeScalar(x => x.SquadId))
                 .ThenBy(w => w.Id).Select(w => w.Name),
             assertOrder: true);
 
@@ -3595,9 +3596,9 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
                 .ThenBy(w => w.Name),
             ss => ss.Set<Weapon>()
                 .OrderBy(w => w.IsAutomatic)
-                .ThenByDescending(w => w.Owner.Nickname)
-                .ThenByDescending(w => w.Owner.MaybeScalar(x => x.SquadId))
-                .ThenBy(w => w.SynergyWith.MaybeScalar(x => x.Id))
+                .ThenByDescending(w => w.Owner!.Nickname)
+                .ThenByDescending(w => w.Owner!.MaybeScalar(x => x.SquadId))
+                .ThenBy(w => w.SynergyWith!.MaybeScalar(x => x.Id))
                 .ThenBy(w => w.Name),
             assertOrder: true);
 
@@ -3663,7 +3664,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
             async,
             ss =>
                 from s in ss.Set<Squad>()
-                join w in ss.Set<Weapon>().Where(ww => ww.IsAutomatic) on s equals w.Owner.Squad
+                join w in ss.Set<Weapon>().Where(ww => ww.IsAutomatic) on s equals w.Owner!.Squad
                 select new { SquadName = s.Name, WeaponName = w.Name },
             elementSorter: e => (e.SquadName, e.WeaponName));
 
@@ -3672,7 +3673,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
         => AssertQuery(
             async,
             ss => from s in ss.Set<Squad>()
-                  join w in ss.Set<Weapon>() on s equals w.Owner.Squad into grouping
+                  join w in ss.Set<Weapon>() on s equals w.Owner!.Squad into grouping
                   from w in grouping.DefaultIfEmpty()
                   select new { SquadName = s.Name, WeaponName = w.Name },
             elementSorter: e => (e.SquadName, e.WeaponName));
@@ -3819,7 +3820,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
         => AssertQuery(
             async,
             ss => ss.Set<Squad>().Select(s
-                => new { s.Name, Gear = s.Members.Where(g => g.HasSoulPatch).Select(g => (MyDTO)null).FirstOrDefault() }));
+                => new { s.Name, Gear = s.Members.Where(g => g.HasSoulPatch).Select(g => (MyDTO)null!).FirstOrDefault() }));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Select_subquery_projecting_single_constant_of_non_mapped_type(bool async)
@@ -3841,7 +3842,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
     public virtual Task Correlated_collection_order_by_constant_null_of_non_mapped_type(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<Gear>().OrderByDescending(s => (MyDTO)null)
+            ss => ss.Set<Gear>().OrderByDescending(s => (MyDTO)null!)
                 .Select(g => new { g.Nickname, Weapons = g.Weapons.Select(w => w.Name).ToList() }),
             elementSorter: e => e.Nickname,
             elementAsserter: (e, a) =>
@@ -3866,7 +3867,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
             async,
             ss => ss.Set<Gear>().OfType<Officer>()
                 .Include(o => o.Reports)
-                .OrderBy(o => o.Weapons.OrderBy(w => w.Id).FirstOrDefault().IsAutomatic).ThenBy(o => o.Nickname),
+                .OrderBy(o => o.Weapons.OrderBy(w => w.Id).FirstOrDefault()!.IsAutomatic).ThenBy(o => o.Nickname),
             elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Officer>(o => o.Reports)),
             assertOrder: true);
 
@@ -3923,7 +3924,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
     public virtual Task Select_subquery_boolean_with_pushdown(bool async)
         => AssertQueryScalar(
             async,
-            ss => ss.Set<Gear>().Select(g => g.Weapons.OrderBy(w => w.Id).FirstOrDefault().IsAutomatic));
+            ss => ss.Set<Gear>().Select(g => g.Weapons.OrderBy(w => w.Id).FirstOrDefault()!.IsAutomatic));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Select_subquery_int_with_inside_cast_and_coalesce(bool async)
@@ -3941,14 +3942,14 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
     public virtual Task Select_subquery_int_with_pushdown_and_coalesce(bool async)
         => AssertQueryScalar(
             async,
-            ss => ss.Set<Gear>().Select(g => (int?)g.Weapons.OrderBy(w => w.Id).FirstOrDefault().Id ?? 42));
+            ss => ss.Set<Gear>().Select(g => (int?)g.Weapons.OrderBy(w => w.Id).FirstOrDefault()!.Id ?? 42));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Select_subquery_int_with_pushdown_and_coalesce2(bool async)
         => AssertQueryScalar(
             async,
             ss => ss.Set<Gear>().Select(g
-                => (int?)g.Weapons.OrderBy(w => w.Id).FirstOrDefault().Id ?? g.Weapons.OrderBy(w => w.Id).FirstOrDefault().Id));
+                => (int?)g.Weapons.OrderBy(w => w.Id).FirstOrDefault()!.Id ?? g.Weapons.OrderBy(w => w.Id).FirstOrDefault()!.Id));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Select_subquery_boolean_empty(bool async)
@@ -3961,7 +3962,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
     public virtual Task Select_subquery_boolean_empty_with_pushdown(bool async)
         => AssertQueryScalar(
             async,
-            ss => ss.Set<Gear>().Select(g => (bool?)g.Weapons.Where(w => w.Name == "BFG").OrderBy(w => w.Id).FirstOrDefault().IsAutomatic),
+            ss => ss.Set<Gear>().Select(g => (bool?)g.Weapons.Where(w => w.Name == "BFG").OrderBy(w => w.Id).FirstOrDefault()!.IsAutomatic),
             ss => ss.Set<Gear>().Select(g => (bool?)null));
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -3969,7 +3970,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
         => AssertQueryScalar(
             async,
             ss => ss.Set<Gear>().Where(g => g.HasSoulPatch)
-                .Select(g => g.Weapons.Where(w => w.Name.Contains("Lancer")).Distinct().Select(w => w.IsAutomatic).SingleOrDefault()),
+                .Select(g => g.Weapons.Where(w => w.Name!.Contains("Lancer")).Distinct().Select(w => w.IsAutomatic).SingleOrDefault()),
             assertOrder: true);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -3977,7 +3978,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
         => AssertQueryScalar(
             async,
             ss => ss.Set<Gear>().Where(g => g.HasSoulPatch)
-                .Select(g => g.Weapons.Where(w => w.Name.Contains("Lancer")).Select(w => w.IsAutomatic).Distinct().SingleOrDefault()),
+                .Select(g => g.Weapons.Where(w => w.Name!.Contains("Lancer")).Select(w => w.IsAutomatic).Distinct().SingleOrDefault()),
             assertOrder: true);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -3985,7 +3986,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
         => AssertQueryScalar(
             async,
             ss => ss.Set<Gear>().Where(g => g.HasSoulPatch)
-                .Select(g => g.Weapons.Where(w => w.Name.Contains("Lancer")).Distinct().SingleOrDefault().IsAutomatic),
+                .Select(g => g.Weapons.Where(w => w.Name!.Contains("Lancer")).Distinct().SingleOrDefault()!.IsAutomatic),
             assertOrder: true);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -4007,7 +4008,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
         => AssertQueryScalar(
             async,
             ss => ss.Set<Gear>().Where(g => g.HasSoulPatch)
-                .Select(g => (bool?)g.Weapons.Where(w => w.Name == "BFG").Distinct().SingleOrDefault().IsAutomatic),
+                .Select(g => (bool?)g.Weapons.Where(w => w.Name == "BFG").Distinct().SingleOrDefault()!.IsAutomatic),
             ss => ss.Set<Gear>().Where(g => g.HasSoulPatch).Select(g => (bool?)null),
             assertOrder: true);
 
@@ -4070,7 +4071,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
     public virtual Task Double_order_by_on_nullable_bool_coming_from_optional_navigation(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<Weapon>().Select(w => w.SynergyWith).OrderBy(w => w.IsAutomatic).OrderBy(w => w.IsAutomatic).ThenBy(w => w.Id),
+            ss => ss.Set<Weapon>().Select(w => w.SynergyWith).OrderBy(w => w!.IsAutomatic).OrderBy(w => w!.IsAutomatic).ThenBy(w => w!.Id),
             ss => ss.Set<Weapon>().Select(w => w.SynergyWith).OrderBy(w => w != null && w.IsAutomatic)
                 .ThenBy(w => w != null ? (int?)w.Id : null),
             assertOrder: true);
@@ -4079,25 +4080,25 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
     public virtual Task Double_order_by_on_Like(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<Weapon>().Select(w => w.SynergyWith).OrderBy(w => EF.Functions.Like(w.Name, "%Lancer"))
-                .OrderBy(w => EF.Functions.Like(w.Name, "%Lancer")).Select(w => w),
-            ss => ss.Set<Weapon>().Select(w => w.SynergyWith).OrderBy(w => w != null && w.Name.EndsWith("Lancer"))
+            ss => ss.Set<Weapon>().Select(w => w.SynergyWith).OrderBy(w => EF.Functions.Like(w!.Name, "%Lancer"))
+                .OrderBy(w => EF.Functions.Like(w!.Name, "%Lancer")).Select(w => w),
+            ss => ss.Set<Weapon>().Select(w => w.SynergyWith).OrderBy(w => w != null && w.Name!.EndsWith("Lancer"))
                 .Select(w => w));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Double_order_by_on_is_null(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<Weapon>().Select(w => w.SynergyWith).OrderBy(w => w.Name == null).OrderBy(w => w.Name == null).Select(w => w),
+            ss => ss.Set<Weapon>().Select(w => w.SynergyWith).OrderBy(w => w!.Name == null).OrderBy(w => w!.Name == null).Select(w => w),
             ss => ss.Set<Weapon>().Select(w => w.SynergyWith).OrderBy(w => w != null && w.Name == null).Select(w => w));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Double_order_by_on_string_compare(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<Weapon>().OrderBy(w => w.Name.CompareTo("Marcus' Lancer") == 0)
-                .OrderBy(w => w.Name.CompareTo("Marcus' Lancer") == 0).ThenBy(w => w.Id),
-            ss => ss.Set<Weapon>().OrderBy(w => w != null && w.Name.CompareTo("Marcus' Lancer") == 0).ThenBy(w => w.Id),
+            ss => ss.Set<Weapon>().OrderBy(w => w.Name!.CompareTo("Marcus' Lancer") == 0)
+                .OrderBy(w => w.Name!.CompareTo("Marcus' Lancer") == 0).ThenBy(w => w.Id),
+            ss => ss.Set<Weapon>().OrderBy(w => w != null && w.Name!.CompareTo("Marcus' Lancer") == 0).ThenBy(w => w.Id),
             assertOrder: true);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -4110,15 +4111,15 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
     public virtual Task String_compare_with_null_conditional_argument(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<Weapon>().Select(w => w.SynergyWith).OrderBy(w => w.Name.CompareTo("Marcus' Lancer") == 0).Select(c => c),
-            ss => ss.Set<Weapon>().Select(w => w.SynergyWith).OrderBy(w => w != null && w.Name.CompareTo("Marcus' Lancer") == 0)
+            ss => ss.Set<Weapon>().Select(w => w.SynergyWith).OrderBy(w => w!.Name!.CompareTo("Marcus' Lancer") == 0).Select(c => c),
+            ss => ss.Set<Weapon>().Select(w => w.SynergyWith).OrderBy(w => w != null && w.Name!.CompareTo("Marcus' Lancer") == 0)
                 .Select(c => c));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task String_compare_with_null_conditional_argument2(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<Weapon>().Select(w => w.SynergyWith).OrderBy(w => "Marcus' Lancer".CompareTo(w.Name) == 0).Select(w => w),
+            ss => ss.Set<Weapon>().Select(w => w.SynergyWith).OrderBy(w => "Marcus' Lancer".CompareTo(w!.Name) == 0).Select(w => w),
             ss => ss.Set<Weapon>().Select(w => w.SynergyWith).OrderBy(w => w != null && "Marcus' Lancer".CompareTo(w.Name) == 0)
                 .Select(w => w));
 
@@ -4126,7 +4127,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
     public virtual Task String_concat_with_null_conditional_argument(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<Weapon>().Select(w => w.SynergyWith).OrderBy(w => w.Name + 5),
+            ss => ss.Set<Weapon>().Select(w => w.SynergyWith).OrderBy(w => w!.Name + 5),
             ss => ss.Set<Weapon>().Select(w => w.SynergyWith).OrderBy(w => w != null ? w.Name + 5 : null),
             assertOrder: true);
 
@@ -4134,14 +4135,14 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
     public virtual Task String_concat_with_null_conditional_argument2(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<Weapon>().Select(w => w.SynergyWith).OrderBy(w => string.Concat(w.Name, "Marcus' Lancer")),
+            ss => ss.Set<Weapon>().Select(w => w.SynergyWith).OrderBy(w => string.Concat(w!.Name, "Marcus' Lancer")),
             ss => ss.Set<Weapon>().Select(w => w.SynergyWith).OrderBy(w => w != null ? string.Concat(w.Name, "Marcus' Lancer") : null),
             assertOrder: true);
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task String_concat_nullable_expressions_are_coalesced(bool async)
     {
-        object nullableParam = null;
+        object nullableParam = null!;
 
         return AssertQuery(
             async,
@@ -4229,11 +4230,11 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
             {
                 Assert.Equal(e.Key, a.Key);
                 Assert.Equal(e.c, a.c);
-                Assert.Equal(e.element.Nickname, a.element.Nickname);
+                Assert.Equal(e.element!.Nickname, a.element!.Nickname);
                 Assert.Equal(e.element.CityOfBirth == null, a.element.CityOfBirth == null);
                 if (e.element.CityOfBirth != null)
                 {
-                    Assert.Equal(e.element.CityOfBirth.Name, a.element.CityOfBirth.Name);
+                    Assert.Equal(e.element.CityOfBirth.Name, a.element.CityOfBirth!.Name);
                 }
             });
 
@@ -4348,8 +4349,8 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
     public virtual Task GetValueOrDefault_with_argument_complex(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<Weapon>().Where(w => w.SynergyWithId.GetValueOrDefault(w.Name.Length + 42) > 10),
-            ss => ss.Set<Weapon>().Where(w => (w.SynergyWithId == null ? w.Name.Length + 42 : w.SynergyWithId) > 10));
+            ss => ss.Set<Weapon>().Where(w => w.SynergyWithId.GetValueOrDefault(w.Name!.Length + 42) > 10),
+            ss => ss.Set<Weapon>().Where(w => (w.SynergyWithId == null ? w.Name!.Length + 42 : w.SynergyWithId) > 10));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Filter_with_complex_predicate_containing_subquery(bool async)
@@ -4369,7 +4370,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
                       = g.Weapons
                           .OrderByDescending(w => w.AmmunitionType)
                           .Where(w => w.IsAutomatic)
-                  select new { g.Nickname, WeaponName = automaticWeapons.FirstOrDefault().Name },
+                  select new { g.Nickname, WeaponName = automaticWeapons.FirstOrDefault()!.Name },
             elementSorter: e => e.Nickname,
             elementAsserter: (e, a) =>
             {
@@ -4382,42 +4383,42 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
         bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<CogTag>().Where(t => t.Note.Substring(0, t.Gear.SquadId) == t.GearNickName),
-            ss => ss.Set<CogTag>().Where(t => t.Gear.Maybe(x => t.Note.Substring(0, x.SquadId)) == t.GearNickName));
+            ss => ss.Set<CogTag>().Where(t => t.Note!.Substring(0, t.Gear!.SquadId) == t.GearNickName),
+            ss => ss.Set<CogTag>().Where(t => t.Gear!.Maybe(x => t.Note!.Substring(0, x.SquadId)) == t.GearNickName));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task
         Null_semantics_is_correctly_applied_for_function_comparisons_that_take_arguments_from_optional_navigation_complex(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<CogTag>().Where(t => t.Note.Substring(0, t.Gear.Squad.Name.Length) == t.GearNickName),
-            ss => ss.Set<CogTag>().Where(t => t.Gear.Maybe(x => t.Note.Substring(0, x.Squad.Name.Length)) == t.GearNickName));
+            ss => ss.Set<CogTag>().Where(t => t.Note!.Substring(0, t.Gear!.Squad.Name!.Length) == t.GearNickName),
+            ss => ss.Set<CogTag>().Where(t => t.Gear!.Maybe(x => t.Note!.Substring(0, x.Squad.Name!.Length)) == t.GearNickName));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task OfTypeNav1(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<Gear>().Where(g => g.Tag.Note != "Foo").OfType<Officer>().Where(o => o.Tag.Note != "Bar"));
+            ss => ss.Set<Gear>().Where(g => g.Tag!.Note != "Foo").OfType<Officer>().Where(o => o.Tag!.Note != "Bar"));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task OfTypeNav2(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<Gear>().Where(g => g.Tag.Note != "Foo").OfType<Officer>().Where(o => o.AssignedCity.Location != "Bar"));
+            ss => ss.Set<Gear>().Where(g => g.Tag!.Note != "Foo").OfType<Officer>().Where(o => o.AssignedCity!.Location != "Bar"));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task OfTypeNav3(bool async)
         => AssertQuery(
             async,
             ss => ss.Set<Gear>()
-                .Where(g => g.Tag.Note != "Foo")
+                .Where(g => g.Tag!.Note != "Foo")
                 .Join(
                     ss.Set<Weapon>(),
                     g => g.FullName,
                     w => w.OwnerFullName,
                     (o, i) => o)
                 .OfType<Officer>()
-                .Where(o => o.Tag.Note != "Bar"));
+                .Where(o => o.Tag!.Note != "Bar"));
 
     [Fact]
     public virtual Task Nav_rewrite_Distinct_with_convert()
@@ -4426,8 +4427,8 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
         {
             using var ctx = CreateContext();
             _ = ctx.Factions.Include(f => ((LocustHorde)f).Commander)
-                .Where(f => f.Capital.Name != "Foo").Select(f => (LocustHorde)f)
-                .Distinct().Where(lh => lh.Commander.Name != "Bar").ToList();
+                .Where(f => f.Capital!.Name != "Foo").Select(f => (LocustHorde)f)
+                .Distinct().Where(lh => lh.Commander!.Name != "Bar").ToList();
             return Task.CompletedTask;
         });
 
@@ -4438,8 +4439,8 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
         {
             using var ctx = CreateContext();
             _ = ctx.Factions.Include(f => ((LocustHorde)f).Commander)
-                .Where(f => f.Capital.Name != "Foo").Select(f => new { horde = (LocustHorde)f })
-                .Distinct().Where(lh => lh.horde.Commander.Name != "Bar").ToList();
+                .Where(f => f.Capital!.Name != "Foo").Select(f => new { horde = (LocustHorde)f })
+                .Distinct().Where(lh => lh.horde.Commander!.Name != "Bar").ToList();
             return Task.CompletedTask;
         });
 
@@ -4447,25 +4448,25 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
     public virtual Task Nav_rewrite_with_convert1(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<Faction>().Where(f => f.Capital.Name != "Foo").Select(f => ((LocustHorde)f).Commander));
+            ss => ss.Set<Faction>().Where(f => f.Capital!.Name != "Foo").Select(f => ((LocustHorde)f).Commander));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Nav_rewrite_with_convert2(bool async)
         => AssertQuery(
             async,
             ss => ss.Set<Faction>()
-                .Where(f => f.Capital.Name != "Foo")
+                .Where(f => f.Capital!.Name != "Foo")
                 .Select(f => (LocustHorde)f)
-                .Where(lh => lh.Commander.Name != "Bar"));
+                .Where(lh => lh.Commander!.Name != "Bar"));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Nav_rewrite_with_convert3(bool async)
         => AssertQuery(
             async,
             ss => ss.Set<Faction>()
-                .Where(f => f.Capital.Name != "Foo")
+                .Where(f => f.Capital!.Name != "Foo")
                 .Select(f => new { horde = (LocustHorde)f })
-                .Where(x => x.horde.Commander.Name != "Bar"),
+                .Where(x => x.horde.Commander!.Name != "Bar"),
             elementSorter: e => e.horde.Id,
             elementAsserter: (e, a) => AssertEqual(e.horde, a.horde));
 
@@ -4487,7 +4488,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
             async,
             ss => ss.Set<Gear>()
                 .Include(g => g.Weapons)
-                .OrderBy(g => g.Weapons.FirstOrDefault(w => w.Name.Contains("Gnasher")).Name)
+                .OrderBy(g => g.Weapons.FirstOrDefault(w => w.Name!.Contains("Gnasher"))!.Name)
                 .ThenBy(g => g.Nickname),
             elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Gear>(e => e.Weapons)),
             assertOrder: true);
@@ -4503,7 +4504,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
     public virtual Task Bool_projection_from_subquery_treated_appropriately_in_where(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<City>().Where(c => ss.Set<Gear>().OrderBy(g => g.Nickname).ThenBy(g => g.SquadId).FirstOrDefault().HasSoulPatch));
+            ss => ss.Set<City>().Where(c => ss.Set<Gear>().OrderBy(g => g.Nickname).ThenBy(g => g.SquadId).FirstOrDefault()!.HasSoulPatch));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task DateTimeOffset_Contains_Less_than_Greater_than(bool async)
@@ -4534,7 +4535,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
         => AssertQuery(
             async,
             ss => ss.Set<Weapon>()
-                .Select(w => w.SynergyWithId.HasValue ? $"SynergyWithOwner: {w.SynergyWith.OwnerFullName}" : string.Empty));
+                .Select(w => w.SynergyWithId.HasValue ? $"SynergyWithOwner: {w.SynergyWith!.OwnerFullName}" : string.Empty));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Left_join_projection_using_coalesce_tracking(bool async)
@@ -4562,7 +4563,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
             async,
             ss => from t in ss.Set<CogTag>()
                   where t.Gear is Officer
-                  select ((Officer)t.Gear).Reports.Take(50),
+                  select ((Officer)t.Gear!).Reports.Take(50),
             elementSorter: e => e?.Count() ?? 0,
             elementAsserter: (e, a) => AssertCollection(e, a));
 
@@ -4572,7 +4573,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
             async,
             ss => from t in ss.Set<CogTag>()
                   where t.Gear is Officer
-                  select ((Officer)t.Gear).Reports,
+                  select ((Officer)t.Gear!).Reports,
             elementSorter: e => e?.Count ?? 0,
             elementAsserter: (e, a) => AssertCollection(e, a));
 
@@ -4704,7 +4705,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
     public virtual Task Navigation_based_on_complex_expression1(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<Faction>().Where(f => f is LocustHorde ? (f as LocustHorde).Commander != null : false));
+            ss => ss.Set<Faction>().Where(f => f is LocustHorde ? (f as LocustHorde)!.Commander != null : false));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Navigation_based_on_complex_expression2(bool async)
@@ -4743,7 +4744,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
             async,
             ss => from lc1 in ss.Set<Faction>().OfType<LocustHorde>().Select(lh => lh.Commander)
                   join lc2 in ss.Set<LocustLeader>().OfType<LocustCommander>() on true equals true
-                  select (lc1.Name == "Queen Myrrah" ? lc1 : lc2).DefeatedBy));
+                  select (lc1!.Name == "Queen Myrrah" ? lc1 : lc2).DefeatedBy));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Select_as_operator(bool async)
@@ -4779,7 +4780,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
                 {
                     w.Id,
                     w.IsAutomatic,
-                    w.SynergyWith.Name
+                    w.SynergyWith!.Name
                 })
             }),
             assertOrder: true,
@@ -4789,10 +4790,10 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
     public virtual Task Reference_include_chain_loads_correctly_when_middle_is_null(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<CogTag>().AsTracking().OrderBy(t => t.Note).Include(t => t.Gear).ThenInclude(g => g.Squad),
+            ss => ss.Set<CogTag>().AsTracking().OrderBy(t => t.Note).Include(t => t.Gear).ThenInclude(g => g!.Squad),
             elementAsserter: (e, a) => AssertInclude(
                 e, a,
-                new ExpectedInclude<CogTag>(t => t.Gear), new ExpectedInclude<Gear>(t => t.Squad, "Gear")));
+                new ExpectedInclude<CogTag>(t => t.Gear!), new ExpectedInclude<Gear>(t => t.Squad, "Gear")));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Accessing_property_of_optional_navigation_in_child_projection_works(bool async)
@@ -4801,7 +4802,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
             ss => ss.Set<CogTag>().OrderBy(e => e.Note).Select(t => new
             {
                 Items = t.Gear != null
-                    ? t.Gear.Weapons.Select(w => new { w.Owner.Nickname }).ToList()
+                    ? t.Gear.Weapons.Select(w => new { w.Owner!.Nickname }).ToList()
                     : null
             }),
             assertOrder: true,
@@ -4828,7 +4829,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
             CoreStrings.IncludeOnNonEntity("c => c.BornGears"),
             (await Assert.ThrowsAsync<InvalidOperationException>(() => AssertQuery(
                 async,
-                ss => ss.Set<Faction>().Select(f => f.Capital).Include(c => c.BornGears)))).Message);
+                ss => ss.Set<Faction>().Select(f => f.Capital!).Include(c => c.BornGears)))).Message);
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual async Task Include_after_select_anonymous_projection_throws(bool async)
@@ -4844,7 +4845,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Include_after_SelectMany_throws(bool async)
-        => AssertQuery(async, ss => ss.Set<Faction>().SelectMany(f => f.Capital.BornGears).Include(g => g.Squad));
+        => AssertQuery(async, ss => ss.Set<Faction>().SelectMany(f => f.Capital!.BornGears).Include(g => g.Squad));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Query_reusing_parameter_doesnt_declare_duplicate_parameter(bool async)
@@ -4910,13 +4911,13 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
 
     private class ComplexParameter
     {
-        public ComplexParameterInner Inner { get; set; }
+        public ComplexParameterInner Inner { get; set; } = null!;
     }
 
     private class ComplexParameterInner
     {
-        public string Nickname { get; set; }
-        public Squad Squad { get; set; }
+        public string Nickname { get; set; } = null!;
+        public Squad Squad { get; set; } = null!;
     }
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -4942,7 +4943,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
         => AssertQuery(
             async,
             ss => (from g in ss.Set<Gear>()
-                   select new { g.AssignedCity.Name, Count = g.Weapons.Count() }).Concat(
+                   select new { g.AssignedCity!.Name, Count = g.Weapons.Count() }).Concat(
                     from g in ss.Set<Gear>()
                     select new { g.CityOfBirth.Name, Count = g.Weapons.Count() })
                 .GroupBy(x => new { x.Name, x.Count })
@@ -4959,7 +4960,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
         => AssertQuery(
             async,
             ss => (from g in ss.Set<Gear>()
-                   select new { g.AssignedCity.Name, Count = g.Weapons.Count() }).Concat(
+                   select new { g.AssignedCity!.Name, Count = g.Weapons.Count() }).Concat(
                     from g in ss.Set<Gear>()
                     select new { g.CityOfBirth.Name, Count = g.Weapons.Count() })
                 .GroupBy(
@@ -5017,11 +5018,11 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
         => AssertQuery(
             async,
             ss => ss.Set<CogTag>()
-                .GroupBy(t => new { HasSoulPatch = (bool?)t.Gear.HasSoulPatch, t.Gear.Squad.Name })
-                .Select(g => new { g.Key.HasSoulPatch, Name = g.Key.Name.ToLower() }),
+                .GroupBy(t => new { HasSoulPatch = (bool?)t.Gear!.HasSoulPatch, t.Gear!.Squad.Name })
+                .Select(g => new { g.Key.HasSoulPatch, Name = g.Key.Name!.ToLower() }),
             ss => ss.Set<CogTag>()
-                .GroupBy(t => new { HasSoulPatch = t.Gear.MaybeScalar(x => x.HasSoulPatch), t.Gear.Squad.Name })
-                .Select(g => new { g.Key.HasSoulPatch, Name = g.Key.Name.Maybe(x => x.ToLower()) }),
+                .GroupBy(t => new { HasSoulPatch = t.Gear!.MaybeScalar(x => x.HasSoulPatch), t.Gear!.Squad.Name })
+                .Select(g => new { g.Key.HasSoulPatch, Name = g.Key.Name!.Maybe(x => x.ToLower())! }),
             elementSorter: e => (e.HasSoulPatch, e.Name));
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -5032,7 +5033,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
                 .Select(g => new
                 {
                     g.Nickname,
-                    AssignedCityName = g.AssignedCity.Name,
+                    AssignedCityName = g.AssignedCity!.Name,
                     CityOfBirthName = g.CityOfBirth.Name,
                     SquadName = g.Squad.Name
                 })
@@ -5050,7 +5051,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Group_by_on_StartsWith_with_null_parameter_as_argument(bool async)
     {
-        var prm = (string)null;
+        var prm = (string)null!;
 
         return AssertQueryScalar(
             async,
@@ -5061,7 +5062,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Group_by_with_having_StartsWith_with_null_parameter_as_argument(bool async)
     {
-        var prm = (string)null;
+        var prm = (string)null!;
 
         return AssertQuery(
             async,
@@ -5073,7 +5074,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Select_StartsWith_with_null_parameter_as_argument(bool async)
     {
-        var prm = (string)null;
+        var prm = (string)null!;
 
         return AssertQueryScalar(
             async,
@@ -5084,7 +5085,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Select_null_parameter_is_not_null(bool async)
     {
-        var prm = (string)null;
+        var prm = (string)null!;
 
         return AssertQueryScalar(
             async,
@@ -5095,7 +5096,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Where_null_parameter_is_not_null(bool async)
     {
-        var prm = (string)null;
+        var prm = (string)null!;
 
         return AssertQuery(
             async,
@@ -5107,7 +5108,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task OrderBy_StartsWith_with_null_parameter_as_argument(bool async)
     {
-        var prm = (string)null;
+        var prm = (string)null!;
 
         return AssertQuery(
             async,
@@ -5157,7 +5158,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
         => AssertQuery(
             async,
             ss => ss.Set<Gear>()
-                .Where(g => g.AssignedCity == ss.Set<Gear>().OrderBy(s => s.Nickname).FirstOrDefault().CityOfBirth));
+                .Where(g => g.AssignedCity == ss.Set<Gear>().OrderBy(s => s.Nickname).FirstOrDefault()!.CityOfBirth));
 
     //=> AssertQuery(
     //    async,
@@ -5168,7 +5169,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
     public virtual Task Conditional_expression_with_test_being_simplified_to_constant_simple(bool isAsync)
     {
         var prm = true;
-        var prm2 = (string)null;
+        var prm2 = (string)null!;
 
         return AssertQuery(
             isAsync,
@@ -5182,7 +5183,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
     {
         var prm = true;
         var prm2 = "Marcus' Lancer";
-        var prm3 = (string)null;
+        var prm3 = (string)null!;
 
         return AssertQuery(
             isAsync,
@@ -5287,8 +5288,8 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
     public virtual Task OrderBy_bool_coming_from_optional_navigation(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<Weapon>().Select(w => w.SynergyWith).OrderBy(w => w.IsAutomatic),
-            ss => ss.Set<Weapon>().Select(w => w.SynergyWith).OrderBy(w => w.MaybeScalar(x => x.IsAutomatic)),
+            ss => ss.Set<Weapon>().Select(w => w.SynergyWith).OrderBy(w => w!.IsAutomatic),
+            ss => ss.Set<Weapon>().Select(w => w.SynergyWith).OrderBy(w => w!.MaybeScalar(x => x.IsAutomatic)),
             assertOrder: true);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -5590,7 +5591,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
     public virtual Task CompareTo_used_with_non_unicode_string_column_and_constant(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<City>().Where(c => c.Location.CompareTo("Unknown") == 0));
+            ss => ss.Set<City>().Where(c => c.Location!.CompareTo("Unknown") == 0));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Coalesce_used_with_non_unicode_string_column_and_constant(bool async)
@@ -5603,7 +5604,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
         => AssertQuery(
             async,
             ss => ss.Set<Weapon>()
-                .GroupBy(w => new { w.Owner.CityOfBirth.Name, w.Owner.CityOfBirth.Location })
+                .GroupBy(w => new { w.Owner!.CityOfBirth.Name, w.Owner.CityOfBirth.Location })
                 .Select(x => new
                 {
                     x.Key.Name,
@@ -5649,11 +5650,11 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
         => AssertQuery(
             async,
             ss => from g in ss.Set<Gear>()
-                  from w in ss.Set<Weapon>().Select(x => x.SynergyWith).Where(x => x.OwnerFullName != g.FullName).DefaultIfEmpty()
+                  from w in ss.Set<Weapon>().Select(x => x.SynergyWith).Where(x => x!.OwnerFullName != g.FullName).DefaultIfEmpty()
                   orderby g.Nickname, w.Id
                   select new { g, w },
             ss => from g in ss.Set<Gear>()
-                  from w in ss.Set<Weapon>().Select(x => x.SynergyWith).Where(x => x.OwnerFullName != g.FullName).MaybeDefaultIfEmpty()
+                  from w in ss.Set<Weapon>().Select(x => x.SynergyWith).Where(x => x!.OwnerFullName != g.FullName).MaybeDefaultIfEmpty()
                   orderby g.Nickname, w.MaybeScalar(xx => xx.Id)
                   select new { g, w },
             assertOrder: true,
@@ -5749,7 +5750,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
 
         await AssertQuery(
             async,
-            ss => ss.Set<LocustLeader>().Where(ll => ll is LocustCommander && (ll as LocustCommander).HighCommandId != 0));
+            ss => ss.Set<LocustLeader>().Where(ll => ll is LocustCommander && (ll as LocustCommander)!.HighCommandId != 0));
     }
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -5757,17 +5758,17 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
         => AssertFirstOrDefault(
             async,
             ss => ss.Set<LocustLeader>().Where(ll => ll.Name.Contains("Queen")).Cast<LocustCommander>().Include(lc => lc.DefeatedBy),
-            asserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<LocustCommander>(x => x.DefeatedBy)));
+            asserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<LocustCommander>(x => x.DefeatedBy!)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Cast_to_derived_followed_by_multiple_includes(bool async)
         => AssertQuery(
             async,
             ss => ss.Set<LocustLeader>().Where(ll => ll.Name.Contains("Queen")).Cast<LocustCommander>().Include(lc => lc.DefeatedBy)
-                .ThenInclude(g => g.Weapons),
+                .ThenInclude(g => g!.Weapons),
             elementAsserter: (e, a) => AssertInclude(
                 e, a,
-                new ExpectedInclude<LocustCommander>(x => x.DefeatedBy),
+                new ExpectedInclude<LocustCommander>(x => x.DefeatedBy!),
                 new ExpectedInclude<Gear>(x => x.Weapons, "DefeatedBy")));
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -5872,12 +5873,12 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
                 Nullable = x.GearNickName != null
                     ? new
                     {
-                        x.Gear.Nickname,
+                        x.Gear!.Nickname,
                         x.Gear.SquadId,
                         x.Gear.HasSoulPatch
                     }
                     : null
-            }).Where(x => x.Nullable.SquadId == 1));
+            }).Where(x => x.Nullable!.SquadId == 1));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Projecting_property_converted_to_nullable_with_addition(bool async)
@@ -5889,19 +5890,19 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
                 Nullable = x.GearNickName != null
                     ? new
                     {
-                        x.Gear.Nickname,
+                        x.Gear!.Nickname,
                         x.Gear.SquadId,
                         x.Gear.HasSoulPatch
                     }
                     : null
-            }).Where(x => x.Nullable.SquadId + 1 == 2),
+            }).Where(x => x.Nullable!.SquadId + 1 == 2),
             ss => ss.Set<CogTag>().Select(x => new
             {
                 x.Note,
                 Nullable = x.GearNickName != null
                     ? new
                     {
-                        x.Gear.Nickname,
+                        x.Gear!.Nickname,
                         x.Gear.SquadId,
                         x.Gear.HasSoulPatch
                     }
@@ -5918,14 +5919,14 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
                 Nullable = x.GearNickName != null
                         ? new
                         {
-                            x.Gear.Nickname,
+                            x.Gear!.Nickname,
                             x.Gear.SquadId,
                             x.Gear.HasSoulPatch
                         }
                         : null
             })
-                .Where(x => x.Nullable.Nickname != null)
-                .Select(x => new { x.Note, Value = x.Nullable.SquadId + 1 }));
+                .Where(x => x.Nullable!.Nickname != null)
+                .Select(x => new { x.Note, Value = x.Nullable!.SquadId + 1 }));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Projecting_property_converted_to_nullable_with_conditional(bool async)
@@ -5937,12 +5938,12 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
                 Nullable = x.GearNickName != null
                     ? new
                     {
-                        x.Gear.Nickname,
+                        x.Gear!.Nickname,
                         x.Gear.SquadId,
                         x.Gear.HasSoulPatch
                     }
                     : null
-            }).Select(x => x.Note != "K.I.A." ? x.Nullable.SquadId : -1));
+            }).Select(x => x.Note != "K.I.A." ? x.Nullable!.SquadId : -1));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Projecting_property_converted_to_nullable_with_function_call(bool async)
@@ -5954,12 +5955,12 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
                 Nullable = x.GearNickName != null
                     ? new
                     {
-                        x.Gear.Nickname,
+                        x.Gear!.Nickname,
                         x.Gear.SquadId,
                         x.Gear.HasSoulPatch
                     }
                     : null
-            }).Select(x => x.Nullable.Nickname.Substring(0, 3)),
+            }).Select(x => x.Nullable!.Nickname.Substring(0, 3)),
             ss => ss.Set<CogTag>().Select(x => x.GearNickName == null ? null : x.GearNickName.Substring(0, 3)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -5972,28 +5973,28 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
                 Nullable = x.GearNickName != null
                         ? new
                         {
-                            x.Gear.Nickname,
+                            x.Gear!.Nickname,
                             x.Gear.SquadId,
                             x.Gear.HasSoulPatch
                         }
                         : null
             })
-                .Where(x => x.Nullable.Nickname != null)
-                .Select(x => new { x.Note, Function = x.Note.Substring(0, x.Nullable.SquadId) }),
+                .Where(x => x.Nullable!.Nickname != null)
+                .Select(x => new { x.Note, Function = x.Note!.Substring(0, x.Nullable!.SquadId) }),
             ss => ss.Set<CogTag>().Select(x => new
             {
                 x.Note,
                 Nullable = x.GearNickName != null
                         ? new
                         {
-                            x.Gear.Nickname,
+                            x.Gear!.Nickname,
                             x.Gear.SquadId,
                             x.Gear.HasSoulPatch
                         }
                         : null
             })
-                .Where(x => x.Nullable.Nickname != null)
-                .Select(x => new { x.Note, Function = x.Nullable == null ? null : x.Note.Substring(0, x.Nullable.SquadId) }));
+                .Where(x => x.Nullable!.Nickname != null)
+                .Select(x => new { x.Note, Function = x.Nullable == null ? null! : x.Note!.Substring(0, x.Nullable.SquadId) }));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Projecting_property_converted_to_nullable_into_element_init(bool async)
@@ -6005,17 +6006,17 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
                 Nullable = x.GearNickName != null
                         ? new
                         {
-                            x.Gear.Nickname,
+                            x.Gear!.Nickname,
                             x.Gear.SquadId,
                             x.Gear.HasSoulPatch
                         }
                         : null
             })
-                .Where(x => x.Nullable.Nickname != null)
+                .Where(x => x.Nullable!.Nickname != null)
                 .OrderBy(x => x.Note)
                 .Select(x => new List<int>
                 {
-                    x.Nullable.Nickname.Length,
+                    x.Nullable!.Nickname.Length,
                     x.Nullable.SquadId,
                     x.Nullable.SquadId + 1,
                     42
@@ -6032,15 +6033,15 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
                 Nullable = x.GearNickName != null
                         ? new
                         {
-                            x.Gear.Nickname,
+                            x.Gear!.Nickname,
                             x.Gear.SquadId,
                             x.Gear.HasSoulPatch
                         }
                         : null
             })
-                .Where(x => x.Nullable.Nickname != null)
+                .Where(x => x.Nullable!.Nickname != null)
                 .OrderBy(x => x.Note)
-                .Select(x => new Squad { Id = x.Nullable.SquadId }),
+                .Select(x => new Squad { Id = x.Nullable!.SquadId }),
             assertOrder: true);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -6053,15 +6054,15 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
                 Nullable = x.GearNickName != null
                         ? new
                         {
-                            x.Gear.Nickname,
+                            x.Gear!.Nickname,
                             x.Gear.SquadId,
                             x.Gear.HasSoulPatch
                         }
                         : null
             })
-                .Where(x => x.Nullable.Nickname != null)
+                .Where(x => x.Nullable!.Nickname != null)
                 .OrderBy(x => x.Note)
-                .Select(x => new[] { x.Nullable.Nickname.Length, x.Nullable.SquadId, x.Nullable.SquadId + 1, 42 }),
+                .Select(x => new[] { x.Nullable!.Nickname.Length, x.Nullable.SquadId, x.Nullable.SquadId + 1, 42 }),
             assertOrder: true);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -6074,15 +6075,15 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
                 Nullable = x.GearNickName != null
                         ? new
                         {
-                            x.Gear.Nickname,
+                            x.Gear!.Nickname,
                             x.Gear.SquadId,
                             x.Gear.HasSoulPatch
                         }
                         : null
             })
-                .Where(x => x.Nullable.Nickname != null)
+                .Where(x => x.Nullable!.Nickname != null)
                 .OrderBy(x => x.Note)
-                .Where(x => !x.Nullable.HasSoulPatch)
+                .Where(x => !x.Nullable!.HasSoulPatch)
                 .Select(x => x.Note),
             assertOrder: true);
 
@@ -6094,11 +6095,11 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
             {
                 x.Nickname,
                 x.CityOfBirthName,
-                Nullable = x.CityOfBirthName != null ? new { x.Tag.IssueDate } : null
+                Nullable = x.CityOfBirthName != null ? new { x.Tag!.IssueDate } : null
             })
                 .Where(x => x.CityOfBirthName != null)
                 .OrderBy(x => x.Nickname)
-                .Where(x => x.Nullable.IssueDate.Month != 5)
+                .Where(x => x.Nullable!.IssueDate.Month != 5)
                 .Select(x => x.Nickname),
             assertOrder: true);
 
@@ -6112,14 +6113,14 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
                 Nullable = x.GearNickName != null
                         ? new
                         {
-                            x.Gear.Nickname,
+                            x.Gear!.Nickname,
                             x.Gear.SquadId,
                             x.Gear.HasSoulPatch
                         }
                         : null
             })
-                .Where(x => x.Nullable.Nickname != null)
-                .OrderBy(x => x.Nullable.SquadId).ThenBy(x => x.Note),
+                .Where(x => x.Nullable!.Nickname != null)
+                .OrderBy(x => x.Nullable!.SquadId).ThenBy(x => x.Note),
             assertOrder: true);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -6256,7 +6257,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
                         {
                             w.Name,
                             w.IsAutomatic,
-                            w.OwnerFullName.Length
+                            w.OwnerFullName!.Length
                         })
                         .Distinct().ToList()
                 }),
@@ -6373,7 +6374,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
                     Key = g.Nickname,
                     Subquery = g.Weapons
                         .Select(w => new { w.Name, w.IsAutomatic })
-                        .GroupBy(x => x.Name.Length)
+                        .GroupBy(x => x.Name!.Length)
                         .Select(x => new { x.Key, Count = x.Count() }).ToList()
                 }),
             elementSorter: e => e.Key,
@@ -6397,11 +6398,11 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
             async,
             ss => ss.Set<Gear>()
                 .OrderBy(g => g.Nickname)
-                .Select(g => g.Weapons.SelectMany(x => x.Owner.AssignedCity.BornGears)
+                .Select(g => g.Weapons.SelectMany(x => x.Owner!.AssignedCity!.BornGears)
                     .Select(x => (bool?)x.HasSoulPatch).Distinct().ToList()),
             ss => ss.Set<Gear>()
                 .OrderBy(g => g.Nickname)
-                .Select(g => g.Weapons.SelectMany(x => x.Owner.AssignedCity.Maybe(x => x.BornGears) ?? new List<Gear>())
+                .Select(g => g.Weapons.SelectMany(x => x.Owner!.AssignedCity!.Maybe(x => x.BornGears) ?? new List<Gear>())
                     .Select(x => (bool?)x.HasSoulPatch).Distinct().ToList()),
             elementAsserter: (e, a) => AssertCollection(e, a, elementSorter: ee => ee),
             assertOrder: true);
@@ -6413,7 +6414,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
             ss => ss.Set<Gear>()
                 .Select(g => g.Weapons)
                 .Distinct(),
-            elementSorter: e => e.OrderBy(w => w.Id).FirstOrDefault().Id,
+            elementSorter: e => e.OrderBy(w => w.Id).FirstOrDefault()!.Id,
             elementAsserter: (e, a) => AssertCollection(e, a));
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -6563,7 +6564,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
         => AssertQuery(
             async,
             ss => ss.Set<Squad>()
-                .Select(s => new { s.Name.Length })
+                .Select(s => new { s.Name!.Length })
                 .Distinct()
                 .Select(x => new
                 {
@@ -6658,22 +6659,22 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
             ss => ss.Set<Gear>().Select(g => new
             {
                 Gear = g,
-                (g as Officer).Tag,
-                IsNull = (g as Officer).Tag == null,
-                Property = (g as Officer).Nickname,
-                PropertyAfterNavigation = (g as Officer).Tag.Id,
+                (g as Officer)!.Tag,
+                IsNull = (g as Officer)!.Tag == null,
+                Property = (g as Officer)!.Nickname,
+                PropertyAfterNavigation = (g as Officer)!.Tag!.Id,
                 NestedOuter = new
                 {
-                    (g as Officer).CityOfBirth,
-                    IsNull = (g as Officer).CityOfBirth == null,
-                    Property = (g as Officer).Nickname,
-                    PropertyAfterNavigation = (g as Officer).CityOfBirth.Name,
+                    (g as Officer)!.CityOfBirth,
+                    IsNull = (g as Officer)!.CityOfBirth == null,
+                    Property = (g as Officer)!.Nickname,
+                    PropertyAfterNavigation = (g as Officer)!.CityOfBirth.Name,
                     NestedInner = new
                     {
-                        (g as Officer).Squad,
-                        IsNull = (g as Officer).Squad == null,
-                        Property = (g as Officer).Nickname,
-                        PropertyAfterNavigation = (g as Officer).Squad.Id
+                        (g as Officer)!.Squad,
+                        IsNull = (g as Officer)!.Squad == null,
+                        Property = (g as Officer)!.Nickname,
+                        PropertyAfterNavigation = (g as Officer)!.Squad.Id
                     }
                 }
             }),
@@ -6683,19 +6684,19 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
                 g.Tag,
                 IsNull = g.Tag == null,
                 Property = g.Nickname,
-                PropertyAfterNavigation = g.Tag.Id,
+                PropertyAfterNavigation = g.Tag!.Id,
                 NestedOuter = new
                 {
                     g.CityOfBirth,
                     IsNull = g.CityOfBirth == null,
                     Property = g.Nickname,
-                    PropertyAfterNavigation = g.CityOfBirth.Name,
+                    PropertyAfterNavigation = g.CityOfBirth!.Name,
                     NestedInner = new
                     {
                         g.Squad,
                         IsNull = g.Squad == null,
                         Property = g.Nickname,
-                        PropertyAfterNavigation = g.Squad.Id
+                        PropertyAfterNavigation = g.Squad!.Id
                     }
                 }
             }),
@@ -6726,44 +6727,44 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
             ss => ss.Set<LocustLeader>().Select(l => new
             {
                 Leader = l,
-                (l as LocustCommander).DefeatedBy,
-                IsNull = (l as LocustCommander).DefeatedBy == null,
-                Property = (l as LocustCommander).DefeatedByNickname,
-                PropertyAfterNavigation = (bool?)(l as LocustCommander).DefeatedBy.HasSoulPatch,
+                (l as LocustCommander)!.DefeatedBy,
+                IsNull = (l as LocustCommander)!.DefeatedBy == null,
+                Property = (l as LocustCommander)!.DefeatedByNickname,
+                PropertyAfterNavigation = (bool?)(l as LocustCommander)!.DefeatedBy!.HasSoulPatch,
                 NestedOuter = new
                 {
-                    (l as LocustCommander).CommandingFaction,
-                    IsNull = (l as LocustCommander).CommandingFaction == null,
-                    Property = (int?)(l as LocustCommander).HighCommandId,
-                    PropertyAfterNavigation = (l as LocustCommander).CommandingFaction.Eradicated,
+                    (l as LocustCommander)!.CommandingFaction,
+                    IsNull = (l as LocustCommander)!.CommandingFaction == null,
+                    Property = (int?)(l as LocustCommander)!.HighCommandId,
+                    PropertyAfterNavigation = (l as LocustCommander)!.CommandingFaction!.Eradicated,
                     NestedInner = new
                     {
-                        (l as LocustCommander).HighCommand,
-                        IsNull = (l as LocustCommander).HighCommand == null,
-                        Property = (l as LocustCommander).DefeatedBySquadId,
-                        PropertyAfterNavigation = (l as LocustCommander).HighCommand.Name
+                        (l as LocustCommander)!.HighCommand,
+                        IsNull = (l as LocustCommander)!.HighCommand == null,
+                        Property = (l as LocustCommander)!.DefeatedBySquadId,
+                        PropertyAfterNavigation = (l as LocustCommander)!.HighCommand!.Name
                     }
                 }
             }),
             ss => ss.Set<LocustLeader>().Select(l => new
             {
                 Leader = l,
-                (l as LocustCommander).DefeatedBy,
-                IsNull = (l as LocustCommander).DefeatedBy == null,
-                Property = (l as LocustCommander).DefeatedByNickname,
-                PropertyAfterNavigation = (bool?)(l as LocustCommander).DefeatedBy.HasSoulPatch,
+                (l as LocustCommander)!.DefeatedBy,
+                IsNull = (l as LocustCommander)!.DefeatedBy == null,
+                Property = (l as LocustCommander)!.DefeatedByNickname,
+                PropertyAfterNavigation = (bool?)(l as LocustCommander)!.DefeatedBy!.HasSoulPatch,
                 NestedOuter = new
                 {
-                    (l as LocustCommander).CommandingFaction,
-                    IsNull = (l as LocustCommander).CommandingFaction == null,
-                    Property = (int?)(l as LocustCommander).HighCommandId,
-                    PropertyAfterNavigation = (l as LocustCommander).CommandingFaction.MaybeScalar(x => x.Eradicated),
+                    (l as LocustCommander)!.CommandingFaction,
+                    IsNull = (l as LocustCommander)!.CommandingFaction == null,
+                    Property = (int?)(l as LocustCommander)!.HighCommandId,
+                    PropertyAfterNavigation = (l as LocustCommander)!.CommandingFaction!.MaybeScalar(x => x.Eradicated),
                     NestedInner = new
                     {
-                        (l as LocustCommander).HighCommand,
-                        IsNull = (l as LocustCommander).HighCommand == null,
-                        Property = (l as LocustCommander).MaybeScalar(x => x.DefeatedBySquadId),
-                        PropertyAfterNavigation = (l as LocustCommander).HighCommand.Name
+                        (l as LocustCommander)!.HighCommand,
+                        IsNull = (l as LocustCommander)!.HighCommand == null,
+                        Property = (l as LocustCommander)!.MaybeScalar(x => x.DefeatedBySquadId),
+                        PropertyAfterNavigation = (l as LocustCommander)!.HighCommand!.Name
                     }
                 }
             }),
@@ -6897,7 +6898,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
         => AssertQuery(
             async,
             ss => ss.Set<Squad>().Where(s => s.Members.OrderBy(m => m.Nickname).ElementAt(s.Id).Nickname == "Cole Train"),
-            ss => ss.Set<Squad>().Where(s => s.Members.OrderBy(m => m.Nickname).ElementAtOrDefault(s.Id).Nickname == "Cole Train"));
+            ss => ss.Set<Squad>().Where(s => s.Members.OrderBy(m => m.Nickname).ElementAtOrDefault(s.Id)!.Nickname == "Cole Train"));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Using_indexer_on_byte_array_and_string_in_projection(bool async)
@@ -6907,7 +6908,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
             {
                 x.Id,
                 ByteArray = x.Banner[0],
-                String = x.Name[1]
+                String = x.Name![1]
             }),
             elementSorter: e => e.Id,
             elementAsserter: (e, a) =>
@@ -6923,9 +6924,9 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
             async,
             ss => ss.Set<Gear>()
                 .Where(x => ss.Set<Gear>().Concat(ss.Set<Gear>()).Select(x => x.Nickname).Contains("Marcus"))
-                .Select(x => new { x.Squad.Name, x.CityOfBirth.Location })
+                .Select(x => new { x.Squad.Name, x.CityOfBirth!.Location })
                 .GroupBy(x => new { x.Name })
-                .Select(x => new { x.Key.Name, SumOfLengths = x.Sum(xx => xx.Location.Length) }));
+                .Select(x => new { x.Key.Name, SumOfLengths = x.Sum(xx => xx.Location!.Length) }));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Nav_expansion_inside_Contains_argument(bool async)
@@ -6944,7 +6945,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
 
         return AssertQuery(
             async,
-            ss => ss.Set<Gear>().Where(x => weapons.Contains(x.Weapons.OrderBy(w => w.Id).FirstOrDefault().Name)));
+            ss => ss.Set<Gear>().Where(x => weapons.Contains(x.Weapons.OrderBy(w => w.Id).FirstOrDefault()!.Name)));
     }
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -6971,7 +6972,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
     public virtual Task Nav_expansion_inside_Take_correlated_to_source(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<Gear>().OrderBy(x => x.Nickname).Select(x => x.Weapons.OrderBy(g => g.Id).Take(x.AssignedCity.Name.Length)));
+            ss => ss.Set<Gear>().OrderBy(x => x.Nickname).Select(x => x.Weapons.OrderBy(g => g.Id).Take(x.AssignedCity!.Name.Length)));
 
     [Theory(Skip = "issue #32303"), MemberData(nameof(IsAsyncData))]
     public virtual Task Nav_expansion_with_member_pushdown_inside_Take_correlated_to_source(bool async)
@@ -6981,7 +6982,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
         return AssertQuery(
             async,
             ss => ss.Set<Gear>().OrderBy(x => x.Nickname).Select(x => x.Weapons.OrderBy(g => g.Id).Take(
-                ss.Set<Gear>().OrderBy(xx => xx.Nickname).FirstOrDefault().AssignedCity.Name.Length)),
+                ss.Set<Gear>().OrderBy(xx => xx.Nickname).FirstOrDefault()!.AssignedCity!.Name.Length)),
             assertOrder: true,
             elementAsserter: (e, a) => AssertCollection(e, a, ordered: true));
     }
@@ -7009,7 +7010,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
                   join lc in ss.Set<LocustLeader>().OfType<LocustCommander>()
                       on g.Nickname equals lc.DefeatedByNickname into grouping
                   from lc in grouping.DefaultIfEmpty()
-                  select new GearLocustLeaderDto { FullName = g.FullName, ThreatLevel = lc.ThreatLevel },
+                  select new GearLocustLeaderDto { FullName = g.FullName, ThreatLevel = lc!.ThreatLevel },
             ss => from g in ss.Set<Gear>()
                   join lc in ss.Set<LocustLeader>().OfType<LocustCommander>()
                       on g.Nickname equals lc.DefeatedByNickname into grouping
@@ -7024,7 +7025,7 @@ public abstract class GearsOfWarQueryTestBase<TFixture>(TFixture fixture) : Quer
 
     private class GearLocustLeaderDto
     {
-        public string FullName { get; set; }
+        public string FullName { get; set; } = null!;
         public int? ThreatLevel { get; set; }
     }
 

--- a/test/EFCore.Specification.Tests/Query/IncludeOneToOneTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/IncludeOneToOneTestBase.cs
@@ -5,8 +5,6 @@
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
-#nullable disable
-
 public abstract class IncludeOneToOneTestBase<TFixture>(TFixture fixture) : IClassFixture<TFixture>
     where TFixture : IncludeOneToOneTestBase<TFixture>.OneToOneQueryFixtureBase, new()
 {
@@ -262,32 +260,32 @@ public abstract class IncludeOneToOneTestBase<TFixture>(TFixture fixture) : ICla
     protected class Person
     {
         public int Id { get; set; }
-        public string Name { get; set; }
-        public Address Address { get; set; }
+        public string Name { get; set; } = null!;
+        public Address? Address { get; set; }
     }
 
     protected class Address
     {
         public int Id { get; set; }
-        public string Street { get; set; }
-        public string City { get; set; }
-        public Person Resident { get; set; }
+        public string Street { get; set; } = null!;
+        public string City { get; set; } = null!;
+        public Person Resident { get; set; } = null!;
     }
 
     protected class Person2
     {
         public int Id { get; set; }
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
 
         // ReSharper disable once MemberHidesStaticFromOuterClass
-        public Address2 Address { get; set; }
+        public Address2 Address { get; set; } = null!;
     }
 
     protected class Address2
     {
-        public string Id { get; set; }
-        public string Street { get; set; }
-        public string City { get; set; }
-        public Person2 Resident { get; set; }
+        public string Id { get; set; } = null!;
+        public string Street { get; set; } = null!;
+        public string City { get; set; } = null!;
+        public Person2 Resident { get; set; } = null!;
     }
 }

--- a/test/EFCore.Specification.Tests/Query/Inheritance/FiltersInheritanceQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/Inheritance/FiltersInheritanceQueryTestBase.cs
@@ -64,7 +64,7 @@ public abstract class FiltersInheritanceQueryTestBase<TFixture>(TFixture fixture
             ss => ss.Set<Animal>()
                 .OfType<Bird>()
                 .Select(b => new { b.Name }),
-            elementSorter: e => e.Name);
+            elementSorter: e => e.Name!);
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Can_use_of_type_bird_first(bool async)

--- a/test/EFCore.Specification.Tests/Query/Inheritance/InheritanceQueryFixtureBase.cs
+++ b/test/EFCore.Specification.Tests/Query/Inheritance/InheritanceQueryFixtureBase.cs
@@ -5,8 +5,6 @@ using Microsoft.EntityFrameworkCore.TestModels.InheritanceModel;
 
 namespace Microsoft.EntityFrameworkCore.Query.Inheritance;
 
-#nullable disable
-
 public abstract class InheritanceQueryFixtureBase : QueryFixtureBase<InheritanceContext>
 {
     private readonly Dictionary<bool, ISetSource> _expectedDataCache = [];
@@ -63,25 +61,25 @@ public abstract class InheritanceQueryFixtureBase : QueryFixtureBase<Inheritance
 
     public override IReadOnlyDictionary<Type, object> EntitySorters { get; } = new Dictionary<Type, Func<object, object>>
     {
-        { typeof(Animal), e => ((Animal)e)?.Species },
-        { typeof(Bird), e => ((Bird)e)?.Species },
-        { typeof(Kiwi), e => ((Kiwi)e)?.Species },
-        { typeof(Eagle), e => ((Eagle)e)?.Species },
-        { typeof(AnimalQuery), e => ((AnimalQuery)e)?.Name },
-        { typeof(BirdQuery), e => ((BirdQuery)e)?.Name },
-        { typeof(KiwiQuery), e => ((KiwiQuery)e)?.Name },
-        { typeof(EagleQuery), e => ((EagleQuery)e)?.Name },
-        { typeof(Plant), e => ((Plant)e)?.Species },
-        { typeof(Flower), e => ((Flower)e)?.Species },
-        { typeof(Daisy), e => ((Daisy)e)?.Species },
-        { typeof(Rose), e => ((Rose)e)?.Species },
-        { typeof(Country), e => ((Country)e)?.Id },
-        { typeof(Drink), e => ((Drink)e)?.SortIndex },
-        { typeof(Coke), e => ((Coke)e)?.SortIndex },
-        { typeof(Lilt), e => ((Lilt)e)?.SortIndex },
-        { typeof(Tea), e => ((Tea)e)?.SortIndex },
-        { typeof(ComplexType), e => ((ComplexType)e)?.UniqueInt },
-        { typeof(NestedComplexType), e => ((NestedComplexType)e)?.UniqueInt },
+        { typeof(Animal), e => ((Animal)e).Species! },
+        { typeof(Bird), e => ((Bird)e).Species! },
+        { typeof(Kiwi), e => ((Kiwi)e).Species! },
+        { typeof(Eagle), e => ((Eagle)e).Species! },
+        { typeof(AnimalQuery), e => ((AnimalQuery)e).Name! },
+        { typeof(BirdQuery), e => ((BirdQuery)e).Name! },
+        { typeof(KiwiQuery), e => ((KiwiQuery)e).Name! },
+        { typeof(EagleQuery), e => ((EagleQuery)e).Name! },
+        { typeof(Plant), e => ((Plant)e).Species },
+        { typeof(Flower), e => ((Flower)e).Species },
+        { typeof(Daisy), e => ((Daisy)e).Species },
+        { typeof(Rose), e => ((Rose)e).Species },
+        { typeof(Country), e => ((Country)e).Id },
+        { typeof(Drink), e => ((Drink)e).SortIndex },
+        { typeof(Coke), e => ((Coke)e).SortIndex },
+        { typeof(Lilt), e => ((Lilt)e).SortIndex },
+        { typeof(Tea), e => ((Tea)e).SortIndex },
+        { typeof(ComplexType), e => e is ComplexType complexType ? complexType.UniqueInt : 0 },
+        { typeof(NestedComplexType), e => e is NestedComplexType nestedComplexType ? nestedComplexType.UniqueInt : 0 },
     }.ToDictionary(e => e.Key, e => (object)e.Value);
 
     public override IReadOnlyDictionary<Type, object> EntityAsserters { get; }
@@ -96,7 +94,7 @@ public abstract class InheritanceQueryFixtureBase : QueryFixtureBase<Inheritance
 
                     if (a != null)
                     {
-                        var ee = (Animal)e;
+                        var ee = (Animal)e!;
                         var aa = (Animal)a;
 
                         Assert.Equal(ee.Species, aa.Species);
@@ -112,7 +110,7 @@ public abstract class InheritanceQueryFixtureBase : QueryFixtureBase<Inheritance
 
                     if (a != null)
                     {
-                        var ee = (Bird)e;
+                        var ee = (Bird)e!;
                         var aa = (Bird)a;
 
                         Assert.Equal(ee.Species, aa.Species);
@@ -129,7 +127,7 @@ public abstract class InheritanceQueryFixtureBase : QueryFixtureBase<Inheritance
 
                     if (a != null)
                     {
-                        var ee = (Eagle)e;
+                        var ee = (Eagle)e!;
                         var aa = (Eagle)a;
 
                         Assert.Equal(ee.Species, aa.Species);
@@ -147,7 +145,7 @@ public abstract class InheritanceQueryFixtureBase : QueryFixtureBase<Inheritance
 
                     if (a != null)
                     {
-                        var ee = (Kiwi)e;
+                        var ee = (Kiwi)e!;
                         var aa = (Kiwi)a;
 
                         Assert.Equal(ee.Species, aa.Species);
@@ -165,7 +163,7 @@ public abstract class InheritanceQueryFixtureBase : QueryFixtureBase<Inheritance
 
                     if (a != null)
                     {
-                        var ee = (AnimalQuery)e;
+                        var ee = (AnimalQuery)e!;
                         var aa = (AnimalQuery)a;
 
                         Assert.Equal(ee.Name, aa.Name);
@@ -180,7 +178,7 @@ public abstract class InheritanceQueryFixtureBase : QueryFixtureBase<Inheritance
 
                     if (a != null)
                     {
-                        var ee = (BirdQuery)e;
+                        var ee = (BirdQuery)e!;
                         var aa = (BirdQuery)a;
 
                         Assert.Equal(ee.Name, aa.Name);
@@ -197,7 +195,7 @@ public abstract class InheritanceQueryFixtureBase : QueryFixtureBase<Inheritance
 
                     if (a != null)
                     {
-                        var ee = (EagleQuery)e;
+                        var ee = (EagleQuery)e!;
                         var aa = (EagleQuery)a;
 
                         Assert.Equal(ee.Name, aa.Name);
@@ -215,7 +213,7 @@ public abstract class InheritanceQueryFixtureBase : QueryFixtureBase<Inheritance
 
                     if (a != null)
                     {
-                        var ee = (KiwiQuery)e;
+                        var ee = (KiwiQuery)e!;
                         var aa = (KiwiQuery)a;
 
                         Assert.Equal(ee.Name, aa.Name);
@@ -233,7 +231,7 @@ public abstract class InheritanceQueryFixtureBase : QueryFixtureBase<Inheritance
 
                     if (a != null)
                     {
-                        var ee = (Plant)e;
+                        var ee = (Plant)e!;
                         var aa = (Plant)a;
 
                         Assert.Equal(ee.Species, aa.Species);
@@ -249,7 +247,7 @@ public abstract class InheritanceQueryFixtureBase : QueryFixtureBase<Inheritance
 
                     if (a != null)
                     {
-                        var ee = (Flower)e;
+                        var ee = (Flower)e!;
                         var aa = (Flower)a;
 
                         Assert.Equal(ee.Species, aa.Species);
@@ -265,7 +263,7 @@ public abstract class InheritanceQueryFixtureBase : QueryFixtureBase<Inheritance
 
                     if (a != null)
                     {
-                        var ee = (Daisy)e;
+                        var ee = (Daisy)e!;
                         var aa = (Daisy)a;
 
                         Assert.Equal(ee.Species, aa.Species);
@@ -281,7 +279,7 @@ public abstract class InheritanceQueryFixtureBase : QueryFixtureBase<Inheritance
 
                     if (a != null)
                     {
-                        var ee = (Rose)e;
+                        var ee = (Rose)e!;
                         var aa = (Rose)a;
 
                         Assert.Equal(ee.Species, aa.Species);
@@ -298,7 +296,7 @@ public abstract class InheritanceQueryFixtureBase : QueryFixtureBase<Inheritance
 
                     if (a != null)
                     {
-                        var ee = (Country)e;
+                        var ee = (Country)e!;
                         var aa = (Country)a;
 
                         Assert.Equal(ee.Id, aa.Id);
@@ -313,7 +311,7 @@ public abstract class InheritanceQueryFixtureBase : QueryFixtureBase<Inheritance
 
                     if (a != null)
                     {
-                        var ee = (Drink)e;
+                        var ee = (Drink)e!;
                         var aa = (Drink)a;
 
                         Assert.Equal(ee.SortIndex, aa.SortIndex);
@@ -330,7 +328,7 @@ public abstract class InheritanceQueryFixtureBase : QueryFixtureBase<Inheritance
 
                     if (a != null)
                     {
-                        var ee = (Coke)e;
+                        var ee = (Coke)e!;
                         var aa = (Coke)a;
 
                         Assert.Equal(ee.SortIndex, aa.SortIndex);
@@ -352,7 +350,7 @@ public abstract class InheritanceQueryFixtureBase : QueryFixtureBase<Inheritance
 
                     if (a != null)
                     {
-                        var ee = (Lilt)e;
+                        var ee = (Lilt)e!;
                         var aa = (Lilt)a;
 
                         Assert.Equal(ee.SortIndex, aa.SortIndex);
@@ -371,7 +369,7 @@ public abstract class InheritanceQueryFixtureBase : QueryFixtureBase<Inheritance
 
                     if (a != null)
                     {
-                        var ee = (Tea)e;
+                        var ee = (Tea)e!;
                         var aa = (Tea)a;
 
                         Assert.Equal(ee.SortIndex, aa.SortIndex);
@@ -391,7 +389,7 @@ public abstract class InheritanceQueryFixtureBase : QueryFixtureBase<Inheritance
 
                     if (a != null)
                     {
-                        var ee = (ComplexType)e;
+                        var ee = (ComplexType)e!;
                         var aa = (ComplexType)a;
 
                         AssertComplexType(ee, aa);
@@ -405,7 +403,7 @@ public abstract class InheritanceQueryFixtureBase : QueryFixtureBase<Inheritance
 
                     if (a != null)
                     {
-                        var ee = (NestedComplexType)e;
+                        var ee = (NestedComplexType)e!;
                         var aa = (NestedComplexType)a;
 
                         AssertNestedComplexType(ee, aa);
@@ -414,7 +412,7 @@ public abstract class InheritanceQueryFixtureBase : QueryFixtureBase<Inheritance
             },
         }.ToDictionary(e => e.Key, e => (object)e.Value);
 
-    private void AssertComplexType(ComplexType e, ComplexType a)
+    private void AssertComplexType(ComplexType? e, ComplexType? a)
     {
         if (!EnableComplexTypes)
         {
@@ -425,7 +423,7 @@ public abstract class InheritanceQueryFixtureBase : QueryFixtureBase<Inheritance
 
         if (e is not null)
         {
-            Assert.Equal(e.UniqueInt, a.UniqueInt);
+            Assert.Equal(e.UniqueInt, a!.UniqueInt);
             Assert.Equal(e.Int, a.Int);
 
             Assert.Equal(e.Nested is null, a.Nested is null);
@@ -436,7 +434,7 @@ public abstract class InheritanceQueryFixtureBase : QueryFixtureBase<Inheritance
         }
     }
 
-    private void AssertNestedComplexType(NestedComplexType e, NestedComplexType a)
+    private void AssertNestedComplexType(NestedComplexType? e, NestedComplexType? a)
     {
         if (!EnableComplexTypes)
         {
@@ -447,12 +445,12 @@ public abstract class InheritanceQueryFixtureBase : QueryFixtureBase<Inheritance
 
         if (e is not null)
         {
-            Assert.Equal(e.UniqueInt, a.UniqueInt);
+            Assert.Equal(e.UniqueInt, a!.UniqueInt);
             Assert.Equal(e.NestedInt, a.NestedInt);
         }
     }
 
-    private void AssertComplexTypes(List<ComplexType> e, List<ComplexType> a)
+    private void AssertComplexTypes(List<ComplexType>? e, List<ComplexType>? a)
     {
         if (!EnableComplexTypes)
         {

--- a/test/EFCore.Specification.Tests/Query/Inheritance/InheritanceQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/Inheritance/InheritanceQueryTestBase.cs
@@ -224,7 +224,7 @@ public abstract class InheritanceQueryTestBase<TFixture>(TFixture fixture) : Que
             async,
             ss => ss.Set<Animal>()
                 .Where(b => "Kiwi" == EF.Property<string>(b, "Discriminator"))
-                .Select(k => new { Predator = EF.Property<string>((Bird)k, "Name") }),
+                .Select(k => new { Predator = EF.Property<string?>((Bird)k, "Name") }),
             ss => ss.Set<Animal>()
                 .Where(b => b is Kiwi)
                 .Select(k => new { Predator = ((Bird)k).Name }),
@@ -261,21 +261,21 @@ public abstract class InheritanceQueryTestBase<TFixture>(TFixture fixture) : Que
                 await context.SaveChangesAsync();
             }, async context =>
             {
-                var kiwi = await context.Set<Kiwi>().SingleAsync(k => k.Species.EndsWith("owenii"));
+                var kiwi = await context.Set<Kiwi>().SingleAsync(k => k.Species!.EndsWith("owenii"));
 
                 kiwi.EagleId = eagleId;
 
                 await context.SaveChangesAsync();
             }, async context =>
             {
-                var kiwi = await context.Set<Kiwi>().SingleAsync(k => k.Species.EndsWith("owenii"));
+                var kiwi = await context.Set<Kiwi>().SingleAsync(k => k.Species!.EndsWith("owenii"));
 
                 context.Set<Bird>().Remove(kiwi);
 
                 await context.SaveChangesAsync();
             }, async context =>
             {
-                var count = await context.Set<Kiwi>().CountAsync(k => k.Species.EndsWith("owenii"));
+                var count = await context.Set<Kiwi>().CountAsync(k => k.Species!.EndsWith("owenii"));
 
                 Assert.Equal(0, count);
             });

--- a/test/EFCore.Specification.Tests/Query/InheritanceRelationshipsQueryFixtureBase.cs
+++ b/test/EFCore.Specification.Tests/Query/InheritanceRelationshipsQueryFixtureBase.cs
@@ -5,8 +5,6 @@ using Microsoft.EntityFrameworkCore.TestModels.InheritanceRelationshipsModel;
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
-#nullable disable
-
 public abstract class InheritanceRelationshipsQueryFixtureBase : QueryFixtureBase<InheritanceRelationshipsContext>
 {
     protected override string StoreName
@@ -17,27 +15,27 @@ public abstract class InheritanceRelationshipsQueryFixtureBase : QueryFixtureBas
 
     public override IReadOnlyDictionary<Type, object> EntitySorters { get; } = new Dictionary<Type, Func<object, object>>
     {
-        { typeof(BaseCollectionOnBase), e => ((BaseCollectionOnBase)e)?.Id },
-        { typeof(DerivedCollectionOnBase), e => ((DerivedCollectionOnBase)e)?.Id },
-        { typeof(BaseCollectionOnDerived), e => ((BaseCollectionOnDerived)e)?.Id },
-        { typeof(DerivedCollectionOnDerived), e => ((DerivedCollectionOnDerived)e)?.Id },
-        { typeof(BaseInheritanceRelationshipEntity), e => ((BaseInheritanceRelationshipEntity)e)?.Id },
-        { typeof(DerivedInheritanceRelationshipEntity), e => ((DerivedInheritanceRelationshipEntity)e)?.Id },
-        { typeof(BaseReferenceOnBase), e => ((BaseReferenceOnBase)e)?.Id },
-        { typeof(DerivedReferenceOnBase), e => ((DerivedReferenceOnBase)e)?.Id },
-        { typeof(BaseReferenceOnDerived), e => ((BaseReferenceOnDerived)e)?.Id },
-        { typeof(DerivedReferenceOnDerived), e => ((DerivedReferenceOnDerived)e)?.Id },
-        { typeof(CollectionOnBase), e => ((CollectionOnBase)e)?.Id },
-        { typeof(CollectionOnDerived), e => ((CollectionOnDerived)e)?.Id },
-        { typeof(NestedCollectionBase), e => ((NestedCollectionBase)e)?.Id },
-        { typeof(NestedCollectionDerived), e => ((NestedCollectionDerived)e)?.Id },
-        { typeof(NestedReferenceBase), e => ((NestedReferenceBase)e)?.Id },
-        { typeof(NonEntityBase), e => ((NonEntityBase)e)?.Id },
-        { typeof(PrincipalEntity), e => ((PrincipalEntity)e)?.Id },
-        { typeof(OwnedEntity), e => ((OwnedEntity)e)?.Id },
-        { typeof(ReferencedEntity), e => ((ReferencedEntity)e)?.Id },
-        { typeof(ReferenceOnBase), e => ((ReferenceOnBase)e)?.Id },
-        { typeof(ReferenceOnDerived), e => ((ReferenceOnDerived)e)?.Id },
+        { typeof(BaseCollectionOnBase), e => ((BaseCollectionOnBase)e).Id },
+        { typeof(DerivedCollectionOnBase), e => ((DerivedCollectionOnBase)e).Id },
+        { typeof(BaseCollectionOnDerived), e => ((BaseCollectionOnDerived)e).Id },
+        { typeof(DerivedCollectionOnDerived), e => ((DerivedCollectionOnDerived)e).Id },
+        { typeof(BaseInheritanceRelationshipEntity), e => ((BaseInheritanceRelationshipEntity)e).Id },
+        { typeof(DerivedInheritanceRelationshipEntity), e => ((DerivedInheritanceRelationshipEntity)e).Id },
+        { typeof(BaseReferenceOnBase), e => ((BaseReferenceOnBase)e).Id },
+        { typeof(DerivedReferenceOnBase), e => ((DerivedReferenceOnBase)e).Id },
+        { typeof(BaseReferenceOnDerived), e => ((BaseReferenceOnDerived)e).Id },
+        { typeof(DerivedReferenceOnDerived), e => ((DerivedReferenceOnDerived)e).Id },
+        { typeof(CollectionOnBase), e => ((CollectionOnBase)e).Id },
+        { typeof(CollectionOnDerived), e => ((CollectionOnDerived)e).Id },
+        { typeof(NestedCollectionBase), e => ((NestedCollectionBase)e).Id },
+        { typeof(NestedCollectionDerived), e => ((NestedCollectionDerived)e).Id },
+        { typeof(NestedReferenceBase), e => ((NestedReferenceBase)e).Id },
+        { typeof(NonEntityBase), e => ((NonEntityBase)e).Id },
+        { typeof(PrincipalEntity), e => ((PrincipalEntity)e).Id },
+        { typeof(OwnedEntity), e => ((OwnedEntity)e).Id },
+        { typeof(ReferencedEntity), e => ((ReferencedEntity)e).Id },
+        { typeof(ReferenceOnBase), e => ((ReferenceOnBase)e).Id },
+        { typeof(ReferenceOnDerived), e => ((ReferenceOnDerived)e).Id },
     }.ToDictionary(e => e.Key, e => (object)e.Value);
 
     public override IReadOnlyDictionary<Type, object> EntityAsserters { get; } = new Dictionary<Type, Action<object, object>>
@@ -49,7 +47,7 @@ public abstract class InheritanceRelationshipsQueryFixtureBase : QueryFixtureBas
 
                 if (a != null)
                 {
-                    var ee = (BaseCollectionOnBase)e;
+                    var ee = (BaseCollectionOnBase)e!;
                     var aa = (BaseCollectionOnBase)a;
 
                     Assert.Equal(ee.Id, aa.Id);
@@ -65,7 +63,7 @@ public abstract class InheritanceRelationshipsQueryFixtureBase : QueryFixtureBas
 
                 if (a != null)
                 {
-                    var ee = (DerivedCollectionOnBase)e;
+                    var ee = (DerivedCollectionOnBase)e!;
                     var aa = (DerivedCollectionOnBase)a;
 
                     Assert.Equal(ee.Id, aa.Id);
@@ -82,7 +80,7 @@ public abstract class InheritanceRelationshipsQueryFixtureBase : QueryFixtureBas
 
                 if (a != null)
                 {
-                    var ee = (BaseCollectionOnDerived)e;
+                    var ee = (BaseCollectionOnDerived)e!;
                     var aa = (BaseCollectionOnDerived)a;
 
                     Assert.Equal(ee.Id, aa.Id);
@@ -98,7 +96,7 @@ public abstract class InheritanceRelationshipsQueryFixtureBase : QueryFixtureBas
 
                 if (a != null)
                 {
-                    var ee = (DerivedCollectionOnDerived)e;
+                    var ee = (DerivedCollectionOnDerived)e!;
                     var aa = (DerivedCollectionOnDerived)a;
 
                     Assert.Equal(ee.Id, aa.Id);
@@ -114,7 +112,7 @@ public abstract class InheritanceRelationshipsQueryFixtureBase : QueryFixtureBas
 
                 if (a != null)
                 {
-                    var ee = (BaseInheritanceRelationshipEntity)e;
+                    var ee = (BaseInheritanceRelationshipEntity)e!;
                     var aa = (BaseInheritanceRelationshipEntity)a;
 
                     Assert.Equal(ee.Id, aa.Id);
@@ -127,7 +125,7 @@ public abstract class InheritanceRelationshipsQueryFixtureBase : QueryFixtureBas
                     if (ee.OwnedCollectionOnBase?.Count > 0)
                     {
                         var orderedExpected = ee.OwnedCollectionOnBase.OrderBy(x => x.Id).ToList();
-                        var orderedActual = aa.OwnedCollectionOnBase.OrderBy(x => x.Id).ToList();
+                        var orderedActual = aa.OwnedCollectionOnBase!.OrderBy(x => x.Id).ToList();
                         for (var i = 0; i < orderedExpected.Count; i++)
                         {
                             Assert.Equal(orderedExpected[i].Id, orderedActual[i].Id);
@@ -144,7 +142,7 @@ public abstract class InheritanceRelationshipsQueryFixtureBase : QueryFixtureBas
 
                 if (a != null)
                 {
-                    var ee = (DerivedInheritanceRelationshipEntity)e;
+                    var ee = (DerivedInheritanceRelationshipEntity)e!;
                     var aa = (DerivedInheritanceRelationshipEntity)a;
 
                     Assert.Equal(ee.Id, aa.Id);
@@ -161,7 +159,7 @@ public abstract class InheritanceRelationshipsQueryFixtureBase : QueryFixtureBas
                     if (ee.OwnedCollectionOnBase?.Count > 0)
                     {
                         var orderedExpected = ee.OwnedCollectionOnBase.OrderBy(x => x.Id).ToList();
-                        var orderedActual = aa.OwnedCollectionOnBase.OrderBy(x => x.Id).ToList();
+                        var orderedActual = aa.OwnedCollectionOnBase!.OrderBy(x => x.Id).ToList();
                         for (var i = 0; i < orderedExpected.Count; i++)
                         {
                             Assert.Equal(orderedExpected[i].Id, orderedActual[i].Id);
@@ -173,7 +171,7 @@ public abstract class InheritanceRelationshipsQueryFixtureBase : QueryFixtureBas
                     if (ee.OwnedCollectionOnDerived?.Count > 0)
                     {
                         var orderedExpected = ee.OwnedCollectionOnDerived.OrderBy(x => x.Id).ToList();
-                        var orderedActual = aa.OwnedCollectionOnDerived.OrderBy(x => x.Id).ToList();
+                        var orderedActual = aa.OwnedCollectionOnDerived!.OrderBy(x => x.Id).ToList();
                         for (var i = 0; i < orderedExpected.Count; i++)
                         {
                             Assert.Equal(orderedExpected[i].Id, orderedActual[i].Id);
@@ -190,7 +188,7 @@ public abstract class InheritanceRelationshipsQueryFixtureBase : QueryFixtureBas
 
                 if (a != null)
                 {
-                    var ee = (BaseReferenceOnBase)e;
+                    var ee = (BaseReferenceOnBase)e!;
                     var aa = (BaseReferenceOnBase)a;
 
                     Assert.Equal(ee.Id, aa.Id);
@@ -206,7 +204,7 @@ public abstract class InheritanceRelationshipsQueryFixtureBase : QueryFixtureBas
 
                 if (a != null)
                 {
-                    var ee = (DerivedReferenceOnBase)e;
+                    var ee = (DerivedReferenceOnBase)e!;
                     var aa = (DerivedReferenceOnBase)a;
 
                     Assert.Equal(ee.Id, aa.Id);
@@ -222,7 +220,7 @@ public abstract class InheritanceRelationshipsQueryFixtureBase : QueryFixtureBas
 
                 if (a != null)
                 {
-                    var ee = (BaseReferenceOnDerived)e;
+                    var ee = (BaseReferenceOnDerived)e!;
                     var aa = (BaseReferenceOnDerived)a;
 
                     Assert.Equal(ee.Id, aa.Id);
@@ -238,7 +236,7 @@ public abstract class InheritanceRelationshipsQueryFixtureBase : QueryFixtureBas
 
                 if (a != null)
                 {
-                    var ee = (DerivedReferenceOnDerived)e;
+                    var ee = (DerivedReferenceOnDerived)e!;
                     var aa = (DerivedReferenceOnDerived)a;
 
                     Assert.Equal(ee.Id, aa.Id);
@@ -254,7 +252,7 @@ public abstract class InheritanceRelationshipsQueryFixtureBase : QueryFixtureBas
 
                 if (a != null)
                 {
-                    var ee = (CollectionOnBase)e;
+                    var ee = (CollectionOnBase)e!;
                     var aa = (CollectionOnBase)a;
 
                     Assert.Equal(ee.Id, aa.Id);
@@ -270,7 +268,7 @@ public abstract class InheritanceRelationshipsQueryFixtureBase : QueryFixtureBas
 
                 if (a != null)
                 {
-                    var ee = (CollectionOnDerived)e;
+                    var ee = (CollectionOnDerived)e!;
                     var aa = (CollectionOnDerived)a;
 
                     Assert.Equal(ee.Id, aa.Id);
@@ -286,7 +284,7 @@ public abstract class InheritanceRelationshipsQueryFixtureBase : QueryFixtureBas
 
                 if (a != null)
                 {
-                    var ee = (NestedCollectionBase)e;
+                    var ee = (NestedCollectionBase)e!;
                     var aa = (NestedCollectionBase)a;
 
                     Assert.Equal(ee.Id, aa.Id);
@@ -303,7 +301,7 @@ public abstract class InheritanceRelationshipsQueryFixtureBase : QueryFixtureBas
 
                 if (a != null)
                 {
-                    var ee = (NestedCollectionDerived)e;
+                    var ee = (NestedCollectionDerived)e!;
                     var aa = (NestedCollectionDerived)a;
 
                     Assert.Equal(ee.Id, aa.Id);
@@ -320,7 +318,7 @@ public abstract class InheritanceRelationshipsQueryFixtureBase : QueryFixtureBas
 
                 if (a != null)
                 {
-                    var ee = (NestedReferenceBase)e;
+                    var ee = (NestedReferenceBase)e!;
                     var aa = (NestedReferenceBase)a;
 
                     Assert.Equal(ee.Id, aa.Id);
@@ -337,7 +335,7 @@ public abstract class InheritanceRelationshipsQueryFixtureBase : QueryFixtureBas
 
                 if (a != null)
                 {
-                    var ee = (NestedReferenceDerived)e;
+                    var ee = (NestedReferenceDerived)e!;
                     var aa = (NestedReferenceDerived)a;
 
                     Assert.Equal(ee.Id, aa.Id);
@@ -354,7 +352,7 @@ public abstract class InheritanceRelationshipsQueryFixtureBase : QueryFixtureBas
 
                 if (a != null)
                 {
-                    var ee = (NonEntityBase)e;
+                    var ee = (NonEntityBase)e!;
                     var aa = (NonEntityBase)a;
 
                     Assert.Equal(ee.Id, aa.Id);
@@ -369,7 +367,7 @@ public abstract class InheritanceRelationshipsQueryFixtureBase : QueryFixtureBas
 
                 if (a != null)
                 {
-                    var ee = (PrincipalEntity)e;
+                    var ee = (PrincipalEntity)e!;
                     var aa = (PrincipalEntity)a;
 
                     Assert.Equal(ee.Id, aa.Id);
@@ -384,7 +382,7 @@ public abstract class InheritanceRelationshipsQueryFixtureBase : QueryFixtureBas
 
                 if (a != null)
                 {
-                    var ee = (ReferencedEntity)e;
+                    var ee = (ReferencedEntity)e!;
                     var aa = (ReferencedEntity)a;
 
                     Assert.Equal(ee.Id, aa.Id);
@@ -399,7 +397,7 @@ public abstract class InheritanceRelationshipsQueryFixtureBase : QueryFixtureBas
 
                 if (a != null)
                 {
-                    var ee = (ReferenceOnBase)e;
+                    var ee = (ReferenceOnBase)e!;
                     var aa = (ReferenceOnBase)a;
 
                     Assert.Equal(ee.Id, aa.Id);
@@ -415,7 +413,7 @@ public abstract class InheritanceRelationshipsQueryFixtureBase : QueryFixtureBas
 
                 if (a != null)
                 {
-                    var ee = (ReferenceOnDerived)e;
+                    var ee = (ReferenceOnDerived)e!;
                     var aa = (ReferenceOnDerived)a;
 
                     Assert.Equal(ee.Id, aa.Id);

--- a/test/EFCore.Specification.Tests/Query/InheritanceRelationshipsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/InheritanceRelationshipsQueryTestBase.cs
@@ -6,8 +6,6 @@ using Microsoft.EntityFrameworkCore.TestModels.InheritanceRelationshipsModel;
 // ReSharper disable InconsistentNaming
 namespace Microsoft.EntityFrameworkCore.Query;
 
-#nullable disable
-
 public abstract class InheritanceRelationshipsQueryTestBase<TFixture>(TFixture fixture) : QueryTestBase<TFixture>(fixture)
     where TFixture : InheritanceRelationshipsQueryFixtureBase, new()
 {
@@ -52,14 +50,14 @@ public abstract class InheritanceRelationshipsQueryTestBase<TFixture>(TFixture f
         using var context = CreateContext();
         var model = context.Model;
         var principalEntityType = model.FindEntityType(typeof(DerivedInheritanceRelationshipEntity));
-        var dependentEntityType = model.FindEntityType(typeof(BaseReferenceOnDerived));
-        var derivedDependentEntityType = model.FindEntityType(typeof(DerivedReferenceOnDerived));
+        var dependentEntityType = model.FindEntityType(typeof(BaseReferenceOnDerived))!;
+        var derivedDependentEntityType = model.FindEntityType(typeof(DerivedReferenceOnDerived))!;
 
         var fkOnBase = dependentEntityType.GetForeignKeys().Single();
         Assert.Equal(principalEntityType, fkOnBase.PrincipalEntityType);
         Assert.Equal(dependentEntityType, fkOnBase.DeclaringEntityType);
-        Assert.Equal(nameof(BaseReferenceOnDerived.BaseParent), fkOnBase.DependentToPrincipal.Name);
-        Assert.Equal(nameof(DerivedInheritanceRelationshipEntity.BaseReferenceOnDerived), fkOnBase.PrincipalToDependent.Name);
+        Assert.Equal(nameof(BaseReferenceOnDerived.BaseParent), fkOnBase.DependentToPrincipal!.Name);
+        Assert.Equal(nameof(DerivedInheritanceRelationshipEntity.BaseReferenceOnDerived), fkOnBase.PrincipalToDependent!.Name);
 
         var fkOnDerived = derivedDependentEntityType.GetDeclaredForeignKeys()
             .Single(fk => fk.PrincipalEntityType != dependentEntityType);
@@ -67,7 +65,7 @@ public abstract class InheritanceRelationshipsQueryTestBase<TFixture>(TFixture f
         Assert.Equal(principalEntityType, fkOnDerived.PrincipalEntityType);
         Assert.Equal(derivedDependentEntityType, fkOnDerived.DeclaringEntityType);
         Assert.Null(fkOnDerived.DependentToPrincipal);
-        Assert.Equal(nameof(DerivedInheritanceRelationshipEntity.DerivedReferenceOnDerived), fkOnDerived.PrincipalToDependent.Name);
+        Assert.Equal(nameof(DerivedInheritanceRelationshipEntity.DerivedReferenceOnDerived), fkOnDerived.PrincipalToDependent!.Name);
     }
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -77,7 +75,7 @@ public abstract class InheritanceRelationshipsQueryTestBase<TFixture>(TFixture f
             ss => ss.Set<BaseInheritanceRelationshipEntity>().Include(e => e.BaseReferenceOnBase),
             elementAsserter: (e, a) => AssertInclude(
                 e, a,
-                new ExpectedInclude<BaseInheritanceRelationshipEntity>(x => x.BaseReferenceOnBase)));
+                new ExpectedInclude<BaseInheritanceRelationshipEntity>(x => x.BaseReferenceOnBase!)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Include_reference_with_inheritance_reverse(bool async)
@@ -86,7 +84,7 @@ public abstract class InheritanceRelationshipsQueryTestBase<TFixture>(TFixture f
             ss => ss.Set<BaseReferenceOnBase>().Include(e => e.BaseParent),
             elementAsserter: (e, a) => AssertInclude(
                 e, a,
-                new ExpectedInclude<BaseReferenceOnBase>(x => x.BaseParent)));
+                new ExpectedInclude<BaseReferenceOnBase>(x => x.BaseParent!)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Include_self_reference_with_inheritance(bool async)
@@ -95,7 +93,7 @@ public abstract class InheritanceRelationshipsQueryTestBase<TFixture>(TFixture f
             ss => ss.Set<BaseInheritanceRelationshipEntity>().Include(e => e.DerivedSefReferenceOnBase),
             elementAsserter: (e, a) => AssertInclude(
                 e, a,
-                new ExpectedInclude<BaseInheritanceRelationshipEntity>(x => x.DerivedSefReferenceOnBase)));
+                new ExpectedInclude<BaseInheritanceRelationshipEntity>(x => x.DerivedSefReferenceOnBase!)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Include_self_reference_with_inheritance_reverse(bool async)
@@ -104,7 +102,7 @@ public abstract class InheritanceRelationshipsQueryTestBase<TFixture>(TFixture f
             ss => ss.Set<DerivedInheritanceRelationshipEntity>().Include(e => e.BaseSelfReferenceOnDerived),
             elementAsserter: (e, a) => AssertInclude(
                 e, a,
-                new ExpectedInclude<DerivedInheritanceRelationshipEntity>(x => x.BaseSelfReferenceOnDerived)));
+                new ExpectedInclude<DerivedInheritanceRelationshipEntity>(x => x.BaseSelfReferenceOnDerived!)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Include_reference_with_inheritance_with_filter(bool async)
@@ -113,7 +111,7 @@ public abstract class InheritanceRelationshipsQueryTestBase<TFixture>(TFixture f
             ss => ss.Set<BaseInheritanceRelationshipEntity>().Include(e => e.BaseReferenceOnBase).Where(e => e.Name != "Bar"),
             elementAsserter: (e, a) => AssertInclude(
                 e, a,
-                new ExpectedInclude<BaseInheritanceRelationshipEntity>(x => x.BaseReferenceOnBase)));
+                new ExpectedInclude<BaseInheritanceRelationshipEntity>(x => x.BaseReferenceOnBase!)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Include_reference_with_inheritance_with_filter_reverse(bool async)
@@ -122,7 +120,7 @@ public abstract class InheritanceRelationshipsQueryTestBase<TFixture>(TFixture f
             ss => ss.Set<BaseReferenceOnBase>().Include(e => e.BaseParent).Where(e => e.Name != "Bar"),
             elementAsserter: (e, a) => AssertInclude(
                 e, a,
-                new ExpectedInclude<BaseReferenceOnBase>(x => x.BaseParent)));
+                new ExpectedInclude<BaseReferenceOnBase>(x => x.BaseParent!)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Include_reference_without_inheritance(bool async)
@@ -131,7 +129,7 @@ public abstract class InheritanceRelationshipsQueryTestBase<TFixture>(TFixture f
             ss => ss.Set<BaseInheritanceRelationshipEntity>().Include(e => e.ReferenceOnBase),
             elementAsserter: (e, a) => AssertInclude(
                 e, a,
-                new ExpectedInclude<BaseInheritanceRelationshipEntity>(x => x.ReferenceOnBase)));
+                new ExpectedInclude<BaseInheritanceRelationshipEntity>(x => x.ReferenceOnBase!)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Include_reference_without_inheritance_reverse(bool async)
@@ -140,7 +138,7 @@ public abstract class InheritanceRelationshipsQueryTestBase<TFixture>(TFixture f
             ss => ss.Set<ReferenceOnBase>().Include(e => e.Parent),
             elementAsserter: (e, a) => AssertInclude(
                 e, a,
-                new ExpectedInclude<ReferenceOnBase>(x => x.Parent)));
+                new ExpectedInclude<ReferenceOnBase>(x => x.Parent!)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Include_reference_without_inheritance_with_filter(bool async)
@@ -149,7 +147,7 @@ public abstract class InheritanceRelationshipsQueryTestBase<TFixture>(TFixture f
             ss => ss.Set<BaseInheritanceRelationshipEntity>().Include(e => e.ReferenceOnBase).Where(e => e.Name != "Bar"),
             elementAsserter: (e, a) => AssertInclude(
                 e, a,
-                new ExpectedInclude<BaseInheritanceRelationshipEntity>(x => x.ReferenceOnBase)));
+                new ExpectedInclude<BaseInheritanceRelationshipEntity>(x => x.ReferenceOnBase!)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Include_reference_without_inheritance_with_filter_reverse(bool async)
@@ -158,7 +156,7 @@ public abstract class InheritanceRelationshipsQueryTestBase<TFixture>(TFixture f
             ss => ss.Set<ReferenceOnBase>().Include(e => e.Parent).Where(e => e.Name != "Bar"),
             elementAsserter: (e, a) => AssertInclude(
                 e, a,
-                new ExpectedInclude<ReferenceOnBase>(x => x.Parent)));
+                new ExpectedInclude<ReferenceOnBase>(x => x.Parent!)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Include_collection_with_inheritance(bool async)
@@ -177,7 +175,7 @@ public abstract class InheritanceRelationshipsQueryTestBase<TFixture>(TFixture f
             elementAsserter: (e, a) => AssertInclude(
                 e,
                 a,
-                new ExpectedInclude<BaseCollectionOnBase>(x => x.BaseParent)));
+                new ExpectedInclude<BaseCollectionOnBase>(x => x.BaseParent!)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Include_collection_with_inheritance_with_filter(bool async)
@@ -195,7 +193,7 @@ public abstract class InheritanceRelationshipsQueryTestBase<TFixture>(TFixture f
             ss => ss.Set<BaseCollectionOnBase>().Include(e => e.BaseParent).Where(e => e.Name != "Bar"),
             elementAsserter: (e, a) => AssertInclude(
                 e, a,
-                new ExpectedInclude<BaseCollectionOnBase>(x => x.BaseParent)));
+                new ExpectedInclude<BaseCollectionOnBase>(x => x.BaseParent!)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Include_collection_without_inheritance(bool async)
@@ -213,7 +211,7 @@ public abstract class InheritanceRelationshipsQueryTestBase<TFixture>(TFixture f
             ss => ss.Set<CollectionOnBase>().Include(e => e.Parent),
             elementAsserter: (e, a) => AssertInclude(
                 e, a,
-                new ExpectedInclude<CollectionOnBase>(x => x.Parent)));
+                new ExpectedInclude<CollectionOnBase>(x => x.Parent!)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Include_collection_without_inheritance_with_filter(bool async)
@@ -231,7 +229,7 @@ public abstract class InheritanceRelationshipsQueryTestBase<TFixture>(TFixture f
             ss => ss.Set<CollectionOnBase>().Include(e => e.Parent).Where(e => e.Name != "Bar"),
             elementAsserter: (e, a) => AssertInclude(
                 e, a,
-                new ExpectedInclude<CollectionOnBase>(x => x.Parent)));
+                new ExpectedInclude<CollectionOnBase>(x => x.Parent!)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Include_reference_with_inheritance_on_derived1(bool async)
@@ -240,7 +238,7 @@ public abstract class InheritanceRelationshipsQueryTestBase<TFixture>(TFixture f
             ss => ss.Set<DerivedInheritanceRelationshipEntity>().Include(e => e.BaseReferenceOnBase),
             elementAsserter: (e, a) => AssertInclude(
                 e, a,
-                new ExpectedInclude<DerivedInheritanceRelationshipEntity>(x => x.BaseReferenceOnBase)));
+                new ExpectedInclude<DerivedInheritanceRelationshipEntity>(x => x.BaseReferenceOnBase!)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Include_reference_with_inheritance_on_derived2(bool async)
@@ -249,7 +247,7 @@ public abstract class InheritanceRelationshipsQueryTestBase<TFixture>(TFixture f
             ss => ss.Set<DerivedInheritanceRelationshipEntity>().Include(e => e.BaseReferenceOnDerived),
             elementAsserter: (e, a) => AssertInclude(
                 e, a,
-                new ExpectedInclude<DerivedInheritanceRelationshipEntity>(x => x.BaseReferenceOnDerived)));
+                new ExpectedInclude<DerivedInheritanceRelationshipEntity>(x => x.BaseReferenceOnDerived!)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Include_reference_with_inheritance_on_derived4(bool async)
@@ -258,7 +256,7 @@ public abstract class InheritanceRelationshipsQueryTestBase<TFixture>(TFixture f
             ss => ss.Set<DerivedInheritanceRelationshipEntity>().Include(e => e.DerivedReferenceOnDerived),
             elementAsserter: (e, a) => AssertInclude(
                 e, a,
-                new ExpectedInclude<DerivedInheritanceRelationshipEntity>(x => x.DerivedReferenceOnDerived)));
+                new ExpectedInclude<DerivedInheritanceRelationshipEntity>(x => x.DerivedReferenceOnDerived!)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Include_reference_with_inheritance_on_derived_reverse(bool async)
@@ -267,7 +265,7 @@ public abstract class InheritanceRelationshipsQueryTestBase<TFixture>(TFixture f
             ss => ss.Set<BaseReferenceOnDerived>().Include(e => e.BaseParent),
             elementAsserter: (e, a) => AssertInclude(
                 e, a,
-                new ExpectedInclude<BaseReferenceOnDerived>(x => x.BaseParent)));
+                new ExpectedInclude<BaseReferenceOnDerived>(x => x.BaseParent!)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Include_reference_with_inheritance_on_derived_with_filter1(bool async)
@@ -276,7 +274,7 @@ public abstract class InheritanceRelationshipsQueryTestBase<TFixture>(TFixture f
             ss => ss.Set<DerivedInheritanceRelationshipEntity>().Include(e => e.BaseReferenceOnBase).Where(e => e.Name != "Bar"),
             elementAsserter: (e, a) => AssertInclude(
                 e, a,
-                new ExpectedInclude<DerivedInheritanceRelationshipEntity>(x => x.BaseReferenceOnBase)));
+                new ExpectedInclude<DerivedInheritanceRelationshipEntity>(x => x.BaseReferenceOnBase!)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Include_reference_with_inheritance_on_derived_with_filter2(bool async)
@@ -285,7 +283,7 @@ public abstract class InheritanceRelationshipsQueryTestBase<TFixture>(TFixture f
             ss => ss.Set<DerivedInheritanceRelationshipEntity>().Include(e => e.BaseReferenceOnDerived).Where(e => e.Name != "Bar"),
             elementAsserter: (e, a) => AssertInclude(
                 e, a,
-                new ExpectedInclude<DerivedInheritanceRelationshipEntity>(x => x.BaseReferenceOnDerived)));
+                new ExpectedInclude<DerivedInheritanceRelationshipEntity>(x => x.BaseReferenceOnDerived!)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Include_reference_with_inheritance_on_derived_with_filter4(bool async)
@@ -294,7 +292,7 @@ public abstract class InheritanceRelationshipsQueryTestBase<TFixture>(TFixture f
             ss => ss.Set<DerivedInheritanceRelationshipEntity>().Include(e => e.DerivedReferenceOnDerived).Where(e => e.Name != "Bar"),
             elementAsserter: (e, a) => AssertInclude(
                 e, a,
-                new ExpectedInclude<DerivedInheritanceRelationshipEntity>(x => x.DerivedReferenceOnDerived)));
+                new ExpectedInclude<DerivedInheritanceRelationshipEntity>(x => x.DerivedReferenceOnDerived!)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Include_reference_with_inheritance_on_derived_with_filter_reverse(bool async)
@@ -303,7 +301,7 @@ public abstract class InheritanceRelationshipsQueryTestBase<TFixture>(TFixture f
             ss => ss.Set<BaseReferenceOnDerived>().Include(e => e.BaseParent).Where(e => e.Name != "Bar"),
             elementAsserter: (e, a) => AssertInclude(
                 e, a,
-                new ExpectedInclude<BaseReferenceOnDerived>(x => x.BaseParent)));
+                new ExpectedInclude<BaseReferenceOnDerived>(x => x.BaseParent!)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Include_reference_without_inheritance_on_derived1(bool async)
@@ -312,7 +310,7 @@ public abstract class InheritanceRelationshipsQueryTestBase<TFixture>(TFixture f
             ss => ss.Set<DerivedInheritanceRelationshipEntity>().Include(e => e.ReferenceOnBase),
             elementAsserter: (e, a) => AssertInclude(
                 e, a,
-                new ExpectedInclude<DerivedInheritanceRelationshipEntity>(x => x.ReferenceOnBase)));
+                new ExpectedInclude<DerivedInheritanceRelationshipEntity>(x => x.ReferenceOnBase!)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Include_reference_without_inheritance_on_derived2(bool async)
@@ -321,7 +319,7 @@ public abstract class InheritanceRelationshipsQueryTestBase<TFixture>(TFixture f
             ss => ss.Set<DerivedInheritanceRelationshipEntity>().Include(e => e.ReferenceOnDerived),
             elementAsserter: (e, a) => AssertInclude(
                 e, a,
-                new ExpectedInclude<DerivedInheritanceRelationshipEntity>(x => x.ReferenceOnDerived)));
+                new ExpectedInclude<DerivedInheritanceRelationshipEntity>(x => x.ReferenceOnDerived!)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Include_reference_without_inheritance_on_derived_reverse(bool async)
@@ -330,7 +328,7 @@ public abstract class InheritanceRelationshipsQueryTestBase<TFixture>(TFixture f
             ss => ss.Set<ReferenceOnDerived>().Include(e => e.Parent),
             elementAsserter: (e, a) => AssertInclude(
                 e, a,
-                new ExpectedInclude<ReferenceOnDerived>(x => x.Parent)));
+                new ExpectedInclude<ReferenceOnDerived>(x => x.Parent!)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Include_collection_with_inheritance_on_derived1(bool async)
@@ -366,67 +364,67 @@ public abstract class InheritanceRelationshipsQueryTestBase<TFixture>(TFixture f
             ss => ss.Set<BaseCollectionOnDerived>().Include(e => e.BaseParent),
             elementAsserter: (e, a) => AssertInclude(
                 e, a,
-                new ExpectedInclude<BaseCollectionOnDerived>(x => x.BaseParent)));
+                new ExpectedInclude<BaseCollectionOnDerived>(x => x.BaseParent!)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Nested_include_with_inheritance_reference_reference(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<BaseInheritanceRelationshipEntity>().Include(e => e.BaseReferenceOnBase.NestedReference),
+            ss => ss.Set<BaseInheritanceRelationshipEntity>().Include(e => e.BaseReferenceOnBase!.NestedReference),
             elementAsserter: (e, a) => AssertInclude(
                 e, a,
-                new ExpectedInclude<BaseInheritanceRelationshipEntity>(x => x.BaseReferenceOnBase),
-                new ExpectedInclude<BaseReferenceOnBase>(x => x.NestedReference)));
+                new ExpectedInclude<BaseInheritanceRelationshipEntity>(x => x.BaseReferenceOnBase!),
+                new ExpectedInclude<BaseReferenceOnBase>(x => x.NestedReference!)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Nested_include_with_inheritance_reference_reference_on_base(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<DerivedInheritanceRelationshipEntity>().Include(e => e.BaseReferenceOnBase.NestedReference),
+            ss => ss.Set<DerivedInheritanceRelationshipEntity>().Include(e => e.BaseReferenceOnBase!.NestedReference),
             elementAsserter: (e, a) => AssertInclude(
                 e, a,
-                new ExpectedInclude<DerivedInheritanceRelationshipEntity>(x => x.BaseReferenceOnBase),
-                new ExpectedInclude<BaseReferenceOnBase>(x => x.NestedReference)));
+                new ExpectedInclude<DerivedInheritanceRelationshipEntity>(x => x.BaseReferenceOnBase!),
+                new ExpectedInclude<BaseReferenceOnBase>(x => x.NestedReference!)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Nested_include_with_inheritance_reference_reference_reverse(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<NestedReferenceBase>().Include(e => e.ParentReference.BaseParent),
+            ss => ss.Set<NestedReferenceBase>().Include(e => e.ParentReference!.BaseParent),
             elementAsserter: (e, a) => AssertInclude(
                 e, a,
-                new ExpectedInclude<NestedReferenceBase>(x => x.ParentReference),
-                new ExpectedInclude<BaseReferenceOnBase>(x => x.BaseParent)));
+                new ExpectedInclude<NestedReferenceBase>(x => x.ParentReference!),
+                new ExpectedInclude<BaseReferenceOnBase>(x => x.BaseParent!)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Nested_include_with_inheritance_reference_collection(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<BaseInheritanceRelationshipEntity>().Include(e => e.BaseReferenceOnBase.NestedCollection),
+            ss => ss.Set<BaseInheritanceRelationshipEntity>().Include(e => e.BaseReferenceOnBase!.NestedCollection),
             elementAsserter: (e, a) => AssertInclude(
                 e, a,
-                new ExpectedInclude<BaseInheritanceRelationshipEntity>(x => x.BaseReferenceOnBase),
+                new ExpectedInclude<BaseInheritanceRelationshipEntity>(x => x.BaseReferenceOnBase!),
                 new ExpectedInclude<BaseReferenceOnBase>(x => x.NestedCollection)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Nested_include_with_inheritance_reference_collection_on_base(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<DerivedInheritanceRelationshipEntity>().Include(e => e.BaseReferenceOnBase.NestedCollection),
+            ss => ss.Set<DerivedInheritanceRelationshipEntity>().Include(e => e.BaseReferenceOnBase!.NestedCollection),
             elementAsserter: (e, a) => AssertInclude(
                 e, a,
-                new ExpectedInclude<DerivedInheritanceRelationshipEntity>(x => x.BaseReferenceOnBase),
+                new ExpectedInclude<DerivedInheritanceRelationshipEntity>(x => x.BaseReferenceOnBase!),
                 new ExpectedInclude<BaseReferenceOnBase>(x => x.NestedCollection)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Nested_include_with_inheritance_reference_collection_reverse(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<NestedCollectionBase>().Include(e => e.ParentReference.BaseParent),
+            ss => ss.Set<NestedCollectionBase>().Include(e => e.ParentReference!.BaseParent),
             elementAsserter: (e, a) => AssertInclude(
                 e, a,
-                new ExpectedInclude<NestedCollectionBase>(x => x.ParentReference),
-                new ExpectedInclude<BaseReferenceOnBase>(x => x.BaseParent)));
+                new ExpectedInclude<NestedCollectionBase>(x => x.ParentReference!),
+                new ExpectedInclude<BaseReferenceOnBase>(x => x.BaseParent!)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Nested_include_with_inheritance_collection_reference(bool async)
@@ -436,17 +434,17 @@ public abstract class InheritanceRelationshipsQueryTestBase<TFixture>(TFixture f
             elementAsserter: (e, a) => AssertInclude(
                 e, a,
                 new ExpectedInclude<BaseInheritanceRelationshipEntity>(x => x.BaseCollectionOnBase),
-                new ExpectedInclude<BaseCollectionOnBase>(x => x.NestedReference)));
+                new ExpectedInclude<BaseCollectionOnBase>(x => x.NestedReference!)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Nested_include_with_inheritance_collection_reference_reverse(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<NestedReferenceBase>().Include(e => e.ParentCollection.BaseParent),
+            ss => ss.Set<NestedReferenceBase>().Include(e => e.ParentCollection!.BaseParent),
             elementAsserter: (e, a) => AssertInclude(
                 e, a,
-                new ExpectedInclude<NestedReferenceBase>(x => x.ParentCollection),
-                new ExpectedInclude<BaseCollectionOnBase>(x => x.BaseParent)));
+                new ExpectedInclude<NestedReferenceBase>(x => x.ParentCollection!),
+                new ExpectedInclude<BaseCollectionOnBase>(x => x.BaseParent!)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Nested_include_with_inheritance_collection_collection(bool async)
@@ -462,11 +460,11 @@ public abstract class InheritanceRelationshipsQueryTestBase<TFixture>(TFixture f
     public virtual Task Nested_include_with_inheritance_collection_collection_reverse(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<NestedCollectionBase>().Include(e => e.ParentCollection.BaseParent),
+            ss => ss.Set<NestedCollectionBase>().Include(e => e.ParentCollection!.BaseParent),
             elementAsserter: (e, a) => AssertInclude(
                 e, a,
-                new ExpectedInclude<NestedCollectionBase>(x => x.ParentCollection),
-                new ExpectedInclude<BaseCollectionOnBase>(x => x.BaseParent)));
+                new ExpectedInclude<NestedCollectionBase>(x => x.ParentCollection!),
+                new ExpectedInclude<BaseCollectionOnBase>(x => x.BaseParent!)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Nested_include_collection_reference_on_non_entity_base(bool async)
@@ -476,7 +474,7 @@ public abstract class InheritanceRelationshipsQueryTestBase<TFixture>(TFixture f
             elementAsserter: (e, a) => AssertInclude(
                 e, a,
                 new ExpectedInclude<ReferencedEntity>(x => x.Principals),
-                new ExpectedInclude<PrincipalEntity>(x => x.Reference)));
+                new ExpectedInclude<PrincipalEntity>(x => x.Reference!)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Collection_projection_on_base_type(bool async)

--- a/test/EFCore.Specification.Tests/Query/JsonQueryFixtureBase.cs
+++ b/test/EFCore.Specification.Tests/Query/JsonQueryFixtureBase.cs
@@ -5,26 +5,24 @@ using Microsoft.EntityFrameworkCore.TestModels.JsonQuery;
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
-#nullable disable
-
 public abstract class JsonQueryFixtureBase : QueryFixtureBase<JsonQueryContext>
 {
-    private JsonQueryData _expectedData;
+    private JsonQueryData _expectedData = null!;
 
     public override ISetSource GetExpectedData()
         => _expectedData ??= new JsonQueryData();
 
     public override IReadOnlyDictionary<Type, object> EntitySorters { get; } = new Dictionary<Type, Func<object, object>>
     {
-        { typeof(EntityBasic), e => ((EntityBasic)e)?.Id },
-        { typeof(JsonEntityBasic), e => ((JsonEntityBasic)e)?.Id },
-        { typeof(JsonEntityBasicForReference), e => ((JsonEntityBasicForReference)e)?.Id },
-        { typeof(JsonEntityBasicForCollection), e => ((JsonEntityBasicForCollection)e)?.Id },
-        { typeof(JsonEntityCustomNaming), e => ((JsonEntityCustomNaming)e)?.Id },
-        { typeof(JsonEntitySingleOwned), e => ((JsonEntitySingleOwned)e)?.Id },
-        { typeof(JsonEntityInheritanceBase), e => ((JsonEntityInheritanceBase)e)?.Id },
-        { typeof(JsonEntityInheritanceDerived), e => ((JsonEntityInheritanceDerived)e)?.Id },
-        { typeof(JsonEntityAllTypes), e => ((JsonEntityAllTypes)e)?.Id },
+        { typeof(EntityBasic), e => ((EntityBasic)e).Id },
+        { typeof(JsonEntityBasic), e => ((JsonEntityBasic)e).Id },
+        { typeof(JsonEntityBasicForReference), e => ((JsonEntityBasicForReference)e).Id },
+        { typeof(JsonEntityBasicForCollection), e => ((JsonEntityBasicForCollection)e).Id },
+        { typeof(JsonEntityCustomNaming), e => ((JsonEntityCustomNaming)e).Id },
+        { typeof(JsonEntitySingleOwned), e => ((JsonEntitySingleOwned)e).Id },
+        { typeof(JsonEntityInheritanceBase), e => ((JsonEntityInheritanceBase)e).Id },
+        { typeof(JsonEntityInheritanceDerived), e => ((JsonEntityInheritanceDerived)e).Id },
+        { typeof(JsonEntityAllTypes), e => ((JsonEntityAllTypes)e).Id },
     }.ToDictionary(e => e.Key, e => (object)e.Value);
 
     public override IReadOnlyDictionary<Type, object> EntityAsserters { get; } = new Dictionary<Type, Action<object, object>>
@@ -35,7 +33,7 @@ public abstract class JsonQueryFixtureBase : QueryFixtureBase<JsonQueryContext>
                 Assert.Equal(e == null, a == null);
                 if (a != null)
                 {
-                    var ee = (EntityBasic)e;
+                    var ee = (EntityBasic)e!;
                     var aa = (EntityBasic)a;
 
                     Assert.Equal(ee.Id, aa.Id);
@@ -49,7 +47,7 @@ public abstract class JsonQueryFixtureBase : QueryFixtureBase<JsonQueryContext>
                 Assert.Equal(e == null, a == null);
                 if (a != null)
                 {
-                    var ee = (JsonEntityBasic)e;
+                    var ee = (JsonEntityBasic)e!;
                     var aa = (JsonEntityBasic)a;
 
                     Assert.Equal(ee.Id, aa.Id);
@@ -57,7 +55,7 @@ public abstract class JsonQueryFixtureBase : QueryFixtureBase<JsonQueryContext>
 
                     if (ee.OwnedReferenceRoot is not null || aa.OwnedReferenceRoot is not null)
                     {
-                        AssertOwnedRoot(ee.OwnedReferenceRoot, aa.OwnedReferenceRoot);
+                        AssertOwnedRoot(ee.OwnedReferenceRoot!, aa.OwnedReferenceRoot!);
 
                         Assert.Equal(ee.OwnedCollectionRoot.Count, aa.OwnedCollectionRoot.Count);
                         for (var i = 0; i < ee.OwnedCollectionRoot.Count; i++)
@@ -74,7 +72,7 @@ public abstract class JsonQueryFixtureBase : QueryFixtureBase<JsonQueryContext>
                 Assert.Equal(e == null, a == null);
                 if (a != null)
                 {
-                    var ee = (JsonEntityBasicForReference)e;
+                    var ee = (JsonEntityBasicForReference)e!;
                     var aa = (JsonEntityBasicForReference)a;
 
                     Assert.Equal(ee.Id, aa.Id);
@@ -89,7 +87,7 @@ public abstract class JsonQueryFixtureBase : QueryFixtureBase<JsonQueryContext>
                 Assert.Equal(e == null, a == null);
                 if (a != null)
                 {
-                    var ee = (JsonEntityBasicForCollection)e;
+                    var ee = (JsonEntityBasicForCollection)e!;
                     var aa = (JsonEntityBasicForCollection)a;
 
                     Assert.Equal(ee.Id, aa.Id);
@@ -103,7 +101,7 @@ public abstract class JsonQueryFixtureBase : QueryFixtureBase<JsonQueryContext>
             {
                 if (a != null)
                 {
-                    var ee = (JsonOwnedRoot)e;
+                    var ee = (JsonOwnedRoot)e!;
                     var aa = (JsonOwnedRoot)a;
 
                     AssertOwnedRoot(ee, aa);
@@ -115,7 +113,7 @@ public abstract class JsonQueryFixtureBase : QueryFixtureBase<JsonQueryContext>
             {
                 if (a != null)
                 {
-                    var ee = (JsonOwnedBranch)e;
+                    var ee = (JsonOwnedBranch)e!;
                     var aa = (JsonOwnedBranch)a;
 
                     AssertOwnedBranch(ee, aa);
@@ -127,7 +125,7 @@ public abstract class JsonQueryFixtureBase : QueryFixtureBase<JsonQueryContext>
             {
                 if (a != null)
                 {
-                    var ee = (JsonOwnedLeaf)e;
+                    var ee = (JsonOwnedLeaf)e!;
                     var aa = (JsonOwnedLeaf)a;
 
                     AssertOwnedLeaf(ee, aa);
@@ -140,7 +138,7 @@ public abstract class JsonQueryFixtureBase : QueryFixtureBase<JsonQueryContext>
                 Assert.Equal(e == null, a == null);
                 if (a != null)
                 {
-                    var ee = (JsonEntityCustomNaming)e;
+                    var ee = (JsonEntityCustomNaming)e!;
                     var aa = (JsonEntityCustomNaming)a;
 
                     Assert.Equal(ee.Id, aa.Id);
@@ -161,7 +159,7 @@ public abstract class JsonQueryFixtureBase : QueryFixtureBase<JsonQueryContext>
             {
                 if (a != null)
                 {
-                    var ee = (JsonOwnedCustomNameRoot)e;
+                    var ee = (JsonOwnedCustomNameRoot)e!;
                     var aa = (JsonOwnedCustomNameRoot)a;
 
                     AssertCustomNameRoot(ee, aa);
@@ -173,7 +171,7 @@ public abstract class JsonQueryFixtureBase : QueryFixtureBase<JsonQueryContext>
             {
                 if (a != null)
                 {
-                    var ee = (JsonOwnedCustomNameBranch)e;
+                    var ee = (JsonOwnedCustomNameBranch)e!;
                     var aa = (JsonOwnedCustomNameBranch)a;
 
                     AssertCustomNameBranch(ee, aa);
@@ -186,16 +184,16 @@ public abstract class JsonQueryFixtureBase : QueryFixtureBase<JsonQueryContext>
                 Assert.Equal(e == null, a == null);
                 if (a != null)
                 {
-                    var ee = (JsonEntitySingleOwned)e;
+                    var ee = (JsonEntitySingleOwned)e!;
                     var aa = (JsonEntitySingleOwned)a;
 
                     Assert.Equal(ee.Id, aa.Id);
                     Assert.Equal(ee.Name, aa.Name);
 
                     Assert.Equal(ee.OwnedCollection?.Count ?? 0, aa.OwnedCollection?.Count ?? 0);
-                    for (var i = 0; i < ee.OwnedCollection.Count; i++)
+                    for (var i = 0; i < ee.OwnedCollection!.Count; i++)
                     {
-                        AssertOwnedLeaf(ee.OwnedCollection[i], aa.OwnedCollection[i]);
+                        AssertOwnedLeaf(ee.OwnedCollection[i], aa.OwnedCollection![i]);
                     }
                 }
             }
@@ -206,7 +204,7 @@ public abstract class JsonQueryFixtureBase : QueryFixtureBase<JsonQueryContext>
                 Assert.Equal(e == null, a == null);
                 if (a != null)
                 {
-                    var ee = (JsonEntityInheritanceBase)e;
+                    var ee = (JsonEntityInheritanceBase)e!;
                     var aa = (JsonEntityInheritanceBase)a;
 
                     Assert.Equal(ee.Id, aa.Id);
@@ -214,9 +212,9 @@ public abstract class JsonQueryFixtureBase : QueryFixtureBase<JsonQueryContext>
 
                     AssertOwnedBranch(ee.ReferenceOnBase, aa.ReferenceOnBase);
                     Assert.Equal(ee.CollectionOnBase?.Count ?? 0, aa.CollectionOnBase?.Count ?? 0);
-                    for (var i = 0; i < ee.CollectionOnBase.Count; i++)
+                    for (var i = 0; i < ee.CollectionOnBase!.Count; i++)
                     {
-                        AssertOwnedBranch(ee.CollectionOnBase[i], aa.CollectionOnBase[i]);
+                        AssertOwnedBranch(ee.CollectionOnBase[i], aa.CollectionOnBase![i]);
                     }
                 }
             }
@@ -227,7 +225,7 @@ public abstract class JsonQueryFixtureBase : QueryFixtureBase<JsonQueryContext>
                 Assert.Equal(e == null, a == null);
                 if (a != null)
                 {
-                    var ee = (JsonEntityInheritanceDerived)e;
+                    var ee = (JsonEntityInheritanceDerived)e!;
                     var aa = (JsonEntityInheritanceDerived)a;
 
                     Assert.Equal(ee.Id, aa.Id);
@@ -238,15 +236,15 @@ public abstract class JsonQueryFixtureBase : QueryFixtureBase<JsonQueryContext>
                     AssertOwnedBranch(ee.ReferenceOnDerived, aa.ReferenceOnDerived);
 
                     Assert.Equal(ee.CollectionOnBase?.Count ?? 0, aa.CollectionOnBase?.Count ?? 0);
-                    for (var i = 0; i < ee.CollectionOnBase.Count; i++)
+                    for (var i = 0; i < ee.CollectionOnBase!.Count; i++)
                     {
-                        AssertOwnedBranch(ee.CollectionOnBase[i], aa.CollectionOnBase[i]);
+                        AssertOwnedBranch(ee.CollectionOnBase[i], aa.CollectionOnBase![i]);
                     }
 
                     Assert.Equal(ee.CollectionOnDerived?.Count ?? 0, aa.CollectionOnDerived?.Count ?? 0);
-                    for (var i = 0; i < ee.CollectionOnDerived.Count; i++)
+                    for (var i = 0; i < ee.CollectionOnDerived!.Count; i++)
                     {
-                        AssertOwnedBranch(ee.CollectionOnDerived[i], aa.CollectionOnDerived[i]);
+                        AssertOwnedBranch(ee.CollectionOnDerived[i], aa.CollectionOnDerived![i]);
                     }
                 }
             }
@@ -257,17 +255,17 @@ public abstract class JsonQueryFixtureBase : QueryFixtureBase<JsonQueryContext>
                 Assert.Equal(e == null, a == null);
                 if (a != null)
                 {
-                    var ee = (JsonEntityAllTypes)e;
+                    var ee = (JsonEntityAllTypes)e!;
                     var aa = (JsonEntityAllTypes)a;
 
                     Assert.Equal(ee.Id, aa.Id);
 
-                    AssertAllTypes(ee.Reference, aa.Reference);
+                    AssertAllTypes(ee.Reference!, aa.Reference!);
 
                     Assert.Equal(ee.Collection?.Count ?? 0, aa.Collection?.Count ?? 0);
-                    for (var i = 0; i < ee.Collection.Count; i++)
+                    for (var i = 0; i < ee.Collection!.Count; i++)
                     {
-                        AssertAllTypes(ee.Collection[i], aa.Collection[i]);
+                        AssertAllTypes(ee.Collection[i], aa.Collection![i]);
                     }
                 }
             }
@@ -278,7 +276,7 @@ public abstract class JsonQueryFixtureBase : QueryFixtureBase<JsonQueryContext>
                 Assert.Equal(e == null, a == null);
                 if (a != null)
                 {
-                    var ee = (JsonOwnedAllTypes)e;
+                    var ee = (JsonOwnedAllTypes)e!;
                     var aa = (JsonOwnedAllTypes)a;
 
                     AssertAllTypes(ee, aa);
@@ -291,7 +289,7 @@ public abstract class JsonQueryFixtureBase : QueryFixtureBase<JsonQueryContext>
                 Assert.Equal(e == null, a == null);
                 if (a != null)
                 {
-                    var ee = (JsonEntityConverters)e;
+                    var ee = (JsonEntityConverters)e!;
                     var aa = (JsonEntityConverters)a;
 
                     Assert.Equal(ee.Id, aa.Id);
@@ -306,7 +304,7 @@ public abstract class JsonQueryFixtureBase : QueryFixtureBase<JsonQueryContext>
                 Assert.Equal(e == null, a == null);
                 if (a != null)
                 {
-                    var ee = (JsonOwnedConverters)e;
+                    var ee = (JsonOwnedConverters)e!;
                     var aa = (JsonOwnedConverters)a;
 
                     AssertConverters(ee, aa);
@@ -322,7 +320,7 @@ public abstract class JsonQueryFixtureBase : QueryFixtureBase<JsonQueryContext>
         Assert.Equal(expected.Names, actual.Names);
         Assert.Equal(expected.Numbers, actual.Numbers);
 
-        AssertOwnedBranch(expected.OwnedReferenceBranch, actual.OwnedReferenceBranch);
+        AssertOwnedBranch(expected.OwnedReferenceBranch!, actual.OwnedReferenceBranch!);
         Assert.Equal(expected.OwnedCollectionBranch.Count, actual.OwnedCollectionBranch.Count);
         for (var i = 0; i < expected.OwnedCollectionBranch.Count; i++)
         {
@@ -364,10 +362,14 @@ public abstract class JsonQueryFixtureBase : QueryFixtureBase<JsonQueryContext>
         }
     }
 
-    public static void AssertCustomNameBranch(JsonOwnedCustomNameBranch expected, JsonOwnedCustomNameBranch actual)
+    public static void AssertCustomNameBranch(JsonOwnedCustomNameBranch? expected, JsonOwnedCustomNameBranch? actual)
     {
-        Assert.Equal(expected.Date, actual.Date);
-        Assert.Equal(expected.Fraction, actual.Fraction);
+        Assert.Equal(expected == null, actual == null);
+        if (expected != null)
+        {
+            Assert.Equal(expected.Date, actual!.Date);
+            Assert.Equal(expected.Fraction, actual.Fraction);
+        }
     }
 
     public static void AssertAllTypes(JsonOwnedAllTypes expected, JsonOwnedAllTypes actual)
@@ -429,7 +431,7 @@ public abstract class JsonQueryFixtureBase : QueryFixtureBase<JsonQueryContext>
             actual.TestNullableEnumWithConverterThatHandlesNullsCollection);
     }
 
-    public static void AssertPrimitiveCollection<T>(IList<T> expected, IList<T> actual)
+    public static void AssertPrimitiveCollection<T>(IList<T>? expected, IList<T>? actual)
     {
         Assert.Equal(expected?.Count, actual?.Count);
         for (var i = 0; i < (expected?.Count ?? 0); i++)
@@ -451,6 +453,7 @@ public abstract class JsonQueryFixtureBase : QueryFixtureBase<JsonQueryContext>
     protected override void OnModelCreating(ModelBuilder modelBuilder, DbContext context)
     {
         modelBuilder.Entity<JsonEntityBasic>().Property(x => x.Id).ValueGeneratedNever();
+        modelBuilder.Entity<JsonEntityBasic>().Property(x => x.Name).IsRequired(false);
         modelBuilder.Entity<EntityBasic>().Property(x => x.Id).ValueGeneratedNever();
         modelBuilder.Entity<JsonEntityBasicForReference>(b =>
         {
@@ -462,6 +465,7 @@ public abstract class JsonQueryFixtureBase : QueryFixtureBase<JsonQueryContext>
         modelBuilder.Entity<JsonEntityBasic>().OwnsOne(
             x => x.OwnedReferenceRoot, b =>
             {
+                b.Property(x => x.Name).IsRequired(false);
                 b.WithOwner(x => x.Owner);
 
                 b.OwnsOne(
@@ -487,6 +491,7 @@ public abstract class JsonQueryFixtureBase : QueryFixtureBase<JsonQueryContext>
         modelBuilder.Entity<JsonEntityBasic>().OwnsMany(
             x => x.OwnedCollectionRoot, b =>
             {
+                b.Property(x => x.Name).IsRequired(false);
                 b.OwnsOne(
                     x => x.OwnedReferenceBranch, bb =>
                     {
@@ -528,6 +533,7 @@ public abstract class JsonQueryFixtureBase : QueryFixtureBase<JsonQueryContext>
         modelBuilder.Entity<JsonEntityInheritanceBase>().Property(x => x.Id).ValueGeneratedNever();
         modelBuilder.Entity<JsonEntityInheritanceBase>(b =>
         {
+            b.Property(x => x.Name).IsRequired(false);
             b.OwnsOne(
                 x => x.ReferenceOnBase, bb =>
                 {

--- a/test/EFCore.Specification.Tests/Query/JsonQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/JsonQueryTestBase.cs
@@ -5,8 +5,6 @@ using Microsoft.EntityFrameworkCore.TestModels.JsonQuery;
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
-#nullable disable
-
 public abstract class JsonQueryTestBase<TFixture>(TFixture fixture) : QueryTestBase<TFixture>(fixture)
     where TFixture : JsonQueryFixtureBase, new()
 {
@@ -77,9 +75,9 @@ public abstract class JsonQueryTestBase<TFixture>(TFixture fixture) : QueryTestB
                 .Select(x => new
                 {
                     Root1 = x.OwnedReferenceRoot,
-                    Leaf1 = x.OwnedReferenceRoot.OwnedReferenceBranch.OwnedReferenceLeaf,
+                    Leaf1 = x.OwnedReferenceRoot.OwnedReferenceBranch!.OwnedReferenceLeaf,
                     Root2 = x.OwnedReferenceRoot,
-                    Leaf2 = x.OwnedReferenceRoot.OwnedReferenceBranch.OwnedReferenceLeaf,
+                    Leaf2 = x.OwnedReferenceRoot.OwnedReferenceBranch!.OwnedReferenceLeaf,
                 }).AsNoTrackingWithIdentityResolution(),
             assertOrder: true,
             elementAsserter: (e, a) =>
@@ -101,7 +99,7 @@ public abstract class JsonQueryTestBase<TFixture>(TFixture fixture) : QueryTestB
     public virtual Task Basic_json_projection_owned_reference_branch_NoTrackingWithIdentityResolution(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<JsonEntityBasic>().Select(x => x.OwnedReferenceRoot.OwnedReferenceBranch).AsNoTrackingWithIdentityResolution());
+            ss => ss.Set<JsonEntityBasic>().Select(x => x.OwnedReferenceRoot.OwnedReferenceBranch!).AsNoTrackingWithIdentityResolution());
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Basic_json_projection_owned_collection_branch_NoTrackingWithIdentityResolution(bool async)
@@ -114,13 +112,13 @@ public abstract class JsonQueryTestBase<TFixture>(TFixture fixture) : QueryTestB
     public virtual Task Basic_json_projection_owned_reference_leaf(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<JsonEntityBasic>().Select(x => x.OwnedReferenceRoot.OwnedReferenceBranch.OwnedReferenceLeaf).AsNoTracking());
+            ss => ss.Set<JsonEntityBasic>().Select(x => x.OwnedReferenceRoot.OwnedReferenceBranch!.OwnedReferenceLeaf).AsNoTracking());
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Basic_json_projection_owned_collection_leaf(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<JsonEntityBasic>().Select(x => x.OwnedReferenceRoot.OwnedReferenceBranch.OwnedCollectionLeaf).AsNoTracking(),
+            ss => ss.Set<JsonEntityBasic>().Select(x => x.OwnedReferenceRoot.OwnedReferenceBranch!.OwnedCollectionLeaf).AsNoTracking(),
             elementAsserter: (e, a) => AssertCollection(e, a, ordered: true));
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -142,7 +140,7 @@ public abstract class JsonQueryTestBase<TFixture>(TFixture fixture) : QueryTestB
             ss => ss.Set<JsonEntityBasic>().Select(x => new
             {
                 x.Id,
-                x.OwnedReferenceRoot.OwnedReferenceBranch.Enum,
+                x.OwnedReferenceRoot.OwnedReferenceBranch!.Enum,
             }),
             elementSorter: e => e.Id,
             elementAsserter: (e, a) =>
@@ -172,7 +170,7 @@ public abstract class JsonQueryTestBase<TFixture>(TFixture fixture) : QueryTestB
         => AssertQueryScalar(
             async,
             ss => ss.Set<JsonEntityBasic>()
-                .Where(x => x.OwnedReferenceRoot.OwnedReferenceBranch.Fraction < 20.5M).Select(x => x.Id));
+                .Where(x => x.OwnedReferenceRoot.OwnedReferenceBranch!.Fraction < 20.5M).Select(x => x.Id));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Json_subquery_property_pushdown_length(bool async)
@@ -180,10 +178,10 @@ public abstract class JsonQueryTestBase<TFixture>(TFixture fixture) : QueryTestB
             async,
             ss => ss.Set<JsonEntityBasic>()
                 .OrderBy(x => x.Id)
-                .Select(x => x.OwnedReferenceRoot.OwnedReferenceBranch.OwnedReferenceLeaf.SomethingSomething)
+                .Select(x => x.OwnedReferenceRoot.OwnedReferenceBranch!.OwnedReferenceLeaf.SomethingSomething)
                 .Take(3)
                 .Distinct()
-                .Select(x => x.Length));
+                .Select(x => x!.Length));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Json_subquery_reference_pushdown_reference(bool async)
@@ -194,7 +192,7 @@ public abstract class JsonQueryTestBase<TFixture>(TFixture fixture) : QueryTestB
                 .Select(x => x.OwnedReferenceRoot)
                 .Take(10)
                 .Distinct()
-                .Select(x => x.OwnedReferenceBranch).AsNoTracking());
+                .Select(x => x.OwnedReferenceBranch!).AsNoTracking());
 
     [Theory(Skip = "issue #24263"), MemberData(nameof(IsAsyncData))]
     public virtual Task Json_subquery_reference_pushdown_reference_anonymous_projection(bool async)
@@ -205,12 +203,12 @@ public abstract class JsonQueryTestBase<TFixture>(TFixture fixture) : QueryTestB
                 .Select(x => new
                 {
                     Entity = x.OwnedReferenceRoot,
-                    Scalar = x.OwnedReferenceRoot.OwnedReferenceBranch.OwnedReferenceLeaf.SomethingSomething
+                    Scalar = x.OwnedReferenceRoot.OwnedReferenceBranch!.OwnedReferenceLeaf.SomethingSomething
                 })
                 .Take(10)
                 .Distinct()
-                .Select(x => new { x.Entity.OwnedReferenceBranch, x.Scalar.Length }).AsNoTracking(),
-            elementSorter: e => (e.OwnedReferenceBranch.Date, e.OwnedReferenceBranch.Fraction, e.Length),
+                .Select(x => new { x.Entity.OwnedReferenceBranch, x.Scalar!.Length }).AsNoTracking(),
+            elementSorter: e => (e.OwnedReferenceBranch!.Date, e.OwnedReferenceBranch!.Fraction, e.Length),
             elementAsserter: (e, a) =>
             {
                 AssertEqual(e.OwnedReferenceBranch, a.OwnedReferenceBranch);
@@ -226,17 +224,17 @@ public abstract class JsonQueryTestBase<TFixture>(TFixture fixture) : QueryTestB
                 .Select(x => new
                 {
                     Root = x.OwnedReferenceRoot,
-                    Scalar = x.OwnedReferenceRoot.OwnedReferenceBranch.OwnedReferenceLeaf.SomethingSomething
+                    Scalar = x.OwnedReferenceRoot.OwnedReferenceBranch!.OwnedReferenceLeaf.SomethingSomething
                 })
                 .Take(10)
                 .Distinct()
-                .Select(x => new { Branch = x.Root.OwnedReferenceBranch, x.Scalar.Length })
+                .Select(x => new { Branch = x.Root.OwnedReferenceBranch, x.Scalar!.Length })
                 .OrderBy(x => x.Length)
                 .Take(10)
                 .Distinct()
                 .Select(x => new
                 {
-                    x.Branch.OwnedReferenceLeaf,
+                    x.Branch!.OwnedReferenceLeaf,
                     x.Branch.OwnedCollectionLeaf,
                     x.Length
                 })
@@ -262,7 +260,7 @@ public abstract class JsonQueryTestBase<TFixture>(TFixture fixture) : QueryTestB
                 .Select(x => x.OwnedReferenceBranch)
                 .Take(10)
                 .Distinct()
-                .Select(x => x.OwnedReferenceLeaf).AsNoTracking());
+                .Select(x => x!.OwnedReferenceLeaf).AsNoTracking());
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Json_subquery_reference_pushdown_reference_pushdown_collection(bool async)
@@ -277,7 +275,7 @@ public abstract class JsonQueryTestBase<TFixture>(TFixture fixture) : QueryTestB
                 .Select(x => x.OwnedReferenceBranch)
                 .Take(10)
                 .Distinct()
-                .Select(x => x.OwnedCollectionLeaf).AsNoTracking(),
+                .Select(x => x!.OwnedCollectionLeaf).AsNoTracking(),
             elementAsserter: (e, a) => AssertCollection(e, a, ordered: true));
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -286,7 +284,7 @@ public abstract class JsonQueryTestBase<TFixture>(TFixture fixture) : QueryTestB
             async,
             ss => ss.Set<JsonEntityBasic>()
                 .OrderBy(x => x.Id)
-                .Select(x => x.OwnedReferenceRoot.OwnedReferenceBranch.OwnedReferenceLeaf)
+                .Select(x => x.OwnedReferenceRoot.OwnedReferenceBranch!.OwnedReferenceLeaf)
                 .Take(10)
                 .Distinct()
                 .Select(x => x.SomethingSomething));
@@ -301,7 +299,7 @@ public abstract class JsonQueryTestBase<TFixture>(TFixture fixture) : QueryTestB
     public virtual Task Custom_naming_projection_owned_reference(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<JsonEntityCustomNaming>().Select(x => x.OwnedReferenceRoot.OwnedReferenceBranch).AsNoTracking());
+            ss => ss.Set<JsonEntityCustomNaming>().Select(x => x.OwnedReferenceRoot.OwnedReferenceBranch!).AsNoTracking());
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Custom_naming_projection_owned_collection(bool async)
@@ -315,7 +313,7 @@ public abstract class JsonQueryTestBase<TFixture>(TFixture fixture) : QueryTestB
     public virtual Task Custom_naming_projection_owned_scalar(bool async)
         => AssertQueryScalar(
             async,
-            ss => ss.Set<JsonEntityCustomNaming>().Select(x => x.OwnedReferenceRoot.OwnedReferenceBranch.Fraction));
+            ss => ss.Set<JsonEntityCustomNaming>().Select(x => x.OwnedReferenceRoot.OwnedReferenceBranch!.Fraction));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Custom_naming_projection_everything(bool async)
@@ -329,7 +327,7 @@ public abstract class JsonQueryTestBase<TFixture>(TFixture fixture) : QueryTestB
                 collection = x.OwnedCollectionRoot,
                 nested_collection = x.OwnedReferenceRoot.OwnedCollectionBranch,
                 scalar = x.OwnedReferenceRoot.Name,
-                nested_scalar = x.OwnedReferenceRoot.OwnedReferenceBranch.Fraction,
+                nested_scalar = x.OwnedReferenceRoot.OwnedReferenceBranch!.Fraction,
             }).AsNoTracking(),
             elementSorter: e => e.root.Id,
             elementAsserter: (e, a) =>
@@ -392,8 +390,8 @@ public abstract class JsonQueryTestBase<TFixture>(TFixture fixture) : QueryTestB
                        Id2 = (int?)e2.Id,
                        e2.OwnedReferenceRoot,
                        e2.OwnedReferenceRoot.OwnedReferenceBranch,
-                       e2.OwnedReferenceRoot.OwnedReferenceBranch.OwnedReferenceLeaf,
-                       e2.OwnedReferenceRoot.OwnedReferenceBranch.OwnedCollectionLeaf
+                       e2.OwnedReferenceRoot.OwnedReferenceBranch!.OwnedReferenceLeaf,
+                       e2.OwnedReferenceRoot.OwnedReferenceBranch!.OwnedCollectionLeaf
                    }).AsNoTracking(),
             elementSorter: e => (e.Id1, e?.Id2),
             elementAsserter: (e, a) =>
@@ -434,8 +432,8 @@ public abstract class JsonQueryTestBase<TFixture>(TFixture fixture) : QueryTestB
                        Id2 = (int?)e2.Id,
                        e1.OwnedReferenceRoot,
                        e1.OwnedReferenceRoot.OwnedReferenceBranch,
-                       e1.OwnedReferenceRoot.OwnedReferenceBranch.OwnedReferenceLeaf,
-                       e1.OwnedReferenceRoot.OwnedReferenceBranch.OwnedCollectionLeaf,
+                       e1.OwnedReferenceRoot.OwnedReferenceBranch!.OwnedReferenceLeaf,
+                       e1.OwnedReferenceRoot.OwnedReferenceBranch!.OwnedCollectionLeaf,
                        e2.Name
                    }).AsNoTracking(),
             elementSorter: e => (e.Id1, e?.Id2),
@@ -459,7 +457,7 @@ public abstract class JsonQueryTestBase<TFixture>(TFixture fixture) : QueryTestB
                 .Select(x => ss.Set<JsonEntityBasic>()
                     .OrderBy(xx => xx.Id)
                     .Select(xx => xx.OwnedReferenceRoot)
-                    .FirstOrDefault().OwnedReferenceBranch.Date));
+                    .FirstOrDefault()!.OwnedReferenceBranch!.Date));
 
     [Theory(Skip = "issue #28733"), MemberData(nameof(IsAsyncData))]
     public virtual Task Project_json_entity_FirstOrDefault_subquery_with_entity_comparison_on_top(bool async)
@@ -470,13 +468,13 @@ public abstract class JsonQueryTestBase<TFixture>(TFixture fixture) : QueryTestB
                 .Select(x => ss.Set<JsonEntityBasic>()
                         .OrderBy(xx => xx.Id)
                         .Select(xx => xx.OwnedReferenceRoot)
-                        .FirstOrDefault().OwnedReferenceBranch
+                        .FirstOrDefault()!.OwnedReferenceBranch
                     == ss.Set<JsonEntityBasic>()
                         .OrderByDescending(x => x.Id)
                         .Select(x => ss.Set<JsonEntityBasic>()
                             .OrderBy(xx => xx.Id)
                             .Select(xx => xx.OwnedReferenceRoot)
-                            .FirstOrDefault().OwnedReferenceBranch)));
+                            .FirstOrDefault()!.OwnedReferenceBranch)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Json_entity_with_inheritance_basic_projection(bool async)
@@ -505,7 +503,7 @@ public abstract class JsonQueryTestBase<TFixture>(TFixture fixture) : QueryTestB
             {
                 Assert.Equal(e.Id, a.Id);
                 AssertEqual(e.ReferenceOnBase, a.ReferenceOnBase);
-                AssertCollection(e.CollectionOnBase, a.CollectionOnBase, ordered: true);
+                AssertCollection(e.CollectionOnBase!, a.CollectionOnBase!, ordered: true);
             });
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -526,15 +524,15 @@ public abstract class JsonQueryTestBase<TFixture>(TFixture fixture) : QueryTestB
                 AssertEqual(e.Id, a.Id);
                 AssertEqual(e.ReferenceOnBase, a.ReferenceOnBase);
                 AssertEqual(e.ReferenceOnDerived, a.ReferenceOnDerived);
-                AssertCollection(e.CollectionOnBase, a.CollectionOnBase, ordered: true);
-                AssertCollection(e.CollectionOnDerived, a.CollectionOnDerived, ordered: true);
+                AssertCollection(e.CollectionOnBase!, a.CollectionOnBase!, ordered: true);
+                AssertCollection(e.CollectionOnDerived!, a.CollectionOnDerived!, ordered: true);
             });
 
     [Theory(Skip = "issue #28645"), MemberData(nameof(IsAsyncData))]
     public virtual Task Json_entity_backtracking(bool async)
         => AssertQueryScalar(
             async,
-            ss => ss.Set<JsonEntityBasic>().Select(x => x.OwnedReferenceRoot.OwnedReferenceBranch.OwnedReferenceLeaf.Parent.Date));
+            ss => ss.Set<JsonEntityBasic>().Select(x => x.OwnedReferenceRoot.OwnedReferenceBranch!.OwnedReferenceLeaf.Parent.Date));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Json_collection_index_in_projection_basic(bool async)
@@ -552,7 +550,7 @@ public abstract class JsonQueryTestBase<TFixture>(TFixture fixture) : QueryTestB
     public virtual Task Json_collection_ElementAtOrDefault_in_projection(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<JsonEntityBasic>().Select(x => x.OwnedCollectionRoot.AsQueryable().ElementAtOrDefault(1)).AsNoTracking());
+            ss => ss.Set<JsonEntityBasic>().Select(x => x.OwnedCollectionRoot.AsQueryable().ElementAtOrDefault(1)!).AsNoTracking());
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Json_collection_index_in_projection_project_collection(bool async)
@@ -575,7 +573,7 @@ public abstract class JsonQueryTestBase<TFixture>(TFixture fixture) : QueryTestB
         => AssertQuery(
             async,
             ss => ss.Set<JsonEntityBasic>()
-                .Select(x => x.OwnedCollectionRoot.AsQueryable().ElementAtOrDefault(1).OwnedCollectionBranch)
+                .Select(x => x.OwnedCollectionRoot.AsQueryable().ElementAtOrDefault(1)!.OwnedCollectionBranch)
                 .AsNoTracking(),
             elementAsserter: (e, a) => AssertCollection(e, a, ordered: true));
 
@@ -608,7 +606,7 @@ public abstract class JsonQueryTestBase<TFixture>(TFixture fixture) : QueryTestB
     public virtual Task Json_collection_index_in_projection_using_untranslatable_client_method2(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<JsonEntityBasic>().Select(x => x.OwnedCollectionRoot[0].OwnedReferenceBranch.OwnedCollectionLeaf[MyMethod(x.Id)])
+            ss => ss.Set<JsonEntityBasic>().Select(x => x.OwnedCollectionRoot[0].OwnedReferenceBranch!.OwnedCollectionLeaf[MyMethod(x.Id)])
                 .AsNoTracking());
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -616,14 +614,14 @@ public abstract class JsonQueryTestBase<TFixture>(TFixture fixture) : QueryTestB
         => AssertQuery(
             async,
             ss => ss.Set<JsonEntityBasic>().Select(x => x.OwnedCollectionRoot[25]).AsNoTracking(),
-            ss => ss.Set<JsonEntityBasic>().Select(x => (JsonOwnedRoot)null));
+            ss => ss.Set<JsonEntityBasic>().Select(x => (JsonOwnedRoot)null!));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Json_collection_index_outside_bounds2(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<JsonEntityBasic>().Select(x => x.OwnedReferenceRoot.OwnedReferenceBranch.OwnedCollectionLeaf[25]).AsNoTracking(),
-            ss => ss.Set<JsonEntityBasic>().Select(x => (JsonOwnedLeaf)null));
+            ss => ss.Set<JsonEntityBasic>().Select(x => x.OwnedReferenceRoot.OwnedReferenceBranch!.OwnedCollectionLeaf[25]).AsNoTracking(),
+            ss => ss.Set<JsonEntityBasic>().Select(x => (JsonOwnedLeaf)null!));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Json_collection_index_outside_bounds_with_property_access(bool async)
@@ -1015,7 +1013,7 @@ public abstract class JsonQueryTestBase<TFixture>(TFixture fixture) : QueryTestB
             async,
             ss => ss.Set<JsonEntityBasic>()
                 .OrderBy(x => x.Id)
-                .Select(x => x.OwnedReferenceRoot.OwnedReferenceBranch.OwnedCollectionLeaf
+                .Select(x => x.OwnedReferenceRoot.OwnedReferenceBranch!.OwnedCollectionLeaf
                     .Where(xx => xx.SomethingSomething != "Baz").ToList())
                 .AsNoTracking(),
             assertOrder: true,
@@ -1029,7 +1027,7 @@ public abstract class JsonQueryTestBase<TFixture>(TFixture fixture) : QueryTestB
                 .OrderBy(x => x.Id)
                 .Select(x => new
                 {
-                    First = x.OwnedReferenceRoot.OwnedReferenceBranch.OwnedCollectionLeaf
+                    First = x.OwnedReferenceRoot.OwnedReferenceBranch!.OwnedCollectionLeaf
                         .Where(xx => xx.SomethingSomething != "Baz").ToList(),
                     Second = x.OwnedCollectionRoot.Distinct().ToList(),
                     Third = x.OwnedCollectionRoot
@@ -1073,7 +1071,7 @@ public abstract class JsonQueryTestBase<TFixture>(TFixture fixture) : QueryTestB
                 .OrderBy(x => x.Id)
                 .Select(x => new
                 {
-                    First = x.OwnedReferenceRoot.OwnedReferenceBranch.OwnedCollectionLeaf.Distinct().ToList(),
+                    First = x.OwnedReferenceRoot.OwnedReferenceBranch!.OwnedCollectionLeaf.Distinct().ToList(),
                     Second = x.EntityCollection.ToList()
                 })
                 .AsNoTracking(),
@@ -1089,33 +1087,33 @@ public abstract class JsonQueryTestBase<TFixture>(TFixture fixture) : QueryTestB
         => AssertQuery(
             async,
             ss => ss.Set<JsonEntityBasic>()
-                .SelectMany(x => x.OwnedReferenceRoot.Names));
+                .SelectMany(x => x.OwnedReferenceRoot.Names!));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Json_collection_of_primitives_index_used_in_predicate(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<JsonEntityBasic>().Where(x => x.OwnedReferenceRoot.Names[0] == "e1_r1"));
+            ss => ss.Set<JsonEntityBasic>().Where(x => x.OwnedReferenceRoot.Names![0] == "e1_r1"));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Json_collection_of_primitives_index_used_in_projection(bool async)
         => AssertQueryScalar(
             async,
-            ss => ss.Set<JsonEntityBasic>().OrderBy(x => x.Id).Select(x => x.OwnedReferenceRoot.OwnedReferenceBranch.Enums[0]),
+            ss => ss.Set<JsonEntityBasic>().OrderBy(x => x.Id).Select(x => x.OwnedReferenceRoot.OwnedReferenceBranch!.Enums![0]),
             assertOrder: true);
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Json_collection_of_primitives_index_used_in_orderby(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<JsonEntityBasic>().OrderBy(x => x.OwnedReferenceRoot.Numbers[0]),
+            ss => ss.Set<JsonEntityBasic>().OrderBy(x => x.OwnedReferenceRoot.Numbers![0]),
             assertOrder: true);
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Json_collection_of_primitives_contains_in_predicate(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<JsonEntityBasic>().Where(x => x.OwnedReferenceRoot.Names.Contains("e1_r1")),
+            ss => ss.Set<JsonEntityBasic>().Where(x => x.OwnedReferenceRoot.Names!.Contains("e1_r1")),
             assertOrder: true);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -1197,7 +1195,7 @@ public abstract class JsonQueryTestBase<TFixture>(TFixture fixture) : QueryTestB
                 x.Id,
                 Duplicate1 = x.OwnedCollectionRoot[0].OwnedReferenceBranch,
                 Original = x.OwnedCollectionRoot[0],
-                Duplicate2 = x.OwnedCollectionRoot[0].OwnedReferenceBranch.OwnedCollectionLeaf
+                Duplicate2 = x.OwnedCollectionRoot[0].OwnedReferenceBranch!.OwnedCollectionLeaf
             }).AsNoTracking(),
             elementSorter: e => e.Id,
             elementAsserter: (e, a) =>
@@ -1220,7 +1218,7 @@ public abstract class JsonQueryTestBase<TFixture>(TFixture fixture) : QueryTestB
                 x.Id,
                 Duplicate1 = x.OwnedReferenceRoot.OwnedCollectionBranch[1],
                 Original = x.OwnedReferenceRoot,
-                Duplicate2 = x.OwnedReferenceRoot.OwnedReferenceBranch.OwnedCollectionLeaf[prm]
+                Duplicate2 = x.OwnedReferenceRoot.OwnedReferenceBranch!.OwnedCollectionLeaf[prm]
             }).AsNoTracking(),
             elementSorter: e => e.Id,
             elementAsserter: (e, a) =>
@@ -1419,7 +1417,7 @@ public abstract class JsonQueryTestBase<TFixture>(TFixture fixture) : QueryTestB
         => AssertQuery(
             async,
             ss => ss.Set<JsonEntityBasic>()
-                .Select(x => new { x, CollectionElement = x.OwnedReferenceRoot.OwnedReferenceBranch.OwnedCollectionLeaf[1] })
+                .Select(x => new { x, CollectionElement = x.OwnedReferenceRoot.OwnedReferenceBranch!.OwnedCollectionLeaf[1] })
                 .AsNoTracking(),
             elementSorter: e => e.x.Id,
             elementAsserter: (e, a) =>
@@ -1433,7 +1431,7 @@ public abstract class JsonQueryTestBase<TFixture>(TFixture fixture) : QueryTestB
         => AssertQuery(
             async,
             ss => ss.Set<JsonEntityBasic>()
-                .Select(x => new { x.Id, CollectionElement = x.OwnedReferenceRoot.OwnedReferenceBranch.OwnedCollectionLeaf[1] })
+                .Select(x => new { x.Id, CollectionElement = x.OwnedReferenceRoot.OwnedReferenceBranch!.OwnedCollectionLeaf[1] })
                 .AsNoTracking(),
             elementSorter: e => e.Id,
             elementAsserter: (e, a) =>
@@ -1527,7 +1525,7 @@ public abstract class JsonQueryTestBase<TFixture>(TFixture fixture) : QueryTestB
         => AssertQuery(
             async,
             ss => ss.Set<JsonEntityBasic>()
-                .Where(x => x.OwnedReferenceRoot.Name != x.OwnedReferenceRoot.OwnedReferenceBranch.OwnedReferenceLeaf.SomethingSomething)
+                .Where(x => x.OwnedReferenceRoot.Name != x.OwnedReferenceRoot.OwnedReferenceBranch!.OwnedReferenceLeaf.SomethingSomething)
                 .Select(x => x.Name));
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -1570,7 +1568,7 @@ public abstract class JsonQueryTestBase<TFixture>(TFixture fixture) : QueryTestB
         => AssertQuery(
             async,
             ss => ss.Set<JsonEntityBasic>()
-                .GroupBy(x => x.OwnedReferenceRoot.OwnedReferenceBranch.Enum)
+                .GroupBy(x => x.OwnedReferenceRoot.OwnedReferenceBranch!.Enum)
                 .Select(g => g.OrderBy(x => x.OwnedReferenceRoot.Number).FirstOrDefault()));
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -1578,7 +1576,7 @@ public abstract class JsonQueryTestBase<TFixture>(TFixture fixture) : QueryTestB
         => AssertQueryScalar(
             async,
             ss => ss.Set<JsonEntityBasic>()
-                .GroupBy(x => x.OwnedReferenceRoot.Name).Select(g => g.First().OwnedReferenceRoot.OwnedReferenceBranch.Enum));
+                .GroupBy(x => x.OwnedReferenceRoot.Name).Select(g => g.First().OwnedReferenceRoot.OwnedReferenceBranch!.Enum));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Json_with_include_on_json_entity(bool async)
@@ -1662,7 +1660,7 @@ public abstract class JsonQueryTestBase<TFixture>(TFixture fixture) : QueryTestB
         => AssertQuery(
             async,
             ss => ss.Set<JsonEntityBasic>()
-                .Select(x => new { x.OwnedReferenceRoot.OwnedReferenceBranch.OwnedReferenceLeaf, x.EntityCollection }).AsNoTracking(),
+                .Select(x => new { x.OwnedReferenceRoot.OwnedReferenceBranch!.OwnedReferenceLeaf, x.EntityCollection }).AsNoTracking(),
             elementAsserter: (e, a) =>
             {
                 AssertEqual(e.OwnedReferenceLeaf, a.OwnedReferenceLeaf);
@@ -1689,7 +1687,7 @@ public abstract class JsonQueryTestBase<TFixture>(TFixture fixture) : QueryTestB
                 Reference1 = x.OwnedReferenceRoot,
                 Reference2 = x.OwnedCollectionRoot[0].OwnedReferenceBranch,
                 x.EntityCollection,
-                Reference3 = x.OwnedCollectionRoot[1].OwnedReferenceBranch.OwnedReferenceLeaf,
+                Reference3 = x.OwnedCollectionRoot[1].OwnedReferenceBranch!.OwnedReferenceLeaf,
                 Reference4 = x.OwnedCollectionRoot[0].OwnedCollectionBranch[0].OwnedReferenceLeaf,
             }).AsNoTracking(),
             elementAsserter: (e, a) =>
@@ -1706,7 +1704,7 @@ public abstract class JsonQueryTestBase<TFixture>(TFixture fixture) : QueryTestB
         => AssertQuery(
             async,
             ss => ss.Set<JsonEntityBasic>()
-                .Select(x => new { x.OwnedReferenceRoot.OwnedReferenceBranch.OwnedCollectionLeaf, x.EntityCollection }).AsNoTracking(),
+                .Select(x => new { x.OwnedReferenceRoot.OwnedReferenceBranch!.OwnedCollectionLeaf, x.EntityCollection }).AsNoTracking(),
             elementAsserter: (e, a) =>
             {
                 AssertCollection(e.OwnedCollectionLeaf, a.OwnedCollectionLeaf, ordered: true);
@@ -1747,11 +1745,11 @@ public abstract class JsonQueryTestBase<TFixture>(TFixture fixture) : QueryTestB
             async,
             ss => ss.Set<JsonEntityBasic>().Select(x => new
             {
-                Collection1 = x.OwnedReferenceRoot.OwnedReferenceBranch.OwnedCollectionLeaf,
+                Collection1 = x.OwnedReferenceRoot.OwnedReferenceBranch!.OwnedCollectionLeaf,
                 x.EntityReference,
-                Reference1 = x.OwnedReferenceRoot.OwnedReferenceBranch.OwnedReferenceLeaf,
+                Reference1 = x.OwnedReferenceRoot.OwnedReferenceBranch!.OwnedReferenceLeaf,
                 x.EntityCollection,
-                Reference2 = x.OwnedReferenceRoot.OwnedReferenceBranch.OwnedCollectionLeaf[0],
+                Reference2 = x.OwnedReferenceRoot.OwnedReferenceBranch!.OwnedCollectionLeaf[0],
                 Collection2 = x.OwnedReferenceRoot.OwnedCollectionBranch,
                 Collection3 = x.OwnedCollectionRoot,
                 Reference3 = x.OwnedCollectionRoot[0].OwnedReferenceBranch,
@@ -1781,9 +1779,9 @@ public abstract class JsonQueryTestBase<TFixture>(TFixture fixture) : QueryTestB
     public virtual Task Json_all_types_projection_from_owned_entity_reference(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<JsonEntityAllTypes>().Select(x => x.Reference).AsNoTracking(),
-            elementSorter: e => e.TestInt32,
-            elementAsserter: (e, a) => AssertEqual(e, a));
+            ss => ss.Set<JsonEntityAllTypes>().Select(x => x.Reference!).AsNoTracking(),
+            elementSorter: e => e!.TestInt32,
+            elementAsserter: (e, a) => AssertEqual(e!, a!));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Json_all_types_projection_individual_properties(bool async)
@@ -1791,254 +1789,254 @@ public abstract class JsonQueryTestBase<TFixture>(TFixture fixture) : QueryTestB
             async,
             ss => ss.Set<JsonEntityAllTypes>().Select(x => new
             {
-                x.Reference.TestDefaultString,
-                x.Reference.TestMaxLengthString,
-                x.Reference.TestBoolean,
-                x.Reference.TestByte,
-                x.Reference.TestCharacter,
-                x.Reference.TestDateTime,
-                x.Reference.TestDateTimeOffset,
-                x.Reference.TestDecimal,
-                x.Reference.TestDouble,
-                x.Reference.TestGuid,
-                x.Reference.TestInt16,
-                x.Reference.TestInt32,
-                x.Reference.TestInt64,
-                x.Reference.TestSignedByte,
-                x.Reference.TestSingle,
-                x.Reference.TestTimeSpan,
-                x.Reference.TestDateOnly,
-                x.Reference.TestTimeOnly,
-                x.Reference.TestUnsignedInt16,
-                x.Reference.TestUnsignedInt32,
-                x.Reference.TestUnsignedInt64,
-                x.Reference.TestEnum,
-                x.Reference.TestEnumWithIntConverter,
-                x.Reference.TestNullableEnum,
-                x.Reference.TestNullableEnumWithIntConverter,
-                x.Reference.TestNullableEnumWithConverterThatHandlesNulls,
+                x.Reference!.TestDefaultString,
+                x.Reference!.TestMaxLengthString,
+                x.Reference!.TestBoolean,
+                x.Reference!.TestByte,
+                x.Reference!.TestCharacter,
+                x.Reference!.TestDateTime,
+                x.Reference!.TestDateTimeOffset,
+                x.Reference!.TestDecimal,
+                x.Reference!.TestDouble,
+                x.Reference!.TestGuid,
+                x.Reference!.TestInt16,
+                x.Reference!.TestInt32,
+                x.Reference!.TestInt64,
+                x.Reference!.TestSignedByte,
+                x.Reference!.TestSingle,
+                x.Reference!.TestTimeSpan,
+                x.Reference!.TestDateOnly,
+                x.Reference!.TestTimeOnly,
+                x.Reference!.TestUnsignedInt16,
+                x.Reference!.TestUnsignedInt32,
+                x.Reference!.TestUnsignedInt64,
+                x.Reference!.TestEnum,
+                x.Reference!.TestEnumWithIntConverter,
+                x.Reference!.TestNullableEnum,
+                x.Reference!.TestNullableEnumWithIntConverter,
+                x.Reference!.TestNullableEnumWithConverterThatHandlesNulls,
             }));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Json_boolean_predicate(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<JsonEntityAllTypes>().Where(x => x.Reference.TestBoolean));
+            ss => ss.Set<JsonEntityAllTypes>().Where(x => x.Reference!.TestBoolean));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Json_boolean_predicate_negated(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<JsonEntityAllTypes>().Where(x => !x.Reference.TestBoolean),
+            ss => ss.Set<JsonEntityAllTypes>().Where(x => !x.Reference!.TestBoolean),
             assertEmpty: true);
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Json_boolean_projection(bool async)
         => AssertQueryScalar(
             async,
-            ss => ss.Set<JsonEntityAllTypes>().Select(x => x.Reference.TestBoolean));
+            ss => ss.Set<JsonEntityAllTypes>().Select(x => x.Reference!.TestBoolean));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Json_boolean_projection_negated(bool async)
         => AssertQueryScalar(
             async,
-            ss => ss.Set<JsonEntityAllTypes>().Select(x => !x.Reference.TestBoolean));
+            ss => ss.Set<JsonEntityAllTypes>().Select(x => !x.Reference!.TestBoolean));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Json_predicate_on_default_string(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<JsonEntityAllTypes>().Where(x => x.Reference.TestDefaultString != "MyDefaultStringInReference1"));
+            ss => ss.Set<JsonEntityAllTypes>().Where(x => x.Reference!.TestDefaultString != "MyDefaultStringInReference1"));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Json_predicate_on_max_length_string(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<JsonEntityAllTypes>().Where(x => x.Reference.TestMaxLengthString != "Foo"));
+            ss => ss.Set<JsonEntityAllTypes>().Where(x => x.Reference!.TestMaxLengthString != "Foo"));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Json_predicate_on_string_condition(bool async)
         => AssertQuery(
             async,
             ss => ss.Set<JsonEntityAllTypes>().Where(x
-                => (!x.Reference.TestBoolean ? x.Reference.TestMaxLengthString : x.Reference.TestDefaultString)
+                => (!x.Reference!.TestBoolean ? x.Reference!.TestMaxLengthString : x.Reference!.TestDefaultString)
                 == "MyDefaultStringInReference1"));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Json_predicate_on_byte(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<JsonEntityAllTypes>().Where(x => x.Reference.TestByte != 3));
+            ss => ss.Set<JsonEntityAllTypes>().Where(x => x.Reference!.TestByte != 3));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Json_predicate_on_byte_array(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<JsonEntityAllTypes>().Where(x => x.Reference.TestByteArray != new byte[] { 1, 2, 3 }),
-            ss => ss.Set<JsonEntityAllTypes>().Where(x => !x.Reference.TestByteArray.SequenceEqual(new byte[] { 1, 2, 3 })));
+            ss => ss.Set<JsonEntityAllTypes>().Where(x => x.Reference!.TestByteArray != new byte[] { 1, 2, 3 }),
+            ss => ss.Set<JsonEntityAllTypes>().Where(x => !x.Reference!.TestByteArray.SequenceEqual(new byte[] { 1, 2, 3 })));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Json_predicate_on_character(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<JsonEntityAllTypes>().Where(x => x.Reference.TestCharacter != 'z'));
+            ss => ss.Set<JsonEntityAllTypes>().Where(x => x.Reference!.TestCharacter != 'z'));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Json_predicate_on_datetime(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<JsonEntityAllTypes>().Where(x => x.Reference.TestDateTime != new DateTime(2000, 1, 3)));
+            ss => ss.Set<JsonEntityAllTypes>().Where(x => x.Reference!.TestDateTime != new DateTime(2000, 1, 3)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Json_predicate_on_datetimeoffset(bool async)
         => AssertQuery(
             async,
             ss => ss.Set<JsonEntityAllTypes>().Where(x
-                => x.Reference.TestDateTimeOffset != new DateTimeOffset(new DateTime(2000, 1, 4), new TimeSpan(3, 2, 0))));
+                => x.Reference!.TestDateTimeOffset != new DateTimeOffset(new DateTime(2000, 1, 4), new TimeSpan(3, 2, 0))));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Json_predicate_on_decimal(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<JsonEntityAllTypes>().Where(x => x.Reference.TestDecimal != 1.35M));
+            ss => ss.Set<JsonEntityAllTypes>().Where(x => x.Reference!.TestDecimal != 1.35M));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Json_predicate_on_double(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<JsonEntityAllTypes>().Where(x => x.Reference.TestDouble != 33.25));
+            ss => ss.Set<JsonEntityAllTypes>().Where(x => x.Reference!.TestDouble != 33.25));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Json_predicate_on_guid(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<JsonEntityAllTypes>().Where(x => x.Reference.TestGuid != new Guid()));
+            ss => ss.Set<JsonEntityAllTypes>().Where(x => x.Reference!.TestGuid != new Guid()));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Json_predicate_on_int16(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<JsonEntityAllTypes>().Where(x => x.Reference.TestInt16 != 3));
+            ss => ss.Set<JsonEntityAllTypes>().Where(x => x.Reference!.TestInt16 != 3));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Json_predicate_on_int32(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<JsonEntityAllTypes>().Where(x => x.Reference.TestInt32 != 33));
+            ss => ss.Set<JsonEntityAllTypes>().Where(x => x.Reference!.TestInt32 != 33));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Json_predicate_on_int64(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<JsonEntityAllTypes>().Where(x => x.Reference.TestInt64 != 333));
+            ss => ss.Set<JsonEntityAllTypes>().Where(x => x.Reference!.TestInt64 != 333));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Json_predicate_on_signedbyte(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<JsonEntityAllTypes>().Where(x => x.Reference.TestSignedByte != 100));
+            ss => ss.Set<JsonEntityAllTypes>().Where(x => x.Reference!.TestSignedByte != 100));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Json_predicate_on_single(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<JsonEntityAllTypes>().Where(x => x.Reference.TestSingle != 10.4f));
+            ss => ss.Set<JsonEntityAllTypes>().Where(x => x.Reference!.TestSingle != 10.4f));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Json_predicate_on_timespan(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<JsonEntityAllTypes>().Where(x => x.Reference.TestTimeSpan != new TimeSpan(3, 2, 0)));
+            ss => ss.Set<JsonEntityAllTypes>().Where(x => x.Reference!.TestTimeSpan != new TimeSpan(3, 2, 0)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Json_predicate_on_dateonly(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<JsonEntityAllTypes>().Where(x => x.Reference.TestDateOnly != new DateOnly(3, 2, 1)));
+            ss => ss.Set<JsonEntityAllTypes>().Where(x => x.Reference!.TestDateOnly != new DateOnly(3, 2, 1)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Json_predicate_on_timeonly(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<JsonEntityAllTypes>().Where(x => x.Reference.TestTimeOnly != new TimeOnly(3, 2, 0)));
+            ss => ss.Set<JsonEntityAllTypes>().Where(x => x.Reference!.TestTimeOnly != new TimeOnly(3, 2, 0)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Json_predicate_on_unisgnedint16(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<JsonEntityAllTypes>().Where(x => x.Reference.TestUnsignedInt16 != 100));
+            ss => ss.Set<JsonEntityAllTypes>().Where(x => x.Reference!.TestUnsignedInt16 != 100));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Json_predicate_on_unsignedint32(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<JsonEntityAllTypes>().Where(x => x.Reference.TestUnsignedInt32 != 1000));
+            ss => ss.Set<JsonEntityAllTypes>().Where(x => x.Reference!.TestUnsignedInt32 != 1000));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Json_predicate_on_unsignedint64(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<JsonEntityAllTypes>().Where(x => x.Reference.TestUnsignedInt64 != 10000));
+            ss => ss.Set<JsonEntityAllTypes>().Where(x => x.Reference!.TestUnsignedInt64 != 10000));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Json_predicate_on_enum(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<JsonEntityAllTypes>().Where(x => x.Reference.TestEnum != JsonEnum.Two));
+            ss => ss.Set<JsonEntityAllTypes>().Where(x => x.Reference!.TestEnum != JsonEnum.Two));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Json_predicate_on_enumwithintconverter(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<JsonEntityAllTypes>().Where(x => x.Reference.TestEnumWithIntConverter != JsonEnum.Three));
+            ss => ss.Set<JsonEntityAllTypes>().Where(x => x.Reference!.TestEnumWithIntConverter != JsonEnum.Three));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Json_predicate_on_nullableenum1(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<JsonEntityAllTypes>().Where(x => x.Reference.TestNullableEnum != JsonEnum.One));
+            ss => ss.Set<JsonEntityAllTypes>().Where(x => x.Reference!.TestNullableEnum != JsonEnum.One));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Json_predicate_on_nullableenum2(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<JsonEntityAllTypes>().Where(x => x.Reference.TestNullableEnum != null));
+            ss => ss.Set<JsonEntityAllTypes>().Where(x => x.Reference!.TestNullableEnum != null));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Json_predicate_on_nullableenumwithconverterthathandlesnulls1(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<JsonEntityAllTypes>().Where(x => x.Reference.TestNullableEnumWithConverterThatHandlesNulls != JsonEnum.One));
+            ss => ss.Set<JsonEntityAllTypes>().Where(x => x.Reference!.TestNullableEnumWithConverterThatHandlesNulls != JsonEnum.One));
 
     [Theory(Skip = "issue #29416"), MemberData(nameof(IsAsyncData))]
     public virtual Task Json_predicate_on_nullableenumwithconverterthathandlesnulls2(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<JsonEntityAllTypes>().Where(x => x.Reference.TestNullableEnumWithConverterThatHandlesNulls != null));
+            ss => ss.Set<JsonEntityAllTypes>().Where(x => x.Reference!.TestNullableEnumWithConverterThatHandlesNulls != null));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Json_predicate_on_nullableenumwithconverter1(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<JsonEntityAllTypes>().Where(x => x.Reference.TestNullableEnumWithIntConverter != JsonEnum.Two));
+            ss => ss.Set<JsonEntityAllTypes>().Where(x => x.Reference!.TestNullableEnumWithIntConverter != JsonEnum.Two));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Json_predicate_on_nullableenumwithconverter2(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<JsonEntityAllTypes>().Where(x => x.Reference.TestNullableEnumWithIntConverter != null));
+            ss => ss.Set<JsonEntityAllTypes>().Where(x => x.Reference!.TestNullableEnumWithIntConverter != null));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Json_predicate_on_nullableint321(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<JsonEntityAllTypes>().Where(x => x.Reference.TestNullableInt32 != 100));
+            ss => ss.Set<JsonEntityAllTypes>().Where(x => x.Reference!.TestNullableInt32 != 100));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Json_predicate_on_nullableint322(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<JsonEntityAllTypes>().Where(x => x.Reference.TestNullableInt32 != null));
+            ss => ss.Set<JsonEntityAllTypes>().Where(x => x.Reference!.TestNullableInt32 != null));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Json_predicate_on_bool_converted_to_int_zero_one(bool async)
@@ -2350,8 +2348,8 @@ public abstract class JsonQueryTestBase<TFixture>(TFixture fixture) : QueryTestB
             ss => ss.Set<JsonEntityBasic>().Select(x => new
             {
                 x.Id,
-                Duplicate = x.OwnedReferenceRoot.OwnedReferenceBranch.OwnedCollectionLeaf[1],
-                Original = x.OwnedReferenceRoot.OwnedReferenceBranch.OwnedCollectionLeaf,
+                Duplicate = x.OwnedReferenceRoot.OwnedReferenceBranch!.OwnedCollectionLeaf[1],
+                Original = x.OwnedReferenceRoot.OwnedReferenceBranch!.OwnedCollectionLeaf,
                 Parent = x.OwnedReferenceRoot.OwnedReferenceBranch,
                 Owner = x
             }).AsNoTrackingWithIdentityResolution(),
@@ -2413,14 +2411,14 @@ public abstract class JsonQueryTestBase<TFixture>(TFixture fixture) : QueryTestB
         var topLevel = result.Single(x => x.Id == 2);
         var nested = result.Single(x => x.Id == 3);
 
-        Assert.Equal(default, topLevel.OptionalReference.Number);
+        Assert.Equal(default, topLevel.OptionalReference!.Number);
         Assert.Equal(default, topLevel.RequiredReference.Number);
         Assert.True(topLevel.Collection.All(x => x.Number == default));
 
         Assert.Equal(default, nested.RequiredReference.NestedRequiredReference.DoB);
-        Assert.Equal(default, nested.RequiredReference.NestedOptionalReference.DoB);
-        Assert.Equal(default, nested.OptionalReference.NestedRequiredReference.DoB);
-        Assert.Equal(default, nested.OptionalReference.NestedOptionalReference.DoB);
+        Assert.Equal(default, nested.RequiredReference.NestedOptionalReference!.DoB);
+        Assert.Equal(default, nested.OptionalReference!.NestedRequiredReference.DoB);
+        Assert.Equal(default, nested.OptionalReference.NestedOptionalReference!.DoB);
         Assert.True(nested.Collection.SelectMany(x => x.NestedCollection).All(x => x.DoB == default));
     }
 
@@ -2449,14 +2447,14 @@ public abstract class JsonQueryTestBase<TFixture>(TFixture fixture) : QueryTestB
         var topLevel = result.Single(x => x.Id == 2);
         var nested = result.Single(x => x.Id == 3);
 
-        Assert.Equal(default, topLevel.OptionalReference.Number);
+        Assert.Equal(default, topLevel.OptionalReference!.Number);
         Assert.Equal(default, topLevel.RequiredReference.Number);
         Assert.True(topLevel.Collection.All(x => x.Number == default));
 
         Assert.Equal(default, nested.RequiredReference.NestedRequiredReference.DoB);
-        Assert.Equal(default, nested.RequiredReference.NestedOptionalReference.DoB);
-        Assert.Equal(default, nested.OptionalReference.NestedRequiredReference.DoB);
-        Assert.Equal(default, nested.OptionalReference.NestedOptionalReference.DoB);
+        Assert.Equal(default, nested.RequiredReference.NestedOptionalReference!.DoB);
+        Assert.Equal(default, nested.OptionalReference!.NestedRequiredReference.DoB);
+        Assert.Equal(default, nested.OptionalReference.NestedOptionalReference!.DoB);
         Assert.True(nested.Collection.SelectMany(x => x.NestedCollection).All(x => x.DoB == default));
     }
 
@@ -2473,7 +2471,7 @@ public abstract class JsonQueryTestBase<TFixture>(TFixture fixture) : QueryTestB
         var query = context.Set<Context21006.Entity>().Where(x => x.Id < 4).Select(x => new
         {
             x.Id,
-            x.OptionalReference.NestedOptionalReference,
+            NestedOptionalReference = x.OptionalReference!.NestedOptionalReference,
             x.RequiredReference.NestedRequiredReference,
             x.Collection[0].NestedCollection
         }).AsNoTracking();
@@ -2485,7 +2483,7 @@ public abstract class JsonQueryTestBase<TFixture>(TFixture fixture) : QueryTestB
         var topLevel = result.Single(x => x.Id == 2);
         var nested = result.Single(x => x.Id == 3);
 
-        Assert.Equal(default, nested.NestedOptionalReference.DoB);
+        Assert.Equal(default, nested.NestedOptionalReference!.DoB);
         Assert.Equal(default, nested.NestedRequiredReference.DoB);
         Assert.True(nested.NestedCollection.All(x => x.DoB == default));
     }
@@ -2534,7 +2532,7 @@ public abstract class JsonQueryTestBase<TFixture>(TFixture fixture) : QueryTestB
         var missingRequiredNav = result.Single();
 
         Assert.Equal(default, missingRequiredNav.RequiredReference.NestedRequiredReference);
-        Assert.Equal(default, missingRequiredNav.OptionalReference.NestedRequiredReference);
+        Assert.Equal(default, missingRequiredNav.OptionalReference!.NestedRequiredReference);
         Assert.True(missingRequiredNav.Collection.All(x => x.NestedRequiredReference == default));
     }
 
@@ -2579,7 +2577,7 @@ public abstract class JsonQueryTestBase<TFixture>(TFixture fixture) : QueryTestB
         var nullRequiredNav = result.Single();
 
         Assert.Equal(default, nullRequiredNav.RequiredReference.NestedRequiredReference);
-        Assert.Equal(default, nullRequiredNav.OptionalReference.NestedRequiredReference);
+        Assert.Equal(default, nullRequiredNav.OptionalReference!.NestedRequiredReference);
         Assert.True(nullRequiredNav.Collection.All(x => x.NestedRequiredReference == default));
     }
 
@@ -2748,31 +2746,32 @@ public abstract class JsonQueryTestBase<TFixture>(TFixture fixture) : QueryTestB
 
     protected class Context21006(DbContextOptions options) : DbContext(options)
     {
-        public DbSet<Entity> Entities { get; set; }
+        public DbSet<Entity> Entities
+            => Set<Entity>();
 
         public class Entity
         {
             public int Id { get; set; }
-            public string Name { get; set; }
-            public JsonEntity OptionalReference { get; set; }
-            public JsonEntity RequiredReference { get; set; }
-            public List<JsonEntity> Collection { get; set; }
+            public string Name { get; set; } = null!;
+            public JsonEntity? OptionalReference { get; set; }
+            public JsonEntity RequiredReference { get; set; } = null!;
+            public List<JsonEntity> Collection { get; set; } = [];
         }
 
         public class JsonEntity
         {
-            public string Text { get; set; }
+            public string Text { get; set; } = null!;
             public double Number { get; set; }
 
-            public JsonEntityNested NestedOptionalReference { get; set; }
-            public JsonEntityNested NestedRequiredReference { get; set; }
-            public List<JsonEntityNested> NestedCollection { get; set; }
+            public JsonEntityNested? NestedOptionalReference { get; set; }
+            public JsonEntityNested NestedRequiredReference { get; set; } = null!;
+            public List<JsonEntityNested> NestedCollection { get; set; } = [];
         }
 
         public class JsonEntityNested
         {
             public DateTime DoB { get; set; }
-            public string Text { get; set; }
+            public string Text { get; set; } = null!;
         }
     }
 
@@ -2854,8 +2853,8 @@ public abstract class JsonQueryTestBase<TFixture>(TFixture fixture) : QueryTestB
         public class MyEntity
         {
             public int Id { get; set; }
-            public MyJsonEntity Reference { get; set; }
-            public List<MyJsonEntity> Collection { get; set; }
+            public MyJsonEntity Reference { get; set; } = null!;
+            public List<MyJsonEntity> Collection { get; set; } = [];
         }
 
         public class MyJsonEntity
@@ -2912,8 +2911,8 @@ public abstract class JsonQueryTestBase<TFixture>(TFixture fixture) : QueryTestB
             x.Json,
             x.Json.OptionalReference,
             x.Json.RequiredReference,
-            NestedOptional = x.Json.OptionalReference.Nested,
-            NestedRequired = x.Json.RequiredReference.Nested,
+            NestedOptional = x.Json.OptionalReference!.Nested,
+            NestedRequired = x.Json.RequiredReference!.Nested,
             x.Json.Collection,
         }).AsNoTracking();
 
@@ -2955,7 +2954,6 @@ public abstract class JsonQueryTestBase<TFixture>(TFixture fixture) : QueryTestB
                     nb.OwnsMany(x => x.Collection, nnb => nnb.OwnsOne(x => x.Nested));
                     nb.OwnsOne(x => x.OptionalReference, nnb => nnb.OwnsOne(x => x.Nested));
                     nb.OwnsOne(x => x.RequiredReference, nnb => nnb.OwnsOne(x => x.Nested));
-                    nb.Navigation(x => x.RequiredReference).IsRequired();
                 });
         });
 
@@ -2966,26 +2964,26 @@ public abstract class JsonQueryTestBase<TFixture>(TFixture fixture) : QueryTestB
         public class MyEntity
         {
             public int Id { get; set; }
-            public MyJsonRootEntity Json { get; set; }
+            public MyJsonRootEntity Json { get; set; } = null!;
         }
 
         public class MyJsonRootEntity
         {
-            public string RootName { get; set; }
-            public MyJsonBranchEntity RequiredReference { get; set; }
-            public MyJsonBranchEntity OptionalReference { get; set; }
-            public List<MyJsonBranchEntity> Collection { get; set; }
+            public string RootName { get; set; } = null!;
+            public MyJsonBranchEntity? RequiredReference { get; set; }
+            public MyJsonBranchEntity? OptionalReference { get; set; }
+            public List<MyJsonBranchEntity>? Collection { get; set; }
         }
 
         public class MyJsonBranchEntity
         {
-            public string BranchName { get; set; }
-            public MyJsonLeafEntity Nested { get; set; }
+            public string BranchName { get; set; } = null!;
+            public MyJsonLeafEntity Nested { get; set; } = null!;
         }
 
         public class MyJsonLeafEntity
         {
-            public string LeafName { get; set; }
+            public string LeafName { get; set; } = null!;
         }
     }
 
@@ -3008,7 +3006,7 @@ public abstract class JsonQueryTestBase<TFixture>(TFixture fixture) : QueryTestB
 
         var result = await query.FirstOrDefaultAsync();
 
-        Assert.Equal("FBI", result.Name);
+        Assert.Equal("FBI", result!.Name);
         Assert.Equal(new DateOnly(2023, 1, 1), result.Visits.DaysVisited.Single());
     }
 
@@ -3038,7 +3036,7 @@ public abstract class JsonQueryTestBase<TFixture>(TFixture fixture) : QueryTestB
 
         public class Visits
         {
-            public string LocationTag { get; set; }
+            public string LocationTag { get; set; } = null!;
             public required List<DateOnly> DaysVisited { get; init; }
         }
     }
@@ -3079,8 +3077,8 @@ public abstract class JsonQueryTestBase<TFixture>(TFixture fixture) : QueryTestB
         public class Entity
         {
             public int Id { get; set; }
-            public JsonEmpty Empty { get; set; }
-            public JsonFieldOnly FieldOnly { get; set; }
+            public JsonEmpty Empty { get; set; } = null!;
+            public JsonFieldOnly FieldOnly { get; set; } = null!;
         }
 
         public class JsonEmpty
@@ -3186,36 +3184,39 @@ public abstract class JsonQueryTestBase<TFixture>(TFixture fixture) : QueryTestB
 
     protected class Context34960(DbContextOptions options) : DbContext(options)
     {
-        public DbSet<Entity> Entities { get; set; }
-        public DbSet<JunkEntity> Junk { get; set; }
+        public DbSet<Entity> Entities
+            => Set<Entity>();
+
+        public DbSet<JunkEntity> Junk
+            => Set<JunkEntity>();
 
         public class Entity
         {
             public int Id { get; set; }
-            public JsonEntity Reference { get; set; }
-            public List<JsonEntity> Collection { get; set; }
+            public JsonEntity? Reference { get; set; }
+            public List<JsonEntity>? Collection { get; set; }
         }
 
         public class JsonEntity
         {
-            public string Name { get; set; }
+            public string? Name { get; set; }
             public double Number { get; set; }
 
-            public JsonEntityNested NestedReference { get; set; }
-            public List<JsonEntityNested> NestedCollection { get; set; }
+            public JsonEntityNested? NestedReference { get; set; }
+            public List<JsonEntityNested>? NestedCollection { get; set; }
         }
 
         public class JsonEntityNested
         {
             public DateTime DoB { get; set; }
-            public string Text { get; set; }
+            public string? Text { get; set; }
         }
 
         public class JunkEntity
         {
             public int Id { get; set; }
-            public JsonEntity Reference { get; set; }
-            public List<JsonEntity> Collection { get; set; }
+            public JsonEntity? Reference { get; set; }
+            public List<JsonEntity>? Collection { get; set; }
         }
     }
 
@@ -3517,14 +3518,14 @@ public abstract class JsonQueryTestBase<TFixture>(TFixture fixture) : QueryTestB
         public class MyEntity
         {
             public int Id { get; set; }
-            public MyJsonEntity Reference { get; set; }
-            public List<MyJsonEntity> Collection { get; set; }
+            public MyJsonEntity Reference { get; set; } = null!;
+            public List<MyJsonEntity> Collection { get; set; } = [];
         }
 
         public class MyJsonEntity
         {
-            public int[] IntArray { get; set; }
-            public List<string> ListOfString { get; set; }
+            public int[] IntArray { get; set; } = [];
+            public List<string> ListOfString { get; set; } = [];
         }
     }
 
@@ -3615,19 +3616,19 @@ public abstract class JsonQueryTestBase<TFixture>(TFixture fixture) : QueryTestB
         public class MyEntity
         {
             public int Id { get; set; }
-            public MyJsonEntity Reference { get; set; }
-            public MyJsonEntityWithCtor ReferenceWithCtor { get; set; }
-            public List<MyJsonEntity> Collection { get; set; }
-            public List<MyJsonEntityWithCtor> CollectionWithCtor { get; set; }
+            public MyJsonEntity Reference { get; set; } = null!;
+            public MyJsonEntityWithCtor ReferenceWithCtor { get; set; } = null!;
+            public List<MyJsonEntity> Collection { get; set; } = [];
+            public List<MyJsonEntityWithCtor> CollectionWithCtor { get; set; } = [];
         }
 
         public class MyJsonEntity
         {
-            public string Name { get; set; }
+            public string Name { get; set; } = null!;
             public double Number { get; set; }
 
-            public MyJsonEntityNested NestedReference { get; set; }
-            public List<MyJsonEntityNested> NestedCollection { get; set; }
+            public MyJsonEntityNested NestedReference { get; set; } = null!;
+            public List<MyJsonEntityNested> NestedCollection { get; set; } = [];
         }
 
         public class MyJsonEntityNested
@@ -3640,8 +3641,8 @@ public abstract class JsonQueryTestBase<TFixture>(TFixture fixture) : QueryTestB
             public bool MyBool { get; set; } = myBool;
             public string Name { get; set; } = name;
 
-            public MyJsonEntityWithCtorNested NestedReference { get; set; }
-            public List<MyJsonEntityWithCtorNested> NestedCollection { get; set; }
+            public MyJsonEntityWithCtorNested NestedReference { get; set; } = null!;
+            public List<MyJsonEntityWithCtorNested> NestedCollection { get; set; } = [];
         }
 
         public class MyJsonEntityWithCtorNested(DateTime doB)
@@ -3692,15 +3693,15 @@ public abstract class JsonQueryTestBase<TFixture>(TFixture fixture) : QueryTestB
         public class MyEntity
         {
             public int Id { get; set; }
-            public MyJsonEntity Reference { get; set; }
+            public MyJsonEntity Reference { get; set; } = null!;
         }
 
         public class MyJsonEntity
         {
-            public string Name { get; set; }
+            public string Name { get; set; } = null!;
             public int Number { get; set; }
-            public MyJsonEntityNested NestedReference { get; set; }
-            public List<MyJsonEntityNested> NestedCollection { get; set; }
+            public MyJsonEntityNested NestedReference { get; set; } = null!;
+            public List<MyJsonEntityNested> NestedCollection { get; set; } = [];
         }
 
         public class MyJsonEntityNested
@@ -3814,17 +3815,17 @@ public abstract class JsonQueryTestBase<TFixture>(TFixture fixture) : QueryTestB
         public class MyEntity
         {
             public int Id { get; set; }
-            public string Name { get; set; }
+            public string Name { get; set; } = null!;
 
-            public MyJsonEntity Reference { get; set; }
-            public List<MyJsonEntity> Collection { get; set; }
-            public MyJsonEntityWithCtor ReferenceWithCtor { get; set; }
-            public List<MyJsonEntityWithCtor> CollectionWithCtor { get; set; }
+            public MyJsonEntity Reference { get; set; } = null!;
+            public List<MyJsonEntity> Collection { get; set; } = [];
+            public MyJsonEntityWithCtor ReferenceWithCtor { get; set; } = null!;
+            public List<MyJsonEntityWithCtor> CollectionWithCtor { get; set; } = [];
         }
 
         public class MyJsonEntity
         {
-            public string Name { get; set; }
+            public string Name { get; set; } = null!;
         }
 
         public class MyJsonEntityWithCtor(string name)
@@ -3966,10 +3967,10 @@ public abstract class JsonQueryTestBase<TFixture>(TFixture fixture) : QueryTestB
         public class MyEntity
         {
             public int Id { get; set; }
-            public string Name { get; set; }
+            public string Name { get; set; } = null!;
 
-            public virtual MyJsonEntityWithCtor Reference { get; set; }
-            public virtual List<MyJsonEntity> Collection { get; set; }
+            public virtual MyJsonEntityWithCtor Reference { get; set; } = null!;
+            public virtual List<MyJsonEntity> Collection { get; set; } = [];
         }
 
         public class MyJsonEntityWithCtor(string name, int number)
@@ -3980,9 +3981,9 @@ public abstract class JsonQueryTestBase<TFixture>(TFixture fixture) : QueryTestB
 
         public class MyJsonEntity
         {
-            public string Name { get; set; }
+            public string Name { get; set; } = null!;
             public int Number { get; set; }
-            public IList<long> Ints { get; set; }
+            public IList<long> Ints { get; set; } = [];
         }
     }
 
@@ -4021,7 +4022,7 @@ public abstract class JsonQueryTestBase<TFixture>(TFixture fixture) : QueryTestB
         {
             public int Id { get; set; }
 
-            public MyJsonEntity Json { get; set; }
+            public MyJsonEntity Json { get; set; } = null!;
         }
 
         public class MyJsonEntity
@@ -4034,7 +4035,7 @@ public abstract class JsonQueryTestBase<TFixture>(TFixture fixture) : QueryTestB
 
         public class MyJsonNestedEntity
         {
-            public string Foo { get; set; }
+            public string Foo { get; set; } = null!;
             public int Bar { get; set; }
         }
     }
@@ -4057,22 +4058,22 @@ public abstract class JsonQueryTestBase<TFixture>(TFixture fixture) : QueryTestB
         var dupNavs = await query.SingleAsync(x => x.Scenario == "duplicated navigations");
 
         // for no tracking, last one wins
-        Assert.Equal(baseline.RequiredReference.NestedOptional.Text + " dupnav", dupNavs.RequiredReference.NestedOptional.Text);
+        Assert.Equal(baseline.RequiredReference.NestedOptional!.Text + " dupnav", dupNavs.RequiredReference.NestedOptional!.Text);
         Assert.Equal(baseline.RequiredReference.NestedRequired.Text + " dupnav", dupNavs.RequiredReference.NestedRequired.Text);
         Assert.Equal(baseline.RequiredReference.NestedCollection[0].Text + " dupnav", dupNavs.RequiredReference.NestedCollection[0].Text);
         Assert.Equal(baseline.RequiredReference.NestedCollection[1].Text + " dupnav", dupNavs.RequiredReference.NestedCollection[1].Text);
 
-        Assert.Equal(baseline.OptionalReference.NestedOptional.Text + " dupnav", dupNavs.OptionalReference.NestedOptional.Text);
+        Assert.Equal(baseline.OptionalReference!.NestedOptional!.Text + " dupnav", dupNavs.OptionalReference!.NestedOptional!.Text);
         Assert.Equal(baseline.OptionalReference.NestedRequired.Text + " dupnav", dupNavs.OptionalReference.NestedRequired.Text);
         Assert.Equal(baseline.OptionalReference.NestedCollection[0].Text + " dupnav", dupNavs.OptionalReference.NestedCollection[0].Text);
         Assert.Equal(baseline.OptionalReference.NestedCollection[1].Text + " dupnav", dupNavs.OptionalReference.NestedCollection[1].Text);
 
-        Assert.Equal(baseline.Collection[0].NestedOptional.Text + " dupnav", dupNavs.Collection[0].NestedOptional.Text);
+        Assert.Equal(baseline.Collection[0].NestedOptional!.Text + " dupnav", dupNavs.Collection[0].NestedOptional!.Text);
         Assert.Equal(baseline.Collection[0].NestedRequired.Text + " dupnav", dupNavs.Collection[0].NestedRequired.Text);
         Assert.Equal(baseline.Collection[0].NestedCollection[0].Text + " dupnav", dupNavs.Collection[0].NestedCollection[0].Text);
         Assert.Equal(baseline.Collection[0].NestedCollection[1].Text + " dupnav", dupNavs.Collection[0].NestedCollection[1].Text);
 
-        Assert.Equal(baseline.Collection[1].NestedOptional.Text + " dupnav", dupNavs.Collection[1].NestedOptional.Text);
+        Assert.Equal(baseline.Collection[1].NestedOptional!.Text + " dupnav", dupNavs.Collection[1].NestedOptional!.Text);
         Assert.Equal(baseline.Collection[1].NestedRequired.Text + " dupnav", dupNavs.Collection[1].NestedRequired.Text);
         Assert.Equal(baseline.Collection[1].NestedCollection[0].Text + " dupnav", dupNavs.Collection[1].NestedCollection[0].Text);
         Assert.Equal(baseline.Collection[1].NestedCollection[1].Text + " dupnav", dupNavs.Collection[1].NestedCollection[1].Text);
@@ -4092,22 +4093,22 @@ public abstract class JsonQueryTestBase<TFixture>(TFixture fixture) : QueryTestB
         var baseline = await query.SingleAsync(x => x.Scenario == "baseline");
         var dupProps = await query.SingleAsync(x => x.Scenario == "duplicated scalars");
 
-        Assert.Equal(baseline.RequiredReference.NestedOptional.Text + " dupprop", dupProps.RequiredReference.NestedOptional.Text);
+        Assert.Equal(baseline.RequiredReference.NestedOptional!.Text + " dupprop", dupProps.RequiredReference.NestedOptional!.Text);
         Assert.Equal(baseline.RequiredReference.NestedRequired.Text + " dupprop", dupProps.RequiredReference.NestedRequired.Text);
         Assert.Equal(baseline.RequiredReference.NestedCollection[0].Text + " dupprop", dupProps.RequiredReference.NestedCollection[0].Text);
         Assert.Equal(baseline.RequiredReference.NestedCollection[1].Text + " dupprop", dupProps.RequiredReference.NestedCollection[1].Text);
 
-        Assert.Equal(baseline.OptionalReference.NestedOptional.Text + " dupprop", dupProps.OptionalReference.NestedOptional.Text);
+        Assert.Equal(baseline.OptionalReference!.NestedOptional!.Text + " dupprop", dupProps.OptionalReference!.NestedOptional!.Text);
         Assert.Equal(baseline.OptionalReference.NestedRequired.Text + " dupprop", dupProps.OptionalReference.NestedRequired.Text);
         Assert.Equal(baseline.OptionalReference.NestedCollection[0].Text + " dupprop", dupProps.OptionalReference.NestedCollection[0].Text);
         Assert.Equal(baseline.OptionalReference.NestedCollection[1].Text + " dupprop", dupProps.OptionalReference.NestedCollection[1].Text);
 
-        Assert.Equal(baseline.Collection[0].NestedOptional.Text + " dupprop", dupProps.Collection[0].NestedOptional.Text);
+        Assert.Equal(baseline.Collection[0].NestedOptional!.Text + " dupprop", dupProps.Collection[0].NestedOptional!.Text);
         Assert.Equal(baseline.Collection[0].NestedRequired.Text + " dupprop", dupProps.Collection[0].NestedRequired.Text);
         Assert.Equal(baseline.Collection[0].NestedCollection[0].Text + " dupprop", dupProps.Collection[0].NestedCollection[0].Text);
         Assert.Equal(baseline.Collection[0].NestedCollection[1].Text + " dupprop", dupProps.Collection[0].NestedCollection[1].Text);
 
-        Assert.Equal(baseline.Collection[1].NestedOptional.Text + " dupprop", dupProps.Collection[1].NestedOptional.Text);
+        Assert.Equal(baseline.Collection[1].NestedOptional!.Text + " dupprop", dupProps.Collection[1].NestedOptional!.Text);
         Assert.Equal(baseline.Collection[1].NestedRequired.Text + " dupprop", dupProps.Collection[1].NestedRequired.Text);
         Assert.Equal(baseline.Collection[1].NestedCollection[0].Text + " dupprop", dupProps.Collection[1].NestedCollection[0].Text);
         Assert.Equal(baseline.Collection[1].NestedCollection[1].Text + " dupprop", dupProps.Collection[1].NestedCollection[1].Text);
@@ -4129,7 +4130,7 @@ public abstract class JsonQueryTestBase<TFixture>(TFixture fixture) : QueryTestB
         Assert.Null(emptyNavs.RequiredReference.NestedRequired);
         Assert.Null(emptyNavs.RequiredReference.NestedCollection);
 
-        Assert.Null(emptyNavs.OptionalReference.NestedOptional);
+        Assert.Null(emptyNavs.OptionalReference!.NestedOptional);
         Assert.Null(emptyNavs.OptionalReference.NestedRequired);
         Assert.Null(emptyNavs.OptionalReference.NestedCollection);
 
@@ -4154,22 +4155,22 @@ public abstract class JsonQueryTestBase<TFixture>(TFixture fixture) : QueryTestB
         var query = noTracking ? context.Entities.AsNoTracking() : context.Entities;
         var emptyNavs = await query.SingleAsync(x => x.Scenario == "empty scalar property names");
 
-        Assert.Null(emptyNavs.RequiredReference.NestedOptional.Text);
+        Assert.Null(emptyNavs.RequiredReference.NestedOptional!.Text);
         Assert.Null(emptyNavs.RequiredReference.NestedRequired.Text);
         Assert.Null(emptyNavs.RequiredReference.NestedCollection[0].Text);
         Assert.Null(emptyNavs.RequiredReference.NestedCollection[1].Text);
 
-        Assert.Null(emptyNavs.OptionalReference.NestedOptional.Text);
+        Assert.Null(emptyNavs.OptionalReference!.NestedOptional!.Text);
         Assert.Null(emptyNavs.OptionalReference.NestedRequired.Text);
         Assert.Null(emptyNavs.OptionalReference.NestedCollection[0].Text);
         Assert.Null(emptyNavs.OptionalReference.NestedCollection[1].Text);
 
-        Assert.Null(emptyNavs.Collection[0].NestedOptional.Text);
+        Assert.Null(emptyNavs.Collection[0].NestedOptional!.Text);
         Assert.Null(emptyNavs.Collection[0].NestedRequired.Text);
         Assert.Null(emptyNavs.Collection[0].NestedCollection[0].Text);
         Assert.Null(emptyNavs.Collection[0].NestedCollection[1].Text);
 
-        Assert.Null(emptyNavs.Collection[1].NestedOptional.Text);
+        Assert.Null(emptyNavs.Collection[1].NestedOptional!.Text);
         Assert.Null(emptyNavs.Collection[1].NestedRequired.Text);
         Assert.Null(emptyNavs.Collection[1].NestedCollection[0].Text);
         Assert.Null(emptyNavs.Collection[1].NestedCollection[1].Text);
@@ -4235,27 +4236,28 @@ public abstract class JsonQueryTestBase<TFixture>(TFixture fixture) : QueryTestB
 
     protected class ContextBadJsonProperties(DbContextOptions options) : DbContext(options)
     {
-        public DbSet<Entity> Entities { get; set; }
+        public DbSet<Entity> Entities
+            => Set<Entity>();
 
         public class Entity
         {
             public int Id { get; set; }
-            public string Scenario { get; set; }
-            public JsonRoot OptionalReference { get; set; }
-            public JsonRoot RequiredReference { get; set; }
-            public List<JsonRoot> Collection { get; set; }
+            public string Scenario { get; set; } = null!;
+            public JsonRoot? OptionalReference { get; set; }
+            public JsonRoot RequiredReference { get; set; } = null!;
+            public List<JsonRoot> Collection { get; set; } = [];
         }
 
         public class JsonRoot
         {
-            public JsonBranch NestedRequired { get; set; }
-            public JsonBranch NestedOptional { get; set; }
-            public List<JsonBranch> NestedCollection { get; set; }
+            public JsonBranch NestedRequired { get; set; } = null!;
+            public JsonBranch? NestedOptional { get; set; }
+            public List<JsonBranch> NestedCollection { get; set; } = [];
         }
 
         public class JsonBranch
         {
-            public string Text { get; set; }
+            public string Text { get; set; } = null!;
         }
     }
 

--- a/test/EFCore.Specification.Tests/Query/ManyToManyFieldsQueryFixtureBase.cs
+++ b/test/EFCore.Specification.Tests/Query/ManyToManyFieldsQueryFixtureBase.cs
@@ -5,14 +5,12 @@ using Microsoft.EntityFrameworkCore.TestModels.ManyToManyFieldsModel;
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
-#nullable disable
-
 public abstract class ManyToManyFieldsQueryFixtureBase : QueryFixtureBase<ManyToManyContext>
 {
     protected override string StoreName
         => "ManyToManyQueryTest";
 
-    private ManyToManyData _data;
+    private ManyToManyData _data = null!;
 
     public override ISetSource GetExpectedData()
     {
@@ -29,13 +27,13 @@ public abstract class ManyToManyFieldsQueryFixtureBase : QueryFixtureBase<ManyTo
 
     public override IReadOnlyDictionary<Type, object> EntitySorters { get; } = new Dictionary<Type, Func<object, object>>
     {
-        { typeof(EntityOne), e => ((EntityOne)e)?.Id },
-        { typeof(EntityTwo), e => ((EntityTwo)e)?.Id },
-        { typeof(EntityThree), e => ((EntityThree)e)?.Id },
-        { typeof(EntityCompositeKey), e => (((EntityCompositeKey)e)?.Key1, ((EntityCompositeKey)e)?.Key2, ((EntityCompositeKey)e)?.Key3) },
-        { typeof(EntityRoot), e => ((EntityRoot)e)?.Id },
-        { typeof(EntityBranch), e => ((EntityBranch)e)?.Id },
-        { typeof(EntityLeaf), e => ((EntityLeaf)e)?.Id },
+        { typeof(EntityOne), e => ((EntityOne)e).Id },
+        { typeof(EntityTwo), e => ((EntityTwo)e).Id },
+        { typeof(EntityThree), e => ((EntityThree)e).Id },
+        { typeof(EntityCompositeKey), e => (((EntityCompositeKey)e).Key1, ((EntityCompositeKey)e).Key2, ((EntityCompositeKey)e).Key3) },
+        { typeof(EntityRoot), e => ((EntityRoot)e).Id },
+        { typeof(EntityBranch), e => ((EntityBranch)e).Id },
+        { typeof(EntityLeaf), e => ((EntityLeaf)e).Id },
     }.ToDictionary(e => e.Key, e => (object)e.Value);
 
     public override IReadOnlyDictionary<Type, object> EntityAsserters { get; } = new Dictionary<Type, Action<object, object>>
@@ -47,7 +45,7 @@ public abstract class ManyToManyFieldsQueryFixtureBase : QueryFixtureBase<ManyTo
 
                 if (a != null)
                 {
-                    var ee = (EntityOne)e;
+                    var ee = (EntityOne)e!;
                     var aa = (EntityOne)a;
 
                     Assert.Equal(ee.Id, aa.Id);
@@ -62,7 +60,7 @@ public abstract class ManyToManyFieldsQueryFixtureBase : QueryFixtureBase<ManyTo
 
                 if (a != null)
                 {
-                    var ee = (EntityTwo)e;
+                    var ee = (EntityTwo)e!;
                     var aa = (EntityTwo)a;
 
                     Assert.Equal(ee.Id, aa.Id);
@@ -77,7 +75,7 @@ public abstract class ManyToManyFieldsQueryFixtureBase : QueryFixtureBase<ManyTo
 
                 if (a != null)
                 {
-                    var ee = (EntityThree)e;
+                    var ee = (EntityThree)e!;
                     var aa = (EntityThree)a;
 
                     Assert.Equal(ee.Id, aa.Id);
@@ -92,7 +90,7 @@ public abstract class ManyToManyFieldsQueryFixtureBase : QueryFixtureBase<ManyTo
 
                 if (a != null)
                 {
-                    var ee = (EntityCompositeKey)e;
+                    var ee = (EntityCompositeKey)e!;
                     var aa = (EntityCompositeKey)a;
 
                     Assert.Equal(ee.Key1, aa.Key1);
@@ -109,7 +107,7 @@ public abstract class ManyToManyFieldsQueryFixtureBase : QueryFixtureBase<ManyTo
 
                 if (a != null)
                 {
-                    var ee = (EntityRoot)e;
+                    var ee = (EntityRoot)e!;
                     var aa = (EntityRoot)a;
 
                     Assert.Equal(ee.Id, aa.Id);
@@ -124,7 +122,7 @@ public abstract class ManyToManyFieldsQueryFixtureBase : QueryFixtureBase<ManyTo
 
                 if (a != null)
                 {
-                    var ee = (EntityBranch)e;
+                    var ee = (EntityBranch)e!;
                     var aa = (EntityBranch)a;
 
                     Assert.Equal(ee.Id, aa.Id);
@@ -140,7 +138,7 @@ public abstract class ManyToManyFieldsQueryFixtureBase : QueryFixtureBase<ManyTo
 
                 if (a != null)
                 {
-                    var ee = (EntityLeaf)e;
+                    var ee = (EntityLeaf)e!;
                     var aa = (EntityLeaf)a;
 
                     Assert.Equal(ee.Id, aa.Id);

--- a/test/EFCore.Specification.Tests/Query/ManyToManyNoTrackingQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/ManyToManyNoTrackingQueryTestBase.cs
@@ -5,20 +5,18 @@ using Microsoft.EntityFrameworkCore.TestModels.ManyToManyModel;
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
-#nullable disable
-
 public abstract class ManyToManyNoTrackingQueryTestBase<TFixture>(TFixture fixture) : ManyToManyQueryTestBase<TFixture>(fixture)
     where TFixture : ManyToManyQueryFixtureBase, new()
 {
     private static readonly MethodInfo _asNoTrackingMethodInfo
         = typeof(EntityFrameworkQueryableExtensions)
-            .GetTypeInfo().GetDeclaredMethod(nameof(EntityFrameworkQueryableExtensions.AsNoTracking));
+            .GetTypeInfo().GetDeclaredMethod(nameof(EntityFrameworkQueryableExtensions.AsNoTracking))!;
 
     protected override Expression RewriteServerQueryExpression(Expression serverQueryExpression)
     {
         serverQueryExpression = base.RewriteServerQueryExpression(serverQueryExpression);
 
-        var elementType = serverQueryExpression.Type.TryGetSequenceType();
+        var elementType = serverQueryExpression.Type.TryGetSequenceType()!;
 
         return elementType.UnwrapNullableType().IsValueType
             && serverQueryExpression is MethodCallExpression methodCallExpression
@@ -30,7 +28,7 @@ public abstract class ManyToManyNoTrackingQueryTestBase<TFixture>(TFixture fixtu
 
         static Expression ApplyNoTracking(Expression source)
             => Expression.Call(
-                _asNoTrackingMethodInfo.MakeGenericMethod(source.Type.TryGetSequenceType()),
+                _asNoTrackingMethodInfo.MakeGenericMethod(source.Type.TryGetSequenceType()!),
                 source);
     }
 

--- a/test/EFCore.Specification.Tests/Query/ManyToManyQueryFixtureBase.cs
+++ b/test/EFCore.Specification.Tests/Query/ManyToManyQueryFixtureBase.cs
@@ -5,14 +5,12 @@ using Microsoft.EntityFrameworkCore.TestModels.ManyToManyModel;
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
-#nullable disable
-
 public abstract class ManyToManyQueryFixtureBase : QueryFixtureBase<ManyToManyContext>
 {
     protected override string StoreName
         => "ManyToManyQueryTest";
 
-    private ManyToManyData _data;
+    private ManyToManyData _data = null!;
 
     public override ISetSource GetExpectedData()
     {
@@ -27,30 +25,30 @@ public abstract class ManyToManyQueryFixtureBase : QueryFixtureBase<ManyToManyCo
         return _data;
     }
 
-    public override IReadOnlyDictionary<Type, object> EntitySorters { get; } = new Dictionary<Type, Func<object, object>>
+    public override IReadOnlyDictionary<Type, object> EntitySorters { get; } = new Dictionary<Type, Func<object?, object?>>
     {
-        { typeof(EntityOne), e => ((EntityOne)e)?.Id },
-        { typeof(EntityTwo), e => ((EntityTwo)e)?.Id },
-        { typeof(EntityThree), e => ((EntityThree)e)?.Id },
-        { typeof(EntityCompositeKey), e => (((EntityCompositeKey)e)?.Key1, ((EntityCompositeKey)e)?.Key2, ((EntityCompositeKey)e)?.Key3) },
-        { typeof(EntityRoot), e => ((EntityRoot)e)?.Id },
-        { typeof(EntityBranch), e => ((EntityBranch)e)?.Id },
-        { typeof(EntityLeaf), e => ((EntityLeaf)e)?.Id },
-        { typeof(EntityBranch2), e => ((EntityBranch2)e)?.Id },
-        { typeof(EntityLeaf2), e => ((EntityLeaf2)e)?.Id },
-        { typeof(EntityTableSharing1), e => ((EntityTableSharing1)e)?.Id },
-        { typeof(EntityTableSharing2), e => ((EntityTableSharing2)e)?.Id },
-        { typeof(UnidirectionalEntityOne), e => ((UnidirectionalEntityOne)e)?.Id },
-        { typeof(UnidirectionalEntityTwo), e => ((UnidirectionalEntityTwo)e)?.Id },
-        { typeof(UnidirectionalEntityThree), e => ((UnidirectionalEntityThree)e)?.Id },
+        { typeof(EntityOne), e => ((EntityOne?)e)?.Id },
+        { typeof(EntityTwo), e => ((EntityTwo?)e)?.Id },
+        { typeof(EntityThree), e => ((EntityThree?)e)?.Id },
+        { typeof(EntityCompositeKey), e => e is EntityCompositeKey entity ? (entity.Key1, entity.Key2, entity.Key3) : null },
+        { typeof(EntityRoot), e => ((EntityRoot?)e)?.Id },
+        { typeof(EntityBranch), e => ((EntityBranch?)e)?.Id },
+        { typeof(EntityLeaf), e => ((EntityLeaf?)e)?.Id },
+        { typeof(EntityBranch2), e => ((EntityBranch2?)e)?.Id },
+        { typeof(EntityLeaf2), e => ((EntityLeaf2?)e)?.Id },
+        { typeof(EntityTableSharing1), e => ((EntityTableSharing1?)e)?.Id },
+        { typeof(EntityTableSharing2), e => ((EntityTableSharing2?)e)?.Id },
+        { typeof(UnidirectionalEntityOne), e => ((UnidirectionalEntityOne?)e)?.Id },
+        { typeof(UnidirectionalEntityTwo), e => ((UnidirectionalEntityTwo?)e)?.Id },
+        { typeof(UnidirectionalEntityThree), e => ((UnidirectionalEntityThree?)e)?.Id },
         {
-            typeof(UnidirectionalEntityCompositeKey), e => (((UnidirectionalEntityCompositeKey)e)?.Key1,
-                ((UnidirectionalEntityCompositeKey)e)?.Key2,
-                ((UnidirectionalEntityCompositeKey)e)?.Key3)
+            typeof(UnidirectionalEntityCompositeKey), e => e is UnidirectionalEntityCompositeKey entity
+                ? (entity.Key1, entity.Key2, entity.Key3)
+                : null
         },
-        { typeof(UnidirectionalEntityRoot), e => ((UnidirectionalEntityRoot)e)?.Id },
-        { typeof(UnidirectionalEntityBranch), e => ((UnidirectionalEntityBranch)e)?.Id },
-        { typeof(UnidirectionalEntityLeaf), e => ((UnidirectionalEntityLeaf)e)?.Id },
+        { typeof(UnidirectionalEntityRoot), e => ((UnidirectionalEntityRoot?)e)?.Id },
+        { typeof(UnidirectionalEntityBranch), e => ((UnidirectionalEntityBranch?)e)?.Id },
+        { typeof(UnidirectionalEntityLeaf), e => ((UnidirectionalEntityLeaf?)e)?.Id },
     }.ToDictionary(e => e.Key, e => (object)e.Value);
 
     public override IReadOnlyDictionary<Type, object> EntityAsserters { get; } = new Dictionary<Type, Action<object, object>>
@@ -62,7 +60,7 @@ public abstract class ManyToManyQueryFixtureBase : QueryFixtureBase<ManyToManyCo
 
                 if (a != null)
                 {
-                    var ee = (EntityOne)e;
+                    var ee = (EntityOne)e!;
                     var aa = (EntityOne)a;
 
                     Assert.Equal(ee.Id, aa.Id);
@@ -77,7 +75,7 @@ public abstract class ManyToManyQueryFixtureBase : QueryFixtureBase<ManyToManyCo
 
                 if (a != null)
                 {
-                    var ee = (EntityTwo)e;
+                    var ee = (EntityTwo)e!;
                     var aa = (EntityTwo)a;
 
                     Assert.Equal(ee.Id, aa.Id);
@@ -92,7 +90,7 @@ public abstract class ManyToManyQueryFixtureBase : QueryFixtureBase<ManyToManyCo
 
                 if (a != null)
                 {
-                    var ee = (EntityThree)e;
+                    var ee = (EntityThree)e!;
                     var aa = (EntityThree)a;
 
                     Assert.Equal(ee.Id, aa.Id);
@@ -107,7 +105,7 @@ public abstract class ManyToManyQueryFixtureBase : QueryFixtureBase<ManyToManyCo
 
                 if (a != null)
                 {
-                    var ee = (EntityCompositeKey)e;
+                    var ee = (EntityCompositeKey)e!;
                     var aa = (EntityCompositeKey)a;
 
                     Assert.Equal(ee.Key1, aa.Key1);
@@ -124,7 +122,7 @@ public abstract class ManyToManyQueryFixtureBase : QueryFixtureBase<ManyToManyCo
 
                 if (a != null)
                 {
-                    var ee = (EntityRoot)e;
+                    var ee = (EntityRoot)e!;
                     var aa = (EntityRoot)a;
 
                     Assert.Equal(ee.Id, aa.Id);
@@ -139,7 +137,7 @@ public abstract class ManyToManyQueryFixtureBase : QueryFixtureBase<ManyToManyCo
 
                 if (a != null)
                 {
-                    var ee = (EntityBranch)e;
+                    var ee = (EntityBranch)e!;
                     var aa = (EntityBranch)a;
 
                     Assert.Equal(ee.Id, aa.Id);
@@ -155,7 +153,7 @@ public abstract class ManyToManyQueryFixtureBase : QueryFixtureBase<ManyToManyCo
 
                 if (a != null)
                 {
-                    var ee = (EntityLeaf)e;
+                    var ee = (EntityLeaf)e!;
                     var aa = (EntityLeaf)a;
 
                     Assert.Equal(ee.Id, aa.Id);
@@ -172,7 +170,7 @@ public abstract class ManyToManyQueryFixtureBase : QueryFixtureBase<ManyToManyCo
 
                 if (a != null)
                 {
-                    var ee = (EntityBranch2)e;
+                    var ee = (EntityBranch2)e!;
                     var aa = (EntityBranch2)a;
 
                     Assert.Equal(ee.Id, aa.Id);
@@ -188,7 +186,7 @@ public abstract class ManyToManyQueryFixtureBase : QueryFixtureBase<ManyToManyCo
 
                 if (a != null)
                 {
-                    var ee = (EntityLeaf2)e;
+                    var ee = (EntityLeaf2)e!;
                     var aa = (EntityLeaf2)a;
 
                     Assert.Equal(ee.Id, aa.Id);
@@ -205,7 +203,7 @@ public abstract class ManyToManyQueryFixtureBase : QueryFixtureBase<ManyToManyCo
 
                 if (a != null)
                 {
-                    var ee = (EntityTableSharing1)e;
+                    var ee = (EntityTableSharing1)e!;
                     var aa = (EntityTableSharing1)a;
 
                     Assert.Equal(ee.Id, aa.Id);
@@ -220,7 +218,7 @@ public abstract class ManyToManyQueryFixtureBase : QueryFixtureBase<ManyToManyCo
 
                 if (a != null)
                 {
-                    var ee = (EntityTableSharing2)e;
+                    var ee = (EntityTableSharing2)e!;
                     var aa = (EntityTableSharing2)a;
 
                     Assert.Equal(ee.Id, aa.Id);
@@ -235,7 +233,7 @@ public abstract class ManyToManyQueryFixtureBase : QueryFixtureBase<ManyToManyCo
 
                 if (a != null)
                 {
-                    var ee = (UnidirectionalEntityOne)e;
+                    var ee = (UnidirectionalEntityOne)e!;
                     var aa = (UnidirectionalEntityOne)a;
 
                     Assert.Equal(ee.Id, aa.Id);
@@ -250,7 +248,7 @@ public abstract class ManyToManyQueryFixtureBase : QueryFixtureBase<ManyToManyCo
 
                 if (a != null)
                 {
-                    var ee = (UnidirectionalEntityTwo)e;
+                    var ee = (UnidirectionalEntityTwo)e!;
                     var aa = (UnidirectionalEntityTwo)a;
 
                     Assert.Equal(ee.Id, aa.Id);
@@ -265,7 +263,7 @@ public abstract class ManyToManyQueryFixtureBase : QueryFixtureBase<ManyToManyCo
 
                 if (a != null)
                 {
-                    var ee = (UnidirectionalEntityThree)e;
+                    var ee = (UnidirectionalEntityThree)e!;
                     var aa = (UnidirectionalEntityThree)a;
 
                     Assert.Equal(ee.Id, aa.Id);
@@ -280,7 +278,7 @@ public abstract class ManyToManyQueryFixtureBase : QueryFixtureBase<ManyToManyCo
 
                 if (a != null)
                 {
-                    var ee = (UnidirectionalEntityCompositeKey)e;
+                    var ee = (UnidirectionalEntityCompositeKey)e!;
                     var aa = (UnidirectionalEntityCompositeKey)a;
 
                     Assert.Equal(ee.Key1, aa.Key1);
@@ -297,7 +295,7 @@ public abstract class ManyToManyQueryFixtureBase : QueryFixtureBase<ManyToManyCo
 
                 if (a != null)
                 {
-                    var ee = (UnidirectionalEntityRoot)e;
+                    var ee = (UnidirectionalEntityRoot)e!;
                     var aa = (UnidirectionalEntityRoot)a;
 
                     Assert.Equal(ee.Id, aa.Id);
@@ -312,7 +310,7 @@ public abstract class ManyToManyQueryFixtureBase : QueryFixtureBase<ManyToManyCo
 
                 if (a != null)
                 {
-                    var ee = (UnidirectionalEntityBranch)e;
+                    var ee = (UnidirectionalEntityBranch)e!;
                     var aa = (UnidirectionalEntityBranch)a;
 
                     Assert.Equal(ee.Id, aa.Id);
@@ -328,7 +326,7 @@ public abstract class ManyToManyQueryFixtureBase : QueryFixtureBase<ManyToManyCo
 
                 if (a != null)
                 {
-                    var ee = (UnidirectionalEntityLeaf)e;
+                    var ee = (UnidirectionalEntityLeaf)e!;
                     var aa = (UnidirectionalEntityLeaf)a;
 
                     Assert.Equal(ee.Id, aa.Id);

--- a/test/EFCore.Specification.Tests/Query/ManyToManyQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/ManyToManyQueryTestBase.cs
@@ -5,8 +5,6 @@ using Microsoft.EntityFrameworkCore.TestModels.ManyToManyModel;
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
-#nullable disable
-
 public abstract class ManyToManyQueryTestBase<TFixture>(TFixture fixture) : QueryTestBase<TFixture>(fixture)
     where TFixture : ManyToManyQueryFixtureBase, new()
 {
@@ -14,20 +12,20 @@ public abstract class ManyToManyQueryTestBase<TFixture>(TFixture fixture) : Quer
     public virtual Task Skip_navigation_all(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<EntityOne>().Where(e => e.TwoSkip.All(e => e.Name.Contains("B"))));
+            ss => ss.Set<EntityOne>().Where(e => e.TwoSkip.All(e => e.Name!.Contains("B"))));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Skip_navigation_any_without_predicate(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<EntityOne>().Where(e => e.ThreeSkipPayloadFull.Where(e => e.Name.Contains("B")).Any()),
+            ss => ss.Set<EntityOne>().Where(e => e.ThreeSkipPayloadFull.Where(e => e.Name!.Contains("B")).Any()),
             assertEmpty: true);
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Skip_navigation_any_with_predicate(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<EntityOne>().Where(e => e.TwoSkipShared.Any(e => e.Name.Contains("B"))),
+            ss => ss.Set<EntityOne>().Where(e => e.TwoSkipShared!.Any(e => e.Name!.Contains("B"))),
             assertEmpty: true);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -47,7 +45,7 @@ public abstract class ManyToManyQueryTestBase<TFixture>(TFixture fixture) : Quer
     public virtual Task Skip_navigation_count_with_predicate(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<EntityOne>().OrderBy(e => e.BranchSkip.Count(e => e.Name.StartsWith("L")))
+            ss => ss.Set<EntityOne>().OrderBy(e => e.BranchSkip.Count(e => e.Name!.StartsWith("L")))
                 .ThenBy(e => e.Id),
             assertOrder: true);
 
@@ -61,7 +59,7 @@ public abstract class ManyToManyQueryTestBase<TFixture>(TFixture fixture) : Quer
     public virtual Task Skip_navigation_long_count_with_predicate(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<EntityTwo>().OrderByDescending(e => e.SelfSkipSharedLeft.LongCount(e => e.Name.StartsWith("L")))
+            ss => ss.Set<EntityTwo>().OrderByDescending(e => e.SelfSkipSharedLeft!.LongCount(e => e.Name!.StartsWith("L")))
                 .ThenBy(e => e.Id),
             assertOrder: true);
 
@@ -159,7 +157,7 @@ public abstract class ManyToManyQueryTestBase<TFixture>(TFixture fixture) : Quer
             async,
             ss => from t in ss.Set<EntityTwo>()
                   join s in ss.Set<EntityTwo>()
-                      on t.Id equals s.SelfSkipSharedRight.OrderBy(e => e.Id).FirstOrDefault().Id
+                      on t.Id equals s.SelfSkipSharedRight.OrderBy(e => e.Id).FirstOrDefault()!.Id
                   select new { t, s },
             elementSorter: e => (e.t.Id, e.s.Id),
             elementAsserter: (e, a) =>
@@ -174,15 +172,15 @@ public abstract class ManyToManyQueryTestBase<TFixture>(TFixture fixture) : Quer
             async,
             ss => from t in ss.Set<EntityCompositeKey>()
                   join s in ss.Set<EntityCompositeKey>()
-                      on t.TwoSkipShared.OrderBy(e => e.Id).FirstOrDefault().Id equals s.ThreeSkipFull.OrderBy(e => e.Id)
-                          .FirstOrDefault().Id into grouping
+                      on t.TwoSkipShared.OrderBy(e => e.Id).FirstOrDefault()!.Id equals s.ThreeSkipFull.OrderBy(e => e.Id)
+                          .FirstOrDefault()!.Id into grouping
                   from s in grouping.DefaultIfEmpty()
-                  orderby t.Key1, s.Key1, t.Key2, s.Key2
+                  orderby t.Key1, s!.Key1, t.Key2, s.Key2
                   select new { t, s },
             ss => from t in ss.Set<EntityCompositeKey>()
                   join s in ss.Set<EntityCompositeKey>()
-                      on t.TwoSkipShared.OrderBy(e => e.Id).FirstOrDefault().MaybeScalar(e => e.Id) equals s.ThreeSkipFull
-                          .OrderBy(e => e.Id).FirstOrDefault().MaybeScalar(e => e.Id) into grouping
+                      on t.TwoSkipShared.OrderBy(e => e.Id).FirstOrDefault().MaybeScalar(e => e!.Id) equals s.ThreeSkipFull
+                          .OrderBy(e => e.Id).FirstOrDefault().MaybeScalar(e => e!.Id) into grouping
                   from s in grouping.DefaultIfEmpty()
                   orderby t.Key1, s.MaybeScalar(e => e.Key1), t.Key2, s.Key2
                   select new { t, s },
@@ -572,12 +570,12 @@ public abstract class ManyToManyQueryTestBase<TFixture>(TFixture fixture) : Quer
             elementAsserter: (e, a) => AssertInclude(
                 e, a,
                 new ExpectedInclude<EntityOne>(e => e.ThreeSkipPayloadFull),
-                new ExpectedInclude<EntityThree>(e => e.CollectionInverse, "ThreeSkipPayloadFull"),
+                new ExpectedInclude<EntityThree>(e => e.CollectionInverse!, "ThreeSkipPayloadFull"),
                 new ExpectedInclude<EntityOne>(e => e.JoinThreePayloadFull),
                 new ExpectedInclude<JoinOneToThreePayloadFull>(e => e.Three, "JoinThreePayloadFull"),
-                new ExpectedInclude<EntityThree>(e => e.ReferenceInverse, "JoinThreePayloadFull.Three"),
-                new ExpectedInclude<EntityThree>(e => e.ReferenceInverse, "ThreeSkipPayloadFull"),
-                new ExpectedInclude<EntityThree>(e => e.CollectionInverse, "JoinThreePayloadFull.Three")));
+                new ExpectedInclude<EntityThree>(e => e.ReferenceInverse!, "JoinThreePayloadFull.Three"),
+                new ExpectedInclude<EntityThree>(e => e.ReferenceInverse!, "ThreeSkipPayloadFull"),
+                new ExpectedInclude<EntityThree>(e => e.CollectionInverse!, "JoinThreePayloadFull.Three")));
 
     [Theory(Skip = "Issue#21332"), MemberData(nameof(IsAsyncData))]
     public virtual Task Filtered_includes_accessed_via_different_path_are_merged(bool async)
@@ -662,13 +660,13 @@ public abstract class ManyToManyQueryTestBase<TFixture>(TFixture fixture) : Quer
     public virtual Task Skip_navigation_all_unidirectional(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<UnidirectionalEntityOne>().Where(e => e.TwoSkip.All(e => e.Name.Contains("B"))));
+            ss => ss.Set<UnidirectionalEntityOne>().Where(e => e.TwoSkip.All(e => e.Name!.Contains("B"))));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Skip_navigation_any_with_predicate_unidirectional(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<UnidirectionalEntityOne>().Where(e => e.TwoSkipShared.Any(e => e.Name.Contains("B"))),
+            ss => ss.Set<UnidirectionalEntityOne>().Where(e => e.TwoSkipShared.Any(e => e.Name!.Contains("B"))),
             assertEmpty: true);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -689,7 +687,7 @@ public abstract class ManyToManyQueryTestBase<TFixture>(TFixture fixture) : Quer
     public virtual Task Skip_navigation_count_with_predicate_unidirectional(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<UnidirectionalEntityOne>().OrderBy(e => e.BranchSkip.Count(e => e.Name.StartsWith("L")))
+            ss => ss.Set<UnidirectionalEntityOne>().OrderBy(e => e.BranchSkip.Count(e => e.Name!.StartsWith("L")))
                 .ThenBy(e => e.Id),
             assertOrder: true);
 
@@ -720,7 +718,7 @@ public abstract class ManyToManyQueryTestBase<TFixture>(TFixture fixture) : Quer
             async,
             ss => from t in ss.Set<UnidirectionalEntityTwo>()
                   join s in ss.Set<UnidirectionalEntityTwo>()
-                      on t.Id equals s.SelfSkipSharedRight.OrderBy(e => e.Id).FirstOrDefault().Id
+                      on t.Id equals s.SelfSkipSharedRight.OrderBy(e => e.Id).FirstOrDefault()!.Id
                   select new { t, s },
             elementSorter: e => (e.t.Id, e.s.Id),
             elementAsserter: (e, a) =>
@@ -735,15 +733,15 @@ public abstract class ManyToManyQueryTestBase<TFixture>(TFixture fixture) : Quer
             async,
             ss => from t in ss.Set<UnidirectionalEntityCompositeKey>()
                   join s in ss.Set<UnidirectionalEntityCompositeKey>()
-                      on t.TwoSkipShared.OrderBy(e => e.Id).FirstOrDefault().Id equals s.ThreeSkipFull.OrderBy(e => e.Id)
-                          .FirstOrDefault().Id into grouping
+                      on t.TwoSkipShared.OrderBy(e => e.Id).FirstOrDefault()!.Id equals s.ThreeSkipFull.OrderBy(e => e.Id)
+                          .FirstOrDefault()!.Id into grouping
                   from s in grouping.DefaultIfEmpty()
-                  orderby t.Key1, s.Key1, t.Key2, s.Key2
+                  orderby t.Key1, s!.Key1, t.Key2, s.Key2
                   select new { t, s },
             ss => from t in ss.Set<UnidirectionalEntityCompositeKey>()
                   join s in ss.Set<UnidirectionalEntityCompositeKey>()
-                      on t.TwoSkipShared.OrderBy(e => e.Id).FirstOrDefault().MaybeScalar(e => e.Id) equals s.ThreeSkipFull
-                          .OrderBy(e => e.Id).FirstOrDefault().MaybeScalar(e => e.Id) into grouping
+                      on t.TwoSkipShared.OrderBy(e => e.Id).FirstOrDefault().MaybeScalar(e => e!.Id) equals s.ThreeSkipFull
+                          .OrderBy(e => e.Id).FirstOrDefault().MaybeScalar(e => e!.Id) into grouping
                   from s in grouping.DefaultIfEmpty()
                   orderby t.Key1, s.MaybeScalar(e => e.Key1), t.Key2, s.Key2
                   select new { t, s },
@@ -1008,8 +1006,11 @@ public abstract class ManyToManyQueryTestBase<TFixture>(TFixture fixture) : Quer
     // Protected so that it can be used by inheriting tests, and so that things like unused setters are not removed.
     protected class MyContext7973(DbContextOptions options) : DbContext(options)
     {
-        public DbSet<User> Users { get; set; }
-        public DbSet<Organisation> Organisations { get; set; }
+        public DbSet<User> Users
+            => Set<User>();
+
+        public DbSet<Organisation> Organisations
+            => Set<Organisation>();
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
@@ -1033,22 +1034,22 @@ public abstract class ManyToManyQueryTestBase<TFixture>(TFixture fixture) : Quer
         public class User
         {
             public int Id { get; set; }
-            public List<OrganisationUser> OrganisationUsers { get; set; }
+            public List<OrganisationUser> OrganisationUsers { get; set; } = [];
         }
 
         public class Organisation
         {
             public int Id { get; set; }
-            public List<OrganisationUser> OrganisationUsers { get; set; }
+            public List<OrganisationUser> OrganisationUsers { get; set; } = [];
         }
 
         public class OrganisationUser
         {
             public int OrganisationId { get; set; }
-            public Organisation Organisation { get; set; }
+            public Organisation Organisation { get; set; } = null!;
 
             public int UserId { get; set; }
-            public User User { get; set; }
+            public User User { get; set; } = null!;
         }
     }
 
@@ -1078,7 +1079,7 @@ public abstract class ManyToManyQueryTestBase<TFixture>(TFixture fixture) : Quer
 
         using (var context = contextFactory.CreateDbContext())
         {
-            var m = context.Find<ManyM_DB>(id);
+            var m = context.Find<ManyM_DB>(id)!;
 
             if (async)
             {
@@ -1100,7 +1101,7 @@ public abstract class ManyToManyQueryTestBase<TFixture>(TFixture fixture) : Quer
 
         using (var context = contextFactory.CreateDbContext())
         {
-            var n = context.Find<ManyN_DB>(id);
+            var n = context.Find<ManyN_DB>(id)!;
 
             if (async)
             {
@@ -1134,15 +1135,15 @@ public abstract class ManyToManyQueryTestBase<TFixture>(TFixture fixture) : Quer
     public class ManyM_DB
     {
         public int Id { get; set; }
-        public ICollection<ManyN_DB> ManyN_DB { get; set; }
-        public ICollection<ManyMN_DB> ManyNM_DB { get; set; }
+        public ICollection<ManyN_DB> ManyN_DB { get; set; } = [];
+        public ICollection<ManyMN_DB> ManyNM_DB { get; set; } = [];
     }
 
     public class ManyN_DB
     {
         public int Id { get; set; }
-        public ICollection<ManyM_DB> ManyM_DB { get; set; }
-        public ICollection<ManyMN_DB> ManyNM_DB { get; set; }
+        public ICollection<ManyM_DB> ManyM_DB { get; set; } = [];
+        public ICollection<ManyMN_DB> ManyNM_DB { get; set; } = [];
     }
 
     public sealed class ManyMN_DB
@@ -1150,10 +1151,10 @@ public abstract class ManyToManyQueryTestBase<TFixture>(TFixture fixture) : Quer
         public int Id { get; set; }
 
         public int ManyM_Id { get; set; }
-        public ManyM_DB ManyM_DB { get; set; }
+        public ManyM_DB ManyM_DB { get; set; } = null!;
 
         public int? ManyN_Id { get; set; }
-        public ManyN_DB ManyN_DB { get; set; }
+        public ManyN_DB? ManyN_DB { get; set; }
     }
 
     #endregion 20277

--- a/test/EFCore.Specification.Tests/Query/NorthwindAggregateOperatorsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindAggregateOperatorsQueryTestBase.cs
@@ -9,8 +9,6 @@ using Microsoft.EntityFrameworkCore.TestModels.Northwind;
 // ReSharper disable InconsistentNaming
 namespace Microsoft.EntityFrameworkCore.Query;
 
-#nullable disable
-
 public abstract class NorthwindAggregateOperatorsQueryTestBase<TFixture>(TFixture fixture) : QueryTestBase<TFixture>(fixture)
     where TFixture : NorthwindQueryFixtureBase<NoopModelCustomizer>, new()
 {
@@ -32,12 +30,12 @@ public abstract class NorthwindAggregateOperatorsQueryTestBase<TFixture>(TFixtur
     private class ProjectedType
     {
         public int Order { get; set; }
-        public string Customer { get; set; }
+        public string? Customer { get; set; }
 
         private bool Equals(ProjectedType other)
             => Equals(Order, other.Order);
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => obj is not null
                 && (ReferenceEquals(this, obj)
                     || (obj.GetType() == GetType()
@@ -142,15 +140,15 @@ public abstract class NorthwindAggregateOperatorsQueryTestBase<TFixture>(TFixtur
             async,
             ss => ss.Set<Customer>(),
             ss => ss.Set<Customer>(),
-            actualSelector: c => c.Orders.FirstOrDefault().OrderID,
-            expectedSelector: c => c.Orders.Any() ? c.Orders.FirstOrDefault().OrderID : 0);
+            actualSelector: c => c.Orders.FirstOrDefault()!.OrderID,
+            expectedSelector: c => c.Orders.Any() ? c.Orders.FirstOrDefault()!.OrderID : 0);
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Sum_over_Any_subquery(bool async)
         => AssertSum(
             async,
             ss => ss.Set<Customer>(),
-            selector: c => c.Orders.Any() ? c.Orders.FirstOrDefault().OrderID : 0);
+            selector: c => c.Orders.Any() ? c.Orders.FirstOrDefault()!.OrderID : 0);
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual async Task Sum_over_uncorrelated_subquery(bool async)
@@ -504,14 +502,14 @@ public abstract class NorthwindAggregateOperatorsQueryTestBase<TFixture>(TFixtur
         => AssertMinBy(
             async,
             ss => ss.Set<Customer>().OrderBy(c => c.CustomerID).Take(3),
-            selector: c => c.Orders.MinBy(o => 5 + o.OrderDetails.MinBy(int (od) => od.ProductID).ProductID).OrderID);
+            selector: c => c.Orders.MinBy(o => 5 + o.OrderDetails.MinBy(int (od) => od.ProductID)!.ProductID)!.OrderID);
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task MinBy_over_max_subquery(bool async)
         => AssertMinBy(
             async,
             ss => ss.Set<Customer>().OrderBy(c => c.CustomerID).Take(3),
-            selector: c => c.Orders.MinBy(o => 5 + o.OrderDetails.Max(int (od) => od.ProductID)).OrderID);
+            selector: c => c.Orders.MinBy(o => 5 + o.OrderDetails.Max(int (od) => od.ProductID))!.OrderID);
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Max_with_no_arg(bool async)
@@ -580,14 +578,14 @@ public abstract class NorthwindAggregateOperatorsQueryTestBase<TFixture>(TFixtur
         => AssertMaxBy(
             async,
             ss => ss.Set<Customer>().OrderBy(c => c.CustomerID).Take(3),
-            selector: c => c.Orders.MaxBy(o => 5 + o.OrderDetails.MaxBy(int (od) => od.ProductID).ProductID).OrderID);
+            selector: c => c.Orders.MaxBy(o => 5 + o.OrderDetails.MaxBy(int (od) => od.ProductID)!.ProductID)!.OrderID);
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task MaxBy_over_sum_subquery(bool async)
         => AssertMaxBy(
             async,
             ss => ss.Set<Customer>().OrderBy(c => c.CustomerID).Take(3),
-            selector: c => c.Orders.MaxBy(o => 5 + o.OrderDetails.Sum(int (od) => od.ProductID)).OrderID);
+            selector: c => c.Orders.MaxBy(o => 5 + o.OrderDetails.Sum(int (od) => od.ProductID))!.OrderID);
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Count_with_no_predicate(bool async)
@@ -824,30 +822,30 @@ public abstract class NorthwindAggregateOperatorsQueryTestBase<TFixture>(TFixtur
         => AssertQuery(
             async,
             ss => ss.Set<Customer>().Where(c
-                => c.CustomerID == "ALFKI" && c.Orders.Where(o => o.CustomerID == "ALFKI").FirstOrDefault().CustomerID == "ALFKI"));
+                => c.CustomerID == "ALFKI" && c.Orders.Where(o => o.CustomerID == "ALFKI").FirstOrDefault()!.CustomerID == "ALFKI"));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Multiple_collection_navigation_with_FirstOrDefault_chained(bool async)
         => AssertQuery(
             async,
             ss => ss.Set<Customer>().Where(c => c.CustomerID.StartsWith("F")).OrderBy(c => c.CustomerID).Select(c
-                => c.Orders.OrderBy(o => o.OrderID).FirstOrDefault().OrderDetails.OrderBy(od => od.ProductID).FirstOrDefault()),
+                => c.Orders.OrderBy(o => o.OrderID).FirstOrDefault()!.OrderDetails.OrderBy(od => od.ProductID).FirstOrDefault()),
             ss => ss.Set<Customer>().Where(c => c.CustomerID.StartsWith("F")).OrderBy(c => c.CustomerID).Select(c => c.Orders
-                .OrderBy(o => o.OrderID).FirstOrDefault()
-                .Maybe(x => x.OrderDetails)
-                .Maybe(xx => xx.OrderBy(od => od.ProductID).FirstOrDefault())));
+                .OrderBy(o => o.OrderID).FirstOrDefault()!
+                .Maybe(x => x.OrderDetails!)
+                .Maybe(xx => xx!.OrderBy(od => od.ProductID).FirstOrDefault())));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Multiple_collection_navigation_with_FirstOrDefault_chained_projecting_scalar(bool async)
         => AssertQueryScalar(
             async,
             ss => ss.Set<Customer>().Where(c => c.CustomerID.StartsWith("A")).OrderBy(c => c.CustomerID).Select(c => (int?)c.Orders
-                .OrderBy(o => o.OrderID).FirstOrDefault().OrderDetails.OrderBy(od => od.ProductID).FirstOrDefault()
+                .OrderBy(o => o.OrderID).FirstOrDefault()!.OrderDetails.OrderBy(od => od.ProductID).FirstOrDefault()!
                 .ProductID),
             ss => ss.Set<Customer>().Where(c => c.CustomerID.StartsWith("A")).OrderBy(c => c.CustomerID).Select(c => c.Orders
-                .OrderBy(o => o.OrderID).FirstOrDefault()
-                .Maybe(x => x.OrderDetails)
-                .MaybeScalar(x => x.OrderBy(od => od.ProductID).FirstOrDefault().ProductID)));
+                .OrderBy(o => o.OrderID).FirstOrDefault()!
+                .Maybe(x => x.OrderDetails!)
+                .MaybeScalar(x => x!.OrderBy(od => od.ProductID).FirstOrDefault()!.ProductID)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task First_inside_subquery_gets_client_evaluated(bool async)
@@ -1008,7 +1006,7 @@ public abstract class NorthwindAggregateOperatorsQueryTestBase<TFixture>(TFixtur
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Contains_with_local_list_closure_all_null(bool async)
     {
-        var ids = new List<string> { null, null };
+        var ids = new List<string?> { null, null };
         return AssertQuery(
             async,
             ss => ss.Set<Customer>().Where(c => ids.Contains(c.CustomerID)),
@@ -1066,7 +1064,7 @@ public abstract class NorthwindAggregateOperatorsQueryTestBase<TFixture>(TFixtur
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Contains_with_local_enumerable_closure_all_null(bool async)
     {
-        var ids = new List<string> { null, null }.Where(e => e != null);
+        var ids = new List<string?> { null, null }.Where(e => e != null);
         return AssertQuery(
             async,
             ss => ss.Set<Customer>().Where(c => ids.Contains(c.CustomerID)),
@@ -1124,7 +1122,7 @@ public abstract class NorthwindAggregateOperatorsQueryTestBase<TFixture>(TFixtur
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Contains_with_local_ordered_enumerable_closure_all_null(bool async)
     {
-        var ids = new List<string> { null, null }.Order();
+        var ids = new List<string?> { null, null }.Order();
         return AssertQuery(
             async,
             ss => ss.Set<Customer>().Where(c => ids.Contains(c.CustomerID)),
@@ -1182,7 +1180,7 @@ public abstract class NorthwindAggregateOperatorsQueryTestBase<TFixture>(TFixtur
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Contains_with_local_ordered_read_only_collection_all_null(bool async)
     {
-        var ids = new List<string> { null, null }.AsReadOnly();
+        var ids = new List<string?> { null, null }.AsReadOnly();
         return AssertQuery(
             async,
             ss => ss.Set<Customer>().Where(c => ids.Contains(c.CustomerID)),
@@ -1353,7 +1351,7 @@ public abstract class NorthwindAggregateOperatorsQueryTestBase<TFixture>(TFixtur
             ss => ss.Set<Order>()
                 .OfType<Order>()
                 .OrderBy(o => o.OrderID)
-                .Select(o => o.Customer.City));
+                .Select(o => o.Customer!.City));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task OfType_Select_OfType_Select(bool async)
@@ -1364,14 +1362,14 @@ public abstract class NorthwindAggregateOperatorsQueryTestBase<TFixture>(TFixtur
                 .Select(o => o)
                 .OfType<Order>()
                 .OrderBy(o => o.OrderID)
-                .Select(o => o.Customer.City));
+                .Select(o => o.Customer!.City));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Average_with_non_matching_types_in_projection_doesnt_produce_second_explicit_cast(bool async)
         => AssertAverage(
             async,
             ss => ss.Set<Order>()
-                .Where(o => o.CustomerID.StartsWith("A"))
+                .Where(o => o.CustomerID!.StartsWith("A"))
                 .OrderBy(o => o.OrderID)
                 .Select(o => (long)o.OrderID));
 
@@ -1380,7 +1378,7 @@ public abstract class NorthwindAggregateOperatorsQueryTestBase<TFixture>(TFixtur
         => AssertMax(
             async,
             ss => ss.Set<Order>()
-                .Where(o => o.CustomerID.StartsWith("A"))
+                .Where(o => o.CustomerID!.StartsWith("A"))
                 .OrderBy(o => o.OrderID)
                 .Select(o => (long)o.OrderID));
 
@@ -1389,7 +1387,7 @@ public abstract class NorthwindAggregateOperatorsQueryTestBase<TFixture>(TFixtur
         => AssertMin(
             async,
             ss => ss.Set<Order>()
-                .Where(o => o.CustomerID.StartsWith("A"))
+                .Where(o => o.CustomerID!.StartsWith("A"))
                 .Select(o => (long)o.OrderID));
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -1735,25 +1733,25 @@ public abstract class NorthwindAggregateOperatorsQueryTestBase<TFixture>(TFixtur
     public virtual Task DefaultIfEmpty_selects_only_required_columns(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<Product>().Select(p => new { p.ProductID, p.ProductName }).DefaultIfEmpty().Select(p => p.ProductName));
+            ss => ss.Set<Product>().Select(p => new { p.ProductID, p.ProductName }).DefaultIfEmpty().Select(p => p!.ProductName));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Collection_Last_member_access_in_projection_translated(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<Customer>().Where(c => c.CustomerID.StartsWith("F"))
+            ss => ss.Set<Customer>().Where(c => c.CustomerID!.StartsWith("F"))
                 .Where(c => c.Orders.OrderByDescending(o => o.OrderID).Last().CustomerID == c.CustomerID),
-            ss => ss.Set<Customer>().Where(c => c.CustomerID.StartsWith("F"))
-                .Where(c => c.Orders.OrderByDescending(o => o.OrderID).LastOrDefault().Maybe(x => x.CustomerID) == c.CustomerID));
+            ss => ss.Set<Customer>().Where(c => c.CustomerID!.StartsWith("F"))
+                .Where(c => c.Orders.OrderByDescending(o => o.OrderID).LastOrDefault()!.Maybe(x => x.CustomerID) == c.CustomerID));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Collection_LastOrDefault_member_access_in_projection_translated(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<Customer>().Where(c => c.CustomerID.StartsWith("F"))
-                .Where(c => c.Orders.OrderByDescending(o => o.OrderID).LastOrDefault().CustomerID == c.CustomerID),
-            ss => ss.Set<Customer>().Where(c => c.CustomerID.StartsWith("F"))
-                .Where(c => c.Orders.OrderByDescending(o => o.OrderID).LastOrDefault().Maybe(x => x.CustomerID) == c.CustomerID));
+            ss => ss.Set<Customer>().Where(c => c.CustomerID!.StartsWith("F"))
+                .Where(c => c.Orders.OrderByDescending(o => o.OrderID).LastOrDefault()!.CustomerID == c.CustomerID),
+            ss => ss.Set<Customer>().Where(c => c.CustomerID!.StartsWith("F"))
+                .Where(c => c.Orders.OrderByDescending(o => o.OrderID).LastOrDefault()!.Maybe(x => x.CustomerID) == c.CustomerID));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Sum_over_explicit_cast_over_column(bool async)
@@ -1866,7 +1864,7 @@ public abstract class NorthwindAggregateOperatorsQueryTestBase<TFixture>(TFixtur
                 Assert.Equal(e.Ave.HasValue, a.Ave.HasValue);
                 if (e.Ave.HasValue)
                 {
-                    Assert.InRange(e.Ave.Value - a.Ave.Value, -0.1D, 0.1D);
+                    Assert.InRange(e.Ave.Value - a.Ave!.Value, -0.1D, 0.1D);
                 }
             });
 
@@ -1977,36 +1975,36 @@ public abstract class NorthwindAggregateOperatorsQueryTestBase<TFixture>(TFixtur
             async,
             ss => ss.Set<Customer>()
                 .Where(x => x.CustomerID == "ALFKI")
-                .Select(x => new CustomerIdAndCityDto { CustomerId = x.CustomerID, City = x.City }),
+                .Select(x => new CustomerIdAndCityDto { CustomerId = x.CustomerID!, City = x.City }),
             asserter: (e, a) => Assert.Equal(e.CustomerId, a.CustomerId));
 
         await AssertFirstOrDefault<CustomerIdDto>(
             async,
             ss => ss.Set<Customer>()
                 .Where(x => x.CustomerID == "ALFKI")
-                .Select(x => new CustomerIdAndCityDto { CustomerId = x.CustomerID, City = x.City }),
-            asserter: (e, a) => Assert.Equal(e.CustomerId, a.CustomerId));
+                .Select(x => new CustomerIdAndCityDto { CustomerId = x.CustomerID!, City = x.City }),
+            asserter: (e, a) => Assert.Equal(e!.CustomerId, a!.CustomerId));
 
         await AssertSingle<CustomerIdDto>(
             async,
             ss => ss.Set<Customer>()
                 .Where(x => x.CustomerID == "ALFKI")
-                .Select(x => new CustomerIdAndCityDto { CustomerId = x.CustomerID, City = x.City }),
+                .Select(x => new CustomerIdAndCityDto { CustomerId = x.CustomerID!, City = x.City }),
             asserter: (e, a) => Assert.Equal(e.CustomerId, a.CustomerId));
 
         await AssertSingleOrDefault<CustomerIdDto>(
             async,
             ss => ss.Set<Customer>()
                 .Where(x => x.CustomerID == "ALFKI")
-                .Select(x => new CustomerIdAndCityDto { CustomerId = x.CustomerID, City = x.City }),
-            asserter: (e, a) => Assert.Equal(e.CustomerId, a.CustomerId));
+                .Select(x => new CustomerIdAndCityDto { CustomerId = x.CustomerID!, City = x.City }),
+            asserter: (e, a) => Assert.Equal(e!.CustomerId, a!.CustomerId));
 
         await AssertLast<CustomerIdDto>(
             async,
             ss => ss.Set<Customer>()
                 .Where(x => x.CustomerID.StartsWith("A"))
                 .OrderBy(x => x.CustomerID)
-                .Select(x => new CustomerIdAndCityDto { CustomerId = x.CustomerID, City = x.City }),
+                .Select(x => new CustomerIdAndCityDto { CustomerId = x.CustomerID!, City = x.City }),
             asserter: (e, a) => Assert.Equal(e.CustomerId, a.CustomerId));
 
         await AssertLastOrDefault<CustomerIdDto>(
@@ -2014,8 +2012,8 @@ public abstract class NorthwindAggregateOperatorsQueryTestBase<TFixture>(TFixtur
             ss => ss.Set<Customer>()
                 .Where(x => x.CustomerID.StartsWith("A"))
                 .OrderBy(x => x.CustomerID)
-                .Select(x => new CustomerIdAndCityDto { CustomerId = x.CustomerID, City = x.City }),
-            asserter: (e, a) => Assert.Equal(e.CustomerId, a.CustomerId));
+                .Select(x => new CustomerIdAndCityDto { CustomerId = x.CustomerID!, City = x.City }),
+            asserter: (e, a) => Assert.Equal(e!.CustomerId, a!.CustomerId));
     }
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -2028,11 +2026,11 @@ public abstract class NorthwindAggregateOperatorsQueryTestBase<TFixture>(TFixtur
 
     private class CustomerIdDto
     {
-        public string CustomerId { get; set; }
+        public string CustomerId { get; set; } = null!;
     }
 
     private class CustomerIdAndCityDto : CustomerIdDto
     {
-        public string City { get; set; }
+        public string? City { get; set; }
     }
 }

--- a/test/EFCore.Specification.Tests/Query/NorthwindAsNoTrackingQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindAsNoTrackingQueryTestBase.cs
@@ -102,7 +102,7 @@ public abstract class NorthwindAsNoTrackingQueryTestBase<TFixture>(TFixture fixt
     public virtual Task Applied_after_navigation_expansion(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<Order>().Where(o => o.Customer.City != "London").AsNoTracking());
+            ss => ss.Set<Order>().Where(o => o.Customer!.City != "London").AsNoTracking());
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Where_simple_shadow(bool async)

--- a/test/EFCore.Specification.Tests/Query/NorthwindCompiledQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindCompiledQueryTestBase.cs
@@ -8,8 +8,6 @@ using Microsoft.EntityFrameworkCore.TestModels.Northwind;
 // ReSharper disable ConvertToExpressionBodyWhenPossible
 namespace Microsoft.EntityFrameworkCore.Query;
 
-#nullable disable
-
 public abstract class NorthwindCompiledQueryTestBase<TFixture>(TFixture fixture) : IClassFixture<TFixture>
     where TFixture : NorthwindQueryFixtureBase<NoopModelCustomizer>, new()
 {
@@ -156,7 +154,7 @@ public abstract class NorthwindCompiledQueryTestBase<TFixture>(TFixture fixture)
     [Fact]
     public virtual void Query_with_two_parameters()
     {
-        var query = EF.CompileQuery((NorthwindContext context, object _, string customerID)
+        var query = EF.CompileQuery((NorthwindContext context, object? _, string customerID)
             => context.Customers.Where(c => c.CustomerID == customerID));
 
         using (var context = CreateContext())
@@ -173,7 +171,7 @@ public abstract class NorthwindCompiledQueryTestBase<TFixture>(TFixture fixture)
     [Fact]
     public virtual void Query_with_three_parameters()
     {
-        var query = EF.CompileQuery((NorthwindContext context, object _, int __, string customerID)
+        var query = EF.CompileQuery((NorthwindContext context, object? _, int __, string customerID)
             => context.Customers.Where(c => c.CustomerID == customerID));
 
         using (var context = CreateContext())
@@ -263,7 +261,7 @@ public abstract class NorthwindCompiledQueryTestBase<TFixture>(TFixture fixture)
     [Fact]
     public virtual void Query_with_closure_null()
     {
-        string customerID = null;
+        string? customerID = null;
 
         var query = EF.CompileQuery((NorthwindContext context)
             => context.Customers.Where(c => c.CustomerID == customerID));
@@ -402,7 +400,7 @@ public abstract class NorthwindCompiledQueryTestBase<TFixture>(TFixture fixture)
     [Fact]
     public virtual async Task Query_with_two_parameters_async()
     {
-        var query = EF.CompileAsyncQuery((NorthwindContext context, object _, string customerID)
+        var query = EF.CompileAsyncQuery((NorthwindContext context, object? _, string customerID)
             => context.Customers.Where(c => c.CustomerID == customerID));
 
         using (var context = CreateContext())
@@ -419,7 +417,7 @@ public abstract class NorthwindCompiledQueryTestBase<TFixture>(TFixture fixture)
     [Fact]
     public virtual async Task Query_with_three_parameters_async()
     {
-        var query = EF.CompileAsyncQuery((NorthwindContext context, object _, int __, string customerID)
+        var query = EF.CompileAsyncQuery((NorthwindContext context, object? _, int __, string customerID)
             => context.Customers.Where(c => c.CustomerID == customerID));
 
         using (var context = CreateContext())
@@ -474,7 +472,7 @@ public abstract class NorthwindCompiledQueryTestBase<TFixture>(TFixture fixture)
     [Fact]
     public virtual async Task Query_with_closure_async_null()
     {
-        string customerID = null;
+        string? customerID = null;
 
         var query = EF.CompileAsyncQuery((NorthwindContext context)
             => context.Customers.Where(c => c.CustomerID == customerID));

--- a/test/EFCore.Specification.Tests/Query/NorthwindEFPropertyIncludeQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindEFPropertyIncludeQueryTestBase.cs
@@ -5,8 +5,6 @@ using Microsoft.EntityFrameworkCore.TestModels.Northwind;
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
-#nullable disable
-
 public abstract class NorthwindEFPropertyIncludeQueryTestBase<TFixture>(TFixture fixture) : NorthwindIncludeQueryTestBase<TFixture>(fixture)
     where TFixture : NorthwindQueryFixtureBase<NoopModelCustomizer>, new()
 {
@@ -189,7 +187,7 @@ public abstract class NorthwindEFPropertyIncludeQueryTestBase<TFixture>(TFixture
             }
         }
 
-        private static string GetPath(Expression expression)
+        private static string? GetPath(Expression? expression)
             => expression switch
             {
                 MemberExpression { Expression: ParameterExpression } memberExpression

--- a/test/EFCore.Specification.Tests/Query/NorthwindFunctionsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindFunctionsQueryTestBase.cs
@@ -15,8 +15,6 @@ using Microsoft.EntityFrameworkCore.TestModels.Northwind;
 #pragma warning disable RCS1155 // Use StringComparison when comparing strings.
 namespace Microsoft.EntityFrameworkCore.Query;
 
-#nullable disable
-
 // ReSharper disable once UnusedTypeParameter
 public abstract class NorthwindFunctionsQueryTestBase<TFixture>(TFixture fixture) : QueryTestBase<TFixture>(fixture)
     where TFixture : NorthwindQueryFixtureBase<NoopModelCustomizer>, new()

--- a/test/EFCore.Specification.Tests/Query/NorthwindGroupByQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindGroupByQueryTestBase.cs
@@ -6,8 +6,6 @@ using Microsoft.EntityFrameworkCore.TestModels.Northwind;
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
-#nullable disable
-
 public abstract class NorthwindGroupByQueryTestBase<TFixture>(TFixture fixture) : QueryTestBase<TFixture>(fixture)
     where TFixture : NorthwindQueryFixtureBase<NoopModelCustomizer>, new()
 {
@@ -32,7 +30,7 @@ public abstract class NorthwindGroupByQueryTestBase<TFixture>(TFixture fixture) 
         => AssertTranslationFailed(() =>
             AssertQueryScalar(
                 async,
-                ss => ss.Set<Order>().Where(o => o.Customer.City != "London")
+                ss => ss.Set<Order>().Where(o => o.Customer!.City != "London")
                     .GroupBy(o => o.CustomerID, (k, es) => new { k, es })
                     .Select(g => g.es.Average(int (o) => o.OrderID))));
 
@@ -224,7 +222,7 @@ public abstract class NorthwindGroupByQueryTestBase<TFixture>(TFixture fixture) 
         => AssertQuery(
             async,
             ss => ss.Set<OrderDetail>()
-                .GroupBy(od => od.Order.CustomerID)
+                .GroupBy(od => od.Order!.CustomerID)
                 .Select(g => new { g.Key, Aggregate = g.Sum(od => od.OrderID) }),
             elementSorter: e => e.Key);
 
@@ -233,7 +231,7 @@ public abstract class NorthwindGroupByQueryTestBase<TFixture>(TFixture fixture) 
         => AssertQuery(
             async,
             ss => ss.Set<OrderDetail>()
-                .GroupBy(od => od.Order.Customer.Country)
+                .GroupBy(od => od.Order!.Customer!.Country)
                 .Select(g => new { g.Key, Aggregate = g.Sum(od => od.OrderID) }),
             elementSorter: e => e.Key);
 
@@ -260,7 +258,7 @@ public abstract class NorthwindGroupByQueryTestBase<TFixture>(TFixture fixture) 
         => AssertQuery(
             async,
             ss => ss.Set<Order>()
-                .GroupBy(o => o.OrderDate.Value.Day)
+                .GroupBy(o => o.OrderDate!.Value.Day)
                 .Select(g => new { g.Key, Count = g.Count() }),
             elementSorter: e => e.Key);
 
@@ -284,7 +282,7 @@ public abstract class NorthwindGroupByQueryTestBase<TFixture>(TFixture fixture) 
             async,
             ss => ss.Set<Order>()
                 .GroupBy(o => o.CustomerID)
-                .Select(g => new { g.Key, Sum = g.Sum(o => o.OrderID + o.CustomerID.Length) }),
+                .Select(g => new { g.Key, Sum = g.Sum(o => o.OrderID + o.CustomerID!.Length) }),
             elementSorter: e => e.Key,
             elementAsserter: (e, a) =>
             {
@@ -315,11 +313,11 @@ public abstract class NorthwindGroupByQueryTestBase<TFixture>(TFixture fixture) 
         => await AssertQuery(
             async,
             ss => ss.Set<Order>()
-                .Where(o => o.CustomerID.StartsWith("A"))
+                .Where(o => o.CustomerID!.StartsWith("A"))
                 .Select(o => new
                 {
                     o.CustomerID,
-                    Age = 2020 - o.OrderDate.Value.Year,
+                    Age = 2020 - o.OrderDate!.Value.Year,
                     o.OrderID
                 })
                 .GroupBy(x => x.CustomerID)
@@ -351,7 +349,7 @@ public abstract class NorthwindGroupByQueryTestBase<TFixture>(TFixture fixture) 
     public virtual Task GroupBy_with_aggregate_through_navigation_property(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<Order>().GroupBy(c => c.EmployeeID).Select(g => new { max = g.Max(i => i.Customer.Region) }),
+            ss => ss.Set<Order>().GroupBy(c => c.EmployeeID).Select(g => new { max = g.Max(i => i.Customer!.Region) }),
             elementSorter: e => e.max);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -363,8 +361,8 @@ public abstract class NorthwindGroupByQueryTestBase<TFixture>(TFixture fixture) 
                 .Select(g => new
                 {
                     g.Key,
-                    Londons = g.Sum(o => o.Customer.City == "London" ? 1 : 0),
-                    Berlins = g.Sum(o => o.Customer.City == "Berlin" ? 1 : 0),
+                    Londons = g.Sum(o => o.Customer!.City == "London" ? 1 : 0),
+                    Berlins = g.Sum(o => o.Customer!.City == "Berlin" ? 1 : 0),
                     Total = g.Sum(o => o.OrderID),
                     Count = g.Count()
                 }),
@@ -376,7 +374,7 @@ public abstract class NorthwindGroupByQueryTestBase<TFixture>(TFixture fixture) 
             async,
             ss => ss.Set<OrderDetail>()
                 .GroupBy(od => od.ProductID)
-                .Select(g => new { g.Key, Londons = g.Sum(od => od.Order.Customer.City == "London" ? 1 : 0) }),
+                .Select(g => new { g.Key, Londons = g.Sum(od => od.Order!.Customer!.City == "London" ? 1 : 0) }),
             elementSorter: e => e.Key);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -385,7 +383,7 @@ public abstract class NorthwindGroupByQueryTestBase<TFixture>(TFixture fixture) 
             async,
             ss => ss.Set<Order>()
                 .GroupBy(o => o.EmployeeID)
-                .Select(g => new { g.Key, Londons = g.Count(o => o.Customer.City == "London") }),
+                .Select(g => new { g.Key, Londons = g.Count(o => o.Customer!.City == "London") }),
             elementSorter: e => e.Key);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -393,8 +391,8 @@ public abstract class NorthwindGroupByQueryTestBase<TFixture>(TFixture fixture) 
         => AssertQuery(
             async,
             ss => ss.Set<Order>()
-                .GroupBy(o => o.Customer.City)
-                .Select(g => new { g.Key, Londons = g.Count(o => o.Customer.City == "London") }),
+                .GroupBy(o => o.Customer!.City)
+                .Select(g => new { g.Key, Londons = g.Count(o => o.Customer!.City == "London") }),
             elementSorter: e => e.Key);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -402,7 +400,7 @@ public abstract class NorthwindGroupByQueryTestBase<TFixture>(TFixture fixture) 
         => AssertQuery(
             async,
             ss => ss.Set<Order>()
-                .Select(o => new { o.EmployeeID, o.Customer.City })
+                .Select(o => new { o.EmployeeID, o.Customer!.City })
                 .GroupBy(x => x.EmployeeID)
                 .Select(g => new { g.Key, Londons = g.Sum(x => x.City == "London" ? 1 : 0) }),
             elementSorter: e => e.Key);
@@ -641,10 +639,10 @@ public abstract class NorthwindGroupByQueryTestBase<TFixture>(TFixture fixture) 
 
     protected class NominalType
     {
-        public string CustomerID { get; set; }
+        public string? CustomerID { get; set; }
         public uint? EmployeeID { get; set; }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => obj is not null && (ReferenceEquals(this, obj) || (obj.GetType() == GetType() && Equals((NominalType)obj)));
 
         public override int GetHashCode()
@@ -677,10 +675,10 @@ public abstract class NorthwindGroupByQueryTestBase<TFixture>(TFixture fixture) 
         public int Min { get; set; }
         public int Max { get; set; }
         public double Avg { get; set; }
-        public string CustomerId { get; set; }
+        public string? CustomerId { get; set; }
         public uint? EmployeeId { get; set; }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => obj != null && (ReferenceEquals(this, obj) || (obj is CompositeDto dto && Equals(dto)));
 
         public override int GetHashCode()
@@ -869,7 +867,7 @@ public abstract class NorthwindGroupByQueryTestBase<TFixture>(TFixture fixture) 
     public virtual Task GroupBy_anonymous_key_type_mismatch_with_aggregate(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<Order>().GroupBy(o => new { I0 = (int?)o.OrderDate.Value.Year })
+            ss => ss.Set<Order>().GroupBy(o => new { I0 = (int?)o.OrderDate!.Value.Year })
                 .OrderBy(g => g.Key.I0)
                 .Select(g => new { I0 = g.Count(), I1 = g.Key.I0 }),
             elementSorter: a => a.I1);
@@ -919,7 +917,7 @@ public abstract class NorthwindGroupByQueryTestBase<TFixture>(TFixture fixture) 
 
     private class NoGroupByWrapper
     {
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => obj != null
                 && (ReferenceEquals(this, obj)
                     || obj is NoGroupByWrapper);
@@ -930,13 +928,13 @@ public abstract class NorthwindGroupByQueryTestBase<TFixture>(TFixture fixture) 
 
     private class NoGroupByAggregationWrapper
     {
-        public LastInChain Container { get; set; }
+        public LastInChain Container { get; set; } = null!;
     }
 
     protected class LastInChain
     {
-        public string Name { get; set; }
-        public object Value { get; set; }
+        public string Name { get; set; } = null!;
+        public object Value { get; set; } = null!;
     }
 
     #endregion
@@ -1100,7 +1098,7 @@ public abstract class NorthwindGroupByQueryTestBase<TFixture>(TFixture fixture) 
                 .GroupBy(
                     x => new
                     {
-                        OrderMonth = groupByMonth ? (int?)x.OrderDate.Value.Month : null,
+                        OrderMonth = groupByMonth ? (int?)x.OrderDate!.Value.Month : null,
                         Customer = groupByCustomer ? x.CustomerID : null
                     },
                     x => x,
@@ -1308,7 +1306,7 @@ public abstract class NorthwindGroupByQueryTestBase<TFixture>(TFixture fixture) 
     public virtual Task GroupBy_optional_navigation_member_Aggregate(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<Order>().GroupBy(o => o.Customer.Country)
+            ss => ss.Set<Order>().GroupBy(o => o.Customer!.Country)
                 .Select(g => new { Country = g.Key, Count = g.Count() }),
             e => e.Country);
 
@@ -1344,7 +1342,7 @@ public abstract class NorthwindGroupByQueryTestBase<TFixture>(TFixture fixture) 
         // selector's member access is folded back to the tuple's constructor argument. Issue #22517.
         => AssertQuery(
             async,
-            ss => from t in ss.Set<Order>().GroupBy(o => o.CustomerID, (k, es) => new ValueTuple<string, int>(k, es.Count()))
+            ss => from t in ss.Set<Order>().GroupBy(o => o.CustomerID, (k, es) => new ValueTuple<string, int>(k!, es.Count()))
                   join c in ss.Set<Customer>() on t.Item1 equals c.CustomerID
                   select new { c.CustomerID, Count = t.Item2 },
             e => e.CustomerID);
@@ -1353,7 +1351,7 @@ public abstract class NorthwindGroupByQueryTestBase<TFixture>(TFixture fixture) 
     public virtual Task GroupBy_multi_navigation_members_Aggregate(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<OrderDetail>().GroupBy(od => new { od.Order.CustomerID, od.Product.ProductName })
+            ss => ss.Set<OrderDetail>().GroupBy(od => new { od.Order!.CustomerID, od.Product!.ProductName })
                 .Select(g => new { CompositeKey = g.Key, Count = g.Count() }),
             e => e.CompositeKey.CustomerID + " " + e.CompositeKey.ProductName);
 
@@ -1390,7 +1388,7 @@ public abstract class NorthwindGroupByQueryTestBase<TFixture>(TFixture fixture) 
     public virtual Task GroupBy_principal_key_property_optimization(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<Order>().GroupBy(o => o.Customer.CustomerID)
+            ss => ss.Set<Order>().GroupBy(o => o.Customer!.CustomerID)
                 .Select(g => new { g.Key, Count = g.Count() }));
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -1414,7 +1412,7 @@ public abstract class NorthwindGroupByQueryTestBase<TFixture>(TFixture fixture) 
         => AssertQuery(
             async,
             ss => ss.Set<Order>()
-                .GroupBy(o => o.Customer.CustomerID.Substring(0, 1))
+                .GroupBy(o => o.Customer!.CustomerID!.Substring(0, 1))
                 .Select(g => new { g.Key, Count = g.Count() }),
             elementSorter: e => (e.Key, e.Count),
             elementAsserter: (e, a) =>
@@ -1428,14 +1426,14 @@ public abstract class NorthwindGroupByQueryTestBase<TFixture>(TFixture fixture) 
         => AssertQuery(
             async,
             ss => from s in from o in ss.Set<Order>()
-                            group o by o.OrderDate.Value.Month
+                            group o by o.OrderDate!.Value.Month
                             into g
                             select new { Month = g.Key, Total = g.Sum(e => e.OrderID) }
                   select new
                   {
                       s.Month,
                       s.Total,
-                      Payment = ss.Set<Order>().Where(e => e.OrderDate.Value.Month == s.Month).Sum(int (e) => e.OrderID)
+                      Payment = ss.Set<Order>().Where(e => e.OrderDate!.Value.Month == s.Month).Sum(int (e) => e.OrderID)
                   },
             elementSorter: e => (e.Month, e.Total),
             elementAsserter: (e, a) =>
@@ -1539,7 +1537,7 @@ public abstract class NorthwindGroupByQueryTestBase<TFixture>(TFixture fixture) 
                 .OrderBy(t => t)
                 .Take(20)
                 .Skip(4)
-                .Select(e => e.Length));
+                .Select(e => e!.Length));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task GroupBy_aggregate_Pushdown_followed_by_projecting_constant(bool async)
@@ -1678,7 +1676,7 @@ public abstract class NorthwindGroupByQueryTestBase<TFixture>(TFixture fixture) 
             async,
             ss =>
                 from c in ss.Set<Customer>()
-                join a in ss.Set<Order>().GroupBy(o => new { o.CustomerID, o.OrderDate.Value.Year })
+                join a in ss.Set<Order>().GroupBy(o => new { o.CustomerID, o.OrderDate!.Value.Year })
                         .Where(g => g.Count() > 5)
                         .Select(g => new { g.Key.CustomerID, LastOrderID = g.Max(o => o.OrderID) })
                         .Distinct()
@@ -1696,7 +1694,7 @@ public abstract class NorthwindGroupByQueryTestBase<TFixture>(TFixture fixture) 
                         .Select(g => new { CustomerID = g.Key, LastOrderID = g.Max(o => o.OrderID) })
                     on c.CustomerID equals a.CustomerID into grouping
                 from g in grouping.DefaultIfEmpty()
-                select new { c, LastOrderID = (int?)g.LastOrderID },
+                select new { c, LastOrderID = (int?)g!.LastOrderID },
             ss =>
                 from c in ss.Set<Customer>().Where(c => c.CustomerID.StartsWith("A"))
                 join a in ss.Set<Order>().GroupBy(o => o.CustomerID)
@@ -1809,8 +1807,8 @@ public abstract class NorthwindGroupByQueryTestBase<TFixture>(TFixture fixture) 
         => AssertQuery(
             async,
             ss => ss.Set<Order>()
-                .Where(c => c.CustomerID.StartsWith("A"))
-                .Select(c => c.Customer.City)
+                .Where(c => c.CustomerID!.StartsWith("A"))
+                .Select(c => c.Customer!.City)
                 .Select(c => new
                 {
                     c1 = ss.Set<Product>().GroupBy(p => p.ProductID).Select(g => g.Key).ToArray(),
@@ -1834,12 +1832,12 @@ public abstract class NorthwindGroupByQueryTestBase<TFixture>(TFixture fixture) 
     private class ProjectedType
     {
         public int Order { get; set; }
-        public string Customer { get; set; }
+        public string? Customer { get; set; }
 
         private bool Equals(ProjectedType other)
             => Equals(Order, other.Order);
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => obj is not null
                 && (ReferenceEquals(this, obj)
                     || (obj.GetType() == GetType()
@@ -1962,7 +1960,7 @@ public abstract class NorthwindGroupByQueryTestBase<TFixture>(TFixture fixture) 
         => AssertQuery(
             async,
             ss => ss.Set<Order>()
-                .GroupBy(o => o.Customer.CustomerID)
+                .GroupBy(o => o.Customer!.CustomerID)
                 .Select(g => new { g.Key, Count = g.Count() })
                 .Where(x => x.Count != 2));
 
@@ -1971,7 +1969,7 @@ public abstract class NorthwindGroupByQueryTestBase<TFixture>(TFixture fixture) 
         => AssertQuery(
             async,
             ss => ss.Set<Order>()
-                .GroupBy(o => o.Customer.CustomerID)
+                .GroupBy(o => o.Customer!.CustomerID)
                 .Select(g => new { g.Key, Count = g.Count() })
                 .Where(x => x.Count < 2 || x.Count > 2));
 
@@ -2056,7 +2054,7 @@ public abstract class NorthwindGroupByQueryTestBase<TFixture>(TFixture fixture) 
             async,
             ss => ss.Set<Order>().GroupBy(o => o.CustomerID)
                 .Select(g => g.OrderByDescending(o => o.OrderDate).FirstOrDefault())
-                .Where(r => r.EmployeeID == 5u));
+                .Where(r => r!.EmployeeID == 5u));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task GroupBy_ResultSelector_Entire_Entity_Where(bool async) // #31209
@@ -2091,7 +2089,7 @@ public abstract class NorthwindGroupByQueryTestBase<TFixture>(TFixture fixture) 
             async,
             ss => ss.Set<Order>().GroupBy(o => o.CustomerID)
                 .Select(g => g.OrderBy(o => o.OrderID).First())
-                .OrderBy(o => o.Customer.City)
+                .OrderBy(o => o.Customer!.City)
                 .ThenBy(o => o.OrderID)
                 // Identity projection: the ordering by City is collation-sensitive, so the order
                 // itself is not asserted across providers.
@@ -2103,7 +2101,7 @@ public abstract class NorthwindGroupByQueryTestBase<TFixture>(TFixture fixture) 
             async,
             ss => ss.Set<Order>().GroupBy(o => o.CustomerID)
                 .Select(g => g.OrderBy(o => o.OrderID).First())
-                .Select(o => new { o.OrderID, o.Customer.City }));
+                .Select(o => new { o.OrderID, o.Customer!.City }));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task GroupBy_Select_Entire_Entity_Where_navigation(bool async)
@@ -2111,7 +2109,7 @@ public abstract class NorthwindGroupByQueryTestBase<TFixture>(TFixture fixture) 
             async,
             ss => ss.Set<Order>().GroupBy(o => o.CustomerID)
                 .Select(g => g.OrderBy(o => o.OrderID).First())
-                .Where(o => o.Customer.City == "London"));
+                .Where(o => o.Customer!.City == "London"));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task GroupBy_Select_Entire_Entity_Select_referenced_twice(bool async)
@@ -2169,7 +2167,7 @@ public abstract class NorthwindGroupByQueryTestBase<TFixture>(TFixture fixture) 
                 .GroupBy(o => o.CustomerID)
                 .Select(g => new { g.Key, Total = g.Count() })
                 .Join(
-                    ss.Set<Order>().Where(o => o.OrderDate.Value.Year == 1997)
+                    ss.Set<Order>().Where(o => o.OrderDate!.Value.Year == 1997)
                         .GroupBy(o => o.CustomerID)
                         .Select(g => new { g.Key, ThatYear = g.Count() }),
                     o => o.Key,
@@ -2210,7 +2208,7 @@ public abstract class NorthwindGroupByQueryTestBase<TFixture>(TFixture fixture) 
         => AssertQuery(
             async,
             ss => ss.Set<Order>()
-                .GroupBy(o => new { o.CustomerID, o.OrderDate.Value.Year })
+                .GroupBy(o => new { o.CustomerID, o.OrderDate!.Value.Year })
                 .Select(g => new { g.Key.CustomerID, g.Key.Year })
                 .GroupBy(e => e.CustomerID)
                 .Select(g => new { g.Key, Count = g.Count() }),
@@ -2481,7 +2479,7 @@ public abstract class NorthwindGroupByQueryTestBase<TFixture>(TFixture fixture) 
         => AssertQuery(
             async,
             ss => ss.Set<Order>().Where(e => e.OrderID < 10500).GroupBy(c => c.Customer),
-            elementSorter: e => e.Key.CustomerID,
+            elementSorter: e => e.Key!.CustomerID,
             elementAsserter: (e, a) => AssertGrouping(e, a));
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -2553,14 +2551,14 @@ public abstract class NorthwindGroupByQueryTestBase<TFixture>(TFixture fixture) 
 
     protected class RandomClass
     {
-        public string City { get; set; }
+        public string? City { get; set; }
         public int Constant { get; set; }
     }
 
     protected class RandomClassEqualityComparer : IEqualityComparer<RandomClass>
     {
-        public bool Equals(RandomClass x, RandomClass y)
-            => x.City == y.City && x.Constant == y.Constant;
+        public bool Equals(RandomClass? x, RandomClass? y)
+            => x is not null && y is not null && x.City == y.City && x.Constant == y.Constant;
 
         public int GetHashCode([DisallowNull] RandomClass obj)
             => HashCode.Combine(obj.City, obj.Constant);
@@ -2662,7 +2660,7 @@ public abstract class NorthwindGroupByQueryTestBase<TFixture>(TFixture fixture) 
     public virtual Task GroupBy_Where_with_grouping_result(bool async)
         => AssertTranslationFailed(() => AssertQuery(
             async,
-            ss => ss.Set<Customer>().GroupBy(c => c.City).Where(e => e.Key.StartsWith("s"))));
+            ss => ss.Set<Customer>().GroupBy(c => c.City).Where(e => e.Key!.StartsWith("s"))));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task GroupBy_OrderBy_with_grouping_result(bool async)
@@ -2712,7 +2710,7 @@ public abstract class NorthwindGroupByQueryTestBase<TFixture>(TFixture fixture) 
         => AssertQuery(
             async,
             ss => ss.Set<Order>()
-                .GroupBy(o => o.Customer.CustomerID.Substring(0, 1))
+                .GroupBy(o => o.Customer!.CustomerID!.Substring(0, 1))
                 .Select(g => new { g.Key, Count = g.Skip(1).Take(2) }),
             elementSorter: e => (e.Key, e.Count),
             elementAsserter: (e, a) =>
@@ -2852,7 +2850,7 @@ public abstract class NorthwindGroupByQueryTestBase<TFixture>(TFixture fixture) 
             ss => ss.Set<OrderDetail>()
                 .GroupBy(od => od.Order.Customer)
                 .Select(g => new { g.Key, Aggregate = g.Sum(od => od.OrderID) }),
-            elementSorter: e => e.Key.CustomerID,
+            elementSorter: e => e.Key!.CustomerID,
             elementAsserter: (e, a) =>
             {
                 AssertEqual(e.Key, a.Key);
@@ -2876,8 +2874,8 @@ public abstract class NorthwindGroupByQueryTestBase<TFixture>(TFixture fixture) 
                 .Select(g => new
                 {
                     g.Key,
-                    Id1 = g.Key.CustomerID,
-                    Id2 = g.Key.Customer.CustomerID,
+                    Id1 = g.Key!.CustomerID,
+                    Id2 = g.Key.Customer!.CustomerID,
                     Id3 = g.Key.OrderID,
                     Aggregate = g.Sum(od => od.OrderID)
                 }),
@@ -3017,9 +3015,9 @@ public abstract class NorthwindGroupByQueryTestBase<TFixture>(TFixture fixture) 
                 .GroupBy(o => o.CustomerID)
                 .Select(e => new Result(e.Key)));
 
-    private class Result(string customerID)
+    private class Result(string? customerID)
     {
-        private readonly string _customerID = customerID;
+        private readonly string? _customerID = customerID;
     }
 
     #endregion
@@ -3057,7 +3055,7 @@ public abstract class NorthwindGroupByQueryTestBase<TFixture>(TFixture fixture) 
                     Subquery = c.Orders
                         .Select(o => new { First = o.CustomerID, Second = o.OrderID })
                         .GroupBy(x => x.First)
-                        .Select(g => new { Max = g.Max(int (x) => x.First.Length), Sum = g.Sum(int (x) => x.Second) }).ToList()
+                        .Select(g => new { Max = g.Max(int (x) => x.First!.Length), Sum = g.Sum(int (x) => x.Second) }).ToList()
                 }),
             elementSorter: e => e.Key,
             elementAsserter: (e, a) =>
@@ -3077,7 +3075,7 @@ public abstract class NorthwindGroupByQueryTestBase<TFixture>(TFixture fixture) 
                     Subquery = ss.Set<Order>()
                         .Select(o => new { First = o.CustomerID, Second = o.OrderID })
                         .GroupBy(x => x.First)
-                        .Select(g => new { Max = g.Max(int (x) => x.First.Length), Sum = g.Sum(int (x) => x.Second) }).ToList()
+                        .Select(g => new { Max = g.Max(int (x) => x.First!.Length), Sum = g.Sum(int (x) => x.Second) }).ToList()
                 }),
             elementSorter: e => e.Key,
             elementAsserter: (e, a) =>
@@ -3095,7 +3093,7 @@ public abstract class NorthwindGroupByQueryTestBase<TFixture>(TFixture fixture) 
                 {
                     Key = c.CustomerID,
                     Subquery = c.Orders
-                        .Select(o => new { First = o.OrderID, Second = o.Customer.City + o.CustomerID })
+                        .Select(o => new { First = o.OrderID, Second = o.Customer!.City + o.CustomerID })
                         .GroupBy(x => x.Second)
                         .Select(g => new { Sum = g.Sum(int (x) => x.First), Count = g.Count(x => x.Second.StartsWith("Lon")) }).ToList()
                 }),
@@ -3111,7 +3109,7 @@ public abstract class NorthwindGroupByQueryTestBase<TFixture>(TFixture fixture) 
         => AssertQuery(
             async,
             ss => from od in ss.Set<OrderDetail>()
-                  where od.Order.Customer.CustomerID == "ALFKI"
+                where od.Order!.Customer!.CustomerID == "ALFKI"
                   group od by od.ProductID
                   into grouping
                   select new
@@ -3151,7 +3149,7 @@ public abstract class NorthwindGroupByQueryTestBase<TFixture>(TFixture fixture) 
                 .Union(
                     ss.Set<Order>()
                         .GroupBy(o => o.CustomerID)
-                        .Select(g => new { CustomerID = g.Key, Sequence = 1 })),
+                        .Select(g => new { CustomerID = g.Key!, Sequence = 1 })),
             elementSorter: e => (e.CustomerID, e.Sequence));
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -3231,8 +3229,8 @@ public abstract class NorthwindGroupByQueryTestBase<TFixture>(TFixture fixture) 
         => AssertQuery(
             async,
             ss => ss.Set<Order>()
-                .Where(c => c.CustomerID.StartsWith("A"))
-                .Select(c => c.Customer.City)
+                .Where(c => c.CustomerID!.StartsWith("A"))
+                .Select(c => c.Customer!.City)
                 .Distinct()
                 .Select(c => new
                 {
@@ -3252,7 +3250,7 @@ public abstract class NorthwindGroupByQueryTestBase<TFixture>(TFixture fixture) 
             async,
             ss => ss.Set<Customer>()
                 .GroupBy(e => e.CustomerID)
-                .Where(g => g.Key.StartsWith("F"))
+                .Where(g => g.Key!.StartsWith("F"))
                 .Select(e => e.Key)
                 .Select(c => new { c, Orders = ss.Set<Order>().Where(o => o.CustomerID == c).ToList() }),
             elementSorter: e => e.c,
@@ -3268,7 +3266,7 @@ public abstract class NorthwindGroupByQueryTestBase<TFixture>(TFixture fixture) 
             async,
             ss => ss.Set<Order>()
                 .GroupBy(e => e.CustomerID)
-                .Where(g => g.Key.StartsWith("F"))
+                .Where(g => g.Key!.StartsWith("F"))
                 .Select(e => e.Key)
                 .Select(c => new { c, Orders = ss.Set<Order>().Where(o => o.CustomerID == c).ToList() }),
             elementSorter: e => e.c,

--- a/test/EFCore.Specification.Tests/Query/NorthwindIncludeNoTrackingQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindIncludeNoTrackingQueryTestBase.cs
@@ -10,14 +10,12 @@ using Microsoft.EntityFrameworkCore.TestModels.Northwind;
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
-#nullable disable
-
 public abstract class NorthwindIncludeNoTrackingQueryTestBase<TFixture>(TFixture fixture) : NorthwindIncludeQueryTestBase<TFixture>(fixture)
     where TFixture : NorthwindQueryFixtureBase<NoopModelCustomizer>, new()
 {
     private static readonly MethodInfo _asNoTrackingMethodInfo
         = typeof(EntityFrameworkQueryableExtensions)
-            .GetTypeInfo().GetDeclaredMethod(nameof(EntityFrameworkQueryableExtensions.AsNoTracking));
+            .GetTypeInfo().GetDeclaredMethod(nameof(EntityFrameworkQueryableExtensions.AsNoTracking))!;
 
     // Include with cycles are not allowed in no tracking query.
     public override async Task Include_multi_level_reference_and_collection_predicate(bool async)
@@ -109,7 +107,7 @@ public abstract class NorthwindIncludeNoTrackingQueryTestBase<TFixture>(TFixture
         using var context = CreateContext();
         var orders = context.Set<Order>().Where(o => o.CustomerID == "ALFKI").ToList();
         Assert.Equal(6, context.ChangeTracker.Entries().Count());
-        Assert.True(orders.All(o => o.Customer.CustomerID == null));
+        Assert.True(orders.All(o => o.Customer!.CustomerID == null));
 
         var customer
             = async
@@ -127,7 +125,7 @@ public abstract class NorthwindIncludeNoTrackingQueryTestBase<TFixture>(TFixture
         Assert.True(customer.Orders.All(e => ReferenceEquals(e.Customer, customer)));
 
         Assert.Equal(6, context.ChangeTracker.Entries().Count());
-        Assert.True(orders.All(o => o.Customer.CustomerID == null));
+        Assert.True(orders.All(o => o.Customer!.CustomerID == null));
     }
 
     public override async Task Include_collection_principal_already_tracked(bool async)
@@ -189,7 +187,7 @@ public abstract class NorthwindIncludeNoTrackingQueryTestBase<TFixture>(TFixture
         serverQueryExpression = base.RewriteServerQueryExpression(serverQueryExpression);
 
         return Expression.Call(
-            _asNoTrackingMethodInfo.MakeGenericMethod(serverQueryExpression.Type.TryGetSequenceType()),
+            _asNoTrackingMethodInfo.MakeGenericMethod(serverQueryExpression.Type.TryGetSequenceType()!),
             serverQueryExpression);
     }
 }

--- a/test/EFCore.Specification.Tests/Query/NorthwindIncludeQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindIncludeQueryTestBase.cs
@@ -10,8 +10,6 @@ using Microsoft.EntityFrameworkCore.TestModels.Northwind;
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
-#nullable disable
-
 public abstract class NorthwindIncludeQueryTestBase<TFixture>(TFixture fixture) : QueryTestBase<TFixture>(fixture)
     where TFixture : NorthwindQueryFixtureBase<NoopModelCustomizer>, new()
 {
@@ -19,20 +17,20 @@ public abstract class NorthwindIncludeQueryTestBase<TFixture>(TFixture fixture) 
     public virtual Task Include_reference_and_collection_order_by(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<Order>().Where(o => o.CustomerID.StartsWith("F")).Include(o => o.Customer.Orders).OrderBy(o => o.OrderID),
+            ss => ss.Set<Order>().Where(o => o.CustomerID!.StartsWith("F")).Include(o => o.Customer!.Orders).OrderBy(o => o.OrderID),
             elementAsserter: (e, a) => AssertInclude(
                 e, a,
-                new ExpectedInclude<Order>(o => o.Customer), new ExpectedInclude<Customer>(c => c.Orders, "Customer")),
+                new ExpectedInclude<Order>(o => o.Customer!), new ExpectedInclude<Customer>(c => c.Orders, "Customer")),
             assertOrder: true);
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual async Task Include_references_then_include_collection(bool async)
         => await AssertQuery(
             async,
-            ss => ss.Set<Order>().Where(o => o.CustomerID.StartsWith("F")).Include(o => o.Customer).ThenInclude(c => c.Orders),
+            ss => ss.Set<Order>().Where(o => o.CustomerID!.StartsWith("F")).Include(o => o.Customer!).ThenInclude(c => c.Orders),
             elementAsserter: (e, a) => AssertInclude(
                 e, a,
-                new ExpectedInclude<Order>(o => o.Customer),
+                new ExpectedInclude<Order>(o => o.Customer!),
                 new ExpectedInclude<Customer>(c => c.Orders, "Customer")));
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -41,7 +39,7 @@ public abstract class NorthwindIncludeQueryTestBase<TFixture>(TFixture fixture) 
             CoreStrings.InvalidIncludeExpression("o.Customer.CustomerID"),
             (await Assert.ThrowsAsync<InvalidOperationException>(() => AssertQuery(
                 async,
-                ss => ss.Set<Order>().Include(o => o.Customer.CustomerID)))).Message);
+                ss => ss.Set<Order>().Include(o => o.Customer!.CustomerID)))).Message);
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual async Task Include_property(bool async)
@@ -65,7 +63,7 @@ public abstract class NorthwindIncludeQueryTestBase<TFixture>(TFixture fixture) 
                 .Include(c => c.Orders)
                 .ThenInclude(o => o.OrderDetails)
                 .Where(c => c.CustomerID.StartsWith("W"))
-                .OrderByDescending(c => c.Orders.OrderByDescending(oo => oo.OrderDate).FirstOrDefault().OrderDate),
+                .OrderByDescending(c => c.Orders.OrderByDescending(oo => oo.OrderDate).FirstOrDefault()!.OrderDate),
             asserter: (e, a) => AssertInclude(
                 e, a,
                 new ExpectedInclude<Customer>(c => c.Orders),
@@ -167,17 +165,17 @@ public abstract class NorthwindIncludeQueryTestBase<TFixture>(TFixture fixture) 
     public virtual Task Include_collection_alias_generation(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<Order>().Where(o => o.CustomerID.StartsWith("F")).Include(o => o.OrderDetails),
+            ss => ss.Set<Order>().Where(o => o.CustomerID!.StartsWith("F")).Include(o => o.OrderDetails),
             elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Order>(o => o.OrderDetails)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Include_collection_and_reference(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<Order>().Where(o => o.CustomerID.StartsWith("F")).Include(o => o.OrderDetails).Include(o => o.Customer),
+            ss => ss.Set<Order>().Where(o => o.CustomerID!.StartsWith("F")).Include(o => o.OrderDetails).Include(o => o.Customer),
             elementAsserter: (e, a) => AssertInclude(
                 e, a,
-                new ExpectedInclude<Order>(o => o.OrderDetails), new ExpectedInclude<Order>(o => o.Customer)));
+                new ExpectedInclude<Order>(o => o.OrderDetails), new ExpectedInclude<Order>(o => o.Customer!)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Include_collection_orderby_take(bool async)
@@ -245,7 +243,7 @@ public abstract class NorthwindIncludeQueryTestBase<TFixture>(TFixture fixture) 
                 .ThenBy(od => od.ProductID)
                 .Skip(1)
                 .Take(2)
-                .Select(od => new { od.Order.CustomerID }));
+                .Select(od => new { od.Order!.CustomerID }));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Include_collection_with_join_clause_with_filter(bool async)
@@ -275,7 +273,7 @@ public abstract class NorthwindIncludeQueryTestBase<TFixture>(TFixture fixture) 
             ss => ss.Set<Customer>()
                 .Include(o => o.Orders)
                 .RightJoin(ss.Set<Order>(), c => c.CustomerID, o => o.CustomerID, (c, o) => new { c, o })
-                .Where(t => t.c.CustomerID.StartsWith("F"))
+                .Where(t => t.c!.CustomerID.StartsWith("F"))
                 .Select(t => t.c),
             elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Customer>(c => c.Orders)));
 
@@ -340,7 +338,7 @@ public abstract class NorthwindIncludeQueryTestBase<TFixture>(TFixture fixture) 
             ss => ss.Set<Customer>()
                 .Include(c => c.Orders)
                 .Where(c => c.CustomerID.StartsWith("W"))
-                .OrderByDescending(c => c.Orders.OrderByDescending(oo => oo.OrderDate).FirstOrDefault().OrderDate),
+                .OrderByDescending(c => c.Orders.OrderByDescending(oo => oo.OrderDate).FirstOrDefault()!.OrderDate),
             asserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Customer>(c => c.Orders)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -492,8 +490,8 @@ public abstract class NorthwindIncludeQueryTestBase<TFixture>(TFixture fixture) 
             elementSorter: e => (e.o1.OrderID, e.o2.OrderID),
             elementAsserter: (e, a) =>
             {
-                AssertInclude(e.o1, a.o1, new ExpectedInclude<Order>(c => c.Customer));
-                AssertInclude(e.o2, a.o2, new ExpectedInclude<Order>(c => c.Customer));
+                AssertInclude(e.o1, a.o1, new ExpectedInclude<Order>(c => c.Customer!));
+                AssertInclude(e.o2, a.o2, new ExpectedInclude<Order>(c => c.Customer!));
             });
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -506,7 +504,7 @@ public abstract class NorthwindIncludeQueryTestBase<TFixture>(TFixture fixture) 
             elementSorter: e => (e.o1.OrderID, e.o2.OrderID),
             elementAsserter: (e, a) =>
             {
-                AssertInclude(e.o1, a.o1, new ExpectedInclude<Order>(c => c.Customer));
+                AssertInclude(e.o1, a.o1, new ExpectedInclude<Order>(c => c.Customer!));
                 AssertEqual(e.o2, a.o2);
             });
 
@@ -521,7 +519,7 @@ public abstract class NorthwindIncludeQueryTestBase<TFixture>(TFixture fixture) 
             elementAsserter: (e, a) =>
             {
                 AssertEqual(e.o1, a.o1);
-                AssertInclude(e.o2, a.o2, new ExpectedInclude<Order>(c => c.Customer));
+                AssertInclude(e.o2, a.o2, new ExpectedInclude<Order>(c => c.Customer!));
             });
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -539,11 +537,11 @@ public abstract class NorthwindIncludeQueryTestBase<TFixture>(TFixture fixture) 
     public virtual Task Include_multi_level_reference_and_collection_predicate(bool async)
         => AssertSingle(
             async,
-            ss => ss.Set<Order>().Include(o => o.Customer.Orders),
+            ss => ss.Set<Order>().Include(o => o.Customer!.Orders),
             o => o.OrderID == 10248,
             asserter: (e, a) => AssertInclude(
                 e, a,
-                new ExpectedInclude<Order>(o => o.Customer),
+                new ExpectedInclude<Order>(o => o.Customer!),
                 new ExpectedInclude<Customer>(c => c.Orders, "Customer")));
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -571,12 +569,12 @@ public abstract class NorthwindIncludeQueryTestBase<TFixture>(TFixture fixture) 
     public virtual Task Include_multiple_references_and_collection_multi_level(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<OrderDetail>().Where(od => od.OrderID % 23 == 13).Include(od => od.Order.Customer.Orders)
+            ss => ss.Set<OrderDetail>().Where(od => od.OrderID % 23 == 13).Include(od => od.Order!.Customer!.Orders)
                 .Include(od => od.Product),
             elementAsserter: (e, a) => AssertInclude(
                 e, a,
-                new ExpectedInclude<OrderDetail>(od => od.Order),
-                new ExpectedInclude<Order>(o => o.Customer, "Order"),
+                new ExpectedInclude<OrderDetail>(od => od.Order!),
+                new ExpectedInclude<Order>(o => o.Customer!, "Order"),
                 new ExpectedInclude<Customer>(c => c.Orders, "Order.Customer"),
                 new ExpectedInclude<OrderDetail>(od => od.Product)));
 
@@ -585,11 +583,11 @@ public abstract class NorthwindIncludeQueryTestBase<TFixture>(TFixture fixture) 
         => AssertQuery(
             async,
             ss => ss.Set<OrderDetail>().Where(od => od.OrderID % 23 == 13).Include(od => od.Product)
-                .Include(od => od.Order.Customer.Orders),
+                .Include(od => od.Order!.Customer!.Orders),
             elementAsserter: (e, a) => AssertInclude(
                 e, a,
-                new ExpectedInclude<OrderDetail>(od => od.Order),
-                new ExpectedInclude<Order>(o => o.Customer, "Order"),
+                new ExpectedInclude<OrderDetail>(od => od.Order!),
+                new ExpectedInclude<Order>(o => o.Customer!, "Order"),
                 new ExpectedInclude<Customer>(c => c.Orders, "Order.Customer"),
                 new ExpectedInclude<OrderDetail>(od => od.Product)));
 
@@ -597,46 +595,46 @@ public abstract class NorthwindIncludeQueryTestBase<TFixture>(TFixture fixture) 
     public virtual Task Include_multiple_references_multi_level(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<OrderDetail>().Where(od => od.OrderID % 23 == 13).Include(o => o.Order.Customer).Include(o => o.Product),
+            ss => ss.Set<OrderDetail>().Where(od => od.OrderID % 23 == 13).Include(o => o.Order!.Customer).Include(o => o.Product),
             elementAsserter: (e, a) => AssertInclude(
                 e, a,
-                new ExpectedInclude<OrderDetail>(od => od.Order),
-                new ExpectedInclude<Order>(o => o.Customer, "Order"),
+                new ExpectedInclude<OrderDetail>(od => od.Order!),
+                new ExpectedInclude<Order>(o => o.Customer!, "Order"),
                 new ExpectedInclude<OrderDetail>(od => od.Product)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Include_multiple_references_multi_level_reverse(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<OrderDetail>().Where(od => od.OrderID % 23 == 13).Include(o => o.Product).Include(o => o.Order.Customer),
+            ss => ss.Set<OrderDetail>().Where(od => od.OrderID % 23 == 13).Include(o => o.Product).Include(o => o.Order!.Customer),
             elementAsserter: (e, a) => AssertInclude(
                 e, a,
-                new ExpectedInclude<OrderDetail>(od => od.Order),
-                new ExpectedInclude<Order>(o => o.Customer, "Order"),
+                new ExpectedInclude<OrderDetail>(od => od.Order!),
+                new ExpectedInclude<Order>(o => o.Customer!, "Order"),
                 new ExpectedInclude<OrderDetail>(od => od.Product)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Include_reference(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<Order>().Where(o => o.CustomerID.StartsWith("F")).Include(o => o.Customer),
-            elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Order>(o => o.Customer)));
+            ss => ss.Set<Order>().Where(o => o.CustomerID!.StartsWith("F")).Include(o => o.Customer),
+            elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Order>(o => o.Customer!)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual async Task Include_reference_alias_generation(bool async)
         => await AssertQuery(
             async,
             ss => ss.Set<OrderDetail>().Where(od => od.OrderID % 23 == 13).Include(o => o.Order),
-            elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<OrderDetail>(od => od.Order)));
+            elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<OrderDetail>(od => od.Order!)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Include_reference_and_collection(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<Order>().Where(o => o.CustomerID.StartsWith("F")).Include(o => o.Customer).Include(o => o.OrderDetails),
+            ss => ss.Set<Order>().Where(o => o.CustomerID!.StartsWith("F")).Include(o => o.Customer).Include(o => o.OrderDetails),
             elementAsserter: (e, a) => AssertInclude(
                 e, a,
-                new ExpectedInclude<Order>(o => o.Customer),
+                new ExpectedInclude<Order>(o => o.Customer!),
                 new ExpectedInclude<Order>(o => o.OrderDetails)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -671,7 +669,7 @@ public abstract class NorthwindIncludeQueryTestBase<TFixture>(TFixture fixture) 
             async,
             ss => ss.Set<Order>().Include(o => o.Customer),
             o => o.OrderID == -1,
-            asserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Order>(o => o.Customer)));
+            asserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Order>(o => o.Customer!)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Include_reference_when_projection(bool async)
@@ -683,12 +681,12 @@ public abstract class NorthwindIncludeQueryTestBase<TFixture>(TFixture fixture) 
     public virtual Task Include_reference_when_entity_in_projection(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<Order>().Where(o => o.CustomerID.StartsWith("F")).Include(o => o.Customer)
+            ss => ss.Set<Order>().Where(o => o.CustomerID!.StartsWith("F")).Include(o => o.Customer)
                 .Select(o => new { o, o.CustomerID }),
             elementSorter: e => e.o.OrderID,
             elementAsserter: (e, a) =>
             {
-                AssertInclude(e.o, a.o, new ExpectedInclude<Order>(o => o.Customer));
+                AssertInclude(e.o, a.o, new ExpectedInclude<Order>(o => o.Customer!));
                 AssertEqual(e.CustomerID, a.CustomerID);
             });
 
@@ -697,24 +695,24 @@ public abstract class NorthwindIncludeQueryTestBase<TFixture>(TFixture fixture) 
         => AssertQuery(
             async,
             ss => ss.Set<Order>().Include(o => o.Customer).Where(o => o.CustomerID == "ALFKI"),
-            elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Order>(o => o.Customer)));
+            elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Order>(o => o.Customer!)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Include_reference_with_filter_reordered(bool async)
         => AssertQuery(
             async,
             ss => ss.Set<Order>().Where(o => o.CustomerID == "ALFKI").Include(o => o.Customer),
-            elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Order>(o => o.Customer)));
+            elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Order>(o => o.Customer!)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Include_references_and_collection_multi_level(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<OrderDetail>().Where(od => od.OrderID % 23 == 13 && od.UnitPrice < 10).Include(o => o.Order.Customer.Orders),
+            ss => ss.Set<OrderDetail>().Where(od => od.OrderID % 23 == 13 && od.UnitPrice < 10).Include(o => o.Order!.Customer!.Orders),
             elementAsserter: (e, a) => AssertInclude(
                 e, a,
-                new ExpectedInclude<OrderDetail>(od => od.Order),
-                new ExpectedInclude<Order>(o => o.Customer, "Order"),
+                new ExpectedInclude<OrderDetail>(od => od.Order!),
+                new ExpectedInclude<Order>(o => o.Customer!, "Order"),
                 new ExpectedInclude<Customer>(c => c.Orders, "Order.Customer")));
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -754,32 +752,32 @@ public abstract class NorthwindIncludeQueryTestBase<TFixture>(TFixture fixture) 
     public virtual Task Include_references_and_collection_multi_level_predicate(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<OrderDetail>().Include(od => od.Order.Customer.Orders).Where(od => od.OrderID == 10248),
+            ss => ss.Set<OrderDetail>().Include(od => od.Order!.Customer!.Orders).Where(od => od.OrderID == 10248),
             elementAsserter: (e, a) => AssertInclude(
                 e, a,
-                new ExpectedInclude<OrderDetail>(od => od.Order),
-                new ExpectedInclude<Order>(o => o.Customer, "Order"),
+                new ExpectedInclude<OrderDetail>(od => od.Order!),
+                new ExpectedInclude<Order>(o => o.Customer!, "Order"),
                 new ExpectedInclude<Customer>(c => c.Orders, "Order.Customer")));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Include_references_multi_level(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<OrderDetail>().Where(od => od.OrderID % 23 == 13).Include(o => o.Order.Customer),
+            ss => ss.Set<OrderDetail>().Where(od => od.OrderID % 23 == 13).Include(o => o.Order!.Customer),
             elementAsserter: (e, a) => AssertInclude(
                 e, a,
-                new ExpectedInclude<OrderDetail>(od => od.Order),
-                new ExpectedInclude<Order>(o => o.Customer, "Order")));
+                new ExpectedInclude<OrderDetail>(od => od.Order!),
+                new ExpectedInclude<Order>(o => o.Customer!, "Order")));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Include_multi_level_reference_then_include_collection_predicate(bool async)
         => AssertSingle(
             async,
-            ss => ss.Set<Order>().Include(o => o.Customer).ThenInclude(c => c.Orders),
+            ss => ss.Set<Order>().Include(o => o.Customer!).ThenInclude(c => c.Orders),
             o => o.OrderID == 10248,
             asserter: (e, a) => AssertInclude(
                 e, a,
-                new ExpectedInclude<Order>(o => o.Customer),
+                new ExpectedInclude<Order>(o => o.Customer!),
                 new ExpectedInclude<Customer>(c => c.Orders, "Customer")));
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -788,12 +786,12 @@ public abstract class NorthwindIncludeQueryTestBase<TFixture>(TFixture fixture) 
             async,
             ss => ss.Set<OrderDetail>()
                 .Where(od => od.OrderID % 23 == 13)
-                .Include(od => od.Order).ThenInclude(o => o.Customer).ThenInclude(c => c.Orders)
+                .Include(od => od.Order).ThenInclude(o => o!.Customer).ThenInclude(c => c!.Orders)
                 .Include(od => od.Product),
             elementAsserter: (e, a) => AssertInclude(
                 e, a,
-                new ExpectedInclude<OrderDetail>(od => od.Order),
-                new ExpectedInclude<Order>(o => o.Customer, "Order"),
+                new ExpectedInclude<OrderDetail>(od => od.Order!),
+                new ExpectedInclude<Order>(o => o.Customer!, "Order"),
                 new ExpectedInclude<Customer>(c => c.Orders, "Order.Customer"),
                 new ExpectedInclude<OrderDetail>(od => od.Product)));
 
@@ -804,11 +802,11 @@ public abstract class NorthwindIncludeQueryTestBase<TFixture>(TFixture fixture) 
             ss => ss.Set<OrderDetail>()
                 .Where(od => od.OrderID % 23 == 13)
                 .Include(od => od.Product)
-                .Include(od => od.Order).ThenInclude(o => o.Customer).ThenInclude(c => c.Orders),
+                .Include(od => od.Order).ThenInclude(o => o!.Customer).ThenInclude(c => c!.Orders),
             elementAsserter: (e, a) => AssertInclude(
                 e, a,
-                new ExpectedInclude<OrderDetail>(od => od.Order),
-                new ExpectedInclude<Order>(o => o.Customer, "Order"),
+                new ExpectedInclude<OrderDetail>(od => od.Order!),
+                new ExpectedInclude<Order>(o => o.Customer!, "Order"),
                 new ExpectedInclude<Customer>(c => c.Orders, "Order.Customer"),
                 new ExpectedInclude<OrderDetail>(od => od.Product)));
 
@@ -818,12 +816,12 @@ public abstract class NorthwindIncludeQueryTestBase<TFixture>(TFixture fixture) 
             async,
             ss => ss.Set<OrderDetail>()
                 .Where(od => od.OrderID % 23 == 13)
-                .Include(od => od.Order).ThenInclude(o => o.Customer)
+                .Include(od => od.Order).ThenInclude(o => o!.Customer)
                 .Include(od => od.Product),
             elementAsserter: (e, a) => AssertInclude(
                 e, a,
-                new ExpectedInclude<OrderDetail>(od => od.Order),
-                new ExpectedInclude<Order>(o => o.Customer, "Order"),
+                new ExpectedInclude<OrderDetail>(od => od.Order!),
+                new ExpectedInclude<Order>(o => o.Customer!, "Order"),
                 new ExpectedInclude<OrderDetail>(od => od.Product)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -833,11 +831,11 @@ public abstract class NorthwindIncludeQueryTestBase<TFixture>(TFixture fixture) 
             ss => ss.Set<OrderDetail>()
                 .Where(od => od.OrderID % 23 == 13)
                 .Include(od => od.Product)
-                .Include(od => od.Order).ThenInclude(o => o.Customer),
+                .Include(od => od.Order).ThenInclude(o => o!.Customer),
             elementAsserter: (e, a) => AssertInclude(
                 e, a,
-                new ExpectedInclude<OrderDetail>(od => od.Order),
-                new ExpectedInclude<Order>(o => o.Customer, "Order"),
+                new ExpectedInclude<OrderDetail>(od => od.Order!),
+                new ExpectedInclude<Order>(o => o.Customer!, "Order"),
                 new ExpectedInclude<OrderDetail>(od => od.Product)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -847,12 +845,12 @@ public abstract class NorthwindIncludeQueryTestBase<TFixture>(TFixture fixture) 
             ss => ss.Set<OrderDetail>()
                 .Where(od => od.ProductID % 23 == 17 && od.Quantity < 10)
                 .Include(od => od.Order)
-                .ThenInclude(o => o.Customer)
-                .ThenInclude(c => c.Orders),
+                .ThenInclude(o => o!.Customer)
+                .ThenInclude(c => c!.Orders),
             elementAsserter: (e, a) => AssertInclude(
                 e, a,
-                new ExpectedInclude<OrderDetail>(od => od.Order),
-                new ExpectedInclude<Order>(o => o.Customer, "Order"),
+                new ExpectedInclude<OrderDetail>(od => od.Order!),
+                new ExpectedInclude<Order>(o => o.Customer!, "Order"),
                 new ExpectedInclude<Customer>(c => c.Orders, "Order.Customer")));
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -861,13 +859,13 @@ public abstract class NorthwindIncludeQueryTestBase<TFixture>(TFixture fixture) 
             async,
             ss => ss.Set<OrderDetail>()
                 .Include(od => od.Order)
-                .ThenInclude(o => o.Customer)
-                .ThenInclude(c => c.Orders)
+                .ThenInclude(o => o!.Customer)
+                .ThenInclude(c => c!.Orders)
                 .Where(od => od.OrderID == 10248),
             elementAsserter: (e, a) => AssertInclude(
                 e, a,
-                new ExpectedInclude<OrderDetail>(od => od.Order),
-                new ExpectedInclude<Order>(o => o.Customer, "Order"),
+                new ExpectedInclude<OrderDetail>(od => od.Order!),
+                new ExpectedInclude<Order>(o => o.Customer!, "Order"),
                 new ExpectedInclude<Customer>(c => c.Orders, "Order.Customer")));
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -877,18 +875,18 @@ public abstract class NorthwindIncludeQueryTestBase<TFixture>(TFixture fixture) 
             ss => ss.Set<OrderDetail>()
                 .Where(od => od.OrderID % 23 == 13)
                 .Include(od => od.Order)
-                .ThenInclude(o => o.Customer),
+                .ThenInclude(o => o!.Customer),
             elementAsserter: (e, a) => AssertInclude(
                 e, a,
-                new ExpectedInclude<OrderDetail>(od => od.Order),
-                new ExpectedInclude<Order>(o => o.Customer, "Order")));
+                new ExpectedInclude<OrderDetail>(od => od.Order!),
+                new ExpectedInclude<Order>(o => o.Customer!, "Order")));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Include_with_complex_projection(bool async)
         => AssertQuery(
             async,
             ss => from o in ss.Set<Order>().Include(o => o.Customer)
-                  select new { CustomerId = new { Id = o.Customer.CustomerID } });
+                  select new { CustomerId = new { Id = o.Customer!.CustomerID } });
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Include_with_complex_projection_does_not_change_ordering_of_projection(bool async)
@@ -1065,7 +1063,7 @@ public abstract class NorthwindIncludeQueryTestBase<TFixture>(TFixture fixture) 
         => AssertQuery(
             async,
             ss => ss.Set<Order>().Where(o => o.OrderID < 10250).Include(o => o.Customer).Distinct(),
-            elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Order>(o => o.Customer)));
+            elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Order>(o => o.Customer!)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Include_collection_distinct_is_server_evaluated(bool async)
@@ -1150,7 +1148,7 @@ public abstract class NorthwindIncludeQueryTestBase<TFixture>(TFixture fixture) 
             async,
             ss => ss.Set<Employee>().Include(e => e.Manager),
             e => e.Manager == null,
-            asserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Employee>(emp => emp.Manager)));
+            asserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Employee>(emp => emp.Manager!)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Include_is_not_ignored_when_projection_contains_client_method_and_complex_expression(bool async)
@@ -1162,7 +1160,7 @@ public abstract class NorthwindIncludeQueryTestBase<TFixture>(TFixture fixture) 
                   select e.Manager != null ? "Employee " + ClientMethod(e) : "");
 
     private static string ClientMethod(Employee e)
-        => e.FirstName + " reports to " + e.Manager.FirstName;
+        => e.FirstName + " reports to " + e.Manager!.FirstName;
 
     // Issue#18672
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -1230,7 +1228,7 @@ public abstract class NorthwindIncludeQueryTestBase<TFixture>(TFixture fixture) 
     public virtual Task Include_with_cycle_does_not_throw_when_AsNoTrackingWithIdentityResolution(bool async)
         => AssertQuery(
             async,
-            ss => (from i in ss.Set<Order>().Include(o => o.Customer.Orders)
+            ss => (from i in ss.Set<Order>().Include(o => o.Customer!.Orders)
                    where i.OrderID < 10800
                    select i)
                 .AsNoTrackingWithIdentityResolution());
@@ -1239,7 +1237,7 @@ public abstract class NorthwindIncludeQueryTestBase<TFixture>(TFixture fixture) 
     public virtual Task Include_with_cycle_does_not_throw_when_AsTracking_NoTrackingWithIdentityResolution(bool async)
         => AssertQuery(
             async,
-            ss => (from i in ss.Set<Order>().Include(o => o.Customer.Orders)
+            ss => (from i in ss.Set<Order>().Include(o => o.Customer!.Orders)
                    where i.OrderID < 10800
                    select i)
                 .AsTracking(QueryTrackingBehavior.NoTrackingWithIdentityResolution));
@@ -1281,7 +1279,7 @@ public abstract class NorthwindIncludeQueryTestBase<TFixture>(TFixture fixture) 
             async,
             ss => ss.Set<Order>()
                 .Include(b => b.OrderDetails)
-                .OrderBy(b => b.Customer.CustomerID != null)
+                .OrderBy(b => b.Customer!.CustomerID != null)
                 .ThenBy(b => b.Customer != null ? b.Customer.CustomerID : string.Empty)
                 .Take(2));
 

--- a/test/EFCore.Specification.Tests/Query/NorthwindJoinQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindJoinQueryTestBase.cs
@@ -6,8 +6,6 @@ using Microsoft.EntityFrameworkCore.TestModels.Northwind;
 // ReSharper disable InconsistentNaming
 namespace Microsoft.EntityFrameworkCore.Query;
 
-#nullable disable
-
 public abstract class NorthwindJoinQueryTestBase<TFixture>(TFixture fixture) : QueryTestBase<TFixture>(fixture)
     where TFixture : NorthwindQueryFixtureBase<NoopModelCustomizer>, new()
 {
@@ -271,7 +269,7 @@ public abstract class NorthwindJoinQueryTestBase<TFixture>(TFixture fixture) : Q
         => AssertQuery(
             async,
             ss =>
-                ss.Set<Order>().Where(o => o.CustomerID.StartsWith("F")).Join(
+                ss.Set<Order>().Where(o => o.CustomerID!.StartsWith("F")).Join(
                     ss.Set<Order>(), o => o.CustomerID, i => i.CustomerID, (_, o) => new { _, o }),
             e => (e._.OrderID, e.o.OrderID));
 
@@ -285,7 +283,7 @@ public abstract class NorthwindJoinQueryTestBase<TFixture>(TFixture fixture) : Q
                     c => c.CustomerID,
                     o => o.CustomerID,
                     (c, o) => new { c, o }),
-            e => (e.c.CustomerID, e.o?.OrderID));
+                    e => (e.c!.CustomerID, e.o?.OrderID));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task RightJoin(bool async)
@@ -297,7 +295,7 @@ public abstract class NorthwindJoinQueryTestBase<TFixture>(TFixture fixture) : Q
                     c => c.CustomerID,
                     o => o.CustomerID,
                     (c, o) => new { c, o }),
-            e => (e.c.CustomerID, e.o?.OrderID));
+                    e => (e.c!.CustomerID, e.o?.OrderID));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task RightJoin_with_filtered_outer(bool async)
@@ -329,7 +327,7 @@ public abstract class NorthwindJoinQueryTestBase<TFixture>(TFixture fixture) : Q
             async,
             ss => ss.Set<Customer>().Where(c => c.CustomerID.StartsWith("A"))
                 .FullJoin(
-                    ss.Set<Order>().Where(o => o.CustomerID.StartsWith("B")),
+                    ss.Set<Order>().Where(o => o.CustomerID!.StartsWith("B")),
                     c => c.CustomerID,
                     o => o.CustomerID,
                     (c, o) => new { c, o }),
@@ -548,7 +546,7 @@ public abstract class NorthwindJoinQueryTestBase<TFixture>(TFixture fixture) : Q
             async,
             ss =>
                 from e in ss.Set<Employee>()
-                join o in ss.Set<Order>().Where(o => o.CustomerID.StartsWith("F")) on e.EmployeeID equals o.EmployeeID into orders
+                join o in ss.Set<Order>().Where(o => o.CustomerID!.StartsWith("F")) on e.EmployeeID equals o.EmployeeID into orders
                 from o in orders.DefaultIfEmpty()
                 select new { e, o },
             e => (e.e.EmployeeID, e.o?.OrderID));
@@ -673,9 +671,10 @@ public abstract class NorthwindJoinQueryTestBase<TFixture>(TFixture fixture) : Q
             async,
             ss => from c in ss.Set<Customer>()
                   join o in ss.Set<Order>().OrderBy(o => o.OrderID).Take(100) on c.CustomerID equals o.CustomerID into lo
-                  from o in lo.Where(x => x.CustomerID.StartsWith("A"))
+                from o in lo.Where(x => x.CustomerID!.StartsWith("A"))
                   select new { c.CustomerID, o.OrderID });
 
+#pragma warning disable CS8619 // Nullability of reference types in value doesn't match target type
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task GroupJoin_aggregate_anonymous_key_selectors(bool async)
         => AssertQuery(
@@ -684,7 +683,7 @@ public abstract class NorthwindJoinQueryTestBase<TFixture>(TFixture fixture) : Q
                 ss.Set<Order>(),
                 x => new { x.CustomerID, x.City },
                 x => new { x.CustomerID, City = "London" },
-                (c, g) => new { c.CustomerID, Sum = g.Sum(x => x.CustomerID.Length) }),
+                (c, g) => new { c.CustomerID, Sum = g.Sum(x => x.CustomerID!.Length) }),
             elementSorter: e => e.CustomerID);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -694,8 +693,8 @@ public abstract class NorthwindJoinQueryTestBase<TFixture>(TFixture fixture) : Q
             ss => ss.Set<Customer>().GroupJoin(
                 ss.Set<Order>(),
                 x => new { x.CustomerID, Year = 1996 },
-                x => new { x.CustomerID, x.OrderDate.Value.Year },
-                (c, g) => new { c.CustomerID, Sum = g.Sum(x => x.CustomerID.Length) }),
+                x => new { x.CustomerID, x.OrderDate!.Value.Year },
+                (c, g) => new { c.CustomerID, Sum = g.Sum(x => x.CustomerID!.Length) }),
             elementSorter: e => e.CustomerID);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -706,7 +705,7 @@ public abstract class NorthwindJoinQueryTestBase<TFixture>(TFixture fixture) : Q
                 ss.Set<Order>(),
                 x => new { x.CustomerID },
                 x => new { x.CustomerID },
-                (c, g) => new { c.CustomerID, Sum = g.Sum(x => x.CustomerID.Length) }),
+                (c, g) => new { c.CustomerID, Sum = g.Sum(x => x.CustomerID!.Length) }),
             elementSorter: e => e.CustomerID);
 
     [Theory(Skip = "issue 35028"), MemberData(nameof(IsAsyncData))]
@@ -716,9 +715,10 @@ public abstract class NorthwindJoinQueryTestBase<TFixture>(TFixture fixture) : Q
             ss => ss.Set<Customer>().GroupJoin(
                 ss.Set<Order>(),
                 x => new { x.CustomerID, Nested = new { x.City, Year = 1996 } },
-                x => new { x.CustomerID, Nested = new { City = "London", x.OrderDate.Value.Year } },
-                (c, g) => new { c.CustomerID, Sum = g.Sum(int (x) => x.CustomerID.Length) }),
+                x => new { x.CustomerID, Nested = new { City = "London", x.OrderDate!.Value.Year } },
+                (c, g) => new { c.CustomerID, Sum = g.Sum(int (x) => x.CustomerID!.Length) }),
             elementSorter: e => e.CustomerID));
+        #pragma warning restore CS8619
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Inner_join_with_tautology_predicate_converts_to_cross_join(bool async)
@@ -805,13 +805,13 @@ public abstract class NorthwindJoinQueryTestBase<TFixture>(TFixture fixture) : Q
                     a.Views.OrderBy(od => od.OrderID).ThenBy(od => od.ProductID));
             });
 
-    private class CustomerViewModel(string customerID, string city, OrderDetailViewModel[] views)
+    private class CustomerViewModel(string customerID, string? city, OrderDetailViewModel[] views)
     {
         public string CustomerID { get; } = customerID;
-        public string City { get; } = city;
+        public string? City { get; } = city;
         public OrderDetailViewModel[] Views { get; } = views;
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => obj is not null
                 && (ReferenceEquals(this, obj)
                     || (obj.GetType() == GetType()
@@ -831,7 +831,7 @@ public abstract class NorthwindJoinQueryTestBase<TFixture>(TFixture fixture) : Q
         public int OrderID { get; } = orderID;
         public int ProductID { get; } = productID;
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => obj is not null
                 && (ReferenceEquals(this, obj)
                     || (obj.GetType() == GetType()
@@ -924,9 +924,9 @@ public abstract class NorthwindJoinQueryTestBase<TFixture>(TFixture fixture) : Q
                 .Select(c => new
                 {
                     Orders = c.Orders.OrderBy(e => e.OrderDate).Take(1)
-                        .Select(o => new { Title = o.CustomerID == o.Customer.City ? "A" : "B" }).ToList()
+                        .Select(o => new { Title = o.CustomerID == o.Customer!.City ? "A" : "B" }).ToList()
                 }),
-            asserter: (e, a) => AssertCollection(e.Orders, a.Orders, ordered: true));
+            asserter: (e, a) => AssertCollection(e!.Orders, a!.Orders, ordered: true));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Condition_on_entity_with_include(bool async)
@@ -938,6 +938,7 @@ public abstract class NorthwindJoinQueryTestBase<TFixture>(TFixture fixture) : Q
                   from o in g.DefaultIfEmpty()
                   select new { a = o != null ? o.OrderID : -1 });
 
+#pragma warning disable CS8619 // Nullability of reference types in value doesn't match target type
     [Theory(Skip = "issue #35028"), MemberData(nameof(IsAsyncData))]
     public virtual Task Join_with_key_selectors_being_nested_anonymous_objects(bool async)
         => AssertQuery(
@@ -945,7 +946,7 @@ public abstract class NorthwindJoinQueryTestBase<TFixture>(TFixture fixture) : Q
             ss => ss.Set<Customer>().Order().Take(10).Join(
                 ss.Set<Order>(),
                 x => new { x.CustomerID, Nested = new { x.City, Year = 1996 } },
-                x => new { x.CustomerID, Nested = new { City = "London", x.OrderDate.Value.Year } },
+                x => new { x.CustomerID, Nested = new { City = "London", x.OrderDate!.Value.Year } },
                 (c, o) => new { c, o }),
             elementSorter: e => (e.c.CustomerID, e.o.OrderID),
             elementAsserter: (e, a) =>
@@ -953,4 +954,5 @@ public abstract class NorthwindJoinQueryTestBase<TFixture>(TFixture fixture) : Q
                 AssertEqual(e.c, a.c);
                 AssertEqual(e.o, a.o);
             });
+#pragma warning restore CS8619
 }

--- a/test/EFCore.Specification.Tests/Query/NorthwindKeylessEntitiesQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindKeylessEntitiesQueryTestBase.cs
@@ -57,8 +57,8 @@ public abstract class NorthwindKeylessEntitiesQueryTestBase<TFixture>(TFixture f
         => AssertQuery(
             async,
             ss => ss.Set<OrderQuery>().Where(ov => ov.CustomerID == "ALFKI").Select(ov => ov.Customer)
-                .OrderBy(c => c.CustomerID)
-                .Select(cv => cv.Orders.Where(cc => true).ToList()),
+                .OrderBy(c => c!.CustomerID)
+                .Select(cv => cv!.Orders.Where(cc => true).ToList()),
             assertOrder: true,
             elementAsserter: (e, a) => AssertCollection(e, a));
 
@@ -78,18 +78,18 @@ public abstract class NorthwindKeylessEntitiesQueryTestBase<TFixture>(TFixture f
             ss => from ov in ss.Set<OrderQuery>().Include(ov => ov.Customer)
                   where ov.CustomerID == "ALFKI"
                   select ov,
-            elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<OrderQuery>(ov => ov.Customer)));
+            elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<OrderQuery>(ov => ov.Customer!)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task KeylessEntity_with_included_navs_multi_level(bool async)
         => AssertQuery(
             async,
-            ss => from ov in ss.Set<OrderQuery>().Include(ov => ov.Customer.Orders)
+            ss => from ov in ss.Set<OrderQuery>().Include(ov => ov.Customer!.Orders)
                   where ov.CustomerID == "ALFKI"
                   select ov,
             elementAsserter: (e, a) => AssertInclude(
                 e, a,
-                new ExpectedInclude<OrderQuery>(ov => ov.Customer),
+                new ExpectedInclude<OrderQuery>(ov => ov.Customer!),
                 new ExpectedInclude<Customer>(c => c.Orders, "Customer")));
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -97,7 +97,7 @@ public abstract class NorthwindKeylessEntitiesQueryTestBase<TFixture>(TFixture f
         => AssertQuery(
             async,
             ss => from ov in ss.Set<OrderQuery>()
-                  where ov.Customer.City == "Seattle"
+                  where ov.Customer!.City == "Seattle"
                   select ov);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -105,7 +105,7 @@ public abstract class NorthwindKeylessEntitiesQueryTestBase<TFixture>(TFixture f
         => AssertQuery(
             async,
             ss => from ov in ss.Set<OrderQuery>()
-                  where ov.Customer.Orders.Any()
+                  where ov.Customer!.Orders.Any()
                   select ov);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -118,7 +118,7 @@ public abstract class NorthwindKeylessEntitiesQueryTestBase<TFixture>(TFixture f
                 {
                     g.Key,
                     Count = g.Count(),
-                    Sum = g.Sum(e => e.Address.Length)
+                    Sum = g.Sum(e => e.Address!.Length)
                 }),
             elementSorter: e => (e.Key, e.Count, e.Sum));
 

--- a/test/EFCore.Specification.Tests/Query/NorthwindMiscellaneousQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindMiscellaneousQueryTestBase.cs
@@ -8,8 +8,6 @@ using Microsoft.EntityFrameworkCore.TestModels.Northwind;
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
-#nullable disable
-
 public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fixture) : QueryTestBase<TFixture>(fixture)
     where TFixture : NorthwindQueryFixtureBase<NoopModelCustomizer>, new()
 {
@@ -392,13 +390,13 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fix
 
     private class CustomerWrapper
     {
-        public Customer Customer { get; set; }
+        public Customer? Customer { get; set; }
 
-        public override bool Equals(object obj)
-            => obj is CustomerWrapper other && other.Customer.Equals(Customer);
+        public override bool Equals(object? obj)
+            => obj is CustomerWrapper other && Equals(other.Customer, Customer);
 
         public override int GetHashCode()
-            => Customer.GetHashCode();
+            => Customer?.GetHashCode() ?? 0;
     }
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -444,7 +442,7 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fix
         => AssertQuery(
             async,
             ss => ss.Set<Customer>().OrderBy(c => c.Orders.FirstOrDefault()),
-            ss => ss.Set<Customer>().OrderBy(c => c.Orders.FirstOrDefault() == null ? (int?)null : c.Orders.FirstOrDefault().OrderID),
+            ss => ss.Set<Customer>().OrderBy(c => c.Orders.FirstOrDefault() == null ? (int?)null : c.Orders.FirstOrDefault()!.OrderID),
             assertOrder: true);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -630,7 +628,7 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fix
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Ternary_should_not_evaluate_both_sides(bool async)
     {
-        Customer customer = null;
+        Customer? customer = null;
         var hasData = customer is not null;
 
         return AssertQuery(
@@ -638,9 +636,9 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fix
             ss => ss.Set<Customer>().Select(c => new
             {
                 c.CustomerID,
-                Data1 = hasData ? customer.CustomerID : "none",
+                Data1 = hasData ? customer!.CustomerID : "none",
                 Data2 = customer != null ? customer.CustomerID : "none",
-                Data3 = !hasData ? "none" : customer.CustomerID
+                Data3 = !hasData ? "none" : customer!.CustomerID
             }));
     }
 
@@ -685,23 +683,23 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fix
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Null_Coalesce_Short_Circuit(bool async)
     {
-        List<int> values = null;
+        List<int>? values = null;
         bool? test = false;
 
         return AssertQuery(
             async,
-            ss => ss.Set<Customer>().Distinct().Select(c => new { Customer = c, Test = test ?? values.Contains(1) }));
+            ss => ss.Set<Customer>().Distinct().Select(c => new { Customer = c, Test = test ?? values!.Contains(1) }));
     }
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Null_Coalesce_Short_Circuit_with_server_correlated_leftover(bool async)
     {
-        List<Customer> values = null;
+        List<Customer>? values = null;
         bool? test = false;
 
         return AssertQuery(
             async,
-            ss => ss.Set<Customer>().Select(c => new { Result = test ?? values.Select(c2 => c2.CustomerID).Contains(c.CustomerID) }));
+            ss => ss.Set<Customer>().Select(c => new { Result = test ?? values!.Select(c2 => c2.CustomerID).Contains(c.CustomerID) }));
     }
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -829,13 +827,13 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fix
         => AssertAny(
             async,
             ss => ss.Set<Customer>(),
-            predicate: c => c.ContactName.StartsWith("A"));
+            predicate: c => c.ContactName!.StartsWith("A"));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Any_nested_negated(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<Customer>().Where(c => !ss.Set<Order>().Any(o => o.CustomerID.StartsWith("A"))),
+            ss => ss.Set<Customer>().Where(c => !ss.Set<Order>().Any(o => o.CustomerID!.StartsWith("A"))),
             assertEmpty: true);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -843,32 +841,32 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fix
         => AssertQuery(
             async,
             ss => ss.Set<Customer>().Where(c => c.City != "London"
-                && !ss.Set<Order>().Any(o => o.CustomerID.StartsWith("ABC"))));
+                && !ss.Set<Order>().Any(o => o.CustomerID!.StartsWith("ABC"))));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Any_nested_negated3(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<Customer>().Where(c => !ss.Set<Order>().Any(o => o.CustomerID.StartsWith("ABC"))
+            ss => ss.Set<Customer>().Where(c => !ss.Set<Order>().Any(o => o.CustomerID!.StartsWith("ABC"))
                 && c.City != "London"));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Any_nested(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<Customer>().Where(c => ss.Set<Order>().Any(o => o.CustomerID.StartsWith("A"))));
+            ss => ss.Set<Customer>().Where(c => ss.Set<Order>().Any(o => o.CustomerID!.StartsWith("A"))));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Any_nested2(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<Customer>().Where(c => c.City != "London" && ss.Set<Order>().Any(o => o.CustomerID.StartsWith("A"))));
+            ss => ss.Set<Customer>().Where(c => c.City != "London" && ss.Set<Order>().Any(o => o.CustomerID!.StartsWith("A"))));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Any_nested3(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<Customer>().Where(c => ss.Set<Order>().Any(o => o.CustomerID.StartsWith("A")) && c.City != "London"));
+            ss => ss.Set<Customer>().Where(c => ss.Set<Order>().Any(o => o.CustomerID!.StartsWith("A")) && c.City != "London"));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Any_with_multiple_conditions_still_uses_exists(bool async)
@@ -899,14 +897,14 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fix
         => AssertAll(
             async,
             ss => ss.Set<Customer>(),
-            predicate: c => c.ContactName.StartsWith("A"));
+            predicate: c => c.ContactName!.StartsWith("A"));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task All_top_level_column(bool async)
         => AssertAll(
             async,
             ss => ss.Set<Customer>(),
-            predicate: c => c.ContactName.StartsWith(c.ContactName));
+            predicate: c => c.ContactName!.StartsWith(c.ContactName));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task All_top_level_subquery(bool async)
@@ -1137,7 +1135,7 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fix
             async,
             ss => ss.Set<Order>()
                 .Where(o => o.OrderID < 10300)
-                .Select(o => new OrderCountDTO(o.Customer.City))
+                .Select(o => new OrderCountDTO(o.Customer!.City))
                 .Distinct(),
             elementSorter: e => e.Id,
             elementAsserter: (e, a) =>
@@ -1263,20 +1261,20 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fix
 
     private class OrderCountDTO
     {
-        public string Id { get; set; }
+        public string? Id { get; set; }
         public int Count { get; set; }
 
         public OrderCountDTO()
         {
         }
 
-        public OrderCountDTO(string id)
+        public OrderCountDTO(string? id)
         {
             Id = id;
             Count = 0;
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => obj is not null && (ReferenceEquals(this, obj) || (obj.GetType() == GetType() && Equals((OrderCountDTO)obj)));
 
         private bool Equals(OrderCountDTO other)
@@ -1327,7 +1325,7 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fix
 
     private class QueryableDto
     {
-        public IQueryable<Order> Orders { get; set; }
+        public IQueryable<Order> Orders { get; set; } = null!;
     }
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -1365,7 +1363,7 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fix
                         CustomerId = c.CustomerID,
                         OrderIds
                             = ss.Set<Order>().Where(o => o.CustomerID == c.CustomerID
-                                    && o.OrderDate.Value.Year == 1997)
+                                    && o.OrderDate!.Value.Year == 1997)
                                 .Select(o => o.OrderID)
                                 .OrderBy(o => o),
                         Customer = c
@@ -1408,7 +1406,7 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fix
                     CustomerId = c.CustomerID,
                     OrderIds
                         = ss.Set<Order>().Where(o => o.CustomerID == c.CustomerID
-                                && o.OrderDate.Value.Year == 1997)
+                                && o.OrderDate!.Value.Year == 1997)
                             .Select(o => o.OrderID)
                             .OrderBy(o => o)
                             .ToArray(),
@@ -1460,7 +1458,7 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fix
         => AssertQuery(
             async,
             ss => from e1 in ss.Set<Employee>()
-                  where e1.FirstName == ss.Set<Employee>().OrderBy(e => e.EmployeeID).FirstOrDefault().FirstName
+                where e1.FirstName == ss.Set<Employee>().OrderBy(e => e.EmployeeID).FirstOrDefault()!.FirstName
                   select e1);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -1578,7 +1576,7 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fix
                       == new Employee { EmployeeID = 1 }
                   select e1,
             ss => from e1 in ss.Set<Employee>()
-                  where ss.Set<Employee>().OrderBy(e2 => e2.EmployeeID).FirstOrDefault(e2 => e2.EmployeeID != e1.ReportsTo).EmployeeID == 1
+                where ss.Set<Employee>().OrderBy(e2 => e2.EmployeeID).FirstOrDefault(e2 => e2.EmployeeID != e1.ReportsTo)!.EmployeeID == 1
                   select e1);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -1631,7 +1629,7 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fix
             ss => from e1 in ss.Set<Employee>().Take(3)
                   where e1.FirstName
                       == (from e2 in ss.Set<Employee>().OrderBy(e => e.EmployeeID)
-                          select e2).FirstOrDefault().FirstName
+                          select e2).FirstOrDefault()!.FirstName
                   select e1);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -1641,7 +1639,7 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fix
             ss => from e1 in ss.Set<Employee>().Take(3)
                   where e1.FirstName
                       == (from e2 in ss.Set<Employee>().OrderBy(e => e.EmployeeID)
-                          select new { Foo = e2 }).FirstOrDefault().Foo.FirstName
+                          select new { Foo = e2 }).FirstOrDefault()!.Foo.FirstName
                   select e1);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -1851,7 +1849,7 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fix
                 from o in c.Orders
                     .Where(x => x.CustomerID == "NONEXISTENT") // Produce empty set for DefaultIfEmpty
                     .DefaultIfEmpty()
-                    .Select(x => x.OrderID)
+                    .Select(x => x!.OrderID)
                 select o));
 
     // DefaultIfEmpty() after Select() to a non-nullable type - should add a COALESCE to the CLR default (0 here).
@@ -2037,7 +2035,7 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fix
 
     protected class Foo
     {
-        public string Bar { get; set; }
+        public string? Bar { get; set; }
     }
 
     protected const uint NonExistentID = uint.MaxValue;
@@ -2233,7 +2231,7 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fix
             async,
             ss => ss.Set<Order>().Where(o => o.OrderID <= 10250
                 && ss.Set<Customer>().OrderBy(c => ss.Set<Customer>().Any(c2 => c2.CustomerID == "ALFKI"))
-                    .FirstOrDefault().City
+                    .FirstOrDefault()!.City
                 != "Nowhere"));
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -2621,10 +2619,10 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fix
             ss => ShadowPropertyWhere(ss.Set<Employee>(), "Title", "Sales Representative"));
 
     protected IQueryable<TOut> ShadowPropertySelect<TIn, TOut>(IQueryable<TIn> source, object column)
-        => source.Select(e => EF.Property<TOut>(e, (string)column));
+        => source.Select(e => EF.Property<TOut>(e!, (string)column));
 
     protected IQueryable<T> ShadowPropertyWhere<T>(IQueryable<T> source, object column, string value)
-        => source.Where(e => EF.Property<string>(e, (string)column) == value);
+        => source.Where(e => EF.Property<string>(e!, (string)column) == value);
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual async Task Where_Property_shadow_closure(bool async)
@@ -2714,9 +2712,9 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fix
                                from c in ss.Set<Customer>()
                                where o.CustomerID == c.CustomerID
                                select c
-                           ).FirstOrDefault()
+                           ).FirstOrDefault()!
                        ).FirstOrDefault()
-                       .City
+                       !.City
                        == "Seattle"
                    select od)
                 .Take(2));
@@ -2864,13 +2862,13 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fix
     public virtual Task String_concat_with_navigation1(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<Order>().Select(o => o.CustomerID + " " + o.Customer.City));
+            ss => ss.Set<Order>().Select(o => o.CustomerID + " " + o.Customer!.City));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task String_concat_with_navigation2(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<Order>().Select(o => o.Customer.City + " " + o.Customer.City));
+            ss => ss.Set<Order>().Select(o => o.Customer!.City + " " + o.Customer.City));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Handle_materialization_properly_when_more_than_two_query_sources_are_involved(bool async)
@@ -2917,8 +2915,8 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fix
             ss => ss.Set<Order>().Where(o => (o.OrderID < 10400)
                 && (dateFilter.HasValue)
                 && (o.OrderDate.HasValue
-                    && o.OrderDate.Value.Month == dateFilter.Value.Month
-                    && o.OrderDate.Value.Year == dateFilter.Value.Year)));
+                    && o.OrderDate!.Value.Month == dateFilter!.Value.Month
+                    && o.OrderDate!.Value.Year == dateFilter.Value.Year)));
 
         dateFilter = null;
 
@@ -2976,7 +2974,7 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fix
             ss => ss.Set<Order>()
                 .Where(o => (o.OrderID < 10400)
                     && o.OrderDate.HasValue
-                    && o.OrderDate.Value.Month == dateFilter.Value.Month
+                    && o.OrderDate.Value.Month == dateFilter!.Value.Month
                     && o.OrderDate.Value.Year == dateFilter.Value.Year)));
     }
 
@@ -3004,7 +3002,7 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fix
             ss =>
                 ss.Set<Order>().OrderBy(o => o.OrderID)
                     .Take(3)
-                    .Select(o => new { OrderId = o.OrderID, ss.Set<Customer>().SingleOrDefault(c => c.CustomerID == o.CustomerID).City })
+                    .Select(o => new { OrderId = o.OrderID, ss.Set<Customer>().SingleOrDefault(c => c.CustomerID == o.CustomerID)!.City })
                     .OrderBy(o => o.City),
             assertOrder: true);
 
@@ -3019,7 +3017,7 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fix
                     {
                         OrderId = o.OrderID,
                         City = EF.Property<string>(
-                            ss.Set<Customer>().SingleOrDefault(c => c.CustomerID == o.CustomerID), "City")
+                            ss.Set<Customer>().SingleOrDefault(c => c.CustomerID == o.CustomerID)!, "City")
                     })
                     .OrderBy(o => o.City),
             assertOrder: true);
@@ -3028,7 +3026,7 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fix
     public virtual Task Query_expression_with_to_string_and_contains(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<Order>().Where(o => o.OrderDate != null && o.EmployeeID.Value.ToString().Contains("7"))
+            ss => ss.Set<Order>().Where(o => o.OrderDate != null && o.EmployeeID!.Value.ToString().Contains("7"))
                 .Select(o => new Order { CustomerID = o.CustomerID }),
             elementSorter: e => e.CustomerID);
 
@@ -3037,7 +3035,7 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fix
         => AssertQuery(
             async,
             ss => ss.Set<Order>().Where(o => o.OrderDate != null)
-                .Select(o => new Order { ShipName = o.OrderDate.Value.ToString() }),
+                .Select(o => new Order { ShipName = o.OrderDate!.Value.ToString() }),
             e => e.ShipName);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -3077,7 +3075,7 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fix
         => AssertQuery(
             async,
             ss => ss.Set<Order>().Where(o => o.OrderDate != null)
-                .Select(o => new Order { OrderDate = o.OrderDate.Value.AddYears(1) }),
+                .Select(o => new Order { OrderDate = o.OrderDate!.Value.AddYears(1) }),
             e => e.OrderDate);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -3086,7 +3084,7 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fix
             async,
             ss => ss.Set<Order>()
                 .Where(o => o.OrderDate != null)
-                .Select(o => new Order { OrderDate = o.OrderDate.Value.AddMonths(1) }),
+                .Select(o => new Order { OrderDate = o.OrderDate!.Value.AddMonths(1) }),
             e => e.OrderDate);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -3094,7 +3092,7 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fix
         => AssertQuery(
             async,
             ss => ss.Set<Order>().Where(o => o.OrderDate != null)
-                .Select(o => new Order { OrderDate = o.OrderDate.Value.AddHours(1) }),
+                .Select(o => new Order { OrderDate = o.OrderDate!.Value.AddHours(1) }),
             e => e.OrderDate);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -3102,7 +3100,7 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fix
         => AssertQuery(
             async,
             ss => ss.Set<Order>().Where(o => o.OrderDate != null)
-                .Select(o => new Order { OrderDate = o.OrderDate.Value.AddMinutes(1) }),
+                .Select(o => new Order { OrderDate = o.OrderDate!.Value.AddMinutes(1) }),
             e => e.OrderDate);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -3110,7 +3108,7 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fix
         => AssertQuery(
             async,
             ss => ss.Set<Order>().Where(o => o.OrderDate != null)
-                .Select(o => new Order { OrderDate = o.OrderDate.Value.AddSeconds(1) }),
+                .Select(o => new Order { OrderDate = o.OrderDate!.Value.AddSeconds(1) }),
             e => e.OrderDate);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -3118,7 +3116,7 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fix
         => AssertQuery(
             async,
             ss => ss.Set<Order>().Where(o => o.OrderDate != null)
-                .Select(o => new Order { OrderDate = o.OrderDate.Value.AddTicks(TimeSpan.TicksPerMillisecond) }),
+                .Select(o => new Order { OrderDate = o.OrderDate!.Value.AddTicks(TimeSpan.TicksPerMillisecond) }),
             e => e.OrderDate);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -3126,7 +3124,7 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fix
         => AssertQuery(
             async,
             ss => ss.Set<Order>().Where(o => o.OrderDate != null)
-                .Select(o => new Order { OrderDate = o.OrderDate.Value.AddMilliseconds(1000000000000) }),
+                .Select(o => new Order { OrderDate = o.OrderDate!.Value.AddMilliseconds(1000000000000) }),
             e => e.OrderDate);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -3134,7 +3132,7 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fix
         => AssertQuery(
             async,
             ss => ss.Set<Order>().Where(o => o.OrderDate != null)
-                .Select(o => new Order { OrderDate = o.OrderDate.Value.AddMilliseconds(-1000000000000) }));
+                .Select(o => new Order { OrderDate = o.OrderDate!.Value.AddMilliseconds(-1000000000000) }));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Select_expression_date_add_milliseconds_large_number_divided(bool async)
@@ -3145,7 +3143,7 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fix
             ss => ss.Set<Order>().Where(o => o.OrderDate != null)
                 .Select(o => new Order
                 {
-                    OrderDate = o.OrderDate.Value
+                    OrderDate = o.OrderDate!.Value
                         .AddDays(o.OrderDate.Value.Millisecond / millisecondsPerDay)
                         .AddMilliseconds(o.OrderDate.Value.Millisecond % millisecondsPerDay)
                 }),
@@ -3170,7 +3168,7 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fix
         return AssertQueryScalar(
             async,
             ss => ss.Set<Order>().Where(o => o.OrderDate != null)
-                .Select(o => o.OrderDate.Value.Year)
+                .Select(o => o.OrderDate!.Value.Year)
                 .Distinct()
                 .Where(x => x < nextYear));
     }
@@ -3179,7 +3177,7 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fix
     public virtual Task DefaultIfEmpty_without_group_join(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<Customer>().Where(c => c.City == "London").DefaultIfEmpty().Where(d => d != null).Select(d => d.CustomerID));
+            ss => ss.Set<Customer>().Where(c => c.City == "London").DefaultIfEmpty().Where(d => d != null).Select(d => d!.CustomerID));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task DefaultIfEmpty_in_subquery(bool async)
@@ -3429,13 +3427,13 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fix
 
         await AssertQuery(
             async,
-            ss => ss.Set<Order>().Where(e => dates.Contains(e.OrderDate.Value.Date)));
+            ss => ss.Set<Order>().Where(e => dates.Contains(e.OrderDate!.Value.Date)));
 
         dates = [new DateTime(1996, 07, 04)];
 
         await AssertQuery(
             async,
-            ss => ss.Set<Order>().Where(e => dates.Contains(e.OrderDate.Value.Date)));
+            ss => ss.Set<Order>().Where(e => dates.Contains(e.OrderDate!.Value.Date)));
     }
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -3507,22 +3505,22 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fix
             async,
             ss => ss.Set<Customer>()
                 .Where(c => c.Orders.Count > 1)
-                .Select(c => new { A = c.Orders.OrderByDescending(o => o.OrderID).FirstOrDefault().OrderDate })
+                .Select(c => new { A = c.Orders.OrderByDescending(o => o.OrderID).FirstOrDefault()!.OrderDate })
                 .OrderBy(n => n.A),
             assertOrder: true);
 
     protected class DTO<T>
     {
-        public T Property { get; set; }
+        public T Property { get; set; } = default!;
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => obj is not null && (ReferenceEquals(this, obj) || (obj.GetType() == GetType() && Equals((DTO<T>)obj)));
 
         private bool Equals(DTO<T> other)
             => EqualityComparer<T>.Default.Equals(Property, other.Property);
 
         public override int GetHashCode()
-            => Property.GetHashCode();
+            => Property!.GetHashCode();
     }
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -3593,7 +3591,7 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fix
             async,
             ss => ss.Set<Customer>()
                 .Where(c => c.Orders.Count > 1)
-                .Select(c => new DTO<DateTime?> { Property = c.Orders.OrderByDescending(o => o.OrderID).FirstOrDefault().OrderDate })
+                .Select(c => new DTO<DateTime?> { Property = c.Orders.OrderByDescending(o => o.OrderID).FirstOrDefault()!.OrderDate })
                 .OrderBy(n => n.Property),
             assertOrder: true,
             elementAsserter: (e, a) => Assert.Equal(e.Property, a.Property));
@@ -3611,7 +3609,7 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fix
             assertOrder: true);
 
     private static IEnumerable<TElement> ClientDefaultIfEmpty<TElement>(IEnumerable<TElement> source)
-        => source?.Count() == 0 ? [default] : source;
+        => source?.Count() == 0 ? [default!] : source!;
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Complex_query_with_repeated_query_model_compiles_correctly(bool async)
@@ -3857,8 +3855,8 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fix
             ss =>
                 from o1 in ss.Set<Order>()
                 from o2 in ss.Set<Order>()
-                where o1.CustomerID.StartsWith("A")
-                where o1.Customer.Equals(o2.Customer)
+                where o1.CustomerID!.StartsWith("A")
+                where o1.Customer!.Equals(o2.Customer)
                 orderby o1.OrderID, o2.OrderID
                 select new { Id1 = o1.OrderID, Id2 = o2.OrderID },
             e => (e.Id1, e.Id2));
@@ -3870,7 +3868,7 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fix
             ss =>
                 from o1 in ss.Set<Order>()
                 from o2 in ss.Set<Order>()
-                where o1.CustomerID.StartsWith("A")
+                where o1.CustomerID!.StartsWith("A")
                 where Equals(o1.Customer, o2.Customer)
                 orderby o1.OrderID, o2.OrderID
                 select new { Id1 = o1.OrderID, Id2 = o2.OrderID },
@@ -3913,7 +3911,7 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fix
             async,
             ss => ss.Set<OrderDetail>()
                 .Where(od => od.OrderID < 10250)
-                .Where(od => od.Order.Customer.Orders != null)
+                .Where(od => od.Order!.Customer!.Orders != null)
                 .OrderBy(od => od.OrderID)
                 .ThenBy(od => od.ProductID)
                 .Select(od => new { od.ProductID, od.OrderID }),
@@ -3960,7 +3958,7 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fix
                 from c in ss.Set<Customer>()
                 where c.CustomerID == "ALFKI"
                 from o in ss.Set<Order>()
-                where c.Orders == o.Customer.Orders
+                where c.Orders == o.Customer!.Orders
                 orderby c.CustomerID, o.OrderID
                 select new { Id1 = c.CustomerID, Id2 = o.OrderID },
             e => (e.Id1, e.Id2));
@@ -4147,14 +4145,14 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fix
     public virtual Task Collection_navigation_equal_to_null_for_subquery(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<Customer>().Where(c => c.Orders.OrderBy(o => o.OrderID).FirstOrDefault().OrderDetails == null),
+            ss => ss.Set<Customer>().Where(c => c.Orders.OrderBy(o => o.OrderID).FirstOrDefault()!.OrderDetails == null),
             ss => ss.Set<Customer>().Where(c => c.Orders.OrderBy(o => o.OrderID).FirstOrDefault() == null));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Dependent_to_principal_navigation_equal_to_null_for_subquery(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<Customer>().Where(c => c.Orders.OrderBy(o => o.OrderID).FirstOrDefault().Customer == null),
+            ss => ss.Set<Customer>().Where(c => c.Orders.OrderBy(o => o.OrderID).FirstOrDefault()!.Customer == null),
             ss => ss.Set<Customer>().Where(c => c.Orders.OrderBy(o => o.OrderID).Select(o => o.CustomerID).FirstOrDefault() == null));
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -4163,26 +4161,26 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fix
         => AssertTranslationFailed(() => AssertQuery(
             async,
             ss => ss.Set<Customer>().Where(c => c.CustomerID.StartsWith("A")
-                && ss.Set<Order>().Where(o => o.OrderID < 10300).OrderBy(o => o.OrderID).FirstOrDefault().OrderDetails
-                == ss.Set<Order>().Where(o => o.OrderID > 10500).OrderBy(o => o.OrderID).FirstOrDefault().OrderDetails)));
+                && ss.Set<Order>().Where(o => o.OrderID < 10300).OrderBy(o => o.OrderID).FirstOrDefault()!.OrderDetails
+                == ss.Set<Order>().Where(o => o.OrderID > 10500).OrderBy(o => o.OrderID).FirstOrDefault()!.OrderDetails)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Inner_parameter_in_nested_lambdas_gets_preserved(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<Customer>().Where(c => c.Orders.Where(o => c == new Customer { CustomerID = o.CustomerID }).Count() > 0));
+            ss => ss.Set<Customer>().Where(c => c.Orders.Where(o => c == new Customer { CustomerID = o.CustomerID! }).Count() > 0));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Convert_to_nullable_on_nullable_value_is_ignored(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<Order>().Select(o => new Order { OrderDate = o.OrderDate.Value }));
+            ss => ss.Set<Order>().Select(o => new Order { OrderDate = o.OrderDate!.Value }));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Navigation_inside_interpolated_string_is_expanded(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<Order>().Select(o => $"CustomerCity:{o.Customer.City}"));
+            ss => ss.Set<Order>().Select(o => $"CustomerCity:{o.Customer!.City}"));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Client_code_using_instance_method_throws(bool async)
@@ -4190,7 +4188,7 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fix
             async,
             ss => ss.Set<Customer>().Select(c => InstanceMethod(c)));
 
-    private string InstanceMethod(Customer c)
+    private string? InstanceMethod(Customer c)
         => c.City;
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -4199,7 +4197,7 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fix
             async,
             ss => ss.Set<Customer>().Select(c => StaticMethod(this, c)));
 
-    private static string StaticMethod(NorthwindMiscellaneousQueryTestBase<TFixture> containingClass, Customer c)
+    private static string? StaticMethod(NorthwindMiscellaneousQueryTestBase<TFixture> containingClass, Customer c)
         => c.City;
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -4212,10 +4210,10 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fix
     public virtual Task Client_code_unknown_method(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<Customer>().Where(c => UnknownMethod(c.ContactName) == "foo"),
+                ss => ss.Set<Customer>().Where(c => UnknownMethod(c.ContactName) == "foo"),
             assertEmpty: true);
 
-    public static string UnknownMethod(string foo)
+            public static string? UnknownMethod(string? foo)
         => foo;
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -4253,7 +4251,7 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fix
     {
         Expression<Func<Order, object>>[] orderingExpressions =
         [
-            o => o.OrderID, o => o.OrderDate, o => o.Customer.CustomerID, o => o.Customer.City
+            o => o.OrderID, o => o.OrderDate!, o => o.Customer!.CustomerID!, o => o.Customer!.City!
         ];
 
         return AssertQuery(
@@ -4281,7 +4279,7 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fix
             elementAsserter: (e, a) => AssertCollection(e, a, ordered: true));
 
     private static Expression<Func<Order, bool>> ValidYear
-        => a => a.OrderDate.Value.Year == 1998;
+        => a => a.OrderDate!.Value.Year == 1998;
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Subquery_DefaultIfEmpty_Any(bool async)
@@ -4355,7 +4353,7 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fix
                 .OrderBy(o => o.OrderID)
                 .Select(o => new { Item = o })
                 .Skip(5)
-                .Select(e => new { e.Item.Customer.City }));
+                .Select(e => new { e.Item.Customer!.City }));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Projection_take_projection(bool async)
@@ -4366,7 +4364,7 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fix
                 .OrderBy(o => o.OrderID)
                 .Select(o => new { Item = o })
                 .Take(10)
-                .Select(e => new { e.Item.Customer.City }));
+                .Select(e => new { e.Item.Customer!.City }));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Projection_skip_take_projection(bool async)
@@ -4378,7 +4376,7 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fix
                 .Select(o => new { Item = o })
                 .Skip(5)
                 .Take(10)
-                .Select(e => new { e.Item.Customer.City }));
+                .Select(e => new { e.Item.Customer!.City }));
 
     // Issue#19207
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -4500,7 +4498,7 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fix
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Entity_equality_contains_with_list_of_null(bool async)
     {
-        var customers = new List<Customer> { null, new() { CustomerID = "ALFKI" } };
+        var customers = new List<Customer?> { null, new() { CustomerID = "ALFKI" } };
 
         return AssertQuery(
             async,
@@ -4522,8 +4520,8 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fix
     private class Dto(string value)
     {
         public string Value { get; } = value;
-        public string CustomerID { get; set; }
-        public Dto NestedDto { get; set; }
+        public string CustomerID { get; set; } = null!;
+        public Dto NestedDto { get; set; } = null!;
     }
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -4575,7 +4573,7 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fix
             .SelectMany(c => c.Orders).Select(o => o.OrderID).ToList();
 
         var query = context.Orders.Where(o => orderIds.Contains(o.OrderID))
-            .Select(o => o.Customer);
+            .Select(o => o.Customer!);
 
         query = useAsTracking
             ? query.AsTracking(QueryTrackingBehavior.NoTrackingWithIdentityResolution)
@@ -4640,14 +4638,14 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fix
     public virtual Task Select_distinct_Select_with_client_bindings(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<Order>().Where(o => o.OrderID < 20000).Select(o => o.OrderDate.Value.Year).Distinct()
+            ss => ss.Set<Order>().Where(o => o.OrderID < 20000).Select(o => o.OrderDate!.Value.Year).Distinct()
                 .Select(e => new DTO<int> { Property = ClientMethod(e) }));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task ToList_over_string(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<Customer>().OrderBy(c => c.CustomerID).Select(e => new { Property = e.City.ToList() }),
+            ss => ss.Set<Customer>().OrderBy(c => c.CustomerID).Select(e => new { Property = e.City!.ToList() }),
             assertOrder: true,
             elementAsserter: (e, a) => Assert.True(e.Property.SequenceEqual(a.Property)));
 
@@ -4655,7 +4653,7 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fix
     public virtual Task ToArray_over_string(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<Customer>().OrderBy(c => c.CustomerID).Select(e => new { Property = e.City.ToArray() }),
+            ss => ss.Set<Customer>().OrderBy(c => c.CustomerID).Select(e => new { Property = e.City!.ToArray() }),
             assertOrder: true,
             elementAsserter: (e, a) => Assert.True(e.Property.SequenceEqual(a.Property)));
 
@@ -4663,7 +4661,7 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fix
     public virtual Task AsEnumerable_over_string(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<Customer>().OrderBy(c => c.CustomerID).Select(e => new { Property = e.City.AsEnumerable() }),
+            ss => ss.Set<Customer>().OrderBy(c => c.CustomerID).Select(e => new { Property = e.City!.AsEnumerable() }),
             assertOrder: true,
             elementAsserter: (e, a) => Assert.True(e.Property.SequenceEqual(a.Property)));
 
@@ -4676,7 +4674,7 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fix
             "Nullable object must have a value.",
             (await Assert.ThrowsAsync<InvalidOperationException>(() => AssertQuery(
                 async,
-                ss => ss.Set<Customer>().Select(e => new { e.Region.Length })))).Message);
+                ss => ss.Set<Customer>().Select(e => new { e.Region!.Length })))).Message);
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual async Task Max_on_empty_sequence_throws(bool async)
@@ -4697,7 +4695,7 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fix
                 .OrderBy(c => c.CustomerID)
                 .Select(c => new
                 {
-                    Complex = (bool?)c.Orders.OrderBy(e => e.OrderDate).FirstOrDefault().Customer.Orders
+                    Complex = (bool?)c.Orders.OrderBy(e => e.OrderDate).FirstOrDefault()!.Customer!.Orders
                         .Any(e => e.OrderID < 11000)
                 }),
             ss => ss.Set<Customer>()
@@ -4706,7 +4704,7 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fix
                 .Select(c => new
                 {
                     Complex = c.Orders.OrderBy(e => e.OrderDate).FirstOrDefault() != null
-                        ? c.Orders.OrderBy(e => e.OrderDate).FirstOrDefault().Customer.Orders.Any(e => e.OrderID < 11000)
+                        ? c.Orders.OrderBy(e => e.OrderDate).FirstOrDefault()!.Customer!.Orders.Any(e => e.OrderID < 11000)
                         : (bool?)false
                 }),
             assertOrder: true);
@@ -4721,7 +4719,7 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fix
                 .Where(c => c.CustomerID != "VAFFE" && c.CustomerID != "DRACD")
                 .Select(e => e.City)
                 .Distinct()
-                .OrderBy(x => x.IndexOf(searchTerm))
+                .OrderBy(x => x!.IndexOf(searchTerm))
                 .ThenBy(x => x)
                 .Take(5),
             assertOrder: true);
@@ -4745,7 +4743,7 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fix
                     c.CustomerID,
                     Order = (c.Orders.Any() ? c.Orders.FirstOrDefault() : null) == null
                         ? null
-                        : new { c.Orders.OrderBy(o => o.OrderID).FirstOrDefault().OrderDate }
+                        : new { c.Orders.OrderBy(o => o.OrderID).FirstOrDefault()!.OrderDate }
                 }),
             elementSorter: c => c.CustomerID,
             elementAsserter: (e, a) => AssertEqual(e.Order, a.Order));
@@ -4766,7 +4764,7 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fix
                 {
                     CustomerID = x.CustomerID,
                     OrderDate = x.Orders
-                        .FirstOrDefault(t => t.OrderID == t.OrderID)
+                        .FirstOrDefault(t => t.OrderID == t.OrderID)!
                         .MaybeScalar(e => e.OrderDate)
                 }),
             assertOrder: true,
@@ -4778,7 +4776,7 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fix
 
     public class TestDto
     {
-        public string CustomerID { get; set; }
+        public string CustomerID { get; set; } = null!;
         public DateTime? OrderDate { get; set; }
 
         public static readonly Expression<Func<Customer, TestDto>> Projection = x => new TestDto
@@ -4786,7 +4784,7 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fix
             CustomerID = x.CustomerID,
             OrderDate = x.Orders
                 .FirstOrDefault(t => t.OrderID == t.OrderID)
-                .OrderDate
+                !.OrderDate
         };
     }
 
@@ -4861,8 +4859,8 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fix
             var tokenSource = new CancellationTokenSource();
             var query = context.Employees.AsNoTracking().ToListAsync(tokenSource.Token);
             tokenSource.Cancel();
-            List<Employee> result = null;
-            Exception exception = null;
+            List<Employee>? result = null;
+            Exception? exception = null;
             try
             {
                 result = await query;
@@ -4879,7 +4877,7 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fix
             }
             else
             {
-                Assert.Equal(9, result.Count);
+                Assert.Equal(9, result!.Count);
             }
         }
     }
@@ -4904,7 +4902,7 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fix
         {
             var results
                 = (await context.Customers
-                    .Select(c => new { c.CustomerID, Orders = context.Orders.Where(o => o.Customer.CustomerID == c.CustomerID) })
+                    .Select(c => new { c.CustomerID, Orders = context.Orders.Where(o => o.Customer!.CustomerID == c.CustomerID) })
                     .ToListAsync())
                 .Select(x => new
                 {
@@ -4990,7 +4988,7 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fix
                         {
                             First = o.OrderID,
                             Second = o.OrderDate,
-                            Third = o.Customer.City
+                            Third = o.Customer!.City
                         })
                         .Distinct().ToList()
                 }),
@@ -5016,7 +5014,7 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fix
             async,
             ss => ss.Set<Customer>()
                 .OrderBy(c => c.CustomerID)
-                .Where(c => c.CustomerID.StartsWith("A"))
+                .Where(c => c.CustomerID!.StartsWith("A"))
                 .Select(c => c.Orders.Any()
                     ? c.Orders.Select(o => o.CustomerID).Distinct().ToArray()
                     : Array.Empty<string>()),
@@ -5028,8 +5026,8 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fix
         => AssertQuery(
             async,
             ss => ss.Set<Customer>().Where(c => c.City == "Seattle").DefaultIfEmpty()
-                .OrderBy(c => c.CustomerID)
-                .Select(e => new { e.Orders }),
+                .OrderBy(c => c!.CustomerID)
+                .Select(e => new { e!.Orders }),
             assertOrder: true,
             elementAsserter: (e, a) => AssertCollection(e.Orders, a.Orders));
 
@@ -5037,14 +5035,14 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fix
     public virtual Task Collection_navigation_equal_to_null_for_subquery_using_ElementAtOrDefault_constant_zero(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<Customer>().Where(c => c.Orders.OrderBy(o => o.OrderID).ElementAtOrDefault(0).OrderDetails == null),
+            ss => ss.Set<Customer>().Where(c => c.Orders.OrderBy(o => o.OrderID).ElementAtOrDefault(0)!.OrderDetails == null),
             ss => ss.Set<Customer>().Where(c => c.Orders.OrderBy(o => o.OrderID).ElementAtOrDefault(0) == null));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Collection_navigation_equal_to_null_for_subquery_using_ElementAtOrDefault_constant_one(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<Customer>().Where(c => c.Orders.OrderBy(o => o.OrderID).ElementAtOrDefault(1).OrderDetails == null),
+            ss => ss.Set<Customer>().Where(c => c.Orders.OrderBy(o => o.OrderID).ElementAtOrDefault(1)!.OrderDetails == null),
             ss => ss.Set<Customer>().Where(c => c.Orders.OrderBy(o => o.OrderID).ElementAtOrDefault(1) == null));
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -5054,7 +5052,7 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fix
 
         return AssertQuery(
             async,
-            ss => ss.Set<Customer>().Where(c => c.Orders.OrderBy(o => o.OrderID).ElementAtOrDefault(prm).OrderDetails == null),
+            ss => ss.Set<Customer>().Where(c => c.Orders.OrderBy(o => o.OrderID).ElementAtOrDefault(prm)!.OrderDetails == null),
             ss => ss.Set<Customer>().Where(c => c.Orders.OrderBy(o => o.OrderID).ElementAtOrDefault(prm) == null));
     }
 
@@ -5128,7 +5126,7 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fix
 
         return AssertQuery(
             async,
-            ss => ss.Set<Order>().Where(o => data.Contains(o.CustomerID + o.Customer.CustomerID)));
+            ss => ss.Set<Order>().Where(o => data.Contains(o.CustomerID + o.Customer!.CustomerID)));
     }
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -5150,8 +5148,8 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fix
 
     private class MyCustomerDetails
     {
-        public string CustomerId { get; set; }
-        public string City { get; set; }
+        public string CustomerId { get; set; } = null!;
+        public string City { get; set; } = null!;
     }
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -5168,7 +5166,7 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fix
         => AssertQuery(
             async,
             // TODO: this is basically just about translation, we don't have data with nanoseconds and microseconds
-            ss => ss.Set<Order>().Where(o => o.OrderDate.Value.Nanosecond != 0 && o.OrderDate.Value.Microsecond != 0),
+            ss => ss.Set<Order>().Where(o => o.OrderDate!.Value.Nanosecond != 0 && o.OrderDate.Value.Microsecond != 0),
             assertEmpty: true);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -5176,14 +5174,14 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fix
         => AssertFirstOrDefault(
             async,
             ss => ss.Set<Order>().OrderBy(x => x.OrderID).Select(x => x != null ? x.OrderID + "" : null),
-            x => x.Contains("1"));
+            x => x!.Contains("1"));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Ternary_Not_Null_endsWith_Non_Numeric_First_Part(bool async)
         => AssertFirstOrDefault(
             async,
             ss => ss.Set<Order>().OrderBy(x => x.OrderID).Select(x => x != null ? "" + x.OrderID + "" : null),
-            x => x.EndsWith("1"));
+            x => x!.EndsWith("1"));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Ternary_Null_Equals_Non_Numeric_First_Part(bool async)
@@ -5197,7 +5195,7 @@ public abstract class NorthwindMiscellaneousQueryTestBase<TFixture>(TFixture fix
         => AssertFirstOrDefault(
             async,
             ss => ss.Set<Order>().OrderBy(x => x.OrderID).Select(x => x == null ? null : x.OrderID + ""),
-            x => x.StartsWith("1"));
+            x => x!.StartsWith("1"));
 
     [Theory, MemberData(nameof(IsAsyncData))] // #35118
     public virtual Task Column_access_inside_subquery_predicate(bool async)

--- a/test/EFCore.Specification.Tests/Query/NorthwindNavigationsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindNavigationsQueryTestBase.cs
@@ -7,8 +7,6 @@ using Microsoft.EntityFrameworkCore.TestModels.Northwind;
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
-#nullable disable
-
 public abstract class NorthwindNavigationsQueryTestBase<TFixture>(TFixture fixture) : QueryTestBase<TFixture>(fixture)
     where TFixture : NorthwindQueryFixtureBase<NoopModelCustomizer>, new()
 {
@@ -48,13 +46,13 @@ public abstract class NorthwindNavigationsQueryTestBase<TFixture>(TFixture fixtu
 
     private static readonly Random _randomGenerator = new();
 
-    private static T ClientProjection<T>(T t, object _)
+    private static T ClientProjection<T>(T t, object? _)
         => t;
 
-    private static bool ClientPredicate<T>(T t, object _)
+    private static bool ClientPredicate<T>(T t, object? _)
         => true;
 
-    private static int ClientOrderBy<T>(T t, object _)
+    private static int ClientOrderBy<T>(T t, object? _)
         => _randomGenerator.Next(0, 20);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -62,7 +60,7 @@ public abstract class NorthwindNavigationsQueryTestBase<TFixture>(TFixture fixtu
         => AssertQuery(
             async,
             ss => from o in ss.Set<Order>()
-                  where o.Customer.City == "Seattle"
+                where o.Customer!.City == "Seattle"
                   select o);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -70,7 +68,7 @@ public abstract class NorthwindNavigationsQueryTestBase<TFixture>(TFixture fixtu
         => AssertQuery(
             async,
             ss => from o in ss.Set<Order>()
-                  where o.Customer.City.Contains("Sea")
+                where o.Customer!.City!.Contains("Sea")
                   select o);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -79,7 +77,7 @@ public abstract class NorthwindNavigationsQueryTestBase<TFixture>(TFixture fixtu
             async,
             ss => from o1 in ss.Set<Order>().Where(o => o.OrderID < 10300)
                   from o2 in ss.Set<Order>().Where(o => o.OrderID < 10400)
-                  where o1.Customer.City == o2.Customer.City
+                where o1.Customer!.City == o2.Customer!.City
                   select new { o1, o2 },
             elementSorter: e => e.o1.OrderID + " " + e.o2.OrderID,
             elementAsserter: (e, a) =>
@@ -94,7 +92,7 @@ public abstract class NorthwindNavigationsQueryTestBase<TFixture>(TFixture fixtu
             async,
             ss => from o1 in ss.Set<Order>().Where(o => o.OrderID < 10300)
                   from o2 in ss.Set<Order>().Where(o => o.OrderID < 10400)
-                  where o1.Customer.City == o2.Customer.City
+                where o1.Customer!.City == o2.Customer!.City
                   select new { o1.CustomerID, C2 = o2.CustomerID },
             elementSorter: e => e.CustomerID + " " + e.C2);
 
@@ -104,7 +102,7 @@ public abstract class NorthwindNavigationsQueryTestBase<TFixture>(TFixture fixtu
             () => AssertQuery(
                 async,
                 ss => from o in ss.Set<Order>()
-                      where o.Customer.IsLondon
+                        where o.Customer!.IsLondon
                       select o),
             CoreStrings.QueryUnableToTranslateMember(nameof(Customer.IsLondon), nameof(Customer)));
 
@@ -113,7 +111,7 @@ public abstract class NorthwindNavigationsQueryTestBase<TFixture>(TFixture fixtu
         => AssertQuery(
             async,
             ss => (from od in ss.Set<OrderDetail>()
-                   where od.Order.Customer.City == "Seattle"
+                     where od.Order!.Customer!.City == "Seattle"
                    orderby od.OrderID, od.ProductID
                    select od).Take(1));
 
@@ -129,7 +127,7 @@ public abstract class NorthwindNavigationsQueryTestBase<TFixture>(TFixture fixtu
         => AssertQuery(
             async,
             ss => ss.Set<Customer>().OrderBy(c => c.CustomerID).Take(2)
-                .Select(c => c.Orders.OrderBy(o => o.OrderID).FirstOrDefault().CustomerID));
+                .Select(c => c.Orders.OrderBy(o => o.OrderID).FirstOrDefault()!.CustomerID));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Select_collection_FirstOrDefault_project_single_column2(bool async)
@@ -194,7 +192,7 @@ public abstract class NorthwindNavigationsQueryTestBase<TFixture>(TFixture fixtu
         => AssertQuery(
             async,
             ss => from e in ss.Set<Employee>()
-                  where e.Manager.Manager == null
+                where e.Manager!.Manager == null
                   select e);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -203,8 +201,8 @@ public abstract class NorthwindNavigationsQueryTestBase<TFixture>(TFixture fixtu
             async,
             ss => from o1 in ss.Set<Order>()
                   from o2 in ss.Set<Order>()
-                  where o1.CustomerID.StartsWith("A")
-                  where o2.CustomerID.StartsWith("A")
+                where o1.CustomerID!.StartsWith("A")
+                where o2.CustomerID!.StartsWith("A")
                   where o1.Customer == o2.Customer
                   select new { o1, o2 },
             elementSorter: e => e.o1.OrderID + " " + e.o2.OrderID);
@@ -214,23 +212,23 @@ public abstract class NorthwindNavigationsQueryTestBase<TFixture>(TFixture fixtu
         => AssertQuery(
             async,
             ss => from o in ss.Set<Order>().Include(o => o.Customer)
-                  where o.Customer.City == "Seattle"
+                where o.Customer!.City == "Seattle"
                   select o,
-            elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Order>(o => o.Customer)));
+            elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Order>(o => o.Customer!)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Include_with_multiple_optional_navigations(bool async)
     {
         var expectedIncludes = new IExpectedInclude[]
         {
-            new ExpectedInclude<OrderDetail>(od => od.Order), new ExpectedInclude<Order>(o => o.Customer, "Order")
+            new ExpectedInclude<OrderDetail>(od => od.Order!), new ExpectedInclude<Order>(o => o.Customer!, "Order")
         };
 
         return AssertQuery(
             async,
             ss => ss.Set<OrderDetail>()
-                .Include(od => od.Order.Customer)
-                .Where(od => od.Order.Customer.City == "London"),
+                .Include(od => od.Order!.Customer)
+                .Where(od => od.Order!.Customer!.City == "London"),
             elementAsserter: (e, a) => AssertInclude(e, a, expectedIncludes));
     }
 
@@ -246,9 +244,9 @@ public abstract class NorthwindNavigationsQueryTestBase<TFixture>(TFixture fixtu
         => AssertQuery(
             async,
             ss => from o in ss.Set<Order>()
-                  where o.Customer.City == "Seattle"
-                  where o.Customer.Phone != "555 555 5555"
-                  select new { B = o.Customer.City },
+                where o.Customer!.City == "Seattle"
+                where o.Customer!.Phone != "555 555 5555"
+                select new { B = o.Customer!.City },
             elementSorter: e => e.B);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -256,9 +254,9 @@ public abstract class NorthwindNavigationsQueryTestBase<TFixture>(TFixture fixtu
         => AssertQuery(
             async,
             ss => from o in ss.Set<Order>()
-                  where o.Customer.City == "Seattle"
-                  where o.Customer.Phone != "555 555 5555"
-                  select new { A = o.Customer, B = o.Customer.City },
+                where o.Customer!.City == "Seattle"
+                where o.Customer!.Phone != "555 555 5555"
+                select new { A = o.Customer, B = o.Customer!.City },
             elementSorter: e => e.A + " " + e.B);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -266,8 +264,8 @@ public abstract class NorthwindNavigationsQueryTestBase<TFixture>(TFixture fixtu
         => AssertQuery(
             async,
             ss => from o in ss.Set<Order>()
-                  where o.Customer.City == "Seattle"
-                      && o.Customer.Phone != "555 555 5555"
+                  where o.Customer!.City == "Seattle"
+                      && o.Customer!.Phone != "555 555 5555"
                   select o);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -295,10 +293,10 @@ public abstract class NorthwindNavigationsQueryTestBase<TFixture>(TFixture fixtu
         => AssertQuery(
             async,
             ss => from o in ss.Set<Order>()
-                  where o.Customer.City == "Seattle"
-                  where o.Customer.Phone != "555 555 5555"
+                where o.Customer!.City == "Seattle"
+                where o.Customer!.Phone != "555 555 5555"
                   select new { A = o.Customer, B = o.Customer },
-            elementSorter: e => e.A.CustomerID,
+            elementSorter: e => e.A!.CustomerID,
             elementAsserter: (e, a) =>
             {
                 AssertEqual(e.A, a.A);
@@ -356,7 +354,7 @@ public abstract class NorthwindNavigationsQueryTestBase<TFixture>(TFixture fixtu
             async,
             ss => from o in ss.Set<Order>()
                   where o.CustomerID == "ALFKI"
-                  select new { o.OrderID, o.Customer.Orders },
+                select new { o.OrderID, o.Customer!.Orders },
             elementSorter: e => e.OrderID,
             elementAsserter: (e, a) =>
             {
@@ -370,8 +368,8 @@ public abstract class NorthwindNavigationsQueryTestBase<TFixture>(TFixture fixtu
             async,
             ss => from od in ss.Set<OrderDetail>()
                   orderby od.OrderID, od.ProductID
-                  where od.Order.CustomerID == "ALFKI" || od.Order.CustomerID == "ANTON"
-                  select new { od.Order.Customer.Orders },
+                where od.Order!.CustomerID == "ALFKI" || od.Order!.CustomerID == "ANTON"
+                select new { od.Order!.Customer!.Orders },
             assertOrder: true,
             elementAsserter: (e, a) => AssertCollection(e.Orders, a.Orders));
 
@@ -519,7 +517,7 @@ public abstract class NorthwindNavigationsQueryTestBase<TFixture>(TFixture fixtu
         => AssertQuery(
             async,
             ss => from o in ss.Set<Order>()
-                  where o.CustomerID.StartsWith("A")
+                where o.CustomerID!.StartsWith("A")
                   select new
                   {
                       collection1 = o.OrderDetails.Count(),
@@ -584,7 +582,7 @@ public abstract class NorthwindNavigationsQueryTestBase<TFixture>(TFixture fixtu
             async,
             ss => from c in ss.Set<Customer>().Where(e => e.CustomerID.StartsWith("A"))
                   orderby c.CustomerID
-                  select new { c.Orders.Where(e => orderIds.Contains(e.OrderID)).FirstOrDefault().Customer },
+                select new { c.Orders.Where(e => orderIds.Contains(e.OrderID)).FirstOrDefault()!.Customer },
             ss => from c in ss.Set<Customer>().Where(e => e.CustomerID.StartsWith("A"))
                   orderby c.CustomerID
                   select new
@@ -604,14 +602,14 @@ public abstract class NorthwindNavigationsQueryTestBase<TFixture>(TFixture fixtu
         => AssertQuery(
             async,
             ss => ss.Set<Customer>().Where(e => e.CustomerID.StartsWith("A"))
-                .Select(c => ss.Set<Order>().FirstOrDefault(o => o.CustomerID == "ALFKI").Customer.City));
+                .Select(c => ss.Set<Order>().FirstOrDefault(o => o.CustomerID == "ALFKI")!.Customer!.City));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Collection_select_nav_prop_single_or_default_then_nav_prop_nested(bool async)
         => AssertQuery(
             async,
             ss => ss.Set<Customer>().Where(e => e.CustomerID.StartsWith("A"))
-                .Select(c => ss.Set<Order>().SingleOrDefault(o => o.OrderID == 10643).Customer.City));
+                .Select(c => ss.Set<Order>().SingleOrDefault(o => o.OrderID == 10643)!.Customer!.City));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Collection_select_nav_prop_first_or_default_then_nav_prop_nested_using_property_method(bool async)
@@ -620,12 +618,12 @@ public abstract class NorthwindNavigationsQueryTestBase<TFixture>(TFixture fixtu
             ss => ss.Set<Customer>().Where(e => e.CustomerID.StartsWith("A"))
                 .Select(c => EF.Property<string>(
                     EF.Property<Customer>(
-                        ss.Set<Order>().FirstOrDefault(oo => oo.CustomerID == "ALFKI"),
+                        ss.Set<Order>().FirstOrDefault(oo => oo.CustomerID == "ALFKI")!,
                         "Customer"),
                     "City")),
             ss => ss.Set<Customer>().Where(c => c.CustomerID.StartsWith("A"))
-                .Select(c => ss.Set<Order>().FirstOrDefault(o => o.CustomerID == "ALFKI").Customer != null
-                    ? ss.Set<Order>().FirstOrDefault(o => o.CustomerID == "ALFKI").Customer.City
+                .Select(c => ss.Set<Order>().FirstOrDefault(o => o.CustomerID == "ALFKI")!.Customer != null
+                    ? ss.Set<Order>().FirstOrDefault(o => o.CustomerID == "ALFKI")!.Customer!.City
                     : null)
         );
 
@@ -634,14 +632,14 @@ public abstract class NorthwindNavigationsQueryTestBase<TFixture>(TFixture fixtu
         => AssertQuery(
             async,
             ss => ss.Set<Customer>().Where(e => e.CustomerID.StartsWith("A"))
-                .Select(c => ss.Set<Order>().OrderBy(o => o.CustomerID).FirstOrDefault(o => o.CustomerID == "ALFKI").Customer.City));
+                .Select(c => ss.Set<Order>().OrderBy(o => o.CustomerID).FirstOrDefault(o => o.CustomerID == "ALFKI")!.Customer!.City));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Navigation_fk_based_inside_contains(bool async)
         => AssertQuery(
             async,
             ss => from o in ss.Set<Order>()
-                  where new[] { "ALFKI" }.Contains(o.Customer.CustomerID)
+                where new[] { "ALFKI" }.Contains(o.Customer!.CustomerID)
                   select o);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -649,7 +647,7 @@ public abstract class NorthwindNavigationsQueryTestBase<TFixture>(TFixture fixtu
         => AssertQuery(
             async,
             ss => from o in ss.Set<Order>()
-                  where new[] { "Novigrad", "Seattle" }.Contains(o.Customer.City)
+                where new[] { "Novigrad", "Seattle" }.Contains(o.Customer!.City)
                   select o);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -657,7 +655,7 @@ public abstract class NorthwindNavigationsQueryTestBase<TFixture>(TFixture fixtu
         => AssertQuery(
             async,
             ss => from od in ss.Set<OrderDetail>()
-                  where new[] { "Novigrad", "Seattle" }.Contains(od.Order.Customer.City)
+                where new[] { "Novigrad", "Seattle" }.Contains(od.Order!.Customer!.City)
                   select od);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -666,7 +664,7 @@ public abstract class NorthwindNavigationsQueryTestBase<TFixture>(TFixture fixtu
             async,
             ss => from od in ss.Set<OrderDetail>()
                   join o in ss.Set<Order>() on od.OrderID equals o.OrderID
-                  where new[] { "USA", "Redania" }.Contains(o.Customer.Country)
+                where new[] { "USA", "Redania" }.Contains(o.Customer!.Country)
                   select od);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -679,7 +677,7 @@ public abstract class NorthwindNavigationsQueryTestBase<TFixture>(TFixture fixtu
                 ss => from p in ss.Set<Product>()
                       where p.OrderDetails.Contains(
                           ss.Set<OrderDetail>().OrderByDescending(o => o.OrderID).ThenBy(o => o.ProductID)
-                              .FirstOrDefault(orderDetail => orderDetail.Quantity == 1))
+                              .FirstOrDefault(orderDetail => orderDetail.Quantity == 1)!)
                       select p))).Message);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -691,7 +689,7 @@ public abstract class NorthwindNavigationsQueryTestBase<TFixture>(TFixture fixtu
                 async,
                 ss => from p in ss.Set<Product>()
                       where p.OrderDetails.Contains(
-                          ss.Set<OrderDetail>().OrderByDescending(o => o.OrderID).ThenBy(o => o.ProductID).FirstOrDefault())
+                          ss.Set<OrderDetail>().OrderByDescending(o => o.OrderID).ThenBy(o => o.ProductID).FirstOrDefault()!)
                       select p))).Message);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -715,7 +713,7 @@ public abstract class NorthwindNavigationsQueryTestBase<TFixture>(TFixture fixtu
             ss => from o in ss.Set<Order>()
                       // ReSharper disable once UseMethodAny.0
                   where (from od in ss.Set<OrderDetail>()
-                         where o.Customer.Country == od.Order.Customer.Country
+                        where o.Customer!.Country == od.Order!.Customer!.Country
                          select od).Count()
                       > 0
                   where o.OrderID == 10643 || o.OrderID == 10692
@@ -729,7 +727,7 @@ public abstract class NorthwindNavigationsQueryTestBase<TFixture>(TFixture fixtu
                   where o.OrderID == 10643 || o.OrderID == 10692
                   // ReSharper disable once UseMethodAny.0
                   where (from od in ss.Set<OrderDetail>()
-                         where o.Customer.Country == od.Order.Customer.Country
+                        where o.Customer!.Country == od.Order!.Customer!.Country
                          select od).Distinct().Count()
                       > 0
                   select o);
@@ -765,7 +763,7 @@ public abstract class NorthwindNavigationsQueryTestBase<TFixture>(TFixture fixtu
                        o.OrderID,
                        OrderDetail = o.OrderDetails.OrderBy(od => od.OrderID).ThenBy(od => od.ProductID).Select(od => od.OrderID)
                            .FirstOrDefault(),
-                       o.Customer.City
+                       o.Customer!.City
                    }).Take(3),
             assertOrder: true);
 
@@ -801,19 +799,19 @@ public abstract class NorthwindNavigationsQueryTestBase<TFixture>(TFixture fixtu
     public virtual Task Navigation_with_collection_with_nullable_type_key(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<Order>().Where(o => o.Customer.Orders.Count(oo => oo.OrderID > 10260) > 30));
+            ss => ss.Set<Order>().Where(o => o.Customer!.Orders.Count(oo => oo.OrderID > 10260) > 30));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Multiple_include_with_multiple_optional_navigations(bool async)
         => AssertQuery(
             async,
             ss => ss.Set<OrderDetail>()
-                .Include(od => od.Order.Customer)
+                .Include(od => od.Order!.Customer)
                 .Include(od => od.Product)
-                .Where(od => od.Order.Customer.City == "London"));
+                .Where(od => od.Order!.Customer!.City == "London"));
 
     private class OrderDTO
     {
-        public Customer Customer { get; set; }
+        public Customer Customer { get; set; } = null!;
     }
 }

--- a/test/EFCore.Specification.Tests/Query/NorthwindQueryFiltersQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindQueryFiltersQueryTestBase.cs
@@ -135,7 +135,7 @@ public abstract class NorthwindQueryFiltersQueryTestBase<TFixture>(TFixture fixt
             async,
             ss => ss.Set<Order>()
                 .GroupBy(o => o.EmployeeID)
-                .Select(g => new { g.Key, Londons = g.Count(o => o.Customer.City == "London") }),
+                .Select(g => new { g.Key, Londons = g.Count(o => o.Customer!.City == "London") }),
             elementSorter: e => e.Key.GetValueOrDefault());
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -148,7 +148,7 @@ public abstract class NorthwindQueryFiltersQueryTestBase<TFixture>(TFixture fixt
                 {
                     g.Key,
                     Total = g.Count(),
-                    Londons = g.Count(o => o.Customer.City == "London")
+                    Londons = g.Count(o => o.Customer!.City == "London")
                 }),
             elementSorter: e => e.Key.GetValueOrDefault());
 
@@ -159,7 +159,7 @@ public abstract class NorthwindQueryFiltersQueryTestBase<TFixture>(TFixture fixt
             ss => ss.Set<Order>()
                 .IgnoreQueryFilters()
                 .GroupBy(o => o.EmployeeID)
-                .Select(g => new { g.Key, Londons = g.Count(o => o.Customer.City == "London") }),
+                .Select(g => new { g.Key, Londons = g.Count(o => o.Customer!.City == "London") }),
             elementSorter: e => e.Key.GetValueOrDefault());
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -173,7 +173,7 @@ public abstract class NorthwindQueryFiltersQueryTestBase<TFixture>(TFixture fixt
         => AssertFilteredQuery(
             async,
             ss => ss.Set<Order>().Include(o => o.Customer),
-            elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Order>(x => x.Customer)));
+            elementAsserter: (e, a) => AssertInclude(e, a, new ExpectedInclude<Order>(x => x.Customer!)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Project_reference_that_itself_has_query_filter_with_another_reference(bool async)

--- a/test/EFCore.Specification.Tests/Query/NorthwindQueryFixtureBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindQueryFixtureBase.cs
@@ -5,12 +5,10 @@ using Microsoft.EntityFrameworkCore.TestModels.Northwind;
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
-#nullable disable
-
 public abstract class NorthwindQueryFixtureBase<TModelCustomizer> : QueryFixtureBase<NorthwindContext>
     where TModelCustomizer : ITestModelCustomizer, new()
 {
-    private readonly Dictionary<(bool, string, string), ISetSource> _expectedDataCache = [];
+    private readonly Dictionary<(bool, string?, string?), ISetSource> _expectedDataCache = [];
 
     public override ISetSource GetExpectedData()
         => NorthwindData.Instance;
@@ -29,14 +27,14 @@ public abstract class NorthwindQueryFixtureBase<TModelCustomizer> : QueryFixture
         var expectedData = new NorthwindData();
         if (applyFilters)
         {
-            var customers = expectedData.Customers.Where(c => c.CompanyName.StartsWith(tenantPrefix)).ToArray();
+            var customers = expectedData.Customers.Where(c => c.CompanyName.StartsWith(tenantPrefix!)).ToArray();
             var customerQueriesWithQueryFilter = expectedData.CustomerQueriesWithQueryFilter
-                .Where(cq => cq.CompanyName.StartsWith(searchTerm)).ToArray();
-            var employees = expectedData.Employees.Where(e => e.Address.StartsWith("A")).ToArray();
+                .Where(cq => cq.CompanyName.StartsWith(searchTerm!)).ToArray();
+            var employees = expectedData.Employees.Where(e => e.Address!.StartsWith("A")).ToArray();
             var products = expectedData.Products.Where(p => p.Discontinued).ToArray();
-            var orders = expectedData.Orders.Where(o => o.Customer.CompanyName.StartsWith(tenantPrefix)).ToArray();
+            var orders = expectedData.Orders.Where(o => o.Customer!.CompanyName.StartsWith(tenantPrefix!)).ToArray();
             var orderDetails = expectedData.OrderDetails
-                .Where(od => od.Order.Customer.CompanyName.StartsWith(tenantPrefix) && od.Quantity > 50).ToArray();
+                .Where(od => od.Order!.Customer!.CompanyName.StartsWith(tenantPrefix!) && od.Quantity > 50).ToArray();
 
             foreach (var product in products)
             {
@@ -50,8 +48,8 @@ public abstract class NorthwindQueryFixtureBase<TModelCustomizer> : QueryFixture
 
             foreach (var orderDetail in orderDetails)
             {
-                orderDetail.Order = orderDetail.Order.Customer.CompanyName.StartsWith(tenantPrefix) ? orderDetail.Order : null;
-                orderDetail.Product = orderDetail.Product.Discontinued ? orderDetail.Product : null;
+                orderDetail.Order = (orderDetail.Order!.Customer!.CompanyName.StartsWith(tenantPrefix!) ? orderDetail.Order : null)!;
+                orderDetail.Product = (orderDetail.Product!.Discontinued ? orderDetail.Product : null)!;
             }
 
             expectedData = new NorthwindData(
@@ -70,21 +68,21 @@ public abstract class NorthwindQueryFixtureBase<TModelCustomizer> : QueryFixture
         return expectedData;
     }
 
-    public override IReadOnlyDictionary<Type, object> EntitySorters { get; } = new Dictionary<Type, Func<object, object>>
+    public override IReadOnlyDictionary<Type, object> EntitySorters { get; } = new Dictionary<Type, Func<object?, object?>>
     {
-        { typeof(Customer), e => ((Customer)e)?.CustomerID },
-        { typeof(CustomerQuery), e => ((CustomerQuery)e)?.CompanyName },
-        { typeof(CustomerQueryWithQueryFilter), e => ((CustomerQueryWithQueryFilter)e)?.CompanyName },
-        { typeof(Order), e => ((Order)e)?.OrderID },
-        { typeof(OrderQuery), e => ((OrderQuery)e)?.CustomerID },
-        { typeof(Employee), e => ((Employee)e)?.EmployeeID },
-        { typeof(Product), e => ((Product)e)?.ProductID },
-        { typeof(ProductQuery), e => ((ProductQuery)e)?.ProductID },
-        { typeof(ProductView), e => ((ProductView)e)?.ProductID },
-        { typeof(OrderDetail), e => (((OrderDetail)e)?.OrderID.ToString(), ((OrderDetail)e)?.ProductID.ToString()) }
+        { typeof(Customer), e => ((Customer?)e)?.CustomerID },
+        { typeof(CustomerQuery), e => ((CustomerQuery?)e)?.CompanyName },
+        { typeof(CustomerQueryWithQueryFilter), e => ((CustomerQueryWithQueryFilter?)e)?.CompanyName },
+        { typeof(Order), e => ((Order?)e)?.OrderID },
+        { typeof(OrderQuery), e => ((OrderQuery?)e)?.CustomerID },
+        { typeof(Employee), e => ((Employee?)e)?.EmployeeID },
+        { typeof(Product), e => ((Product?)e)?.ProductID },
+        { typeof(ProductQuery), e => ((ProductQuery?)e)?.ProductID },
+        { typeof(ProductView), e => ((ProductView?)e)?.ProductID },
+        { typeof(OrderDetail), e => (((OrderDetail?)e)?.OrderID.ToString(), ((OrderDetail?)e)?.ProductID.ToString()) }
     }.ToDictionary(e => e.Key, e => (object)e.Value);
 
-    public override IReadOnlyDictionary<Type, object> EntityAsserters { get; } = new Dictionary<Type, Action<object, object>>
+    public override IReadOnlyDictionary<Type, object> EntityAsserters { get; } = new Dictionary<Type, Action<object?, object?>>
     {
         {
             typeof(Customer), (e, a) =>
@@ -93,7 +91,7 @@ public abstract class NorthwindQueryFixtureBase<TModelCustomizer> : QueryFixture
 
                 if (a != null)
                 {
-                    var ee = (Customer)e;
+                    var ee = (Customer)e!;
                     var aa = (Customer)a;
 
                     Assert.Equal(ee.CustomerID, aa.CustomerID);
@@ -115,7 +113,7 @@ public abstract class NorthwindQueryFixtureBase<TModelCustomizer> : QueryFixture
 
                 if (a != null)
                 {
-                    var ee = (CustomerQuery)e;
+                    var ee = (CustomerQuery)e!;
                     var aa = (CustomerQuery)a;
 
                     Assert.Equal(ee.CompanyName, aa.CompanyName);
@@ -133,7 +131,7 @@ public abstract class NorthwindQueryFixtureBase<TModelCustomizer> : QueryFixture
 
                 if (a != null)
                 {
-                    var ee = (CustomerQueryWithQueryFilter)e;
+                    var ee = (CustomerQueryWithQueryFilter)e!;
                     var aa = (CustomerQueryWithQueryFilter)a;
 
                     Assert.Equal(ee.CompanyName, aa.CompanyName);
@@ -149,7 +147,7 @@ public abstract class NorthwindQueryFixtureBase<TModelCustomizer> : QueryFixture
 
                 if (a != null)
                 {
-                    var ee = (Order)e;
+                    var ee = (Order)e!;
                     var aa = (Order)a;
 
                     Assert.Equal(ee.OrderID, aa.OrderID);
@@ -166,7 +164,7 @@ public abstract class NorthwindQueryFixtureBase<TModelCustomizer> : QueryFixture
 
                 if (a != null)
                 {
-                    var ee = (OrderQuery)e;
+                    var ee = (OrderQuery)e!;
                     var aa = (OrderQuery)a;
 
                     Assert.Equal(ee.CustomerID, aa.CustomerID);
@@ -180,7 +178,7 @@ public abstract class NorthwindQueryFixtureBase<TModelCustomizer> : QueryFixture
 
                 if (a != null)
                 {
-                    var ee = (Employee)e;
+                    var ee = (Employee)e!;
                     var aa = (Employee)a;
 
                     Assert.Equal(ee.EmployeeID, aa.EmployeeID);
@@ -198,7 +196,7 @@ public abstract class NorthwindQueryFixtureBase<TModelCustomizer> : QueryFixture
 
                 if (a != null)
                 {
-                    var ee = (Product)e;
+                    var ee = (Product)e!;
                     var aa = (Product)a;
 
                     Assert.Equal(ee.ProductID, aa.ProductID);
@@ -216,7 +214,7 @@ public abstract class NorthwindQueryFixtureBase<TModelCustomizer> : QueryFixture
 
                 if (a != null)
                 {
-                    var ee = (ProductQuery)e;
+                    var ee = (ProductQuery)e!;
                     var aa = (ProductQuery)a;
 
                     Assert.Equal(ee.ProductID, aa.ProductID);
@@ -232,7 +230,7 @@ public abstract class NorthwindQueryFixtureBase<TModelCustomizer> : QueryFixture
 
                 if (a != null)
                 {
-                    var ee = (ProductView)e;
+                    var ee = (ProductView)e!;
                     var aa = (ProductView)a;
 
                     Assert.Equal(ee.ProductID, aa.ProductID);
@@ -248,7 +246,7 @@ public abstract class NorthwindQueryFixtureBase<TModelCustomizer> : QueryFixture
 
                 if (a != null)
                 {
-                    var ee = (OrderDetail)e;
+                    var ee = (OrderDetail)e!;
                     var aa = (OrderDetail)a;
 
                     Assert.Equal(ee.OrderID, aa.OrderID);

--- a/test/EFCore.Specification.Tests/Query/NorthwindSelectQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindSelectQueryTestBase.cs
@@ -8,8 +8,6 @@ using Microsoft.EntityFrameworkCore.TestModels.Northwind;
 // ReSharper disable InconsistentNaming
 namespace Microsoft.EntityFrameworkCore.Query;
 
-#nullable disable
-
 public abstract class NorthwindSelectQueryTestBase<TFixture>(TFixture fixture) : QueryTestBase<TFixture>(fixture)
     where TFixture : NorthwindQueryFixtureBase<NoopModelCustomizer>, new()
 {
@@ -106,7 +104,7 @@ public abstract class NorthwindSelectQueryTestBase<TFixture>(TFixture fixture) :
         => AssertQuery(
             async,
             ss => ss.Set<Employee>().Where(e => e.EmployeeID == 1)
-                .Select(e => new object[] { e.EmployeeID, e.ReportsTo, EF.Property<string>(e, "Title") }),
+                .Select(e => new object[] { e.EmployeeID, e.ReportsTo!, EF.Property<string>(e, "Title") }),
             elementAsserter: (e, a) => AssertArrays(e, a, 3));
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -122,7 +120,7 @@ public abstract class NorthwindSelectQueryTestBase<TFixture>(TFixture fixture) :
         => AssertQuery(
             async,
             ss => ss.Set<Order>().OrderBy(o => o.OrderID).Where(o => o.OrderID < 10300)
-                .Select(o => new object[] { o, o.Customer }),
+                .Select(o => new object[] { o, o.Customer! }),
             assertOrder: true);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -147,7 +145,7 @@ public abstract class NorthwindSelectQueryTestBase<TFixture>(TFixture fixture) :
 
         for (var i = 0; i < expectedArray.Length; i++)
         {
-            Assert.Same(expectedArray[i].GetType(), actualArray[i].GetType());
+            Assert.Same(expectedArray[i]!.GetType(), actualArray[i]!.GetType());
             Assert.Equal(expectedArray[i], actualArray[i]);
         }
     }
@@ -294,7 +292,7 @@ public abstract class NorthwindSelectQueryTestBase<TFixture>(TFixture fixture) :
     public virtual Task Select_constant_null_string(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<Customer>().Select(c => (string)null));
+            ss => ss.Set<Customer>().Select(c => (string)null!));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Select_local(bool async)
@@ -343,7 +341,7 @@ public abstract class NorthwindSelectQueryTestBase<TFixture>(TFixture fixture) :
                 orderby c.CustomerID
                 select ss.Set<Order>()
                     .Where(o => o.CustomerID == c.CustomerID
-                        && o.OrderDate.Value.Year == 1997)
+                        && o.OrderDate!.Value.Year == 1997)
                     .Select(o => o.OrderID)
                     .OrderBy(o => o)
                     .ToList(),
@@ -485,7 +483,7 @@ public abstract class NorthwindSelectQueryTestBase<TFixture>(TFixture fixture) :
                 orderby c.CustomerID
                 select (from o1 in ss.Set<Order>()
                         where o1.CustomerID == c.CustomerID
-                            && o1.OrderDate.Value.Year == 1997
+                            && o1.OrderDate!.Value.Year == 1997
                         orderby o1.OrderID
                         select (from o2 in ss.Set<Order>()
                                 where o1.CustomerID == c.CustomerID
@@ -509,7 +507,7 @@ public abstract class NorthwindSelectQueryTestBase<TFixture>(TFixture fixture) :
                  select new { c.City }).Distinct().Select(x =>
                     (from o1 in ss.Set<Order>()
                      where o1.CustomerID == x.City
-                         && o1.OrderDate.Value.Year == 1997
+                         && o1.OrderDate!.Value.Year == 1997
                      orderby o1.OrderID
                      select o1).Distinct().Select(xx =>
                         (from o2 in ss.Set<Order>()
@@ -549,7 +547,7 @@ public abstract class NorthwindSelectQueryTestBase<TFixture>(TFixture fixture) :
             ss => ss.Set<Order>()
                 .Where(o => o.CustomerID == "ALFKI")
                 .OrderBy(o => o.OrderID)
-                .Select(o => (long)o.EmployeeID),
+                .Select(o => (long)o.EmployeeID!),
             assertOrder: true);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -559,7 +557,7 @@ public abstract class NorthwindSelectQueryTestBase<TFixture>(TFixture fixture) :
             ss => ss.Set<Order>()
                 .Where(o => o.CustomerID == "ALFKI")
                 .OrderBy(o => o.OrderID)
-                .Select(o => (uint)o.EmployeeID),
+                .Select(o => (uint)o.EmployeeID!),
             assertOrder: true);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -619,7 +617,7 @@ public abstract class NorthwindSelectQueryTestBase<TFixture>(TFixture fixture) :
             ss => ss.Set<Order>()
                 .Where(o => o.CustomerID == "ALFKI")
                 .OrderBy(o => o.OrderID)
-                .Select(o => (long)o.CustomerID.Length),
+                .Select(o => (long)o.CustomerID!.Length),
             assertOrder: true);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -909,7 +907,7 @@ public abstract class NorthwindSelectQueryTestBase<TFixture>(TFixture fixture) :
         => AssertQueryScalar(
             async,
             ss => ss.Set<Order>().Where(o => o.OrderID < 10300)
-                .Select(o => o.OrderDate.Value - new DateTime(1997, 1, 1)));
+                .Select(o => o.OrderDate!.Value - new DateTime(1997, 1, 1)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Project_single_element_from_collection_with_OrderBy_Take_and_FirstOrDefault(bool async)
@@ -943,10 +941,10 @@ public abstract class NorthwindSelectQueryTestBase<TFixture>(TFixture fixture) :
             async,
             ss => ss.Set<Customer>()
                 .Select(c => c.Orders.OrderBy(o => o.OrderID).Select(o => o.CustomerID).Distinct().FirstOrDefault())
-                .Select(e => (int?)e.Length),
+                .Select(e => (int?)e!.Length),
             ss => ss.Set<Customer>()
                 .Select(c => c.Orders.OrderBy(o => o.OrderID).Select(o => o.CustomerID).Distinct().FirstOrDefault())
-                .Select(e => e.MaybeScalar(e => e.Length)));
+                .Select(e => e!.MaybeScalar(e => e.Length)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Project_single_element_from_collection_with_OrderBy_Take_and_SingleOrDefault(bool async)
@@ -984,12 +982,12 @@ public abstract class NorthwindSelectQueryTestBase<TFixture>(TFixture fixture) :
                 .ThenByDescending(o => o.OrderDate)
                 .Select(o => o.CustomerID)
                 .Take(2)
-                .FirstOrDefault().Length),
+                .FirstOrDefault()!.Length),
             ss => ss.Set<Customer>().Select(c => c.Orders.OrderBy(o => o.OrderID)
                 .ThenByDescending(o => o.OrderDate)
                 .Select(o => o.CustomerID)
                 .Take(2)
-                .FirstOrDefault().MaybeScalar(x => x.Length)));
+                .FirstOrDefault()!.MaybeScalar(x => x.Length)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Project_single_element_from_collection_with_multiple_OrderBys_Take_and_FirstOrDefault_2(bool async)
@@ -1019,67 +1017,67 @@ public abstract class NorthwindSelectQueryTestBase<TFixture>(TFixture fixture) :
     public virtual Task Select_datetime_year_component(bool async)
         => AssertQueryScalar(
             async,
-            ss => ss.Set<Order>().Select(o => o.OrderDate.Value.Year));
+            ss => ss.Set<Order>().Select(o => o.OrderDate!.Value.Year));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Select_datetime_month_component(bool async)
         => AssertQueryScalar(
             async,
-            ss => ss.Set<Order>().Select(o => o.OrderDate.Value.Month));
+            ss => ss.Set<Order>().Select(o => o.OrderDate!.Value.Month));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Select_datetime_day_of_year_component(bool async)
         => AssertQueryScalar(
             async,
-            ss => ss.Set<Order>().Select(o => o.OrderDate.Value.DayOfYear));
+            ss => ss.Set<Order>().Select(o => o.OrderDate!.Value.DayOfYear));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Select_datetime_day_component(bool async)
         => AssertQueryScalar(
             async,
-            ss => ss.Set<Order>().Select(o => o.OrderDate.Value.Day));
+            ss => ss.Set<Order>().Select(o => o.OrderDate!.Value.Day));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Select_datetime_hour_component(bool async)
         => AssertQueryScalar(
             async,
-            ss => ss.Set<Order>().Select(o => o.OrderDate.Value.Hour));
+            ss => ss.Set<Order>().Select(o => o.OrderDate!.Value.Hour));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Select_datetime_minute_component(bool async)
         => AssertQueryScalar(
             async,
-            ss => ss.Set<Order>().Select(o => o.OrderDate.Value.Minute));
+            ss => ss.Set<Order>().Select(o => o.OrderDate!.Value.Minute));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Select_datetime_second_component(bool async)
         => AssertQueryScalar(
             async,
-            ss => ss.Set<Order>().Select(o => o.OrderDate.Value.Second));
+            ss => ss.Set<Order>().Select(o => o.OrderDate!.Value.Second));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Select_datetime_millisecond_component(bool async)
         => AssertQueryScalar(
             async,
-            ss => ss.Set<Order>().Select(o => o.OrderDate.Value.Millisecond));
+            ss => ss.Set<Order>().Select(o => o.OrderDate!.Value.Millisecond));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Select_datetime_DayOfWeek_component(bool async)
         => AssertQueryScalar(
             async,
-            ss => ss.Set<Order>().Select(o => (int)o.OrderDate.Value.DayOfWeek));
+            ss => ss.Set<Order>().Select(o => (int)o.OrderDate!.Value.DayOfWeek));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Select_datetime_Ticks_component(bool async)
         => AssertQueryScalar(
             async,
-            ss => ss.Set<Order>().Select(o => o.OrderDate.Value.Ticks));
+            ss => ss.Set<Order>().Select(o => o.OrderDate!.Value.Ticks));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Select_datetime_TimeOfDay_component(bool async)
         => AssertQueryScalar(
             async,
-            ss => ss.Set<Order>().Select(o => o.OrderDate.Value.TimeOfDay));
+            ss => ss.Set<Order>().Select(o => o.OrderDate!.Value.TimeOfDay));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Select_byte_constant(bool async)
@@ -1121,7 +1119,7 @@ public abstract class NorthwindSelectQueryTestBase<TFixture>(TFixture fixture) :
             async,
             ss => from o in ss.Set<Order>()
                   orderby o.CustomerID
-                  select new { A = o.Customer.CustomerID, B = o.CustomerID });
+                select new { A = o.Customer!.CustomerID, B = o.CustomerID });
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Select_GetValueOrDefault_on_DateTime(bool async)
@@ -1140,7 +1138,7 @@ public abstract class NorthwindSelectQueryTestBase<TFixture>(TFixture fixture) :
             ss => from c in ss.Set<Customer>()
                   join o in ss.Set<Order>() on c.CustomerID equals o.CustomerID into grouping
                   from o in grouping.DefaultIfEmpty()
-                  select o != null ? o.OrderDate.Value : new DateTime(1753, 1, 1));
+                  select o != null ? o.OrderDate!.Value : new DateTime(1753, 1, 1));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Cast_on_top_level_projection_brings_explicit_Cast(bool async)
@@ -1298,7 +1296,7 @@ public abstract class NorthwindSelectQueryTestBase<TFixture>(TFixture fixture) :
         => AssertQuery(
             async,
             ss => from c in ss.Set<Customer>()
-                  from o in ss.Set<Order>().Where(o => c.CustomerID.Length >= o.CustomerID.Length)
+                from o in ss.Set<Order>().Where(o => c.CustomerID.Length >= o.CustomerID!.Length)
                       .OrderBy(o => c.City).ThenBy(o => o.OrderID).Take(2).DefaultIfEmpty()
                   select new { c, o },
             elementSorter: e => (e.c.CustomerID, e.o?.OrderID),
@@ -1345,16 +1343,16 @@ public abstract class NorthwindSelectQueryTestBase<TFixture>(TFixture fixture) :
         => AssertQueryScalar(
             async,
             ss => ss.Set<Customer>().Select(c
-                => (int?)ss.Set<Order>().Where(o => o.CustomerID == "John Doe").Select(o => o.CustomerID).FirstOrDefault().Length),
+                => (int?)ss.Set<Order>().Where(o => o.CustomerID == "John Doe").Select(o => o.CustomerID).FirstOrDefault()!.Length),
             ss => ss.Set<Customer>().Select(c => ss.Set<Order>().Where(o => o.CustomerID == "John Doe").Select(o => o.CustomerID)
-                .FirstOrDefault()
+                .FirstOrDefault()!
                 .MaybeScalar(e => e.Length)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Member_binding_after_ctor_arguments_fails_with_client_eval(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<Customer>().Select(c => new CustomerListItem(c.CustomerID, c.City)).OrderBy(c => c.City),
+            ss => ss.Set<Customer>().Select(c => new CustomerListItem(c.CustomerID, c.City!)).OrderBy(c => c.City),
             assertOrder: true);
 
     protected class CustomerListItem(string id, string city)
@@ -1362,7 +1360,7 @@ public abstract class NorthwindSelectQueryTestBase<TFixture>(TFixture fixture) :
         public string Id { get; } = id;
         public string City { get; } = city;
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => obj != null
                 && (ReferenceEquals(this, obj)
                     || (obj is CustomerListItem customerListItem
@@ -1428,7 +1426,7 @@ public abstract class NorthwindSelectQueryTestBase<TFixture>(TFixture fixture) :
     public virtual Task Select_with_complex_expression_that_can_be_funcletized(bool async)
         => AssertQueryScalar(
             async,
-            ss => ss.Set<Customer>().Where(c => c.CustomerID == "ALFKI").Select(c => (int?)c.Region.IndexOf("")),
+            ss => ss.Set<Customer>().Where(c => c.CustomerID == "ALFKI").Select(c => (int?)c.Region!.IndexOf("")),
             ss => ss.Set<Customer>().Where(c => c.CustomerID == "ALFKI")
                 .Select(c => c.Region == null ? default(int?) : c.Region.IndexOf("")),
             assertOrder: true);
@@ -1437,7 +1435,7 @@ public abstract class NorthwindSelectQueryTestBase<TFixture>(TFixture fixture) :
     public virtual Task Select_chained_entity_navigation_doesnt_materialize_intermittent_entities(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<Order>().OrderBy(o => o.OrderID).Select(o => o.Customer.Orders),
+            ss => ss.Set<Order>().OrderBy(o => o.OrderID).Select(o => o.Customer!.Orders),
             elementAsserter: (e, a) => AssertCollection(e, a),
             assertOrder: true);
 
@@ -1500,7 +1498,7 @@ public abstract class NorthwindSelectQueryTestBase<TFixture>(TFixture fixture) :
         => AssertQuery(
             async,
             ss => ss.Set<Customer>().Where(c => c.CustomerID.StartsWith("A"))
-                .Select(c => new { c, c.Orders.OrderByDescending(o => o.OrderID).LastOrDefault().OrderDate }));
+                .Select(c => new { c, c.Orders.OrderByDescending(o => o.OrderID).LastOrDefault()!.OrderDate }));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Projection_with_parameterized_constructor(bool async)
@@ -1520,7 +1518,7 @@ public abstract class NorthwindSelectQueryTestBase<TFixture>(TFixture fixture) :
 
     private class CustomerWrapper(Customer customer)
     {
-        public string City { get; set; }
+        public string? City { get; set; }
         public Customer Customer { get; } = customer;
     }
 
@@ -1549,9 +1547,9 @@ public abstract class NorthwindSelectQueryTestBase<TFixture>(TFixture fixture) :
     public virtual Task Project_uint_through_collection_FirstOrDefault(bool async)
         => AssertQueryScalar(
             async,
-            ss => ss.Set<Customer>().Select(c => c.Orders.OrderBy(o => o.OrderID).FirstOrDefault()).Select(e => e.EmployeeID),
+            ss => ss.Set<Customer>().Select(c => c.Orders.OrderBy(o => o.OrderID).FirstOrDefault()).Select(e => e!.EmployeeID),
             ss => ss.Set<Customer>().Select(c => c.Orders.OrderBy(o => o.OrderID).FirstOrDefault())
-                .Select(e => e.MaybeScalar(x => x.EmployeeID)));
+                .Select(e => e!.MaybeScalar(x => x.EmployeeID)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Project_keyless_entity_FirstOrDefault_without_orderby(bool async)
@@ -1590,8 +1588,8 @@ public abstract class NorthwindSelectQueryTestBase<TFixture>(TFixture fixture) :
 
     private class IdName<T>
     {
-        public T Id { get; set; }
-        public string Name { get; set; }
+        public T Id { get; set; } = default!;
+        public string Name { get; set; } = null!;
     }
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -1619,11 +1617,11 @@ public abstract class NorthwindSelectQueryTestBase<TFixture>(TFixture fixture) :
                 .Distinct()
                 .Select(c => new
                 {
-                    c.CustomerID,
-                    Orders = c.Orders.Where(x => filteredOrderIds.Contains(x.OrderID)).OrderBy(x => x.OrderID)
+                    c!.CustomerID,
+                    Orders = c!.Orders.Where(x => filteredOrderIds.Contains(x.OrderID)).OrderBy(x => x.OrderID)
                         .Select(x => new
                         {
-                            c.CustomerID,
+                            c!.CustomerID,
                             x.OrderID,
                             x.OrderDate
                         })
@@ -1644,7 +1642,7 @@ public abstract class NorthwindSelectQueryTestBase<TFixture>(TFixture fixture) :
         return AssertQuery(
             async,
             ss => ss.Set<Order>()
-                .Select(o => new { o.OrderID, Complex = o.OrderDate.Value.Month })
+                .Select(o => new { o.OrderID, Complex = o.OrderDate!.Value.Month })
                 .Distinct()
                 .Select(c => new
                 {
@@ -1713,7 +1711,7 @@ public abstract class NorthwindSelectQueryTestBase<TFixture>(TFixture fixture) :
                 {
                     o.OrderDate,
                     o.CustomerID,
-                    Complex = o.OrderDate.Value.Month
+                    Complex = o.OrderDate!.Value.Month
                 })
                 .Distinct()
                 .Select(c => new
@@ -1751,7 +1749,7 @@ public abstract class NorthwindSelectQueryTestBase<TFixture>(TFixture fixture) :
         return AssertQuery(
             async,
             ss => ss.Set<Order>()
-                .GroupBy(o => new { o.OrderID, Complex = o.OrderDate.Value.Month })
+                .GroupBy(o => new { o.OrderID, Complex = o.OrderDate!.Value.Month })
                 .Select(g => new { g.Key, Aggregate = g.Count() })
                 .Select(c => new
                 {
@@ -1783,7 +1781,7 @@ public abstract class NorthwindSelectQueryTestBase<TFixture>(TFixture fixture) :
                 .Select(o => new Order
                 {
                     OrderID = o.OrderID,
-                    Customer = new Customer { CustomerID = o.Customer.CustomerID, City = o.Customer.City },
+                    Customer = new Customer { CustomerID = o.Customer!.CustomerID, City = o.Customer!.City },
                     OrderDate = o.OrderDate
                 }),
             elementAsserter: (e, a) =>
@@ -1798,10 +1796,10 @@ public abstract class NorthwindSelectQueryTestBase<TFixture>(TFixture fixture) :
             async,
             ss => ss.Set<Customer>()
                 .OrderBy(c => c.CustomerID)
-                .Select(c => (int?)c.Orders.OrderBy(o => o.OrderID).Select(o => o.CustomerID).FirstOrDefault().Length),
+                .Select(c => (int?)c.Orders.OrderBy(o => o.OrderID).Select(o => o.CustomerID).FirstOrDefault()!.Length),
             ss => ss.Set<Customer>()
                 .OrderBy(c => c.CustomerID)
-                .Select(c => c.Orders.OrderBy(o => o.OrderID).Select(o => o.CustomerID).FirstOrDefault().MaybeScalar(x => x.Length)),
+                .Select(c => c.Orders.OrderBy(o => o.OrderID).Select(o => o.CustomerID).FirstOrDefault()!.MaybeScalar(x => x.Length)),
             assertOrder: true);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -1822,7 +1820,7 @@ public abstract class NorthwindSelectQueryTestBase<TFixture>(TFixture fixture) :
         var selector = Expression.Lambda<Func<Customer, int>>(
             Expression.Property(
                 Expression.Property(prm, "Orders"),
-                collectionCount),
+                collectionCount!),
             prm);
 
         return AssertQueryScalar(
@@ -1948,7 +1946,7 @@ public abstract class NorthwindSelectQueryTestBase<TFixture>(TFixture fixture) :
                 .OrderBy(e => e.OrderID)
                 .Select(o => new
                 {
-                    CustomerID = ClientMethod(o.CustomerID),
+                    CustomerID = ClientMethod(o.CustomerID!),
                     OrderDate = o.OrderDate.HasValue ? o.OrderDate.Value : new DateTime(o.OrderID - 10000, 1, 1),
                     OrderDate2 = o.OrderDate.HasValue == false ? new DateTime(o.OrderID - 10000, 1, 1) : o.OrderDate.Value
                 }),
@@ -1969,7 +1967,7 @@ public abstract class NorthwindSelectQueryTestBase<TFixture>(TFixture fixture) :
             async,
             ss =>
             {
-                var orders = ss.Set<Order>().Where(o => o.CustomerID.StartsWith("A")).ToList();
+                var orders = ss.Set<Order>().Where(o => o.CustomerID!.StartsWith("A")).ToList();
 
                 return ss.Set<Customer>()
                     .Select(c => new { Customer = c, HasOrder = orders.Any(o => o.CustomerID == c.CustomerID) });
@@ -1989,7 +1987,7 @@ public abstract class NorthwindSelectQueryTestBase<TFixture>(TFixture fixture) :
         return AssertQuery(
             async,
             ss => ss.Set<Order>()
-                .GroupBy(o => new { o.CustomerID, Complex = o.OrderDate.Value.Month })
+                .GroupBy(o => new { o.CustomerID, Complex = o.OrderDate!.Value.Month })
                 .Select(g => new { g.Key, Aggregate = g.Count() })
                 .Select(c => new
                 {
@@ -2052,7 +2050,7 @@ public abstract class NorthwindSelectQueryTestBase<TFixture>(TFixture fixture) :
             async,
             ss =>
                 ss.Set<Order>()
-                    .Where(o => o.CustomerID.StartsWith("F"))
+                    .Where(o => o.CustomerID!.StartsWith("F"))
                     .Select(o => new Order
                     {
                         OrderID = o.OrderID,
@@ -2080,10 +2078,10 @@ public abstract class NorthwindSelectQueryTestBase<TFixture>(TFixture fixture) :
                     .Select(o => new
                     {
                         Orders = o.Orders.OrderBy(a => a.OrderDate).Take(1)
-                            .Select(e => new { Title = e.CustomerID == e.Customer.CustomerID ? "A" : "B" }).ToList()
+                            .Select(e => new { Title = e.CustomerID == e.Customer!.CustomerID ? "A" : "B" }).ToList()
                     }),
             asserter: (e, a) => AssertCollection(
-                e.Orders, a.Orders, ordered: true,
+                e!.Orders, a!.Orders, ordered: true,
                 elementAsserter: (ee, aa) => AssertEqual(ee.Title, aa.Title)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -2095,7 +2093,7 @@ public abstract class NorthwindSelectQueryTestBase<TFixture>(TFixture fixture) :
                     .Where(c => c.CustomerID == "ALFKI")
                     .Include(c => c.Orders)
                     .Select(c => new CustomerDetailsWithCount(
-                        c.CustomerID, c.City,
+                        c.CustomerID, c.City!,
                         c.Orders.Select(o => new OrderInfo(o.OrderID, o.OrderDate)).ToList(), c.Orders.Count)),
             asserter: (e, a) =>
             {
@@ -2135,7 +2133,7 @@ public abstract class NorthwindSelectQueryTestBase<TFixture>(TFixture fixture) :
                 .Select(c => new
                 {
                     c.CustomerID,
-                    Order = c.Orders.FirstOrDefault(o => o.OrderID < 11000).OrderDate,
+                    Order = c.Orders.FirstOrDefault(o => o.OrderID < 11000)!.OrderDate,
                     InterpolatedString = $"test{c.City}",
                     NonInterpolatedString = "test" + c.City,
                     Collection = new List<string>
@@ -2151,7 +2149,7 @@ public abstract class NorthwindSelectQueryTestBase<TFixture>(TFixture fixture) :
                 .Select(c => new
                 {
                     c.CustomerID,
-                    Order = c.Orders.FirstOrDefault(o => o.OrderID < 11000).MaybeScalar(e => e.OrderDate),
+                    Order = c.Orders.FirstOrDefault(o => o.OrderID < 11000)!.MaybeScalar(e => e.OrderDate),
                     InterpolatedString = $"test{c.City}",
                     NonInterpolatedString = "test" + c.City,
                     Collection = new List<string>

--- a/test/EFCore.Specification.Tests/Query/NorthwindSetOperationsQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindSetOperationsQueryTestBase.cs
@@ -6,8 +6,6 @@ using Microsoft.EntityFrameworkCore.TestModels.Northwind;
 // ReSharper disable InconsistentNaming
 namespace Microsoft.EntityFrameworkCore.Query;
 
-#nullable disable
-
 public abstract class NorthwindSetOperationsQueryTestBase<TFixture>(TFixture fixture) : QueryTestBase<TFixture>(fixture)
     where TFixture : NorthwindQueryFixtureBase<NoopModelCustomizer>, new()
 {
@@ -53,7 +51,7 @@ public abstract class NorthwindSetOperationsQueryTestBase<TFixture>(TFixture fix
             async,
             ss => ss.Set<Customer>()
                 .Where(c => c.City == "London")
-                .Except(ss.Set<Customer>().Where(c => c.ContactName.Contains("Thomas"))));
+                .Except(ss.Set<Customer>().Where(c => c.ContactName!.Contains("Thomas"))));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Except_simple_followed_by_projecting_constant(bool async)
@@ -105,7 +103,7 @@ public abstract class NorthwindSetOperationsQueryTestBase<TFixture>(TFixture fix
             async,
             ss => ss.Set<Customer>()
                 .Where(c => c.City == "London")
-                .Intersect(ss.Set<Customer>().Where(c => c.ContactName.Contains("Thomas"))));
+                .Intersect(ss.Set<Customer>().Where(c => c.ContactName!.Contains("Thomas"))));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Intersect_nested(bool async)
@@ -178,7 +176,7 @@ public abstract class NorthwindSetOperationsQueryTestBase<TFixture>(TFixture fix
             ss => ss.Set<Customer>()
                 .Where(c => c.City == "Berlin")
                 .Union(ss.Set<Customer>().Where(c => c.City == "London"))
-                .Where(c => c.ContactName.Contains("Thomas"))); // pushdown
+                .Where(c => c.ContactName!.Contains("Thomas"))); // pushdown
 
     // Should cause pushdown into a subquery, keeping the ordering, offset and limit inside the subquery
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -191,7 +189,7 @@ public abstract class NorthwindSetOperationsQueryTestBase<TFixture>(TFixture fix
                 .OrderBy(c => c.Region)
                 .ThenBy(c => c.City)
                 .Skip(0) // prevent pushdown from removing OrderBy
-                .Where(c => c.ContactName.Contains("Thomas"))); // pushdown
+                .Where(c => c.ContactName!.Contains("Thomas"))); // pushdown
 
     // Nested set operation with same operation type - no parentheses are needed.
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -212,7 +210,7 @@ public abstract class NorthwindSetOperationsQueryTestBase<TFixture>(TFixture fix
             ss => ss.Set<Customer>()
                 .Where(c => c.City == "Berlin")
                 .Union(ss.Set<Customer>().Where(c => c.City == "London"))
-                .Intersect(ss.Set<Customer>().Where(c => c.ContactName.Contains("Thomas"))));
+                .Intersect(ss.Set<Customer>().Where(c => c.ContactName!.Contains("Thomas"))));
 
     // The evaluation order of Concat and Union can matter: A UNION ALL (B UNION C) can be different from (A UNION ALL B) UNION C.
     // Make sure parentheses are added.
@@ -259,7 +257,7 @@ public abstract class NorthwindSetOperationsQueryTestBase<TFixture>(TFixture fix
                 .Where(c => c.City == "Berlin")
                 .Union(ss.Set<Customer>().Where(c => c.City == "London"))
                 .Select(c => c.Address)
-                .Where(a => a.Contains("Hanover")));
+                .Where(a => a!.Contains("Hanover")));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Union_Select_scalar(bool async)
@@ -280,9 +278,9 @@ public abstract class NorthwindSetOperationsQueryTestBase<TFixture>(TFixture fix
 
     public class CustomerDeets
     {
-        public string Id { get; set; }
+        public string Id { get; set; } = null!;
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => obj is not null
                 && (ReferenceEquals(this, obj)
                     || (obj.GetType() == GetType()
@@ -471,7 +469,7 @@ public abstract class NorthwindSetOperationsQueryTestBase<TFixture>(TFixture fix
                 .Select(c => "NonNullableConstant")
                 .Concat(
                     ss.Set<Customer>()
-                        .Select(c => (string)null)));
+                        .Select(c => (string?)null)));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Union_over_column_column(bool async)
@@ -805,7 +803,7 @@ public abstract class NorthwindSetOperationsQueryTestBase<TFixture>(TFixture fix
                     ss.Set<Customer>()
                         .Where(c => c.CustomerID.StartsWith("F"))
                         .Select(c => new { c.Orders })),
-            elementSorter: a => a.Orders.FirstOrDefault().Maybe(e => e.CustomerID),
+            elementSorter: a => a.Orders.FirstOrDefault()!.Maybe(e => e.CustomerID),
             elementAsserter: (e, a) => AssertCollection(e.Orders, a.Orders));
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -813,7 +811,7 @@ public abstract class NorthwindSetOperationsQueryTestBase<TFixture>(TFixture fix
         => AssertQuery(
             async,
             ss => ss.Set<Order>()
-                .Where(c => c.Customer.City == "Seatte")
+                .Where(c => c.Customer!.City == "Seatte")
                 .Select(c => new { c.OrderDate })
                 .Union(
                     ss.Set<Order>()
@@ -826,10 +824,10 @@ public abstract class NorthwindSetOperationsQueryTestBase<TFixture>(TFixture fix
     public virtual Task Union_on_entity_with_correlated_collection(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<Order>().Where(c => c.Customer.City == "Seatte").Select(c => c.Customer)
+            ss => ss.Set<Order>().Where(c => c.Customer!.City == "Seatte").Select(c => c.Customer)
                 .Union(ss.Set<Order>().Where(o => o.OrderID < 10250).Select(c => c.Customer))
-                .OrderBy(c => c.CustomerID)
-                .Select(c => c.Orders),
+                .OrderBy(c => c!.CustomerID)
+                .Select(c => c!.Orders),
             assertOrder: true,
             elementAsserter: (e, a) => AssertCollection(e, a));
 
@@ -837,10 +835,10 @@ public abstract class NorthwindSetOperationsQueryTestBase<TFixture>(TFixture fix
     public virtual Task Union_on_entity_plus_other_column_with_correlated_collection(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<Order>().Where(c => c.Customer.City == "Seatte").Select(c => new { c.Customer, c.OrderDate })
+            ss => ss.Set<Order>().Where(c => c.Customer!.City == "Seatte").Select(c => new { c.Customer, c.OrderDate })
                 .Union(ss.Set<Order>().Where(o => o.OrderID < 10250).Select(c => new { c.Customer, c.OrderDate }))
-                .OrderBy(c => c.Customer.CustomerID)
-                .Select(c => new { c.OrderDate, Orders = ss.Set<Order>().Where(o => o.CustomerID == c.Customer.CustomerID).ToList() }),
+                .OrderBy(c => c.Customer!.CustomerID)
+                .Select(c => new { c.OrderDate, Orders = ss.Set<Order>().Where(o => o.CustomerID == c.Customer!.CustomerID).ToList() }),
             assertOrder: true,
             elementAsserter: (e, a) =>
             {

--- a/test/EFCore.Specification.Tests/Query/NorthwindStringIncludeQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindStringIncludeQueryTestBase.cs
@@ -11,8 +11,6 @@ using Microsoft.EntityFrameworkCore.TestModels.Northwind;
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
-#nullable disable
-
 public abstract class NorthwindStringIncludeQueryTestBase<TFixture>(TFixture fixture) : NorthwindIncludeQueryTestBase<TFixture>(fixture)
     where TFixture : NorthwindQueryFixtureBase<NoopModelCustomizer>, new()
 {
@@ -41,7 +39,7 @@ public abstract class NorthwindStringIncludeQueryTestBase<TFixture>(TFixture fix
                 .GenerateMessage("CustomerID", "Customer.CustomerID"),
             (await Assert.ThrowsAsync<InvalidOperationException>(() => AssertQuery(
                 async,
-                ss => ss.Set<Order>().Include(o => o.Customer.CustomerID)))).Message);
+                ss => ss.Set<Order>().Include(o => o.Customer!.CustomerID)))).Message);
 
     public override Task Include_property_expression_invalid(bool async)
         // Property expression cannot be converted to string include
@@ -193,7 +191,7 @@ public abstract class NorthwindStringIncludeQueryTestBase<TFixture>(TFixture fix
                     || genericMethodDefinition == _thenIncludeAfterReferenceMethodInfo)
                 {
                     var innerIncludeMethodCall = (MethodCallExpression)Visit(methodCallExpression.Arguments[0]);
-                    var innerNavigationPath = (string)((ConstantExpression)innerIncludeMethodCall.Arguments[1]).Value;
+                    var innerNavigationPath = (string)((ConstantExpression)innerIncludeMethodCall.Arguments[1]).Value!;
                     var currentNavigationpath = GetPath(methodCallExpression.Arguments[1].UnwrapLambdaFromQuote().Body);
 
                     return innerIncludeMethodCall.Update(
@@ -207,7 +205,7 @@ public abstract class NorthwindStringIncludeQueryTestBase<TFixture>(TFixture fix
             return base.VisitMethodCall(methodCallExpression);
         }
 
-        private static string GetPath(Expression expression)
+        private static string GetPath(Expression? expression)
             => expression switch
             {
                 MemberExpression { Expression: ParameterExpression } memberExpression

--- a/test/EFCore.Specification.Tests/Query/NorthwindWhereQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindWhereQueryTestBase.cs
@@ -5,8 +5,6 @@ using Microsoft.EntityFrameworkCore.TestModels.Northwind;
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
-#nullable disable
-
 // ReSharper disable ConvertToConstant.Local
 // ReSharper disable RedundantBoolCompare
 // ReSharper disable InconsistentNaming
@@ -232,13 +230,13 @@ public abstract class NorthwindWhereQueryTestBase<TFixture>(TFixture fixture) : 
 
         await AssertQuery(
             async,
-            ss => ss.Set<Customer>().Where(c => c.City == city.Nested.InstanceFieldValue));
+            ss => ss.Set<Customer>().Where(c => c.City == city.Nested!.InstanceFieldValue));
 
-        city.Nested.InstanceFieldValue = "Seattle";
+        city.Nested!.InstanceFieldValue = "Seattle";
 
         await AssertQuery(
             async,
-            ss => ss.Set<Customer>().Where(c => c.City == city.Nested.InstanceFieldValue));
+            ss => ss.Set<Customer>().Where(c => c.City == city.Nested!.InstanceFieldValue));
     }
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -248,13 +246,13 @@ public abstract class NorthwindWhereQueryTestBase<TFixture>(TFixture fixture) : 
 
         await AssertQuery(
             async,
-            ss => ss.Set<Customer>().Where(c => c.City == city.Nested.InstancePropertyValue));
+            ss => ss.Set<Customer>().Where(c => c.City == city.Nested!.InstancePropertyValue));
 
-        city.Nested.InstancePropertyValue = "Seattle";
+        city.Nested!.InstancePropertyValue = "Seattle";
 
         await AssertQuery(
             async,
-            ss => ss.Set<Customer>().Where(c => c.City == city.Nested.InstancePropertyValue));
+            ss => ss.Set<Customer>().Where(c => c.City == city.Nested!.InstancePropertyValue));
     }
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -264,7 +262,7 @@ public abstract class NorthwindWhereQueryTestBase<TFixture>(TFixture fixture) : 
 
         return Assert.ThrowsAsync<InvalidOperationException>(() => AssertQuery(
             async,
-            ss => ss.Set<Customer>().Where(c => c.City == city.Nested.InstanceFieldValue)));
+            ss => ss.Set<Customer>().Where(c => c.City == city.Nested!.InstanceFieldValue)));
     }
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -305,17 +303,17 @@ public abstract class NorthwindWhereQueryTestBase<TFixture>(TFixture fixture) : 
 
     private class City
     {
-        public static string StaticFieldValue;
-        public static string StaticPropertyValue { get; set; }
+        public static string StaticFieldValue = null!;
+        public static string StaticPropertyValue { get; set; } = null!;
 
-        public string InstanceFieldValue;
-        public string InstancePropertyValue { get; set; }
+        public string InstanceFieldValue = null!;
+        public string InstancePropertyValue { get; set; } = null!;
 
         public int Int { get; set; }
 
         public int? NullableInt { get; set; }
 
-        public City Nested;
+        public City? Nested;
 
         public City Throw()
             => throw new NotImplementedException();
@@ -372,7 +370,7 @@ public abstract class NorthwindWhereQueryTestBase<TFixture>(TFixture fixture) : 
     public virtual async Task Where_subquery_closure_via_query_cache(bool async)
     {
         using var context = CreateContext();
-        string customerID = null;
+        string? customerID = null;
 
         var orders = context.Orders.Where(o => o.CustomerID == customerID);
 
@@ -427,7 +425,7 @@ public abstract class NorthwindWhereQueryTestBase<TFixture>(TFixture fixture) : 
             ss => from e in ss.Set<Employee>()
                   where EF.Property<string>(e, "Title")
                       == EF.Property<string>(
-                          ss.Set<Employee>().OrderBy(e2 => EF.Property<string>(e2, "Title")).FirstOrDefault(), "Title")
+                          ss.Set<Employee>().OrderBy(e2 => EF.Property<string>(e2, "Title")).FirstOrDefault()!, "Title")
                   select e);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -980,7 +978,7 @@ public abstract class NorthwindWhereQueryTestBase<TFixture>(TFixture fixture) : 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Where_expression_invoke_2(bool async)
     {
-        Expression<Func<Order, Customer>> customer = o => o.Customer;
+        Expression<Func<Order, Customer?>> customer = o => o.Customer;
         Expression<Func<Customer, bool>> predicate = c => c.CustomerID == "ALFKI";
         var exp = Expression.Lambda<Func<Order, bool>>(
             Expression.Invoke(predicate, customer.Body),
@@ -1091,21 +1089,21 @@ public abstract class NorthwindWhereQueryTestBase<TFixture>(TFixture fixture) : 
     public virtual Task Where_compare_tuple_constructed_equal(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<Customer>().Where(c => new Tuple<string>(c.City) == new Tuple<string>("London")),
+            ss => ss.Set<Customer>().Where(c => new Tuple<string?>(c.City) == new Tuple<string?>("London")),
             ss => ss.Set<Customer>().Where(c => c.City == "London"));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Where_compare_tuple_constructed_multi_value_equal(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<Customer>().Where(c => new Tuple<string, string>(c.City, c.Country) == new Tuple<string, string>("London", "UK")),
+            ss => ss.Set<Customer>().Where(c => new Tuple<string?, string?>(c.City, c.Country) == new Tuple<string?, string?>("London", "UK")),
             ss => ss.Set<Customer>().Where(c => c.City == "London" && c.Country == "UK"));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Where_compare_tuple_constructed_multi_value_not_equal(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<Customer>().Where(c => new Tuple<string, string>(c.City, c.Country) != new Tuple<string, string>("London", "UK")),
+            ss => ss.Set<Customer>().Where(c => new Tuple<string?, string?>(c.City, c.Country) != new Tuple<string?, string?>("London", "UK")),
             ss => ss.Set<Customer>().Where(c => c.City != "London" || c.Country != "UK"));
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -1146,7 +1144,7 @@ public abstract class NorthwindWhereQueryTestBase<TFixture>(TFixture fixture) : 
         => AssertQuery(
             async,
             // ReSharper disable twice RedundantCast
-            ss => ss.Set<Customer>().Where(c => (object)c.City == (object)"London"));
+            ss => ss.Set<Customer>().Where(c => (object?)c.City == (object)"London"));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Where_projection(bool async)
@@ -1224,7 +1222,7 @@ public abstract class NorthwindWhereQueryTestBase<TFixture>(TFixture fixture) : 
         => AssertQuery(
             async,
             ss => ss.Set<Customer>().Where(c => c.Orders.OrderBy(o => o.OrderID).FirstOrDefault() == new Order { OrderID = 10276 }),
-            ss => ss.Set<Customer>().Where(c => c.Orders.OrderBy(o => o.OrderID).FirstOrDefault().OrderID == 10276));
+            ss => ss.Set<Customer>().Where(c => c.Orders.OrderBy(o => o.OrderID).FirstOrDefault()!.OrderID == 10276));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task TypeBinary_short_circuit(bool async)
@@ -1289,7 +1287,7 @@ public abstract class NorthwindWhereQueryTestBase<TFixture>(TFixture fixture) : 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Generic_Ilist_contains_translates_to_server(bool async)
     {
-        var cities = new List<string> { "Seattle" } as IList<string>;
+        var cities = new List<string?> { "Seattle" } as IList<string?>;
 
         return AssertQuery(
             async,
@@ -1308,7 +1306,7 @@ public abstract class NorthwindWhereQueryTestBase<TFixture>(TFixture fixture) : 
         => AssertQuery(
             async,
             ss => ss.Set<Customer>().Where(c
-                => ss.Set<Order>().Where(o => o.CustomerID == "John Doe").Select(o => o.CustomerID).FirstOrDefault().Length == 0),
+                => ss.Set<Order>().Where(o => o.CustomerID == "John Doe").Select(o => o.CustomerID).FirstOrDefault()!.Length == 0),
             ss => ss.Set<Customer>().Where(c => false),
             assertEmpty: true);
 
@@ -1475,7 +1473,7 @@ public abstract class NorthwindWhereQueryTestBase<TFixture>(TFixture fixture) : 
                 // Check also with Enumerable here so we don't handle the null check
                 // incorrectly because Contains is coverted in
                 // QueryableMethodNormalizingExpressionVisitor.TryConvertCollectionContainsToQueryableContains.
-                List<string> ids = withNull ? null : ["ALFKI", "ANATR"];
+                List<string>? ids = withNull ? null : ["ALFKI", "ANATR"];
                 return ss.Set<Customer>().Where(c => ids != null && ids.Contains(c.CustomerID));
             },
             assertEmpty: withNull);
@@ -1493,7 +1491,7 @@ public abstract class NorthwindWhereQueryTestBase<TFixture>(TFixture fixture) : 
                 // Check also with Enumerable here so we don't handle the null check
                 // incorrectly because Contains is coverted in
                 // QueryableMethodNormalizingExpressionVisitor.TryConvertCollectionContainsToQueryableContains.
-                List<string> ids = withNull ? null : ["ALFKI", "ANATR"];
+                List<string>? ids = withNull ? null : ["ALFKI", "ANATR"];
                 return ss.Set<Customer>().Where(c => ids == null || !ids.Contains(c.CustomerID));
             });
 
@@ -1676,7 +1674,7 @@ public abstract class NorthwindWhereQueryTestBase<TFixture>(TFixture fixture) : 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Multiple_OrElse_on_same_column_with_null_parameter_comparison_converted_to_in(bool async)
     {
-        string prm = null;
+        string? prm = null;
 
         return AssertQuery(
             async,

--- a/test/EFCore.Specification.Tests/Query/NullKeysTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NullKeysTestBase.cs
@@ -5,8 +5,6 @@
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
-#nullable disable
-
 public abstract class NullKeysTestBase<TFixture>(TFixture fixture) : IClassFixture<TFixture>
     where TFixture : NullKeysTestBase<TFixture>.NullKeysFixtureBase, new()
 {
@@ -38,7 +36,7 @@ public abstract class NullKeysTestBase<TFixture>(TFixture fixture) : IClassFixtu
 
         Assert.Equal(
             ["Empire", "Fire", "Stereo", "Stereo"],
-            results.Skip(2).Select(e => e.Principal.Id));
+            results.Skip(2).Select(e => e.Principal!.Id));
     }
 
     [Fact]
@@ -81,9 +79,9 @@ public abstract class NullKeysTestBase<TFixture>(TFixture fixture) : IClassFixtu
             results.Select(e => e.Fk));
 
         Assert.Null(results[0].Principal);
-        Assert.Equal(1, results[1].Principal.Id);
+        Assert.Equal(1, results[1].Principal!.Id);
         Assert.Null(results[2].Principal);
-        Assert.Equal(2, results[3].Principal.Id);
+        Assert.Equal(2, results[3].Principal!.Id);
         Assert.Null(results[4].Principal);
         Assert.Null(results[5].Principal);
     }
@@ -106,9 +104,9 @@ public abstract class NullKeysTestBase<TFixture>(TFixture fixture) : IClassFixtu
             results.Select(e => e.Fk));
 
         Assert.Null(results[0].Principal);
-        Assert.Equal(1, results[1].Principal.Id);
+        Assert.Equal(1, results[1].Principal!.Id);
         Assert.Null(results[2].Principal);
-        Assert.Equal(2, results[3].Principal.Id);
+        Assert.Equal(2, results[3].Principal!.Id);
         Assert.Null(results[4].Principal);
         Assert.Null(results[5].Principal);
     }
@@ -131,36 +129,36 @@ public abstract class NullKeysTestBase<TFixture>(TFixture fixture) : IClassFixtu
             results.Select(e => e.SelfFk).ToArray());
 
         Assert.Null(results[0].Self);
-        Assert.Equal("And", results[1].Self.Id);
+        Assert.Equal("And", results[1].Self!.Id);
         Assert.Null(results[2].Self);
         Assert.Null(results[3].Self);
-        Assert.Equal("Wendy", results[4].Self.Id);
+        Assert.Equal("Wendy", results[4].Self!.Id);
         Assert.Null(results[5].Self);
     }
 
     protected class WithStringKey
     {
-        public string Id { get; set; }
+        public string Id { get; set; } = null!;
 
-        public ICollection<WithStringFk> Dependents { get; set; }
+        public ICollection<WithStringFk> Dependents { get; set; } = [];
     }
 
     protected class WithStringFk
     {
-        public string Id { get; set; }
+        public string Id { get; set; } = null!;
 
-        public string Fk { get; set; }
-        public WithStringKey Principal { get; set; }
+        public string? Fk { get; set; }
+        public WithStringKey? Principal { get; set; }
 
-        public string SelfFk { get; set; }
-        public WithStringFk Self { get; set; }
+        public string? SelfFk { get; set; }
+        public WithStringFk? Self { get; set; }
     }
 
     protected class WithIntKey
     {
         public int Id { get; set; }
 
-        public ICollection<WithNullableIntFk> Dependents { get; set; }
+        public ICollection<WithNullableIntFk> Dependents { get; set; } = [];
     }
 
     protected class WithNullableIntFk
@@ -168,14 +166,14 @@ public abstract class NullKeysTestBase<TFixture>(TFixture fixture) : IClassFixtu
         public int Id { get; set; }
 
         public int? Fk { get; set; }
-        public WithIntKey Principal { get; set; }
+        public WithIntKey? Principal { get; set; }
     }
 
     protected class WithNullableIntKey
     {
         public int? Id { get; set; }
 
-        public ICollection<WithIntFk> Dependents { get; set; }
+        public ICollection<WithIntFk> Dependents { get; set; } = [];
     }
 
     protected class WithIntFk
@@ -183,14 +181,14 @@ public abstract class NullKeysTestBase<TFixture>(TFixture fixture) : IClassFixtu
         public int Id { get; set; }
 
         public int Fk { get; set; }
-        public WithNullableIntKey Principal { get; set; }
+        public WithNullableIntKey Principal { get; set; } = null!;
     }
 
     protected class WithAllNullableIntKey
     {
         public int? Id { get; set; }
 
-        public ICollection<WithAllNullableIntFk> Dependents { get; set; }
+        public ICollection<WithAllNullableIntFk> Dependents { get; set; } = [];
     }
 
     protected class WithAllNullableIntFk
@@ -198,7 +196,7 @@ public abstract class NullKeysTestBase<TFixture>(TFixture fixture) : IClassFixtu
         public int Id { get; set; }
 
         public int? Fk { get; set; }
-        public WithAllNullableIntKey Principal { get; set; }
+        public WithAllNullableIntKey? Principal { get; set; }
     }
 
     public abstract class NullKeysFixtureBase : SharedStoreFixtureBase<PoolableDbContext>

--- a/test/EFCore.Specification.Tests/Query/OwnedEntityQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/OwnedEntityQueryTestBase.cs
@@ -5,8 +5,6 @@ using System.Collections.ObjectModel;
 
 namespace Microsoft.EntityFrameworkCore;
 
-#nullable disable
-
 public abstract class OwnedEntityQueryTestBase(NonSharedFixture fixture) : NonSharedModelTestBase(fixture), IClassFixture<NonSharedFixture>
 {
     protected override string NonSharedStoreName
@@ -45,8 +43,8 @@ public abstract class OwnedEntityQueryTestBase(NonSharedFixture fixture) : NonSh
     // Protected so that it can be used by inheriting tests, and so that things like unused setters are not removed.
     protected class Context9202(DbContextOptions options) : DbContext(options)
     {
-        public DbSet<Movie> Movies { get; set; }
-        public DbSet<Actor> Actors { get; set; }
+        public DbSet<Movie> Movies { get; set; } = null!;
+        public DbSet<Actor> Actors { get; set; } = null!;
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
@@ -80,23 +78,23 @@ public abstract class OwnedEntityQueryTestBase(NonSharedFixture fixture) : NonSh
         public class Movie
         {
             public int Id { get; set; }
-            public string Title { get; set; }
+            public string Title { get; set; } = null!;
 
-            public List<Actor> Cast { get; set; }
+            public List<Actor> Cast { get; set; } = null!;
 
-            public Details Details { get; set; }
+            public Details Details { get; set; } = null!;
         }
 
         public class Actor
         {
             public int Id { get; set; }
-            public string Name { get; set; }
-            public Details Details { get; set; }
+            public string Name { get; set; } = null!;
+            public Details Details { get; set; } = null!;
         }
 
         public class Details
         {
-            public string Info { get; set; }
+            public string Info { get; set; } = null!;
             public int Rating { get; set; }
         }
     }
@@ -117,7 +115,7 @@ public abstract class OwnedEntityQueryTestBase(NonSharedFixture fixture) : NonSh
     // Protected so that it can be used by inheriting tests, and so that things like unused setters are not removed.
     protected class Context13079(DbContextOptions options) : DbContext(options)
     {
-        public virtual DbSet<BaseEntity> BaseEntities { get; set; }
+        public virtual DbSet<BaseEntity> BaseEntities { get; set; } = null!;
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
             => modelBuilder.Entity<DerivedEntity>().OwnsOne(e => e.Data, b => b.OwnsOne(e => e.SubData));
@@ -130,13 +128,13 @@ public abstract class OwnedEntityQueryTestBase(NonSharedFixture fixture) : NonSh
         public class DerivedEntity : BaseEntity
         {
             public int Property { get; set; }
-            public OwnedData Data { get; set; }
+            public OwnedData Data { get; set; } = null!;
         }
 
         public class OwnedData
         {
             public int Property { get; set; }
-            public OwnedSubData SubData { get; set; }
+            public OwnedSubData SubData { get; set; } = null!;
         }
 
         public class OwnedSubData
@@ -180,7 +178,7 @@ public abstract class OwnedEntityQueryTestBase(NonSharedFixture fixture) : NonSh
     // Protected so that it can be used by inheriting tests, and so that things like unused setters are not removed.
     protected class Context13157(DbContextOptions options) : DbContext(options)
     {
-        public virtual DbSet<Partner> Partners { get; set; }
+        public virtual DbSet<Partner> Partners { get; set; } = null!;
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
             => modelBuilder.Entity<Address>().OwnsOne(x => x.Turnovers);
@@ -203,13 +201,13 @@ public abstract class OwnedEntityQueryTestBase(NonSharedFixture fixture) : NonSh
         public class Partner
         {
             public int Id { get; set; }
-            public ICollection<Address> Addresses { get; set; }
+            public ICollection<Address> Addresses { get; set; } = null!;
         }
 
         public class Address
         {
             public int Id { get; set; }
-            public AddressTurnovers Turnovers { get; set; }
+            public AddressTurnovers? Turnovers { get; set; }
         }
 
         public class AddressTurnovers
@@ -227,10 +225,10 @@ public abstract class OwnedEntityQueryTestBase(NonSharedFixture fixture) : NonSh
     {
         var contextFactory = await InitializeNonSharedTest<Context14911>(seed: c => c.SeedAsync());
         using var context = contextFactory.CreateDbContext();
-        var aggregate = context.Set<Context14911.Aggregate>().OrderByDescending(e => e.Id).FirstOrDefault();
-        Assert.Equal(10, aggregate.FirstValueObject.SecondValueObjects[0].FourthValueObject.FifthValueObjects[0].AnyValue);
+        var aggregate = context.Set<Context14911.Aggregate>().OrderByDescending(e => e.Id).FirstOrDefault()!;
+        Assert.Equal(10, aggregate.FirstValueObject!.SecondValueObjects[0].FourthValueObject!.FifthValueObjects[0].AnyValue);
         Assert.Equal(
-            20, aggregate.FirstValueObject.SecondValueObjects[0].ThirdValueObjects[0].FourthValueObject.FifthValueObjects[0].AnyValue);
+            20, aggregate.FirstValueObject.SecondValueObjects[0].ThirdValueObjects[0].FourthValueObject!.FifthValueObjects[0].AnyValue);
     }
 
     protected class Context14911(DbContextOptions options) : DbContext(options)
@@ -309,30 +307,30 @@ public abstract class OwnedEntityQueryTestBase(NonSharedFixture fixture) : NonSh
         public class Aggregate
         {
             public int Id { get; set; }
-            public FirstValueObject FirstValueObject { get; set; }
+            public FirstValueObject? FirstValueObject { get; set; }
         }
 
         public class FirstValueObject
         {
             public int Value { get; set; }
-            public List<SecondValueObject> SecondValueObjects { get; set; }
+            public List<SecondValueObject> SecondValueObjects { get; set; } = null!;
         }
 
         public class SecondValueObject
         {
-            public FourthValueObject FourthValueObject { get; set; }
-            public List<ThirdValueObject> ThirdValueObjects { get; set; }
+            public FourthValueObject? FourthValueObject { get; set; }
+            public List<ThirdValueObject> ThirdValueObjects { get; set; } = null!;
         }
 
         public class ThirdValueObject
         {
-            public FourthValueObject FourthValueObject { get; set; }
+            public FourthValueObject? FourthValueObject { get; set; }
         }
 
         public class FourthValueObject
         {
             public int Value { get; set; }
-            public List<FifthValueObject> FifthValueObjects { get; set; }
+            public List<FifthValueObject> FifthValueObjects { get; set; } = null!;
         }
 
         public class FifthValueObject
@@ -369,7 +367,7 @@ public abstract class OwnedEntityQueryTestBase(NonSharedFixture fixture) : NonSh
     // Protected so that it can be used by inheriting tests, and so that things like unused setters are not removed.
     protected class Context18582(DbContextOptions options) : DbContext(options)
     {
-        public DbSet<Warehouse> Warehouses { get; set; }
+        public DbSet<Warehouse> Warehouses { get; set; } = null!;
 
         public Task SeedAsync()
         {
@@ -397,22 +395,22 @@ public abstract class OwnedEntityQueryTestBase(NonSharedFixture fixture) : NonSh
         public class Warehouse
         {
             public int Id { get; set; }
-            public string WarehouseCode { get; set; }
+            public string WarehouseCode { get; set; } = null!;
             public ICollection<WarehouseDestinationCountry> DestinationCountries { get; set; } = new HashSet<WarehouseDestinationCountry>();
         }
 
         public class WarehouseDestinationCountry
         {
-            public string Id { get; set; }
-            public string WarehouseCode { get; set; }
-            public string CountryCode { get; set; }
+            public string Id { get; set; } = null!;
+            public string WarehouseCode { get; set; } = null!;
+            public string CountryCode { get; set; } = null!;
         }
 
         public class WarehouseModel
         {
-            public string WarehouseCode { get; set; }
+            public string WarehouseCode { get; set; } = null!;
 
-            public ICollection<string> DestinationCountryCodes { get; set; }
+            public ICollection<string> DestinationCountryCodes { get; set; } = null!;
         }
     }
 
@@ -429,14 +427,14 @@ public abstract class OwnedEntityQueryTestBase(NonSharedFixture fixture) : NonSh
             .Select(b => context.OtherEntities.Where(o => o.OtherEntityData == ((Context19138.SubEntity)b).Data).FirstOrDefault())
             .ToList();
 
-        Assert.Equal("A", Assert.Single(result).OtherEntityData);
+        Assert.Equal("A", Assert.Single(result)!.OtherEntityData);
     }
 
     // Protected so that it can be used by inheriting tests, and so that things like unused setters are not removed.
     protected class Context19138(DbContextOptions options) : DbContext(options)
     {
-        public DbSet<BaseEntity> BaseEntities { get; set; }
-        public DbSet<OtherEntity> OtherEntities { get; set; }
+        public DbSet<BaseEntity> BaseEntities { get; set; } = null!;
+        public DbSet<OtherEntity> OtherEntities { get; set; } = null!;
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
@@ -460,20 +458,20 @@ public abstract class OwnedEntityQueryTestBase(NonSharedFixture fixture) : NonSh
 
         public class SubEntity : BaseEntity
         {
-            public string Data { get; set; }
-            public Owned Owned { get; set; }
+            public string Data { get; set; } = null!;
+            public Owned Owned { get; set; } = null!;
         }
 
         public class Owned
         {
-            public string OwnedData { get; set; }
+            public string OwnedData { get; set; } = null!;
             public int Value { get; set; }
         }
 
         public class OtherEntity
         {
             public int Id { get; set; }
-            public string OtherEntityData { get; set; }
+            public string OtherEntityData { get; set; } = null!;
         }
     }
 
@@ -530,20 +528,20 @@ public abstract class OwnedEntityQueryTestBase(NonSharedFixture fixture) : NonSh
         public class Entity
         {
             public int Id { get; set; }
-            public List<Child> Children { get; set; }
+            public List<Child> Children { get; set; } = null!;
         }
 
         public class Child
         {
             public int Id { get; set; }
             public int Type { get; set; }
-            public Owned Owned { get; set; }
+            public Owned Owned { get; set; } = null!;
         }
 
         public class Owned
         {
             public bool IsDeleted { get; set; }
-            public string Value { get; set; }
+            public string Value { get; set; } = null!;
         }
     }
 
@@ -582,7 +580,7 @@ public abstract class OwnedEntityQueryTestBase(NonSharedFixture fixture) : NonSh
     // Protected so that it can be used by inheriting tests, and so that things like unused setters are not removed.
     protected class Context21540(DbContextOptions options) : DbContext(options)
     {
-        public DbSet<Parent> Parents { get; set; }
+        public DbSet<Parent> Parents { get; set; } = null!;
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
@@ -622,31 +620,31 @@ public abstract class OwnedEntityQueryTestBase(NonSharedFixture fixture) : NonSh
         public class Parent
         {
             public int Id { get; set; }
-            public Reference Reference { get; set; }
-            public Owned OwnedReference { get; set; }
-            public List<Collection> Collection { get; set; }
-            public List<OtherSide> SkipOtherSide { get; set; }
+            public Reference Reference { get; set; } = null!;
+            public Owned OwnedReference { get; set; } = null!;
+            public List<Collection> Collection { get; set; } = null!;
+            public List<OtherSide> SkipOtherSide { get; set; } = null!;
         }
 
         public class JoinEntity
         {
             public int ParentId { get; set; }
-            public Parent Parent { get; set; }
+            public Parent Parent { get; set; } = null!;
             public int OtherSideId { get; set; }
-            public OtherSide OtherSide { get; set; }
+            public OtherSide OtherSide { get; set; } = null!;
         }
 
         public class OtherSide
         {
             public int Id { get; set; }
-            public List<Parent> SkipParent { get; set; }
+            public List<Parent> SkipParent { get; set; } = null!;
         }
 
         public class Reference
         {
             public int Id { get; set; }
             public int ParentId { get; set; }
-            public Parent Parent { get; set; }
+            public Parent Parent { get; set; } = null!;
         }
 
         public class Owned
@@ -658,7 +656,7 @@ public abstract class OwnedEntityQueryTestBase(NonSharedFixture fixture) : NonSh
         {
             public int Id { get; set; }
             public int ParentId { get; set; }
-            public Parent Parent { get; set; }
+            public Parent Parent { get; set; } = null!;
         }
     }
 
@@ -701,21 +699,21 @@ public abstract class OwnedEntityQueryTestBase(NonSharedFixture fixture) : NonSh
 
         public class Entity
         {
-            public string Id { get; set; }
-            public Contact Contact { get; set; }
+            public string Id { get; set; } = null!;
+            public Contact Contact { get; set; } = null!;
         }
 
         public class Contact
         {
-            public string Name { get; set; }
-            public Address Address { get; set; }
+            public string? Name { get; set; }
+            public Address Address { get; set; } = null!;
         }
 
         public class Address
         {
-            public string Street { get; set; }
-            public string City { get; set; }
-            public string State { get; set; }
+            public string? Street { get; set; }
+            public string? City { get; set; }
+            public string? State { get; set; }
             public int Zip { get; set; }
         }
     }
@@ -741,7 +739,7 @@ public abstract class OwnedEntityQueryTestBase(NonSharedFixture fixture) : NonSh
     // Protected so that it can be used by inheriting tests, and so that things like unused setters are not removed.
     protected class Context22089(DbContextOptions options) : DbContext(options)
     {
-        public DbSet<Contact> Contacts { get; set; }
+        public DbSet<Contact> Contacts { get; set; } = null!;
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
@@ -758,7 +756,7 @@ public abstract class OwnedEntityQueryTestBase(NonSharedFixture fixture) : NonSh
         public class ContactDto
         {
             public Guid Id { get; set; }
-            public IReadOnlyList<NameDto> Names { get; set; }
+            public IReadOnlyList<NameDto> Names { get; set; } = null!;
         }
 
         public class Name
@@ -822,7 +820,7 @@ public abstract class OwnedEntityQueryTestBase(NonSharedFixture fixture) : NonSh
 
         public class Post
         {
-            public string Title { get; set; }
+            public string Title { get; set; } = null!;
             public int CommentsCount { get; set; }
         }
 
@@ -830,12 +828,12 @@ public abstract class OwnedEntityQueryTestBase(NonSharedFixture fixture) : NonSh
         {
             public int Id { get; set; }
             public int TotalComments { get; set; }
-            public IEnumerable<PostDto> Posts { get; set; }
+            public IEnumerable<PostDto> Posts { get; set; } = null!;
         }
 
         public class PostDto
         {
-            public string Title { get; set; }
+            public string Title { get; set; } = null!;
             public int CommentsCount { get; set; }
         }
     }
@@ -853,30 +851,30 @@ public abstract class OwnedEntityQueryTestBase(NonSharedFixture fixture) : NonSh
 
         var company = Assert.Single(result);
         Assert.Equal("Acme Inc.", company.Name);
-        Assert.Equal("Regular", company.CustomerData.AdditionalCustomerData);
-        Assert.Equal("Free shipping", company.SupplierData.AdditionalSupplierData);
+        Assert.Equal("Regular", company.CustomerData!.AdditionalCustomerData);
+        Assert.Equal("Free shipping", company.SupplierData!.AdditionalSupplierData);
     }
 
     protected virtual async Task Owned_references_on_same_level_nested_expanded_at_different_times_around_take_helper(
         MyContext26592Base context,
         bool async)
     {
-        var query = context.Owners.Where(e => e.OwnedEntity.CustomerData != null).OrderBy(e => e.Id).Take(10);
+        var query = context.Owners.Where(e => e.OwnedEntity!.CustomerData != null).OrderBy(e => e.Id).Take(10);
         var result = async
             ? await query.ToListAsync()
             : query.ToList();
 
         var owner = Assert.Single(result);
         Assert.Equal("Owner1", owner.Name);
-        Assert.Equal("Intermediate1", owner.OwnedEntity.Name);
-        Assert.Equal("IM Regular", owner.OwnedEntity.CustomerData.AdditionalCustomerData);
-        Assert.Equal("IM Free shipping", owner.OwnedEntity.SupplierData.AdditionalSupplierData);
+        Assert.Equal("Intermediate1", owner.OwnedEntity!.Name);
+        Assert.Equal("IM Regular", owner.OwnedEntity.CustomerData!.AdditionalCustomerData);
+        Assert.Equal("IM Free shipping", owner.OwnedEntity.SupplierData!.AdditionalSupplierData);
     }
 
     protected abstract class MyContext26592Base(DbContextOptions options) : DbContext(options)
     {
-        public DbSet<Company> Companies { get; set; }
-        public DbSet<Owner> Owners { get; set; }
+        public DbSet<Company> Companies { get; set; } = null!;
+        public DbSet<Owner> Owners { get; set; } = null!;
 
         public Task SeedAsync()
         {
@@ -906,39 +904,39 @@ public abstract class OwnedEntityQueryTestBase(NonSharedFixture fixture) : NonSh
         public class Company
         {
             public int Id { get; set; }
-            public string Name { get; set; }
-            public CustomerData CustomerData { get; set; }
-            public SupplierData SupplierData { get; set; }
+            public string? Name { get; set; }
+            public CustomerData? CustomerData { get; set; }
+            public SupplierData? SupplierData { get; set; }
         }
 
         [Owned]
         public class CustomerData
         {
             public int Id { get; set; }
-            public string AdditionalCustomerData { get; set; }
+            public string? AdditionalCustomerData { get; set; }
         }
 
         [Owned]
         public class SupplierData
         {
             public int Id { get; set; }
-            public string AdditionalSupplierData { get; set; }
+            public string? AdditionalSupplierData { get; set; }
         }
 
         public class Owner
         {
             public int Id { get; set; }
-            public string Name { get; set; }
-            public IntermediateOwnedEntity OwnedEntity { get; set; }
+            public string? Name { get; set; }
+            public IntermediateOwnedEntity? OwnedEntity { get; set; }
         }
 
         [Owned]
         public class IntermediateOwnedEntity
         {
             public int Id { get; set; }
-            public string Name { get; set; }
-            public CustomerData CustomerData { get; set; }
-            public SupplierData SupplierData { get; set; }
+            public string? Name { get; set; }
+            public CustomerData? CustomerData { get; set; }
+            public SupplierData? SupplierData { get; set; }
         }
     }
 }

--- a/test/EFCore.Specification.Tests/Query/OwnedQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/OwnedQueryTestBase.cs
@@ -5,8 +5,6 @@
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
-#nullable disable
-
 public abstract class OwnedQueryTestBase<TFixture> : QueryTestBase<TFixture>
     where TFixture : OwnedQueryTestBase<TFixture>.OwnedQueryFixtureBase, new()
 {
@@ -63,7 +61,7 @@ public abstract class OwnedQueryTestBase<TFixture> : QueryTestBase<TFixture>
             async,
             ss => from a in ss.Set<LeafA>()
                   from b in ss.Set<LeafB>()
-                  where a.LeafAAddress.Equals(b.LeafBAddress)
+                  where a.LeafAAddress!.Equals(b.LeafBAddress)
                   select a,
             assertEmpty: true);
 
@@ -128,20 +126,20 @@ public abstract class OwnedQueryTestBase<TFixture> : QueryTestBase<TFixture>
     public virtual Task Project_owned_reference_navigation_which_does_not_own_additional(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<OwnedPerson>().OrderBy(o => o.Id).Select(p => p.PersonAddress.Country));
+            ss => ss.Set<OwnedPerson>().OrderBy(o => o.Id).Select(p => p.PersonAddress!.Country));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Navigation_rewrite_on_owned_reference_projecting_scalar(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<OwnedPerson>().Where(p => p.PersonAddress.Country.Name == "USA")
-                .Select(p => p.PersonAddress.Country.Name));
+            ss => ss.Set<OwnedPerson>().Where(p => p.PersonAddress!.Country!.Name == "USA")
+                .Select(p => p.PersonAddress!.Country!.Name));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Navigation_rewrite_on_owned_reference_projecting_entity(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<OwnedPerson>().Where(p => p.PersonAddress.Country.Name == "USA"));
+            ss => ss.Set<OwnedPerson>().Where(p => p.PersonAddress!.Country!.Name == "USA"));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Navigation_rewrite_on_owned_collection(bool async)
@@ -163,7 +161,7 @@ public abstract class OwnedQueryTestBase<TFixture> : QueryTestBase<TFixture>
         => AssertQuery(
             async,
             ss => ss.Set<OwnedPerson>()
-                .Select(p => p.Orders.OrderBy(o => o.Id).Select(o => o.Client.PersonAddress.Country.Name).FirstOrDefault()));
+                .Select(p => p.Orders.OrderBy(o => o.Id).Select(o => o.Client.PersonAddress!.Country!.Name).FirstOrDefault()));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task SelectMany_on_owned_collection(bool async)
@@ -191,13 +189,13 @@ public abstract class OwnedQueryTestBase<TFixture> : QueryTestBase<TFixture>
     public virtual Task Navigation_rewrite_on_owned_reference_followed_by_regular_entity(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<OwnedPerson>().Select(p => p.PersonAddress.Country.Planet));
+            ss => ss.Set<OwnedPerson>().Select(p => p.PersonAddress!.Country!.Planet));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Filter_owned_entity_chained_with_regular_entity_followed_by_projecting_owned_collection(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<OwnedPerson>().Where(p => p.PersonAddress.Country.Planet.Id != 42).OrderBy(p => p.Id)
+            ss => ss.Set<OwnedPerson>().Where(p => p.PersonAddress!.Country!.Planet.Id != 42).OrderBy(p => p.Id)
                 .Select(p => new { p.Orders }),
             assertOrder: true,
             elementAsserter: (e, a) => AssertCollection(e.Orders, a.Orders));
@@ -211,7 +209,7 @@ public abstract class OwnedQueryTestBase<TFixture> : QueryTestBase<TFixture>
                 {
                     p.Orders,
                     p.PersonAddress,
-                    p.PersonAddress.Country.Planet
+                    p.PersonAddress!.Country!.Planet
                 }),
             assertOrder: true,
             elementAsserter: (e, a) =>
@@ -227,8 +225,8 @@ public abstract class OwnedQueryTestBase<TFixture> : QueryTestBase<TFixture>
             async,
             ss => ss.Set<OwnedPerson>().OrderBy(p => p.Id).Select(p => new
             {
-                Count = p.Orders.Where(o => o.Client.PersonAddress.Country.Planet.Star.Id != 42).Count(),
-                p.PersonAddress.Country.Planet
+                Count = p.Orders.Where(o => o.Client.PersonAddress!.Country!.Planet.Star.Id != 42).Count(),
+                p.PersonAddress!.Country!.Planet
             }),
             assertOrder: true,
             elementAsserter: (e, a) =>
@@ -241,7 +239,7 @@ public abstract class OwnedQueryTestBase<TFixture> : QueryTestBase<TFixture>
     public virtual Task Navigation_rewrite_on_owned_reference_followed_by_regular_entity_filter(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<OwnedPerson>().Where(p => p.PersonAddress.Country.Planet.Id != 7).Select(p => new { p }),
+            ss => ss.Set<OwnedPerson>().Where(p => p.PersonAddress!.Country!.Planet.Id != 7).Select(p => new { p }),
             elementSorter: e => e.p.Id,
             elementAsserter: (e, a) => AssertEqual(e.p, a.p));
 
@@ -249,13 +247,13 @@ public abstract class OwnedQueryTestBase<TFixture> : QueryTestBase<TFixture>
     public virtual Task Navigation_rewrite_on_owned_reference_followed_by_regular_entity_and_property(bool async)
         => AssertQueryScalar(
             async,
-            ss => ss.Set<OwnedPerson>().Select(p => p.PersonAddress.Country.Planet.Id));
+            ss => ss.Set<OwnedPerson>().Select(p => p.PersonAddress!.Country!.Planet.Id));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Navigation_rewrite_on_owned_reference_followed_by_regular_entity_and_collection(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<OwnedPerson>().OrderBy(p => p.Id).Select(p => p.PersonAddress.Country.Planet.Moons),
+            ss => ss.Set<OwnedPerson>().OrderBy(p => p.Id).Select(p => p.PersonAddress!.Country!.Planet.Moons),
             assertOrder: true,
             elementAsserter: (e, a) => AssertCollection(e, a));
 
@@ -263,31 +261,31 @@ public abstract class OwnedQueryTestBase<TFixture> : QueryTestBase<TFixture>
     public virtual Task SelectMany_on_owned_reference_followed_by_regular_entity_and_collection(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<OwnedPerson>().SelectMany(p => p.PersonAddress.Country.Planet.Moons));
+            ss => ss.Set<OwnedPerson>().SelectMany(p => p.PersonAddress!.Country!.Planet.Moons));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task SelectMany_on_owned_reference_with_entity_in_between_ending_in_owned_collection(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<OwnedPerson>().SelectMany(p => p.PersonAddress.Country.Planet.Star.Composition));
+            ss => ss.Set<OwnedPerson>().SelectMany(p => p.PersonAddress!.Country!.Planet.Star.Composition));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Navigation_rewrite_on_owned_reference_followed_by_regular_entity_and_collection_count(bool async)
         => AssertQueryScalar(
             async,
-            ss => ss.Set<OwnedPerson>().Select(p => p.PersonAddress.Country.Planet.Moons.Count));
+            ss => ss.Set<OwnedPerson>().Select(p => p.PersonAddress!.Country!.Planet.Moons.Count));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Navigation_rewrite_on_owned_reference_followed_by_regular_entity_and_another_reference(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<OwnedPerson>().Select(p => p.PersonAddress.Country.Planet.Star));
+            ss => ss.Set<OwnedPerson>().Select(p => p.PersonAddress!.Country!.Planet.Star));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Navigation_rewrite_on_owned_reference_followed_by_regular_entity_and_another_reference_and_scalar(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<OwnedPerson>().Select(p => p.PersonAddress.Country.Planet.Star.Name),
+            ss => ss.Set<OwnedPerson>().Select(p => p.PersonAddress!.Country!.Planet.Star.Name),
             elementSorter: e => e);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -295,8 +293,8 @@ public abstract class OwnedQueryTestBase<TFixture> : QueryTestBase<TFixture>
         Navigation_rewrite_on_owned_reference_followed_by_regular_entity_and_another_reference_in_predicate_and_projection(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<OwnedPerson>().Where(p => p.PersonAddress.Country.Planet.Star.Name == "Sol")
-                .Select(p => p.PersonAddress.Country.Planet.Star));
+            ss => ss.Set<OwnedPerson>().Where(p => p.PersonAddress!.Country!.Planet.Star.Name == "Sol")
+                .Select(p => p.PersonAddress!.Country!.Planet.Star));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Query_with_OfType_eagerly_loads_correct_owned_navigations(bool async)
@@ -314,7 +312,7 @@ public abstract class OwnedQueryTestBase<TFixture> : QueryTestBase<TFixture>
     public virtual async Task Throw_for_owned_entities_without_owner_in_tracking_query(bool async)
     {
         using var context = CreateContext();
-        var query = context.Set<OwnedPerson>().Select(e => e.PersonAddress);
+        var query = context.Set<OwnedPerson>().Select(e => e.PersonAddress!);
         var noTrackingQuery = query.AsNoTracking();
         var asTrackingQuery = query.AsTracking();
 
@@ -336,7 +334,7 @@ public abstract class OwnedQueryTestBase<TFixture> : QueryTestBase<TFixture>
     public virtual async Task Owned_entity_without_owner_does_not_throw_for_identity_resolution(bool async, bool useAsTracking)
     {
         using var context = CreateContext();
-        var query = context.Set<OwnedPerson>().Select(e => e.PersonAddress);
+        var query = context.Set<OwnedPerson>().Select(e => e.PersonAddress!);
 
         query = useAsTracking
             ? query.AsTracking(QueryTrackingBehavior.NoTrackingWithIdentityResolution)
@@ -398,7 +396,7 @@ public abstract class OwnedQueryTestBase<TFixture> : QueryTestBase<TFixture>
             ss => ss.Set<OwnedPerson>().OrderBy(e => e.Id).Select(e => Map(e)).Skip(1).Take(2));
 
     private static string Map(OwnedPerson person)
-        => person.PersonAddress.Country.Name;
+        => person.PersonAddress!.Country!.Name;
 
     // Issue#18734
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -492,7 +490,7 @@ public abstract class OwnedQueryTestBase<TFixture> : QueryTestBase<TFixture>
     public virtual Task Can_query_on_owned_indexer_properties(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<OwnedPerson>().Where(c => (int)c.PersonAddress["ZipCode"] == 38654).Select(c => (string)c["Name"]));
+            ss => ss.Set<OwnedPerson>().Where(c => (int)c.PersonAddress!["ZipCode"] == 38654).Select(c => (string)c["Name"]));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Can_query_on_indexer_property_when_property_name_from_closure(bool async)
@@ -513,7 +511,7 @@ public abstract class OwnedQueryTestBase<TFixture> : QueryTestBase<TFixture>
     public virtual Task Can_project_owned_indexer_properties(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<OwnedPerson>().Select(c => c.PersonAddress["AddressLine"]));
+            ss => ss.Set<OwnedPerson>().Select(c => c.PersonAddress!["AddressLine"]));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Can_project_indexer_properties_converted(bool async)
@@ -525,7 +523,7 @@ public abstract class OwnedQueryTestBase<TFixture> : QueryTestBase<TFixture>
     public virtual Task Can_project_owned_indexer_properties_converted(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<OwnedPerson>().Select(c => (string)c.PersonAddress["AddressLine"]));
+            ss => ss.Set<OwnedPerson>().Select(c => (string)c.PersonAddress!["AddressLine"]));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Can_OrderBy_indexer_properties(bool async)
@@ -545,14 +543,14 @@ public abstract class OwnedQueryTestBase<TFixture> : QueryTestBase<TFixture>
     public virtual Task Can_OrderBy_owned_indexer_properties(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<OwnedPerson>().OrderBy(c => c.PersonAddress["ZipCode"]).ThenBy(c => c.Id).Select(c => (string)c["Name"]),
+            ss => ss.Set<OwnedPerson>().OrderBy(c => c.PersonAddress!["ZipCode"]).ThenBy(c => c.Id).Select(c => (string)c["Name"]),
             assertOrder: true);
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Can_OrderBy_owned_indexer_properties_converted(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<OwnedPerson>().OrderBy(c => (int)c.PersonAddress["ZipCode"]).ThenBy(c => c.Id).Select(c => (string)c["Name"]),
+            ss => ss.Set<OwnedPerson>().OrderBy(c => (int)c.PersonAddress!["ZipCode"]).ThenBy(c => c.Id).Select(c => (string)c["Name"]),
             assertOrder: true);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -571,13 +569,13 @@ public abstract class OwnedQueryTestBase<TFixture> : QueryTestBase<TFixture>
     public virtual Task Can_group_by_owned_indexer_property(bool async)
         => AssertQueryScalar(
             async,
-            ss => ss.Set<OwnedPerson>().GroupBy(c => c.PersonAddress["ZipCode"]).Select(g => g.Count()));
+            ss => ss.Set<OwnedPerson>().GroupBy(c => c.PersonAddress!["ZipCode"]).Select(g => g.Count()));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Can_group_by_converted_owned_indexer_property(bool async)
         => AssertQueryScalar(
             async,
-            ss => ss.Set<OwnedPerson>().GroupBy(c => (int)c.PersonAddress["ZipCode"]).Select(g => g.Count()));
+            ss => ss.Set<OwnedPerson>().GroupBy(c => (int)c.PersonAddress!["ZipCode"]).Select(g => g.Count()));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Can_join_on_indexer_property_on_query(bool async)
@@ -586,29 +584,29 @@ public abstract class OwnedQueryTestBase<TFixture> : QueryTestBase<TFixture>
             ss =>
                 (from c1 in ss.Set<OwnedPerson>()
                  join c2 in ss.Set<OwnedPerson>()
-                     on c1.PersonAddress["ZipCode"] equals c2.PersonAddress["ZipCode"]
-                 select new { c1.Id, c2.PersonAddress.Country.Name }));
+                     on c1.PersonAddress!["ZipCode"] equals c2.PersonAddress!["ZipCode"]
+                 select new { c1.Id, c2.PersonAddress!.Country!.Name }));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Projecting_indexer_property_ignores_include(bool async)
         => AssertQuery(
             async,
             ss => from c in ss.Set<OwnedPerson>().AsTracking()
-                  select new { Nation = c.PersonAddress["ZipCode"] });
+                  select new { Nation = c.PersonAddress!["ZipCode"] });
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Projecting_indexer_property_ignores_include_converted(bool async)
         => AssertQuery(
             async,
             ss => from c in ss.Set<OwnedPerson>().AsTracking()
-                  select new { Nation = (int)c.PersonAddress["ZipCode"] });
+                  select new { Nation = (int)c.PersonAddress!["ZipCode"] });
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Indexer_property_is_pushdown_into_subquery(bool async)
         => AssertQuery(
             async,
             ss => ss.Set<OwnedPerson>()
-                .Where(g => (string)ss.Set<OwnedPerson>().Where(c => c.Id == g.Id).FirstOrDefault()["Name"] == "Mona Cy")
+                .Where(g => (string)ss.Set<OwnedPerson>().Where(c => c.Id == g.Id).FirstOrDefault()!["Name"] == "Mona Cy")
                 .Select(c => (string)c["Name"]));
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -667,7 +665,7 @@ public abstract class OwnedQueryTestBase<TFixture> : QueryTestBase<TFixture>
     public virtual Task GroupBy_with_multiple_aggregates_on_owned_navigation_properties(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<OwnedPerson>().GroupBy(e => 1, x => x.PersonAddress.Country.Planet.Star).Select(e => new
+            ss => ss.Set<OwnedPerson>().GroupBy(e => 1, x => x.PersonAddress!.Country!.Planet.Star).Select(e => new
             {
                 p1 = e.Average(x => x.Id),
                 p2 = e.Sum(x => x.Id),
@@ -680,13 +678,13 @@ public abstract class OwnedQueryTestBase<TFixture> : QueryTestBase<TFixture>
             "Nullable object must have a value.",
             (await Assert.ThrowsAsync<InvalidOperationException>(() => AssertQuery(
                 async,
-                ss => ss.Set<Barton>().Select(e => new { e.Throned.Value })))).Message);
+                ss => ss.Set<Barton>().Select(e => new { e.Throned!.Value })))).Message);
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Ordering_by_identifying_projection(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<OwnedPerson>().OrderBy(p => p.PersonAddress.PlaceType).ThenBy(e => e.Id),
+            ss => ss.Set<OwnedPerson>().OrderBy(p => p.PersonAddress!.PlaceType).ThenBy(e => e.Id),
             assertOrder: true);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -715,7 +713,7 @@ public abstract class OwnedQueryTestBase<TFixture> : QueryTestBase<TFixture>
     public virtual Task Projecting_collection_correlated_with_keyless_entity_after_navigation_works_using_parent_identifiers(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<Fink>().OrderBy(f => f.Id).Select(f => f.Barton.Throned.Value)
+            ss => ss.Set<Fink>().OrderBy(f => f.Id).Select(f => f.Barton!.Throned!.Value)
                 .Select(t => new { t, Planets = ss.Set<Planet>().Where(p => p.Id != t).ToList() }),
             assertOrder: true,
             elementAsserter: (e, a) =>
@@ -731,7 +729,7 @@ public abstract class OwnedQueryTestBase<TFixture> : QueryTestBase<TFixture>
 
         return AssertQuery(
             async,
-            ss => ss.Set<OwnedPerson>().Where(p => (int)p.PersonAddress[zipCode] == 38654));
+            ss => ss.Set<OwnedPerson>().Where(p => (int)p.PersonAddress![zipCode] == 38654));
     }
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -744,8 +742,8 @@ public abstract class OwnedQueryTestBase<TFixture> : QueryTestBase<TFixture>
             using var ctx = CreateContext();
 
             var query = async
-                ? await ctx.Set<OwnedPerson>().Where(p => (int)p.PersonAddress[n] == 38654).ToListAsync()
-                : ctx.Set<OwnedPerson>().Where(p => (int)p.PersonAddress[n] == 38654).ToList();
+                ? await ctx.Set<OwnedPerson>().Where(p => (int)p.PersonAddress![n] == 38654).ToListAsync()
+                : ctx.Set<OwnedPerson>().Where(p => (int)p.PersonAddress![n] == 38654).ToList();
 
             Assert.Single(query);
         };
@@ -817,7 +815,7 @@ public abstract class OwnedQueryTestBase<TFixture> : QueryTestBase<TFixture>
             async,
             ss => ss.Set<OwnedPerson>()
                 .GroupBy(e => e.Id)
-                .Select(e => new { e.Key, Sum = e.Sum(i => i.PersonAddress.Country.PlanetId) }),
+                .Select(e => new { e.Key, Sum = e.Sum(i => i.PersonAddress!.Country!.PlanetId) }),
             elementSorter: e => e.Key,
             elementAsserter: (e, a) =>
             {
@@ -862,8 +860,8 @@ public abstract class OwnedQueryTestBase<TFixture> : QueryTestBase<TFixture>
     public virtual Task ElementAtOrDefault_over_owned_collection(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<OwnedPerson>().Where(p => p.Orders.ElementAtOrDefault(10).Id == -11),
-            ss => ss.Set<OwnedPerson>().Where(p => p.Orders.Count >= 11 && p.Orders.ElementAtOrDefault(1).Id == -11),
+            ss => ss.Set<OwnedPerson>().Where(p => p.Orders.ElementAtOrDefault(10)!.Id == -11),
+            ss => ss.Set<OwnedPerson>().Where(p => p.Orders.Count >= 11 && p.Orders.ElementAtOrDefault(1)!.Id == -11),
             assertEmpty: true);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -883,9 +881,9 @@ public abstract class OwnedQueryTestBase<TFixture> : QueryTestBase<TFixture>
     public virtual Task FirstOrDefault_over_owned_collection(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<OwnedPerson>().Where(p => ((DateTime)p.Orders.FirstOrDefault(o => o.Id > -20)["OrderDate"]).Year == 2018),
+            ss => ss.Set<OwnedPerson>().Where(p => ((DateTime)p.Orders.FirstOrDefault(o => o.Id > -20)!["OrderDate"]).Year == 2018),
             ss => ss.Set<OwnedPerson>().Where(p => p.Orders.FirstOrDefault(o => o.Id > -20) != null
-                && ((DateTime)p.Orders.FirstOrDefault(o => o.Id > -20)["OrderDate"]).Year == 2018));
+                && ((DateTime)p.Orders.FirstOrDefault(o => o.Id > -20)!["OrderDate"]).Year == 2018));
 
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Distinct_over_owned_collection(bool async)
@@ -905,7 +903,7 @@ public abstract class OwnedQueryTestBase<TFixture> : QueryTestBase<TFixture>
 
     public abstract class OwnedQueryFixtureBase : QueryFixtureBase<PoolableDbContext>
     {
-        private OwnedQueryData _expectedData;
+        private OwnedQueryData _expectedData = null!;
 
         private static void AssertAddress(OwnedAddress expectedAddress, OwnedAddress actualAddress)
         {
@@ -915,7 +913,7 @@ public abstract class OwnedQueryTestBase<TFixture> : QueryTestBase<TFixture>
             Assert.Equal(expectedAddress["LeafType"], actualAddress["LeafType"]);
             Assert.Equal(expectedAddress["LeafBType"], actualAddress["LeafBType"]);
             Assert.Equal(expectedAddress.PlaceType, actualAddress.PlaceType);
-            Assert.Equal(expectedAddress.Country.PlanetId, actualAddress.Country.PlanetId);
+            Assert.Equal(expectedAddress.Country!.PlanetId, actualAddress.Country!.PlanetId);
             Assert.Equal(expectedAddress.Country.Name, actualAddress.Country.Name);
         }
 
@@ -945,28 +943,28 @@ public abstract class OwnedQueryTestBase<TFixture> : QueryTestBase<TFixture>
         public override ISetSource GetExpectedData()
             => _expectedData ??= new OwnedQueryData();
 
-        public override IReadOnlyDictionary<Type, object> EntitySorters { get; } = new Dictionary<Type, Func<object, object>>
+        public override IReadOnlyDictionary<Type, object> EntitySorters { get; } = new Dictionary<Type, Func<object?, object?>>
         {
-            { typeof(OwnedPerson), e => ((OwnedPerson)e)?.Id },
-            { typeof(Branch), e => ((Branch)e)?.Id },
-            { typeof(LeafA), e => ((LeafA)e)?.Id },
-            { typeof(LeafB), e => ((LeafB)e)?.Id },
-            { typeof(Planet), e => ((Planet)e)?.Id },
-            { typeof(Star), e => ((Star)e)?.Id },
-            { typeof(Moon), e => ((Moon)e)?.Id },
-            { typeof(Fink), e => ((Fink)e)?.Id },
-            { typeof(Barton), e => ((Barton)e)?.Id },
+            { typeof(OwnedPerson), e => ((OwnedPerson?)e)?.Id },
+            { typeof(Branch), e => ((Branch?)e)?.Id },
+            { typeof(LeafA), e => ((LeafA?)e)?.Id },
+            { typeof(LeafB), e => ((LeafB?)e)?.Id },
+            { typeof(Planet), e => ((Planet?)e)?.Id },
+            { typeof(Star), e => ((Star?)e)?.Id },
+            { typeof(Moon), e => ((Moon?)e)?.Id },
+            { typeof(Fink), e => ((Fink?)e)?.Id },
+            { typeof(Barton), e => ((Barton?)e)?.Id },
 
             // owned entities - still need comparers in case they are projected directly
-            { typeof(Order), e => ((Order)e)?.Id },
-            { typeof(OrderDetail), e => ((OrderDetail)e)?.Detail },
-            { typeof(OwnedAddress), e => ((OwnedAddress)e)?.Country.Name },
-            { typeof(OwnedCountry), e => ((OwnedCountry)e)?.Name },
-            { typeof(Element), e => ((Element)e)?.Id },
-            { typeof(Throned), e => ((Throned)e)?.Property }
+            { typeof(Order), e => ((Order?)e)?.Id },
+            { typeof(OrderDetail), e => ((OrderDetail?)e)?.Detail },
+            { typeof(OwnedAddress), e => ((OwnedAddress?)e)?.Country!.Name },
+            { typeof(OwnedCountry), e => ((OwnedCountry?)e)?.Name },
+            { typeof(Element), e => ((Element?)e)?.Id },
+            { typeof(Throned), e => ((Throned?)e)?.Property }
         }.ToDictionary(e => e.Key, e => (object)e.Value);
 
-        public override IReadOnlyDictionary<Type, object> EntityAsserters { get; } = new Dictionary<Type, Action<object, object>>
+        public override IReadOnlyDictionary<Type, object> EntityAsserters { get; } = new Dictionary<Type, Action<object?, object?>>
         {
             {
                 typeof(OwnedPerson), (e, a) =>
@@ -974,28 +972,28 @@ public abstract class OwnedQueryTestBase<TFixture> : QueryTestBase<TFixture>
                     Assert.Equal(e == null, a == null);
                     if (a != null)
                     {
-                        var ee = (OwnedPerson)e;
+                        var ee = (OwnedPerson)e!;
                         var aa = (OwnedPerson)a;
 
                         Assert.Equal(ee.Id, aa.Id);
                         Assert.Equal(ee["Name"], aa["Name"]);
-                        AssertAddress(ee.PersonAddress, aa.PersonAddress);
+                        AssertAddress(ee.PersonAddress!, aa.PersonAddress!);
                         AssertOrders(ee.Orders, aa.Orders);
                     }
 
                     if (e is Branch branch)
                     {
-                        AssertAddress(branch.BranchAddress, ((Branch)a).BranchAddress);
+                        AssertAddress(branch.BranchAddress!, ((Branch)a!).BranchAddress!);
                     }
 
                     if (e is LeafA leafA)
                     {
-                        AssertAddress(leafA.LeafAAddress, ((LeafA)a).LeafAAddress);
+                        AssertAddress(leafA.LeafAAddress!, ((LeafA)a!).LeafAAddress!);
                     }
 
                     if (e is LeafB leafB)
                     {
-                        AssertAddress(leafB.LeafBAddress, ((LeafB)a).LeafBAddress);
+                        AssertAddress(leafB.LeafBAddress!, ((LeafB)a!).LeafBAddress!);
                     }
                 }
             },
@@ -1005,18 +1003,18 @@ public abstract class OwnedQueryTestBase<TFixture> : QueryTestBase<TFixture>
                     Assert.Equal(e == null, a == null);
                     if (a != null)
                     {
-                        var ee = (Branch)e;
+                        var ee = (Branch)e!;
                         var aa = (Branch)a;
 
                         Assert.Equal(ee.Id, aa.Id);
-                        AssertAddress(ee.PersonAddress, aa.PersonAddress);
-                        AssertAddress(ee.BranchAddress, aa.BranchAddress);
+                        AssertAddress(ee.PersonAddress!, aa.PersonAddress!);
+                        AssertAddress(ee.BranchAddress!, aa.BranchAddress!);
                         AssertOrders(ee.Orders, aa.Orders);
                     }
 
                     if (e is LeafA leafA)
                     {
-                        AssertAddress(leafA.LeafAAddress, ((LeafA)a).LeafAAddress);
+                        AssertAddress(leafA.LeafAAddress!, ((LeafA)a!).LeafAAddress!);
                     }
                 }
             },
@@ -1026,13 +1024,13 @@ public abstract class OwnedQueryTestBase<TFixture> : QueryTestBase<TFixture>
                     Assert.Equal(e == null, a == null);
                     if (a != null)
                     {
-                        var ee = (LeafA)e;
+                        var ee = (LeafA)e!;
                         var aa = (LeafA)a;
 
                         Assert.Equal(ee.Id, aa.Id);
-                        AssertAddress(ee.PersonAddress, aa.PersonAddress);
-                        AssertAddress(ee.BranchAddress, aa.BranchAddress);
-                        AssertAddress(ee.LeafAAddress, aa.LeafAAddress);
+                        AssertAddress(ee.PersonAddress!, aa.PersonAddress!);
+                        AssertAddress(ee.BranchAddress!, aa.BranchAddress!);
+                        AssertAddress(ee.LeafAAddress!, aa.LeafAAddress!);
                         AssertOrders(ee.Orders, aa.Orders);
                     }
                 }
@@ -1043,12 +1041,12 @@ public abstract class OwnedQueryTestBase<TFixture> : QueryTestBase<TFixture>
                     Assert.Equal(e == null, a == null);
                     if (a != null)
                     {
-                        var ee = (LeafB)e;
+                        var ee = (LeafB)e!;
                         var aa = (LeafB)a;
 
                         Assert.Equal(ee.Id, aa.Id);
-                        AssertAddress(ee.PersonAddress, aa.PersonAddress);
-                        AssertAddress(ee.LeafBAddress, aa.LeafBAddress);
+                        AssertAddress(ee.PersonAddress!, aa.PersonAddress!);
+                        AssertAddress(ee.LeafBAddress!, aa.LeafBAddress!);
                         AssertOrders(ee.Orders, aa.Orders);
                     }
                 }
@@ -1059,7 +1057,7 @@ public abstract class OwnedQueryTestBase<TFixture> : QueryTestBase<TFixture>
                     Assert.Equal(e == null, a == null);
                     if (a != null)
                     {
-                        var ee = (Planet)e;
+                        var ee = (Planet)e!;
                         var aa = (Planet)a;
 
                         Assert.Equal(ee.Id, aa.Id);
@@ -1074,7 +1072,7 @@ public abstract class OwnedQueryTestBase<TFixture> : QueryTestBase<TFixture>
                     Assert.Equal(e == null, a == null);
                     if (a != null)
                     {
-                        var ee = (Star)e;
+                        var ee = (Star)e!;
                         var aa = (Star)a;
 
                         Assert.Equal(ee.Id, aa.Id);
@@ -1095,7 +1093,7 @@ public abstract class OwnedQueryTestBase<TFixture> : QueryTestBase<TFixture>
                     Assert.Equal(e == null, a == null);
                     if (a != null)
                     {
-                        var ee = (Moon)e;
+                        var ee = (Moon)e!;
                         var aa = (Moon)a;
 
                         Assert.Equal(ee.Id, aa.Id);
@@ -1110,7 +1108,7 @@ public abstract class OwnedQueryTestBase<TFixture> : QueryTestBase<TFixture>
                     Assert.Equal(e == null, a == null);
                     if (a != null)
                     {
-                        Assert.Equal(((Fink)e).Id, ((Fink)a).Id);
+                        Assert.Equal(((Fink)e!).Id, ((Fink)a).Id);
                     }
                 }
             },
@@ -1120,12 +1118,12 @@ public abstract class OwnedQueryTestBase<TFixture> : QueryTestBase<TFixture>
                     Assert.Equal(e == null, a == null);
                     if (a != null)
                     {
-                        var ee = (Barton)e;
+                        var ee = (Barton)e!;
                         var aa = (Barton)a;
 
                         Assert.Equal(ee.Id, aa.Id);
                         Assert.Equal(ee.Simple, aa.Simple);
-                        Assert.Equal(ee.Throned.Property, aa.Throned.Property);
+                        Assert.Equal(ee.Throned!.Property, aa.Throned!.Property);
                     }
                 }
             },
@@ -1137,7 +1135,7 @@ public abstract class OwnedQueryTestBase<TFixture> : QueryTestBase<TFixture>
                     Assert.Equal(e == null, a == null);
                     if (a != null)
                     {
-                        Assert.Equal(((Order)e).Id, ((Order)a).Id);
+                        Assert.Equal(((Order)e!).Id, ((Order)a).Id);
                     }
                 }
             },
@@ -1147,18 +1145,18 @@ public abstract class OwnedQueryTestBase<TFixture> : QueryTestBase<TFixture>
                     Assert.Equal(e == null, a == null);
                     if (a != null)
                     {
-                        Assert.Equal(((OrderDetail)e).Detail, ((OrderDetail)a).Detail);
+                        Assert.Equal(((OrderDetail)e!).Detail, ((OrderDetail)a).Detail);
                     }
                 }
             },
-            { typeof(OwnedAddress), (e, a) => AssertAddress((OwnedAddress)e, (OwnedAddress)a) },
+            { typeof(OwnedAddress), (e, a) => AssertAddress((OwnedAddress)e!, (OwnedAddress)a!) },
             {
                 typeof(OwnedCountry), (e, a) =>
                 {
                     Assert.Equal(e == null, a == null);
                     if (a != null)
                     {
-                        var ee = (OwnedCountry)e;
+                        var ee = (OwnedCountry)e!;
                         var aa = (OwnedCountry)a;
 
                         Assert.Equal(ee.Name, aa.Name);
@@ -1172,7 +1170,7 @@ public abstract class OwnedQueryTestBase<TFixture> : QueryTestBase<TFixture>
                     Assert.Equal(e == null, a == null);
                     if (a != null)
                     {
-                        var ee = (Element)e;
+                        var ee = (Element)e!;
                         var aa = (Element)a;
 
                         Assert.Equal(ee.Id, aa.Id);
@@ -1187,8 +1185,8 @@ public abstract class OwnedQueryTestBase<TFixture> : QueryTestBase<TFixture>
                     Assert.Equal(e == null, a == null);
                     if (a != null)
                     {
-                        Assert.Equal(((Throned)e).Value, ((Throned)a).Value);
-                        Assert.Equal(((Throned)e).Property, ((Throned)a).Property);
+                        Assert.Equal(((Throned)e!).Value, ((Throned)a).Value);
+                        Assert.Equal(((Throned)e!).Property, ((Throned)a).Property);
                     }
                 }
             }
@@ -1210,6 +1208,7 @@ public abstract class OwnedQueryTestBase<TFixture> : QueryTestBase<TFixture>
                     {
                         ab.IndexerProperty<string>("AddressLine");
                         ab.IndexerProperty(typeof(int), "ZipCode");
+                        ab.Property(a => a.PlaceType).IsRequired(false);
                         ab.HasData(
                             new
                             {
@@ -1243,6 +1242,7 @@ public abstract class OwnedQueryTestBase<TFixture> : QueryTestBase<TFixture>
                         ab.OwnsOne(
                             a => a.Country, cb =>
                             {
+                                cb.Property(c => c.Name).IsRequired(false);
                                 cb.HasData(
                                     new
                                     {
@@ -1272,7 +1272,9 @@ public abstract class OwnedQueryTestBase<TFixture> : QueryTestBase<TFixture>
                                 cb.HasOne(cc => cc.Planet).WithMany().HasForeignKey(ee => ee.PlanetId)
                                     .OnDelete(DeleteBehavior.Restrict);
                             });
+                                ab.Navigation(a => a.Country).IsRequired(false);
                     });
+                eb.Navigation(p => p.PersonAddress).IsRequired(false);
 
                 eb.OwnsMany(
                     p => p.Orders, ob =>
@@ -1352,6 +1354,7 @@ public abstract class OwnedQueryTestBase<TFixture> : QueryTestBase<TFixture>
                     p => p.BranchAddress, ab =>
                     {
                         ab.IndexerProperty<string>("BranchName").IsRequired();
+                        ab.Property(a => a.PlaceType).IsRequired(false);
                         ab.HasData(
                             new
                             {
@@ -1367,20 +1370,26 @@ public abstract class OwnedQueryTestBase<TFixture> : QueryTestBase<TFixture>
                             });
 
                         ab.OwnsOne(
-                            a => a.Country, cb => cb.HasData(
-                                new
-                                {
-                                    OwnedAddressBranchId = 2,
-                                    PlanetId = 1,
-                                    Name = "Canada"
-                                },
-                                new
-                                {
-                                    OwnedAddressBranchId = 3,
-                                    PlanetId = 1,
-                                    Name = "Canada"
-                                }));
+                            a => a.Country, cb =>
+                            {
+                                cb.Property(c => c.Name).IsRequired(false);
+                                cb.HasData(
+                                    new
+                                    {
+                                        OwnedAddressBranchId = 2,
+                                        PlanetId = 1,
+                                        Name = "Canada"
+                                    },
+                                    new
+                                    {
+                                        OwnedAddressBranchId = 3,
+                                        PlanetId = 1,
+                                        Name = "Canada"
+                                    });
+                            });
+                        ab.Navigation(a => a.Country).IsRequired(false);
                     });
+                eb.Navigation(p => p.BranchAddress).IsRequired(false);
             });
 
             modelBuilder.Entity<LeafA>(eb =>
@@ -1393,6 +1402,7 @@ public abstract class OwnedQueryTestBase<TFixture> : QueryTestBase<TFixture>
                     p => p.LeafAAddress, ab =>
                     {
                         ab.IndexerProperty<int>("LeafType");
+                        ab.Property(a => a.PlaceType).IsRequired(false);
 
                         ab.HasData(
                             new
@@ -1405,6 +1415,7 @@ public abstract class OwnedQueryTestBase<TFixture> : QueryTestBase<TFixture>
                         ab.OwnsOne(
                             a => a.Country, cb =>
                             {
+                                cb.Property(c => c.Name).IsRequired(false);
                                 cb.HasOne(c => c.Planet).WithMany().HasForeignKey(c => c.PlanetId)
                                     .OnDelete(DeleteBehavior.Restrict);
 
@@ -1416,6 +1427,7 @@ public abstract class OwnedQueryTestBase<TFixture> : QueryTestBase<TFixture>
                                         Name = "Mexico"
                                     });
                             });
+                                ab.Navigation(a => a.Country).IsRequired(false);
                     });
             });
 
@@ -1429,6 +1441,7 @@ public abstract class OwnedQueryTestBase<TFixture> : QueryTestBase<TFixture>
                     p => p.LeafBAddress, ab =>
                     {
                         ab.IndexerProperty<string>("LeafBType").IsRequired();
+                        ab.Property(a => a.PlaceType).IsRequired(false);
                         ab.HasData(
                             new
                             {
@@ -1440,6 +1453,7 @@ public abstract class OwnedQueryTestBase<TFixture> : QueryTestBase<TFixture>
                         ab.OwnsOne(
                             a => a.Country, cb =>
                             {
+                                cb.Property(c => c.Name).IsRequired(false);
                                 cb.HasOne(c => c.Planet).WithMany().HasForeignKey(c => c.PlanetId)
                                     .OnDelete(DeleteBehavior.Restrict);
 
@@ -1451,7 +1465,9 @@ public abstract class OwnedQueryTestBase<TFixture> : QueryTestBase<TFixture>
                                         Name = "Panama"
                                     });
                             });
+                                ab.Navigation(a => a.Country).IsRequired(false);
                     });
+                            eb.Navigation(p => p.LeafBAddress).IsRequired(false);
             });
 
             modelBuilder.Entity<Planet>(pb => pb.HasData(
@@ -1813,20 +1829,20 @@ public abstract class OwnedQueryTestBase<TFixture> : QueryTestBase<TFixture>
             IReadOnlyList<Fink> finks,
             IReadOnlyList<Barton> bartons)
         {
-            ownedPeople[0].PersonAddress.Country.Planet = planets[0];
+            ownedPeople[0].PersonAddress!.Country!.Planet = planets[0];
 
             var branch = (Branch)ownedPeople[1];
-            branch.PersonAddress.Country.Planet = planets[0];
-            branch.BranchAddress.Country.Planet = planets[0];
+            branch.PersonAddress!.Country!.Planet = planets[0];
+            branch.BranchAddress!.Country!.Planet = planets[0];
 
             var leafA = (LeafA)ownedPeople[2];
-            leafA.PersonAddress.Country.Planet = planets[0];
-            leafA.BranchAddress.Country.Planet = planets[0];
-            leafA.LeafAAddress.Country.Planet = planets[0];
+            leafA.PersonAddress!.Country!.Planet = planets[0];
+            leafA.BranchAddress!.Country!.Planet = planets[0];
+            leafA.LeafAAddress!.Country!.Planet = planets[0];
 
             var leafB = (LeafB)ownedPeople[3];
-            leafB.PersonAddress.Country.Planet = planets[0];
-            leafB.LeafBAddress.Country.Planet = planets[0];
+            leafB.PersonAddress!.Country!.Planet = planets[0];
+            leafB.LeafBAddress!.Country!.Planet = planets[0];
 
             planets[0].Moons = [moons[0]];
             planets[0].Star = stars[0];
@@ -1838,14 +1854,14 @@ public abstract class OwnedQueryTestBase<TFixture> : QueryTestBase<TFixture>
 
     protected class OwnedAddress
     {
-        private string _addressLine;
+        private string _addressLine = null!;
         private int _zipCode;
-        private string _branchName;
+        private string _branchName = null!;
         private int _leafAType;
-        private string _leafBType;
+        private string _leafBType = null!;
 
-        public string PlaceType { get; set; }
-        public OwnedCountry Country { get; set; }
+        public string PlaceType { get; set; } = null!;
+        public OwnedCountry? Country { get; set; }
 
         public object this[string name]
         {
@@ -1894,15 +1910,15 @@ public abstract class OwnedQueryTestBase<TFixture> : QueryTestBase<TFixture>
 
     protected class OwnedCountry
     {
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
 
         public int PlanetId { get; set; }
-        public Planet Planet { get; set; }
+        public Planet Planet { get; set; } = null!;
     }
 
     protected class OwnedPerson
     {
-        private string _name;
+        private string _name = null!;
 
         public int Id { get; set; }
 
@@ -1917,12 +1933,12 @@ public abstract class OwnedQueryTestBase<TFixture> : QueryTestBase<TFixture>
                 : throw new InvalidOperationException($"Indexer property with key {name} is not defined on {nameof(OwnedPerson)}.");
         }
 
-        public OwnedAddress PersonAddress { get; set; }
+        public OwnedAddress? PersonAddress { get; set; }
 
         public int ReadOnlyProperty
             => 10;
 
-        public ICollection<Order> Orders { get; set; }
+        public ICollection<Order> Orders { get; set; } = null!;
     }
 
     protected class Order
@@ -1941,41 +1957,41 @@ public abstract class OwnedQueryTestBase<TFixture> : QueryTestBase<TFixture>
                 : throw new InvalidOperationException($"Indexer property with key {name} is not defined on {nameof(OwnedPerson)}.");
         }
 
-        public OwnedPerson Client { get; set; }
+        public OwnedPerson Client { get; set; } = null!;
 
-        public List<OrderDetail> Details { get; set; }
+        public List<OrderDetail> Details { get; set; } = null!;
     }
 
     protected class OrderDetail
     {
-        public string Detail { get; set; }
+        public string Detail { get; set; } = null!;
     }
 
     protected class Branch : OwnedPerson
     {
-        public OwnedAddress BranchAddress { get; set; }
+        public OwnedAddress? BranchAddress { get; set; }
     }
 
     protected class LeafA : Branch
     {
-        public OwnedAddress LeafAAddress { get; set; }
+        public OwnedAddress? LeafAAddress { get; set; }
     }
 
     protected class LeafB : OwnedPerson
     {
-        public OwnedAddress LeafBAddress { get; set; }
+        public OwnedAddress? LeafBAddress { get; set; }
     }
 
     protected class Planet
     {
         public int Id { get; set; }
 
-        public string Name { get; set; }
+        public string? Name { get; set; }
 
         public int StarId { get; set; }
-        public Star Star { get; set; }
+        public Star Star { get; set; } = null!;
 
-        public List<Moon> Moons { get; set; }
+        public List<Moon> Moons { get; set; } = null!;
     }
 
     protected class Moon
@@ -1989,17 +2005,17 @@ public abstract class OwnedQueryTestBase<TFixture> : QueryTestBase<TFixture>
     protected class Star
     {
         public int Id { get; set; }
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
 
-        public List<Element> Composition { get; set; }
+        public List<Element> Composition { get; set; } = null!;
 
-        public List<Planet> Planets { get; set; }
+        public List<Planet> Planets { get; set; } = null!;
     }
 
     protected class Element
     {
-        public string Id { get; set; }
-        public string Name { get; set; }
+        public string Id { get; set; } = null!;
+        public string Name { get; set; } = null!;
 
         public int StarId { get; set; }
     }
@@ -2008,14 +2024,14 @@ public abstract class OwnedQueryTestBase<TFixture> : QueryTestBase<TFixture>
     {
         public int Id { get; set; }
 
-        public Throned Throned { get; set; }
+        public Throned? Throned { get; set; }
 
-        public string Simple { get; set; }
+        public string? Simple { get; set; }
     }
 
     protected class Fink
     {
-        public Barton Barton { get; set; }
+        public Barton? Barton { get; set; }
 
         public int Id { get; set; }
     }
@@ -2023,12 +2039,12 @@ public abstract class OwnedQueryTestBase<TFixture> : QueryTestBase<TFixture>
     protected class Throned
     {
         public int Value { get; set; }
-        public string Property { get; set; }
+        public string? Property { get; set; }
     }
 
     protected abstract class Balloon
     {
-        public string Id { get; set; }
+        public string Id { get; set; } = null!;
     }
 
     protected class Helium
@@ -2043,11 +2059,11 @@ public abstract class OwnedQueryTestBase<TFixture> : QueryTestBase<TFixture>
 
     protected class HeliumBalloon : Balloon
     {
-        public Helium Gas { get; set; }
+        public Helium Gas { get; set; } = null!;
     }
 
     protected class HydrogenBalloon : Balloon
     {
-        public Hydrogen Gas { get; set; }
+        public Hydrogen Gas { get; set; } = null!;
     }
 }

--- a/test/EFCore.Specification.Tests/Query/SharedTypeQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/SharedTypeQueryTestBase.cs
@@ -3,8 +3,6 @@
 
 namespace Microsoft.EntityFrameworkCore;
 
-#nullable disable
-
 public abstract class SharedTypeQueryTestBase(NonSharedFixture fixture) : NonSharedModelTestBase(fixture), IClassFixture<NonSharedFixture>
 {
     protected override string NonSharedStoreName
@@ -51,6 +49,6 @@ public abstract class SharedTypeQueryTestBase(NonSharedFixture fixture) : NonSha
 
     protected class ViewQuery24601
     {
-        public string Value { get; set; }
+        public string? Value { get; set; }
     }
 }

--- a/test/EFCore.Specification.Tests/Query/SpatialQueryFixtureBase.cs
+++ b/test/EFCore.Specification.Tests/Query/SpatialQueryFixtureBase.cs
@@ -7,25 +7,23 @@ using NetTopologySuite.Geometries;
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
-#nullable disable
-
 public abstract class SpatialQueryFixtureBase : QueryFixtureBase<SpatialContext>
 {
-    private GeometryFactory _geometryFactory;
+    private GeometryFactory _geometryFactory = null!;
 
     public override ISetSource GetExpectedData()
         => new SpatialData(GeometryFactory);
 
-    public override IReadOnlyDictionary<Type, object> EntitySorters { get; } = new Dictionary<Type, Func<object, object>>
+    public override IReadOnlyDictionary<Type, object> EntitySorters { get; } = new Dictionary<Type, Func<object?, object?>>
     {
-        { typeof(PointEntity), e => ((PointEntity)e)?.Id },
-        { typeof(LineStringEntity), e => ((LineStringEntity)e)?.Id },
-        { typeof(PolygonEntity), e => ((PolygonEntity)e)?.Id },
-        { typeof(MultiLineStringEntity), e => ((MultiLineStringEntity)e)?.Id },
-        { typeof(GeoPointEntity), e => ((GeoPointEntity)e)?.Id },
+        { typeof(PointEntity), e => ((PointEntity?)e)?.Id },
+        { typeof(LineStringEntity), e => ((LineStringEntity?)e)?.Id },
+        { typeof(PolygonEntity), e => ((PolygonEntity?)e)?.Id },
+        { typeof(MultiLineStringEntity), e => ((MultiLineStringEntity?)e)?.Id },
+        { typeof(GeoPointEntity), e => ((GeoPointEntity?)e)?.Id },
     }.ToDictionary(e => e.Key, e => (object)e.Value);
 
-    public override IReadOnlyDictionary<Type, object> EntityAsserters { get; } = new Dictionary<Type, Action<object, object>>
+    public override IReadOnlyDictionary<Type, object> EntityAsserters { get; } = new Dictionary<Type, Action<object?, object?>>
     {
         {
             typeof(PointEntity), (e, a) =>
@@ -34,7 +32,7 @@ public abstract class SpatialQueryFixtureBase : QueryFixtureBase<SpatialContext>
 
                 if (a != null)
                 {
-                    var ee = (PointEntity)e;
+                    var ee = (PointEntity)e!;
                     var aa = (PointEntity)a;
 
                     Assert.Equal(ee.Id, aa.Id);
@@ -53,7 +51,7 @@ public abstract class SpatialQueryFixtureBase : QueryFixtureBase<SpatialContext>
 
                 if (a != null)
                 {
-                    var ee = (LineStringEntity)e;
+                    var ee = (LineStringEntity)e!;
                     var aa = (LineStringEntity)a;
 
                     Assert.Equal(ee.Id, aa.Id);
@@ -68,7 +66,7 @@ public abstract class SpatialQueryFixtureBase : QueryFixtureBase<SpatialContext>
 
                 if (a != null)
                 {
-                    var ee = (PolygonEntity)e;
+                    var ee = (PolygonEntity)e!;
                     var aa = (PolygonEntity)a;
 
                     Assert.Equal(ee.Id, aa.Id);
@@ -83,18 +81,18 @@ public abstract class SpatialQueryFixtureBase : QueryFixtureBase<SpatialContext>
 
                 if (a != null)
                 {
-                    var ee = (MultiLineStringEntity)e;
+                    var ee = (MultiLineStringEntity)e!;
                     var aa = (MultiLineStringEntity)a;
 
                     Assert.Equal(ee.Id, aa.Id);
                     Assert.Equal(ee.MultiLineString != null, aa.MultiLineString != null);
                     if (ee.MultiLineString != null)
                     {
-                        Assert.Equal(ee.MultiLineString.Count, aa.MultiLineString.Count);
-                        Assert.Equal(ee.MultiLineString.Area, aa.MultiLineString.Area);
+                        Assert.Equal(ee.MultiLineString.Count, aa.MultiLineString!.Count);
+                        Assert.Equal(ee.MultiLineString.Area, aa.MultiLineString!.Area);
                         for (var i = 0; i < ee.MultiLineString.Count; i++)
                         {
-                            Assert.Equal(ee.MultiLineString[i], aa.MultiLineString[i], GeometryComparer.Instance);
+                            Assert.Equal(ee.MultiLineString[i], aa.MultiLineString![i], GeometryComparer.Instance);
                         }
                     }
                 }
@@ -107,7 +105,7 @@ public abstract class SpatialQueryFixtureBase : QueryFixtureBase<SpatialContext>
 
                 if (a != null)
                 {
-                    var ee = (GeoPointEntity)e;
+                    var ee = (GeoPointEntity)e!;
                     var aa = (GeoPointEntity)a;
 
                     Assert.Equal(ee.Id, aa.Id);

--- a/test/EFCore.Specification.Tests/Query/SpatialQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/SpatialQueryTestBase.cs
@@ -8,8 +8,6 @@ using NetTopologySuite.Operation.Union;
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
-#nullable disable
-
 public abstract class SpatialQueryTestBase<TFixture>(TFixture fixture) : QueryTestBase<TFixture>(fixture)
     where TFixture : SpatialQueryFixtureBase, new()
 {
@@ -66,8 +64,8 @@ public abstract class SpatialQueryTestBase<TFixture>(TFixture fixture) : QueryTe
     public virtual Task AsBinary(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<PointEntity>().Select(e => new { e.Id, Binary = e.Point.AsBinary() }),
-            ss => ss.Set<PointEntity>().Select(e => new { e.Id, Binary = e.Point == null ? null : e.Point.AsBinary() }),
+            ss => ss.Set<PointEntity>().Select(e => new { e.Id, Binary = e.Point!.AsBinary() }),
+            ss => ss.Set<PointEntity>().Select(e => new { e.Id, Binary = e.Point == null ? null! : e.Point.AsBinary() }),
             elementSorter: x => x.Id,
             elementAsserter: (e, a) =>
             {
@@ -91,8 +89,8 @@ public abstract class SpatialQueryTestBase<TFixture>(TFixture fixture) : QueryTe
     public virtual Task AsText(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<PointEntity>().Select(e => new { e.Id, Text = e.Point.AsText() }),
-            ss => ss.Set<PointEntity>().Select(e => new { e.Id, Text = e.Point == null ? null : e.Point.AsText() }),
+            ss => ss.Set<PointEntity>().Select(e => new { e.Id, Text = e.Point!.AsText() }),
+            ss => ss.Set<PointEntity>().Select(e => new { e.Id, Text = e.Point == null ? null! : e.Point.AsText() }),
             elementSorter: x => x.Id,
             elementAsserter: (e, a) =>
             {
@@ -116,8 +114,8 @@ public abstract class SpatialQueryTestBase<TFixture>(TFixture fixture) : QueryTe
     public virtual Task Buffer(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<PolygonEntity>().Select(e => new { e.Id, Buffer = e.Polygon.Buffer(1.0) }),
-            ss => ss.Set<PolygonEntity>().Select(e => new { e.Id, Buffer = e.Polygon == null ? null : e.Polygon.Buffer(1.0) }),
+            ss => ss.Set<PolygonEntity>().Select(e => new { e.Id, Buffer = e.Polygon!.Buffer(1.0) }),
+            ss => ss.Set<PolygonEntity>().Select(e => new { e.Id, Buffer = e.Polygon == null ? null! : e.Polygon.Buffer(1.0) }),
             elementSorter: x => x.Id,
             elementAsserter: (e, a) =>
             {
@@ -130,7 +128,7 @@ public abstract class SpatialQueryTestBase<TFixture>(TFixture fixture) : QueryTe
                 }
                 else if (AssertDistances)
                 {
-                    Assert.Equal(e.Buffer.Area, a.Buffer.Area, precision: 0);
+                    Assert.Equal(e.Buffer.Area, a.Buffer!.Area, precision: 0);
                 }
             });
 
@@ -138,8 +136,8 @@ public abstract class SpatialQueryTestBase<TFixture>(TFixture fixture) : QueryTe
     public virtual Task Buffer_quadrantSegments(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<PolygonEntity>().Select(e => new { e.Id, Buffer = e.Polygon.Buffer(1.0, 8) }),
-            ss => ss.Set<PolygonEntity>().Select(e => new { e.Id, Buffer = e.Polygon == null ? null : e.Polygon.Buffer(1.0, 8) }),
+            ss => ss.Set<PolygonEntity>().Select(e => new { e.Id, Buffer = e.Polygon!.Buffer(1.0, 8) }),
+            ss => ss.Set<PolygonEntity>().Select(e => new { e.Id, Buffer = e.Polygon == null ? null! : e.Polygon.Buffer(1.0, 8) }),
             elementSorter: x => x.Id,
             elementAsserter: (e, a) =>
             {
@@ -152,7 +150,7 @@ public abstract class SpatialQueryTestBase<TFixture>(TFixture fixture) : QueryTe
                 }
                 else if (AssertDistances)
                 {
-                    Assert.Equal(e.Buffer.Area, a.Buffer.Area, precision: 0);
+                    Assert.Equal(e.Buffer.Area, a.Buffer!.Area, precision: 0);
                 }
             });
 
@@ -211,7 +209,7 @@ public abstract class SpatialQueryTestBase<TFixture>(TFixture fixture) : QueryTe
 
         return AssertQuery(
             async,
-            ss => ss.Set<PolygonEntity>().Select(e => new { e.Id, Contains = (bool?)e.Polygon.Contains(point) }),
+            ss => ss.Set<PolygonEntity>().Select(e => new { e.Id, Contains = (bool?)e.Polygon!.Contains(point) }),
             ss => ss.Set<PolygonEntity>()
                 .Select(e => new { e.Id, Contains = e.Polygon == null ? (bool?)null : e.Polygon.Contains(point) }),
             elementSorter: x => x.Id);
@@ -221,8 +219,8 @@ public abstract class SpatialQueryTestBase<TFixture>(TFixture fixture) : QueryTe
     public virtual Task ConvexHull(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<PolygonEntity>().Select(e => new { e.Id, ConvexHull = e.Polygon.ConvexHull() }),
-            ss => ss.Set<PolygonEntity>().Select(e => new { e.Id, ConvexHull = e.Polygon == null ? null : e.Polygon.ConvexHull() }),
+            ss => ss.Set<PolygonEntity>().Select(e => new { e.Id, ConvexHull = e.Polygon!.ConvexHull() }),
+            ss => ss.Set<PolygonEntity>().Select(e => new { e.Id, ConvexHull = e.Polygon == null ? null! : e.Polygon.ConvexHull() }),
             elementSorter: x => x.Id,
             elementAsserter: (e, a) =>
             {
@@ -268,7 +266,7 @@ public abstract class SpatialQueryTestBase<TFixture>(TFixture fixture) : QueryTe
 
         return AssertQuery(
             async,
-            ss => ss.Set<PointEntity>().Select(e => new { e.Id, CoveredBy = (bool?)e.Point.CoveredBy(polygon) }),
+            ss => ss.Set<PointEntity>().Select(e => new { e.Id, CoveredBy = (bool?)e.Point!.CoveredBy(polygon) }),
             ss => ss.Set<PointEntity>()
                 .Select(e => new { e.Id, CoveredBy = e.Point == null ? (bool?)null : e.Point.CoveredBy(polygon) }),
             elementSorter: x => x.Id);
@@ -281,7 +279,7 @@ public abstract class SpatialQueryTestBase<TFixture>(TFixture fixture) : QueryTe
 
         return AssertQuery(
             async,
-            ss => ss.Set<PolygonEntity>().Select(e => new { e.Id, Covers = (bool?)e.Polygon.Covers(point) }),
+            ss => ss.Set<PolygonEntity>().Select(e => new { e.Id, Covers = (bool?)e.Polygon!.Covers(point) }),
             ss => ss.Set<PolygonEntity>().Select(e => new { e.Id, Covers = e.Polygon == null ? (bool?)null : e.Polygon.Covers(point) }),
             elementSorter: x => x.Id);
     }
@@ -293,7 +291,7 @@ public abstract class SpatialQueryTestBase<TFixture>(TFixture fixture) : QueryTe
 
         return AssertQuery(
             async,
-            ss => ss.Set<LineStringEntity>().Select(e => new { e.Id, Crosses = (bool?)e.LineString.Crosses(lineString) }),
+            ss => ss.Set<LineStringEntity>().Select(e => new { e.Id, Crosses = (bool?)e.LineString!.Crosses(lineString) }),
             ss => ss.Set<LineStringEntity>()
                 .Select(e => new { e.Id, Crosses = e.LineString == null ? (bool?)null : e.LineString.Crosses(lineString) }),
             elementSorter: x => x.Id);
@@ -307,9 +305,9 @@ public abstract class SpatialQueryTestBase<TFixture>(TFixture fixture) : QueryTe
 
         return AssertQuery(
             async,
-            ss => ss.Set<PolygonEntity>().Select(e => new { e.Id, Difference = e.Polygon.Difference(polygon) }),
+            ss => ss.Set<PolygonEntity>().Select(e => new { e.Id, Difference = e.Polygon!.Difference(polygon) }),
             ss => ss.Set<PolygonEntity>()
-                .Select(e => new { e.Id, Difference = e.Polygon == null ? null : e.Polygon.Difference(polygon) }),
+                .Select(e => new { e.Id, Difference = e.Polygon == null ? null! : e.Polygon.Difference(polygon) }),
             elementSorter: x => x.Id,
             elementAsserter: (e, a) =>
             {
@@ -332,7 +330,7 @@ public abstract class SpatialQueryTestBase<TFixture>(TFixture fixture) : QueryTe
 
         return AssertQuery(
             async,
-            ss => ss.Set<PolygonEntity>().Select(e => new { e.Id, Disjoint = (bool?)e.Polygon.Disjoint(point) }),
+            ss => ss.Set<PolygonEntity>().Select(e => new { e.Id, Disjoint = (bool?)e.Polygon!.Disjoint(point) }),
             ss => ss.Set<PolygonEntity>()
                 .Select(e => new { e.Id, Disjoint = e.Polygon == null ? (bool?)null : e.Polygon.Disjoint(point) }),
             elementSorter: x => x.Id);
@@ -357,7 +355,7 @@ public abstract class SpatialQueryTestBase<TFixture>(TFixture fixture) : QueryTe
 
         return AssertQuery(
             async,
-            ss => ss.Set<PointEntity>().Select(e => new { e.Id, Distance = (double?)e.Point.Distance(point) }),
+            ss => ss.Set<PointEntity>().Select(e => new { e.Id, Distance = (double?)e.Point!.Distance(point) }),
             ss => ss.Set<PointEntity>()
                 .Select(e => new { e.Id, Distance = e.Point == null ? (double?)null : e.Point.Distance(point) }),
             elementSorter: e => e.Id,
@@ -383,7 +381,7 @@ public abstract class SpatialQueryTestBase<TFixture>(TFixture fixture) : QueryTe
 
         return AssertQuery(
             async,
-            ss => ss.Set<PointEntity>().Select(e => new { e.Id, Distance = (double?)e.Point.Distance(point) }),
+            ss => ss.Set<PointEntity>().Select(e => new { e.Id, Distance = (double?)e.Point!.Distance(point) }),
             ss => ss.Set<PointEntity>().Select(e => new { e.Id, Distance = e.Point == null ? (double?)null : e.Point.Distance(point) }),
             elementSorter: e => e.Id,
             elementAsserter: (e, a) =>
@@ -408,7 +406,7 @@ public abstract class SpatialQueryTestBase<TFixture>(TFixture fixture) : QueryTe
 
         return AssertQuery(
             async,
-            ss => ss.Set<PointEntity>().Select(e => new { e.Id, Distance = (double?)e.Geometry.Distance(point) }),
+            ss => ss.Set<PointEntity>().Select(e => new { e.Id, Distance = (double?)e.Geometry!.Distance(point) }),
             ss => ss.Set<PointEntity>()
                 .Select(e => new { e.Id, Distance = e.Geometry == null ? (double?)null : e.Geometry.Distance(point) }),
             elementSorter: e => e.Id,
@@ -431,7 +429,7 @@ public abstract class SpatialQueryTestBase<TFixture>(TFixture fixture) : QueryTe
     public virtual Task Distance_constant(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<PointEntity>().Select(e => new { e.Id, Distance = (double?)e.Point.Distance(new Point(0, 1)) }),
+            ss => ss.Set<PointEntity>().Select(e => new { e.Id, Distance = (double?)e.Point!.Distance(new Point(0, 1)) }),
             ss => ss.Set<PointEntity>()
                 .Select(e => new { e.Id, Distance = e.Point == null ? (double?)null : e.Point.Distance(new Point(0, 1)) }),
             elementSorter: e => e.Id,
@@ -454,7 +452,7 @@ public abstract class SpatialQueryTestBase<TFixture>(TFixture fixture) : QueryTe
         => AssertQuery(
             async,
             ss => ss.Set<PointEntity>()
-                .Select(e => new { e.Id, Distance = (double?)e.Point.Distance(new Point(1, 1) { SRID = 4326 }) }),
+                .Select(e => new { e.Id, Distance = (double?)e.Point!.Distance(new Point(1, 1) { SRID = 4326 }) }),
             ss => ss.Set<PointEntity>().Select(e
                 => new { e.Id, Distance = e.Point == null ? (double?)null : e.Point.Distance(new Point(1, 1) { SRID = 4326 }) }),
             elementSorter: e => e.Id,
@@ -574,7 +572,7 @@ public abstract class SpatialQueryTestBase<TFixture>(TFixture fixture) : QueryTe
 
         return AssertQuery(
             async,
-            ss => ss.Set<PointEntity>().Select(e => new { e.Id, EqualsTopologically = (bool?)e.Point.EqualsTopologically(point) }),
+            ss => ss.Set<PointEntity>().Select(e => new { e.Id, EqualsTopologically = (bool?)e.Point!.EqualsTopologically(point) }),
             ss => ss.Set<PointEntity>().Select(e
                 => new { e.Id, EqualsTopologically = e.Point == null ? (bool?)null : e.Point.EqualsTopologically(point) }),
             elementSorter: x => x.Id);
@@ -598,9 +596,9 @@ public abstract class SpatialQueryTestBase<TFixture>(TFixture fixture) : QueryTe
     public virtual Task GetGeometryN(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<MultiLineStringEntity>().Select(e => new { e.Id, Geometry0 = e.MultiLineString.GetGeometryN(0) }),
+            ss => ss.Set<MultiLineStringEntity>().Select(e => new { e.Id, Geometry0 = e.MultiLineString!.GetGeometryN(0) }),
             ss => ss.Set<MultiLineStringEntity>().Select(e
-                => new { e.Id, Geometry0 = e.MultiLineString == null ? null : e.MultiLineString.GetGeometryN(0) }),
+                => new { e.Id, Geometry0 = e.MultiLineString == null ? null! : e.MultiLineString.GetGeometryN(0) }),
             elementSorter: x => x.Id);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -610,9 +608,9 @@ public abstract class SpatialQueryTestBase<TFixture>(TFixture fixture) : QueryTe
             ss => ss.Set<MultiLineStringEntity>().Select(e => new
             {
                 e.Id,
-                Geometry0 = e.MultiLineString.GetGeometryN(ss.Set<MultiLineStringEntity>().Where(ee => false).Max(ee => ee.Id))
+                Geometry0 = e.MultiLineString!.GetGeometryN(ss.Set<MultiLineStringEntity>().Where(ee => false).Max(ee => ee.Id))
             }),
-            ss => ss.Set<MultiLineStringEntity>().Select(e => new { e.Id, Geometry0 = default(Geometry) }),
+            ss => ss.Set<MultiLineStringEntity>().Select(e => new { e.Id, Geometry0 = default(Geometry)! }),
             elementSorter: x => x.Id);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -622,9 +620,9 @@ public abstract class SpatialQueryTestBase<TFixture>(TFixture fixture) : QueryTe
             ss => ss.Set<PolygonEntity>().Select(e => new
             {
                 e.Id,
-                InteriorRing0 = e.Polygon.NumInteriorRings == 0
+                InteriorRing0 = e.Polygon!.NumInteriorRings == 0
                     ? null
-                    : e.Polygon.GetInteriorRingN(0)
+                    : e.Polygon!.GetInteriorRingN(0)
             }),
             ss => ss.Set<PolygonEntity>().Select(e => new
             {
@@ -639,9 +637,9 @@ public abstract class SpatialQueryTestBase<TFixture>(TFixture fixture) : QueryTe
     public virtual Task GetPointN(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<LineStringEntity>().Select(e => new { e.Id, Point0 = e.LineString.GetPointN(0) }),
+            ss => ss.Set<LineStringEntity>().Select(e => new { e.Id, Point0 = e.LineString!.GetPointN(0) }),
             ss => ss.Set<LineStringEntity>()
-                .Select(e => new { e.Id, Point0 = e.LineString == null ? null : e.LineString.GetPointN(0) }),
+                .Select(e => new { e.Id, Point0 = e.LineString == null ? null! : e.LineString.GetPointN(0) }),
             elementSorter: x => x.Id);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -665,7 +663,7 @@ public abstract class SpatialQueryTestBase<TFixture>(TFixture fixture) : QueryTe
                 }
                 else
                 {
-                    Assert.True(a.Polygon.Contains(e.InteriorPoint));
+                    Assert.True(a.Polygon!.Contains(e.InteriorPoint));
                 }
             });
 
@@ -677,9 +675,9 @@ public abstract class SpatialQueryTestBase<TFixture>(TFixture fixture) : QueryTe
 
         return AssertQuery(
             async,
-            ss => ss.Set<PolygonEntity>().Select(e => new { e.Id, Intersection = e.Polygon.Intersection(polygon) }),
+            ss => ss.Set<PolygonEntity>().Select(e => new { e.Id, Intersection = e.Polygon!.Intersection(polygon) }),
             ss => ss.Set<PolygonEntity>()
-                .Select(e => new { e.Id, Intersection = e.Polygon == null ? null : e.Polygon.Intersection(polygon) }),
+                .Select(e => new { e.Id, Intersection = e.Polygon == null ? null! : e.Polygon.Intersection(polygon) }),
             elementSorter: x => x.Id,
             elementAsserter: (e, a) =>
             {
@@ -695,7 +693,7 @@ public abstract class SpatialQueryTestBase<TFixture>(TFixture fixture) : QueryTe
 
         return AssertQuery(
             async,
-            ss => ss.Set<LineStringEntity>().Select(e => new { e.Id, Intersects = (bool?)e.LineString.Intersects(lineString) }),
+            ss => ss.Set<LineStringEntity>().Select(e => new { e.Id, Intersects = (bool?)e.LineString!.Intersects(lineString) }),
             ss => ss.Set<LineStringEntity>().Select(e
                 => new { e.Id, Intersects = e.LineString == null ? (bool?)null : e.LineString.Intersects(lineString) }),
             elementSorter: x => x.Id);
@@ -756,7 +754,7 @@ public abstract class SpatialQueryTestBase<TFixture>(TFixture fixture) : QueryTe
 
         return AssertQuery(
             async,
-            ss => ss.Set<PointEntity>().Select(e => new { e.Id, IsWithinDistance = (bool?)e.Point.IsWithinDistance(point, 1) }),
+            ss => ss.Set<PointEntity>().Select(e => new { e.Id, IsWithinDistance = (bool?)e.Point!.IsWithinDistance(point, 1) }),
             ss => ss.Set<PointEntity>().Select(e
                 => new { e.Id, IsWithinDistance = e.Point == null ? (bool?)null : e.Point.IsWithinDistance(point, 1) }),
             elementSorter: e => e.Id,
@@ -779,9 +777,9 @@ public abstract class SpatialQueryTestBase<TFixture>(TFixture fixture) : QueryTe
     public virtual Task Item(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<MultiLineStringEntity>().Select(e => new { e.Id, Item0 = e.MultiLineString[0] }),
+            ss => ss.Set<MultiLineStringEntity>().Select(e => new { e.Id, Item0 = e.MultiLineString![0] }),
             ss => ss.Set<MultiLineStringEntity>()
-                .Select(e => new { e.Id, Item0 = e.MultiLineString == null ? null : e.MultiLineString[0] }),
+                .Select(e => new { e.Id, Item0 = e.MultiLineString == null ? null! : e.MultiLineString[0] }),
             elementSorter: x => x.Id);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -829,8 +827,8 @@ public abstract class SpatialQueryTestBase<TFixture>(TFixture fixture) : QueryTe
     public virtual Task Normalized(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<PolygonEntity>().Select(e => new { e.Id, Normalized = e.Polygon.Normalized() }),
-            ss => ss.Set<PolygonEntity>().Select(e => new { e.Id, Normalized = e.Polygon == null ? null : e.Polygon.Normalized() }),
+            ss => ss.Set<PolygonEntity>().Select(e => new { e.Id, Normalized = e.Polygon!.Normalized() }),
+            ss => ss.Set<PolygonEntity>().Select(e => new { e.Id, Normalized = e.Polygon == null ? null! : e.Polygon.Normalized() }),
             elementSorter: x => x.Id,
             elementAsserter: (e, a) =>
             {
@@ -878,7 +876,7 @@ public abstract class SpatialQueryTestBase<TFixture>(TFixture fixture) : QueryTe
 
         return AssertQuery(
             async,
-            ss => ss.Set<PolygonEntity>().Select(e => new { e.Id, Overlaps = (bool?)e.Polygon.Overlaps(polygon) }),
+            ss => ss.Set<PolygonEntity>().Select(e => new { e.Id, Overlaps = (bool?)e.Polygon!.Overlaps(polygon) }),
             ss => ss.Set<PolygonEntity>()
                 .Select(e => new { e.Id, Overlaps = e.Polygon == null ? (bool?)null : e.Polygon.Overlaps(polygon) }),
             elementSorter: x => x.Id);
@@ -905,7 +903,7 @@ public abstract class SpatialQueryTestBase<TFixture>(TFixture fixture) : QueryTe
                 }
                 else
                 {
-                    Assert.True(a.Polygon.Contains(e.PointOnSurface));
+                    Assert.True(a.Polygon!.Contains(e.PointOnSurface));
                 }
             });
 
@@ -917,7 +915,7 @@ public abstract class SpatialQueryTestBase<TFixture>(TFixture fixture) : QueryTe
 
         return AssertQuery(
             async,
-            ss => ss.Set<PolygonEntity>().Select(e => new { e.Id, Relate = (bool?)e.Polygon.Relate(polygon, "212111212") }),
+            ss => ss.Set<PolygonEntity>().Select(e => new { e.Id, Relate = (bool?)e.Polygon!.Relate(polygon, "212111212") }),
             ss => ss.Set<PolygonEntity>().Select(e
                 => new { e.Id, Relate = e.Polygon == null ? (bool?)null : e.Polygon.Relate(polygon, "212111212") }),
             elementSorter: x => x.Id);
@@ -927,8 +925,8 @@ public abstract class SpatialQueryTestBase<TFixture>(TFixture fixture) : QueryTe
     public virtual Task Reverse(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<LineStringEntity>().Select(e => new { e.Id, Reverse = e.LineString.Reverse() }),
-            ss => ss.Set<LineStringEntity>().Select(e => new { e.Id, Reverse = e.LineString == null ? null : e.LineString.Reverse() }),
+            ss => ss.Set<LineStringEntity>().Select(e => new { e.Id, Reverse = e.LineString!.Reverse() }),
+            ss => ss.Set<LineStringEntity>().Select(e => new { e.Id, Reverse = e.LineString == null ? null! : e.LineString.Reverse() }),
             elementSorter: x => x.Id);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -961,9 +959,9 @@ public abstract class SpatialQueryTestBase<TFixture>(TFixture fixture) : QueryTe
 
         return AssertQuery(
             async,
-            ss => ss.Set<PolygonEntity>().Select(e => new { e.Id, SymmetricDifference = e.Polygon.SymmetricDifference(polygon) }),
+            ss => ss.Set<PolygonEntity>().Select(e => new { e.Id, SymmetricDifference = e.Polygon!.SymmetricDifference(polygon) }),
             ss => ss.Set<PolygonEntity>().Select(e
-                => new { e.Id, SymmetricDifference = e.Polygon == null ? null : e.Polygon.SymmetricDifference(polygon) }),
+                => new { e.Id, SymmetricDifference = e.Polygon == null ? null! : e.Polygon.SymmetricDifference(polygon) }),
             elementSorter: x => x.Id,
             elementAsserter: (e, a) =>
             {
@@ -976,8 +974,8 @@ public abstract class SpatialQueryTestBase<TFixture>(TFixture fixture) : QueryTe
     public virtual Task ToBinary(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<PointEntity>().Select(e => new { e.Id, Binary = e.Point.ToBinary() }),
-            ss => ss.Set<PointEntity>().Select(e => new { e.Id, Binary = e.Point == null ? null : e.Point.ToBinary() }),
+            ss => ss.Set<PointEntity>().Select(e => new { e.Id, Binary = e.Point!.ToBinary() }),
+            ss => ss.Set<PointEntity>().Select(e => new { e.Id, Binary = e.Point == null ? null! : e.Point.ToBinary() }),
             elementSorter: e => e.Id,
             elementAsserter: (e, a) =>
             {
@@ -989,8 +987,8 @@ public abstract class SpatialQueryTestBase<TFixture>(TFixture fixture) : QueryTe
     public virtual Task ToText(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<PointEntity>().Select(e => new { e.Id, Text = e.Point.ToText() }),
-            ss => ss.Set<PointEntity>().Select(e => new { e.Id, Text = e.Point == null ? null : e.Point.ToText() }),
+            ss => ss.Set<PointEntity>().Select(e => new { e.Id, Text = e.Point!.ToText() }),
+            ss => ss.Set<PointEntity>().Select(e => new { e.Id, Text = e.Point == null ? null! : e.Point.ToText() }),
             elementSorter: e => e.Id,
             elementAsserter: (e, a) =>
             {
@@ -1006,7 +1004,7 @@ public abstract class SpatialQueryTestBase<TFixture>(TFixture fixture) : QueryTe
 
         return AssertQuery(
             async,
-            ss => ss.Set<PolygonEntity>().Select(e => new { e.Id, Touches = (bool?)e.Polygon.Touches(polygon) }),
+            ss => ss.Set<PolygonEntity>().Select(e => new { e.Id, Touches = (bool?)e.Polygon!.Touches(polygon) }),
             ss => ss.Set<PolygonEntity>()
                 .Select(e => new { e.Id, Touches = e.Polygon == null ? (bool?)null : e.Polygon.Touches(polygon) }),
             elementSorter: x => x.Id);
@@ -1020,8 +1018,8 @@ public abstract class SpatialQueryTestBase<TFixture>(TFixture fixture) : QueryTe
 
         return AssertQuery(
             async,
-            ss => ss.Set<PolygonEntity>().Select(e => new { e.Id, Union = e.Polygon.Union(polygon) }),
-            ss => ss.Set<PolygonEntity>().Select(e => new { e.Id, Union = e.Polygon == null ? null : e.Polygon.Union(polygon) }),
+            ss => ss.Set<PolygonEntity>().Select(e => new { e.Id, Union = e.Polygon!.Union(polygon) }),
+            ss => ss.Set<PolygonEntity>().Select(e => new { e.Id, Union = e.Polygon == null ? null! : e.Polygon.Union(polygon) }),
             elementSorter: x => x.Id,
             elementAsserter: (e, a) =>
             {
@@ -1049,9 +1047,9 @@ public abstract class SpatialQueryTestBase<TFixture>(TFixture fixture) : QueryTe
     public virtual Task Union_void(bool async)
         => AssertQuery(
             async,
-            ss => ss.Set<MultiLineStringEntity>().Select(e => new { e.Id, Union = e.MultiLineString.Union() }),
+            ss => ss.Set<MultiLineStringEntity>().Select(e => new { e.Id, Union = e.MultiLineString!.Union() }),
             ss => ss.Set<MultiLineStringEntity>()
-                .Select(e => new { e.Id, Union = e.MultiLineString == null ? null : e.MultiLineString.Union() }),
+                .Select(e => new { e.Id, Union = e.MultiLineString == null ? null! : e.MultiLineString.Union() }),
             elementSorter: x => x.Id);
 
     [Theory, MemberData(nameof(IsAsyncData))]
@@ -1062,7 +1060,7 @@ public abstract class SpatialQueryTestBase<TFixture>(TFixture fixture) : QueryTe
 
         return AssertQuery(
             async,
-            ss => ss.Set<PointEntity>().Select(e => new { e.Id, Within = (bool?)e.Point.Within(polygon) }),
+            ss => ss.Set<PointEntity>().Select(e => new { e.Id, Within = (bool?)e.Point!.Within(polygon) }),
             ss => ss.Set<PointEntity>().Select(e => new { e.Id, Within = e.Point == null ? (bool?)null : e.Point.Within(polygon) }),
             elementSorter: x => x.Id);
     }
@@ -1115,7 +1113,7 @@ public abstract class SpatialQueryTestBase<TFixture>(TFixture fixture) : QueryTe
                 }),
             asserter: (e, a) =>
             {
-                AssertEqual(e.Id, a.Id);
+                AssertEqual(e!.Id, a!.Id);
                 AssertEqual(e.I, a.I);
                 AssertCollection(e.List, a.List);
             });
@@ -1125,7 +1123,7 @@ public abstract class SpatialQueryTestBase<TFixture>(TFixture fixture) : QueryTe
         => AssertQueryScalar(
             async,
 #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            ss => ss.Set<PointEntity>().Where(e => e.Point.IsEmpty == null).Select(e => e.Id),
+            ss => ss.Set<PointEntity>().Where(e => e.Point!.IsEmpty == null).Select(e => e.Id),
 #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             ss => ss.Set<PointEntity>().Where(e => e.Point == null).Select(e => e.Id));
 
@@ -1134,7 +1132,7 @@ public abstract class SpatialQueryTestBase<TFixture>(TFixture fixture) : QueryTe
         => AssertQueryScalar(
             async,
 #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            ss => ss.Set<PointEntity>().Where(e => e.Point.IsEmpty != null).Select(e => e.Id),
+            ss => ss.Set<PointEntity>().Where(e => e.Point!.IsEmpty != null).Select(e => e.Id),
 #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             ss => ss.Set<PointEntity>().Where(e => e.Point != null).Select(e => e.Id));
 
@@ -1146,7 +1144,7 @@ public abstract class SpatialQueryTestBase<TFixture>(TFixture fixture) : QueryTe
         await AssertQueryScalar(
             async,
 #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            ss => ss.Set<LineStringEntity>().Where(e => e.LineString.Intersects(lineString) == null).Select(e => e.Id),
+            ss => ss.Set<LineStringEntity>().Where(e => e.LineString!.Intersects(lineString) == null).Select(e => e.Id),
 #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             ss => ss.Set<LineStringEntity>().Where(e => e.LineString == null).Select(e => e.Id));
 
@@ -1166,7 +1164,7 @@ public abstract class SpatialQueryTestBase<TFixture>(TFixture fixture) : QueryTe
         await AssertQueryScalar(
             async,
 #pragma warning disable CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
-            ss => ss.Set<LineStringEntity>().Where(e => e.LineString.Intersects(lineString) != null).Select(e => e.Id),
+            ss => ss.Set<LineStringEntity>().Where(e => e.LineString!.Intersects(lineString) != null).Select(e => e.Id),
 #pragma warning restore CS0472 // The result of the expression is always the same since a value of this type is never equal to 'null'
             ss => ss.Set<LineStringEntity>().Where(e => e.LineString != null).Select(e => e.Id));
 

--- a/test/EFCore.Specification.Tests/QueryExpressionInterceptionTestBase.cs
+++ b/test/EFCore.Specification.Tests/QueryExpressionInterceptionTestBase.cs
@@ -3,8 +3,6 @@
 
 namespace Microsoft.EntityFrameworkCore;
 
-#nullable disable
-
 public abstract class QueryExpressionInterceptionTestBase(InterceptionTestBase.InterceptionFixtureBase fixture)
     : InterceptionTestBase(fixture)
 {
@@ -32,7 +30,7 @@ public abstract class QueryExpressionInterceptionTestBase(InterceptionTestBase.I
         var interceptor2 = new QueryChangingExpressionInterceptor();
 
         using var context = await CreateContextAsync(
-            appInterceptor: null, interceptor1, interceptor2);
+            appInterceptor: null!, interceptor1, interceptor2);
 
         using var listener = Fixture.SubscribeToDiagnosticListener(context.ContextId);
 
@@ -45,8 +43,8 @@ public abstract class QueryExpressionInterceptionTestBase(InterceptionTestBase.I
         AssertNormalOutcome(context, interceptor2);
 
         listener.AssertEventsInOrder(
-            CoreEventId.QueryCompilationStarting.Name,
-            CoreEventId.QueryExecutionPlanned.Name);
+            CoreEventId.QueryCompilationStarting.Name!,
+            CoreEventId.QueryExecutionPlanned.Name!);
 
         _ = async ? await query.ToListAsync() : query.ToList();
     }
@@ -120,15 +118,15 @@ public abstract class QueryExpressionInterceptionTestBase(InterceptionTestBase.I
     protected class TestQueryExpressionInterceptor : IQueryExpressionInterceptor
     {
         public bool QueryCompilationStartingCalled { get; set; }
-        public string QueryExpression { get; set; }
-        public DbContext Context { get; set; }
+        public string QueryExpression { get; set; } = null!;
+        public DbContext Context { get; set; } = null!;
 
         public virtual Expression QueryCompilationStarting(
             Expression queryExpression,
             QueryExpressionEventData eventData)
         {
             QueryCompilationStartingCalled = true;
-            Context = eventData.Context;
+            Context = eventData.Context!;
             QueryExpression = eventData.ExpressionPrinter.PrintExpression(queryExpression);
 
             return queryExpression;

--- a/test/EFCore.Specification.Tests/SaveChangesInterceptionTestBase.cs
+++ b/test/EFCore.Specification.Tests/SaveChangesInterceptionTestBase.cs
@@ -3,8 +3,6 @@
 
 namespace Microsoft.EntityFrameworkCore;
 
-#nullable disable
-
 public abstract class SaveChangesInterceptionTestBase(InterceptionTestBase.InterceptionFixtureBase fixture) : InterceptionTestBase(fixture)
 {
     [Theory, InlineData(false, false, false), InlineData(true, false, false), InlineData(false, true, false),
@@ -18,7 +16,7 @@ public abstract class SaveChangesInterceptionTestBase(InterceptionTestBase.Inter
 
         var savingEventCalled = false;
         var resultFromEvent = 0;
-        Exception exceptionFromEvent = null;
+        Exception exceptionFromEvent = null!;
 
         context.SavingChanges += (sender, args) =>
         {
@@ -61,8 +59,8 @@ public abstract class SaveChangesInterceptionTestBase(InterceptionTestBase.Inter
         AssertNormalOutcome(context, interceptor, async);
 
         listener.AssertEventsInOrder(
-            CoreEventId.SaveChangesStarting.Name,
-            CoreEventId.SaveChangesCompleted.Name);
+            CoreEventId.SaveChangesStarting.Name!,
+            CoreEventId.SaveChangesCompleted.Name!);
 
         Assert.Equal(1, context.Set<Singularity>().AsNoTracking().Count(e => e.Id == 35));
     }
@@ -80,7 +78,7 @@ public abstract class SaveChangesInterceptionTestBase(InterceptionTestBase.Inter
 
         var savingEventCalled = false;
         var resultFromEvent = 0;
-        Exception exceptionFromEvent = null;
+        Exception exceptionFromEvent = null!;
 
         context.SavingChanges += (sender, args) =>
         {
@@ -123,8 +121,8 @@ public abstract class SaveChangesInterceptionTestBase(InterceptionTestBase.Inter
         AssertNormalOutcome(context, interceptor, async);
 
         listener.AssertEventsInOrder(
-            CoreEventId.SaveChangesStarting.Name,
-            CoreEventId.SaveChangesCompleted.Name);
+            CoreEventId.SaveChangesStarting.Name!,
+            CoreEventId.SaveChangesCompleted.Name!);
 
         Assert.Equal(0, context.Set<Singularity>().AsNoTracking().Count(e => e.Id == 35));
     }
@@ -160,7 +158,7 @@ public abstract class SaveChangesInterceptionTestBase(InterceptionTestBase.Inter
 
         var savingEventCalled = false;
         var resultFromEvent = 0;
-        Exception exceptionFromEvent = null;
+        Exception exceptionFromEvent = null!;
 
         context.SavingChanges += (sender, args) =>
         {
@@ -203,8 +201,8 @@ public abstract class SaveChangesInterceptionTestBase(InterceptionTestBase.Inter
         AssertNormalOutcome(context, interceptor, async);
 
         listener.AssertEventsInOrder(
-            CoreEventId.SaveChangesStarting.Name,
-            CoreEventId.SaveChangesCompleted.Name);
+            CoreEventId.SaveChangesStarting.Name!,
+            CoreEventId.SaveChangesCompleted.Name!);
 
         Assert.Equal(1, context.Set<Singularity>().AsNoTracking().Count(e => e.Id == 35));
     }
@@ -258,7 +256,7 @@ public abstract class SaveChangesInterceptionTestBase(InterceptionTestBase.Inter
 
         var savingEventCalled = false;
         var resultFromEvent = -1;
-        Exception exceptionFromEvent = null;
+        Exception exceptionFromEvent = null!;
 
         context.SavingChanges += (sender, args) =>
         {
@@ -283,7 +281,7 @@ public abstract class SaveChangesInterceptionTestBase(InterceptionTestBase.Inter
 
         using var listener = Fixture.SubscribeToDiagnosticListener(context.ContextId);
 
-        Exception thrown = null;
+        Exception thrown = null!;
 
         try
         {
@@ -318,14 +316,14 @@ public abstract class SaveChangesInterceptionTestBase(InterceptionTestBase.Inter
             Assert.Same(entry.Entity, interceptor.Entries[0].Entity);
 
             listener.AssertEventsInOrder(
-                CoreEventId.SaveChangesStarting.Name,
-                CoreEventId.OptimisticConcurrencyException.Name);
+                CoreEventId.SaveChangesStarting.Name!,
+                CoreEventId.OptimisticConcurrencyException.Name!);
         }
         else
         {
             listener.AssertEventsInOrder(
-                CoreEventId.SaveChangesStarting.Name,
-                CoreEventId.SaveChangesFailed.Name);
+                CoreEventId.SaveChangesStarting.Name!,
+                CoreEventId.SaveChangesFailed.Name!);
         }
     }
 
@@ -347,7 +345,7 @@ public abstract class SaveChangesInterceptionTestBase(InterceptionTestBase.Inter
 
         var savingEventCalled = false;
         var resultFromEvent = -1;
-        Exception exceptionFromEvent = null;
+        Exception exceptionFromEvent = null!;
 
         context.SavingChanges += (sender, args) =>
         {
@@ -372,7 +370,7 @@ public abstract class SaveChangesInterceptionTestBase(InterceptionTestBase.Inter
 
         using var listener = Fixture.SubscribeToDiagnosticListener(context.ContextId);
 
-        Exception thrown = null;
+        Exception thrown = null!;
 
         try
         {
@@ -405,9 +403,9 @@ public abstract class SaveChangesInterceptionTestBase(InterceptionTestBase.Inter
         Assert.Same(entry.Entity, interceptor.Entries[0].Entity);
 
         listener.AssertEventsInOrder(
-            CoreEventId.SaveChangesStarting.Name,
-            CoreEventId.OptimisticConcurrencyException.Name,
-            CoreEventId.SaveChangesCompleted.Name);
+            CoreEventId.SaveChangesStarting.Name!,
+            CoreEventId.OptimisticConcurrencyException.Name!,
+            CoreEventId.SaveChangesCompleted.Name!);
     }
 
     protected class ConcurrencySuppressingSaveChangesInterceptor : SaveChangesInterceptorBase
@@ -466,17 +464,17 @@ public abstract class SaveChangesInterceptionTestBase(InterceptionTestBase.Inter
         AssertNormalOutcome(context, interceptor4, async);
 
         listener.AssertEventsInOrder(
-            CoreEventId.SaveChangesStarting.Name,
-            CoreEventId.SaveChangesCompleted.Name);
+            CoreEventId.SaveChangesStarting.Name!,
+            CoreEventId.SaveChangesCompleted.Name!);
 
         Assert.Equal(1, context.Set<Singularity>().AsNoTracking().Count(e => e.Id == 35));
     }
 
     protected abstract class SaveChangesInterceptorBase : ISaveChangesInterceptor
     {
-        public DbContext Context { get; set; }
-        public Exception Exception { get; set; }
-        public IReadOnlyList<EntityEntry> Entries { get; set; }
+        public DbContext Context { get; set; } = null!;
+        public Exception Exception { get; set; } = null!;
+        public IReadOnlyList<EntityEntry> Entries { get; set; } = null!;
         public bool AsyncCalled { get; set; }
         public bool SyncCalled { get; set; }
         public bool FailedCalled { get; set; }

--- a/test/EFCore.Specification.Tests/SeedingTestBase.cs
+++ b/test/EFCore.Specification.Tests/SeedingTestBase.cs
@@ -5,8 +5,6 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace Microsoft.EntityFrameworkCore;
 
-#nullable disable
-
 public abstract class SeedingTestBase
 {
     [Theory, InlineData(false), InlineData(true)]
@@ -65,7 +63,7 @@ public abstract class SeedingTestBase
         [DatabaseGenerated(DatabaseGeneratedOption.None)]
         public int Id { get; set; }
 
-        public string Species { get; set; }
+        public string Species { get; set; } = null!;
     }
 
     public class KeylessSeedingContext(DbContextOptions options) : DbContext(options)
@@ -81,6 +79,6 @@ public abstract class SeedingTestBase
 
     public class KeylessSeed
     {
-        public string Species { get; set; }
+        public string Species { get; set; } = null!;
     }
 }

--- a/test/EFCore.Specification.Tests/SerializationTestBase.cs
+++ b/test/EFCore.Specification.Tests/SerializationTestBase.cs
@@ -9,8 +9,6 @@ using JsonSerializer = System.Text.Json.JsonSerializer;
 
 namespace Microsoft.EntityFrameworkCore;
 
-#nullable disable
-
 public abstract class SerializationTestBase<TFixture>(TFixture fixture) : IClassFixture<TFixture>
     where TFixture : F1FixtureBase<byte[]>, new()
 {
@@ -39,16 +37,16 @@ public abstract class SerializationTestBase<TFixture>(TFixture fixture) : IClass
 
         foreach (var team in teamsAgain)
         {
-            VerifyTeam(context, team, teamsMap);
-            VerifyEngine(context, team.Engine, enginesMap);
-            VerifyEngineSupplier(context, team.Engine.EngineSupplier, engineSupplierMap);
+            VerifyTeam(context, team, teamsMap!);
+            VerifyEngine(context, team.Engine, enginesMap!);
+            VerifyEngineSupplier(context, team.Engine.EngineSupplier, engineSupplierMap!);
         }
     }
 
     private static void VerifyTeam(F1Context context, Team team, IDictionary<int, Team> teamsMap)
     {
         var trackedTeam = context.Teams.Find(team.Id);
-        Assert.Equal(trackedTeam.Constructor, team.Constructor);
+        Assert.Equal(trackedTeam!.Constructor, team.Constructor);
         Assert.Equal(trackedTeam.Name, team.Name);
         Assert.Equal(trackedTeam.Poles, team.Poles);
         Assert.Equal(trackedTeam.Principal, team.Principal);
@@ -73,7 +71,7 @@ public abstract class SerializationTestBase<TFixture>(TFixture fixture) : IClass
     private static void VerifyEngine(F1Context context, Engine engine, IDictionary<int, Engine> enginesMap)
     {
         var trackedEngine = context.Engines.Find(engine.Id);
-        Assert.Equal(trackedEngine.StorageLocation.Latitude, engine.StorageLocation.Latitude);
+        Assert.Equal(trackedEngine!.StorageLocation!.Latitude, engine.StorageLocation!.Latitude);
         Assert.Equal(trackedEngine.StorageLocation.Longitude, engine.StorageLocation.Longitude);
         Assert.Equal(trackedEngine.Name, engine.Name);
 
@@ -94,7 +92,7 @@ public abstract class SerializationTestBase<TFixture>(TFixture fixture) : IClass
         IDictionary<string, EngineSupplier> engineSupplierMap)
     {
         var trackedEngineSupplier = context.EngineSuppliers.Find(engineSupplier.Name);
-        Assert.Equal(trackedEngineSupplier.Name, engineSupplier.Name);
+        Assert.Equal(trackedEngineSupplier!.Name, engineSupplier.Name);
 
         if (engineSupplierMap != null)
         {
@@ -118,7 +116,7 @@ public abstract class SerializationTestBase<TFixture>(TFixture fixture) : IClass
             MaxDepth = maxDepth
         };
 
-        return JsonSerializer.Deserialize<T>(JsonSerializer.Serialize(collection, options), options);
+        return JsonSerializer.Deserialize<T>(JsonSerializer.Serialize(collection, options), options)!;
     }
 
     private static T RoundtripThroughNewtonsoftJson<T>(T collection, bool ignoreLoops, bool writeIndented)
@@ -139,6 +137,6 @@ public abstract class SerializationTestBase<TFixture>(TFixture fixture) : IClass
 
         var serializeObject = JsonConvert.SerializeObject(collection, options);
 
-        return JsonConvert.DeserializeObject<T>(serializeObject);
+        return JsonConvert.DeserializeObject<T>(serializeObject)!;
     }
 }

--- a/test/EFCore.Specification.Tests/ServiceProviderFixtureBase.cs
+++ b/test/EFCore.Specification.Tests/ServiceProviderFixtureBase.cs
@@ -3,8 +3,6 @@
 
 namespace Microsoft.EntityFrameworkCore;
 
-#nullable disable
-
 public abstract class ServiceProviderFixtureBase : FixtureBase
 {
     public IServiceProvider ServiceProvider { get; }
@@ -31,12 +29,12 @@ public abstract class ServiceProviderFixtureBase : FixtureBase
     protected virtual bool ShouldLogCategory(string logCategory)
         => false;
 
-    protected virtual object GetAdditionalModelCacheKey(DbContext context)
+    protected virtual object? GetAdditionalModelCacheKey(DbContext context)
         => null;
 
-    private class FuncCacheKeyFactory(Func<DbContext, object> getAdditionalKey) : IModelCacheKeyFactory
+    private class FuncCacheKeyFactory(Func<DbContext, object?> getAdditionalKey) : IModelCacheKeyFactory
     {
-        private readonly Func<DbContext, object> _getAdditionalKey = getAdditionalKey;
+        private readonly Func<DbContext, object?> _getAdditionalKey = getAdditionalKey;
 
         public object Create(DbContext context)
             => Tuple.Create(context.GetType(), _getAdditionalKey(context));

--- a/test/EFCore.Specification.Tests/SpatialTestBase.cs
+++ b/test/EFCore.Specification.Tests/SpatialTestBase.cs
@@ -6,8 +6,6 @@ using NetTopologySuite.Geometries;
 
 namespace Microsoft.EntityFrameworkCore;
 
-#nullable disable
-
 public abstract class SpatialTestBase<TFixture>(TFixture fixture) : IClassFixture<TFixture>
     where TFixture : SpatialFixtureBase, new()
 {
@@ -22,7 +20,7 @@ public abstract class SpatialTestBase<TFixture>(TFixture fixture) : IClassFixtur
 
         entity.Point.X = 1;
 
-        Assert.Equal(0, db.Entry(entity).Property(e => e.Point).OriginalValue.X);
+        Assert.Equal(0, db.Entry(entity).Property(e => e.Point).OriginalValue!.X);
     }
 
     [Fact]
@@ -71,8 +69,8 @@ public abstract class SpatialTestBase<TFixture>(TFixture fixture) : IClassFixtur
                 Assert.Equal(CreatePoint(), fromStore1.Point);
                 Assert.Equal(CreatePolygon(), fromStore2.Polygon);
 
-                fromStore1.Point.Y = 22.2;
-                fromStore2.Polygon.Coordinates[1].Y = 22.2;
+                fromStore1.Point!.Y = 22.2;
+                fromStore2.Polygon!.Coordinates[1].Y = 22.2;
 
                 context.Entry(fromStore2).State = EntityState.Unchanged;
 
@@ -114,18 +112,18 @@ public abstract class SpatialTestBase<TFixture>(TFixture fixture) : IClassFixtur
         Assert.NotNull(entity.Point);
         Assert.True(double.IsNaN(entity.Point.Z));
         Assert.True(double.IsNaN(entity.Point.M));
-        Assert.Equal(0, entity.PointZ.Z);
+        Assert.Equal(0, entity.PointZ!.Z);
         Assert.True(double.IsNaN(entity.PointZ.M));
-        Assert.True(double.IsNaN(entity.PointM.Z));
+        Assert.True(double.IsNaN(entity.PointM!.Z));
         Assert.Equal(0, entity.PointM.M);
-        Assert.Equal(0, entity.PointZM.Z);
+        Assert.Equal(0, entity.PointZM!.Z);
         Assert.Equal(0, entity.PointZM.M);
     }
 
     protected virtual Task ExecuteWithStrategyInTransactionAsync(
         Func<SpatialContext, Task> testOperation,
-        Func<SpatialContext, Task> nestedTestOperation1 = null,
-        Func<SpatialContext, Task> nestedTestOperation2 = null)
+        Func<SpatialContext, Task>? nestedTestOperation1 = null,
+        Func<SpatialContext, Task>? nestedTestOperation2 = null)
         => TestHelpers.ExecuteWithStrategyInTransactionAsync(
             CreateContext, UseTransaction,
             testOperation, nestedTestOperation1, nestedTestOperation2);

--- a/test/EFCore.Specification.Tests/StoreGeneratedFixupTestBase.cs
+++ b/test/EFCore.Specification.Tests/StoreGeneratedFixupTestBase.cs
@@ -10,8 +10,6 @@ using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 // ReSharper disable InconsistentNaming
 namespace Microsoft.EntityFrameworkCore;
 
-#nullable disable
-
 public abstract class StoreGeneratedFixupTestBase<TFixture>(TFixture fixture) : IClassFixture<TFixture>
     where TFixture : StoreGeneratedFixupTestBase<TFixture>.StoreGeneratedFixupFixtureBase, new()
 {
@@ -3835,7 +3833,7 @@ public abstract class StoreGeneratedFixupTestBase<TFixture>(TFixture fixture) : 
         entry.Property(g => g.Id).IsTemporary = true;
         var internalEntry = ((IInfrastructure<InternalEntityEntry>)entry).Instance;
         internalEntry.PrepareToSave();
-        internalEntry.SetProperty(entry.Metadata.FindProperty("Id"), Guid77, false);
+        internalEntry.SetProperty(entry.Metadata.FindProperty("Id")!, Guid77, false);
         internalEntry.AcceptChanges();
 
         Assert.Equal(EntityState.Unchanged, internalEntry.EntityState);
@@ -3962,7 +3960,7 @@ public abstract class StoreGeneratedFixupTestBase<TFixture>(TFixture fixture) : 
 
         var expectedState = tempKeys ? EntityState.Added : EntityState.Unchanged;
 
-        if (context.Database.ProviderName.EndsWith("InMemory", StringComparison.OrdinalIgnoreCase))
+        if (context.Database.ProviderName!.EndsWith("InMemory", StringComparison.OrdinalIgnoreCase))
         {
             tempKeys = false;
         }
@@ -4001,7 +3999,7 @@ public abstract class StoreGeneratedFixupTestBase<TFixture>(TFixture fixture) : 
     protected class FirstLevel
     {
         public int Id { get; set; }
-        public IList<SecondLevel> SecondLevels { get; set; }
+        public IList<SecondLevel> SecondLevels { get; set; } = null!;
     }
 
     private static void AddData(FirstLevel first)
@@ -4014,15 +4012,15 @@ public abstract class StoreGeneratedFixupTestBase<TFixture>(TFixture fixture) : 
     {
         public int Id { get; set; }
         public int FirstLevelId { get; set; }
-        public FirstLevel FirstLevel { get; set; }
-        public IList<ThirdLevel> ThirdLevels { get; set; }
+        public FirstLevel FirstLevel { get; set; } = null!;
+        public IList<ThirdLevel> ThirdLevels { get; set; } = null!;
     }
 
     protected class ThirdLevel
     {
         public int Id { get; set; }
         public int SecondLevelId { get; set; }
-        public SecondLevel SecondLevel { get; set; }
+        public SecondLevel SecondLevel { get; set; } = null!;
     }
 
     protected class Parent
@@ -4030,7 +4028,7 @@ public abstract class StoreGeneratedFixupTestBase<TFixture>(TFixture fixture) : 
         public int Id1 { get; set; }
         public Guid Id2 { get; set; }
 
-        public Child Child { get; set; }
+        public Child Child { get; set; } = null!;
     }
 
     protected class Child
@@ -4041,7 +4039,7 @@ public abstract class StoreGeneratedFixupTestBase<TFixture>(TFixture fixture) : 
         public int ParentId1 { get; set; }
         public Guid ParentId2 { get; set; }
 
-        public Parent Parent { get; set; }
+        public Parent Parent { get; set; } = null!;
     }
 
     protected class ParentPN
@@ -4050,7 +4048,7 @@ public abstract class StoreGeneratedFixupTestBase<TFixture>(TFixture fixture) : 
         public Guid Id2 { get; set; }
 
         // ReSharper disable once MemberHidesStaticFromOuterClass
-        public ChildPN Child { get; set; }
+        public ChildPN Child { get; set; } = null!;
     }
 
     protected class ChildPN
@@ -4077,7 +4075,7 @@ public abstract class StoreGeneratedFixupTestBase<TFixture>(TFixture fixture) : 
         public Guid ParentId2 { get; set; }
 
         // ReSharper disable once MemberHidesStaticFromOuterClass
-        public ParentDN Parent { get; set; }
+        public ParentDN Parent { get; set; } = null!;
     }
 
     protected class ParentNN
@@ -4110,7 +4108,7 @@ public abstract class StoreGeneratedFixupTestBase<TFixture>(TFixture fixture) : 
         public Guid CategoryId2 { get; set; }
 
         // ReSharper disable once MemberHidesStaticFromOuterClass
-        public CategoryDN Category { get; set; }
+        public CategoryDN Category { get; set; } = null!;
     }
 
     protected class CategoryPN
@@ -4160,14 +4158,14 @@ public abstract class StoreGeneratedFixupTestBase<TFixture>(TFixture fixture) : 
 
         public int CategoryId1 { get; set; }
         public Guid CategoryId2 { get; set; }
-        public Category Category { get; set; }
+        public Category Category { get; set; } = null!;
     }
 
     protected class Level
     {
         public virtual int Id { get; set; }
         public virtual Guid GameId { get; set; }
-        public virtual Game Game { get; set; }
+        public virtual Game Game { get; set; } = null!;
 
         public virtual ICollection<Item> Items { get; } = [];
         public virtual ICollection<Actor> Actors { get; } = [];
@@ -4178,10 +4176,10 @@ public abstract class StoreGeneratedFixupTestBase<TFixture>(TFixture fixture) : 
         public int Id { get; set; }
 
         public Guid GameId { get; set; }
-        public Game Game { get; set; }
+        public Game Game { get; set; } = null!;
 
         public int LevelId { get; set; }
-        public Level Level { get; set; }
+        public Level Level { get; set; } = null!;
     }
 
     protected class Item : GameEntity;

--- a/test/EFCore.Specification.Tests/TestModels/AspNetIdentity/IdentityDbContext``.cs
+++ b/test/EFCore.Specification.Tests/TestModels/AspNetIdentity/IdentityDbContext``.cs
@@ -3,8 +3,6 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.AspNetIdentity;
 
-#nullable disable
-
 public abstract class
     IdentityDbContext<TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken> : IdentityUserContext<TUser, TKey,
     TUserClaim, TUserLogin, TUserToken>
@@ -26,9 +24,9 @@ public abstract class
     {
     }
 
-    public virtual DbSet<TUserRole> UserRoles { get; set; }
-    public virtual DbSet<TRole> Roles { get; set; }
-    public virtual DbSet<TRoleClaim> RoleClaims { get; set; }
+    public virtual DbSet<TUserRole> UserRoles { get; set; } = null!;
+    public virtual DbSet<TRole> Roles { get; set; } = null!;
+    public virtual DbSet<TRoleClaim> RoleClaims { get; set; } = null!;
 
     protected override void OnModelCreating(ModelBuilder builder)
     {

--- a/test/EFCore.Specification.Tests/TestModels/AspNetIdentity/IdentityRole.cs
+++ b/test/EFCore.Specification.Tests/TestModels/AspNetIdentity/IdentityRole.cs
@@ -3,8 +3,6 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.AspNetIdentity;
 
-#nullable disable
-
 public class IdentityRole<TKey>
     where TKey : IEquatable<TKey>
 {
@@ -16,16 +14,16 @@ public class IdentityRole<TKey>
         : this()
         => Name = roleName;
 
-    public virtual TKey Id { get; set; }
+    public virtual TKey Id { get; set; } = default!;
 
-    public virtual string Name { get; set; }
+    public virtual string? Name { get; set; }
 
-    public virtual string NormalizedName { get; set; }
+    public virtual string? NormalizedName { get; set; }
 
-    public virtual string ConcurrencyStamp { get; set; } = Guid.NewGuid().ToString();
+    public virtual string? ConcurrencyStamp { get; set; } = Guid.NewGuid().ToString();
 
     public override string ToString()
-        => Name;
+        => Name!;
 }
 
 public class IdentityRole : IdentityRole<string>

--- a/test/EFCore.Specification.Tests/TestModels/AspNetIdentity/IdentityRoleClaim.cs
+++ b/test/EFCore.Specification.Tests/TestModels/AspNetIdentity/IdentityRoleClaim.cs
@@ -3,13 +3,11 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.AspNetIdentity;
 
-#nullable disable
-
 public class IdentityRoleClaim<TKey>
     where TKey : IEquatable<TKey>
 {
     public virtual int Id { get; set; }
-    public virtual TKey RoleId { get; set; }
-    public virtual string ClaimType { get; set; }
-    public virtual string ClaimValue { get; set; }
+    public virtual TKey RoleId { get; set; } = default!;
+    public virtual string? ClaimType { get; set; }
+    public virtual string? ClaimValue { get; set; }
 }

--- a/test/EFCore.Specification.Tests/TestModels/AspNetIdentity/IdentityUserClaim.cs
+++ b/test/EFCore.Specification.Tests/TestModels/AspNetIdentity/IdentityUserClaim.cs
@@ -3,13 +3,11 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.AspNetIdentity;
 
-#nullable disable
-
 public class IdentityUserClaim<TKey>
     where TKey : IEquatable<TKey>
 {
     public virtual int Id { get; set; }
-    public virtual TKey UserId { get; set; }
-    public virtual string ClaimType { get; set; }
-    public virtual string ClaimValue { get; set; }
+    public virtual TKey UserId { get; set; } = default!;
+    public virtual string? ClaimType { get; set; }
+    public virtual string? ClaimValue { get; set; }
 }

--- a/test/EFCore.Specification.Tests/TestModels/AspNetIdentity/IdentityUserContext.cs
+++ b/test/EFCore.Specification.Tests/TestModels/AspNetIdentity/IdentityUserContext.cs
@@ -3,8 +3,6 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.AspNetIdentity;
 
-#nullable disable
-
 public abstract class IdentityUserContext<TUser, TKey, TUserClaim, TUserLogin, TUserToken> : DbContext
     where TUser : IdentityUser<TKey>
     where TKey : IEquatable<TKey>
@@ -21,10 +19,10 @@ public abstract class IdentityUserContext<TUser, TKey, TUserClaim, TUserLogin, T
     {
     }
 
-    public virtual DbSet<TUser> Users { get; set; }
-    public virtual DbSet<TUserClaim> UserClaims { get; set; }
-    public virtual DbSet<TUserLogin> UserLogins { get; set; }
-    public virtual DbSet<TUserToken> UserTokens { get; set; }
+    public virtual DbSet<TUser> Users { get; set; } = null!;
+    public virtual DbSet<TUserClaim> UserClaims { get; set; } = null!;
+    public virtual DbSet<TUserLogin> UserLogins { get; set; } = null!;
+    public virtual DbSet<TUserToken> UserTokens { get; set; } = null!;
 
     private class PersonalDataConverter(IPersonalDataProtector protector) : ValueConverter<string, string>(
         s => protector.Protect(s),

--- a/test/EFCore.Specification.Tests/TestModels/AspNetIdentity/IdentityUserLogin.cs
+++ b/test/EFCore.Specification.Tests/TestModels/AspNetIdentity/IdentityUserLogin.cs
@@ -3,13 +3,11 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.AspNetIdentity;
 
-#nullable disable
-
 public class IdentityUserLogin<TKey>
     where TKey : IEquatable<TKey>
 {
-    public virtual string LoginProvider { get; set; }
-    public virtual string ProviderKey { get; set; }
-    public virtual string ProviderDisplayName { get; set; }
-    public virtual TKey UserId { get; set; }
+    public virtual string LoginProvider { get; set; } = null!;
+    public virtual string ProviderKey { get; set; } = null!;
+    public virtual string? ProviderDisplayName { get; set; }
+    public virtual TKey UserId { get; set; } = default!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/AspNetIdentity/IdentityUserRole.cs
+++ b/test/EFCore.Specification.Tests/TestModels/AspNetIdentity/IdentityUserRole.cs
@@ -3,11 +3,9 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.AspNetIdentity;
 
-#nullable disable
-
 public class IdentityUserRole<TKey>
     where TKey : IEquatable<TKey>
 {
-    public virtual TKey UserId { get; set; }
-    public virtual TKey RoleId { get; set; }
+    public virtual TKey UserId { get; set; } = default!;
+    public virtual TKey RoleId { get; set; } = default!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/AspNetIdentity/IdentityUserToken.cs
+++ b/test/EFCore.Specification.Tests/TestModels/AspNetIdentity/IdentityUserToken.cs
@@ -3,15 +3,13 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.AspNetIdentity;
 
-#nullable disable
-
 public class IdentityUserToken<TKey>
     where TKey : IEquatable<TKey>
 {
-    public virtual TKey UserId { get; set; }
-    public virtual string LoginProvider { get; set; }
-    public virtual string Name { get; set; }
+    public virtual TKey UserId { get; set; } = default!;
+    public virtual string LoginProvider { get; set; } = null!;
+    public virtual string Name { get; set; } = null!;
 
     [ProtectedPersonalData]
-    public virtual string Value { get; set; }
+    public virtual string? Value { get; set; }
 }

--- a/test/EFCore.Specification.Tests/TestModels/AspNetIdentity/IdentityUser`.cs
+++ b/test/EFCore.Specification.Tests/TestModels/AspNetIdentity/IdentityUser`.cs
@@ -3,8 +3,6 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.AspNetIdentity;
 
-#nullable disable
-
 public class IdentityUser<TKey>
     where TKey : IEquatable<TKey>
 {
@@ -17,29 +15,29 @@ public class IdentityUser<TKey>
         => UserName = userName;
 
     [PersonalData]
-    public virtual TKey Id { get; set; }
+    public virtual TKey Id { get; set; } = default!;
 
     [ProtectedPersonalData]
-    public virtual string UserName { get; set; }
+    public virtual string? UserName { get; set; }
 
-    public virtual string NormalizedUserName { get; set; }
+    public virtual string? NormalizedUserName { get; set; }
 
     [ProtectedPersonalData]
-    public virtual string Email { get; set; }
+    public virtual string? Email { get; set; }
 
-    public virtual string NormalizedEmail { get; set; }
+    public virtual string? NormalizedEmail { get; set; }
 
     [PersonalData]
     public virtual bool EmailConfirmed { get; set; }
 
-    public virtual string PasswordHash { get; set; }
+    public virtual string? PasswordHash { get; set; }
 
-    public virtual string SecurityStamp { get; set; }
+    public virtual string? SecurityStamp { get; set; }
 
-    public virtual string ConcurrencyStamp { get; set; } = Guid.NewGuid().ToString();
+    public virtual string? ConcurrencyStamp { get; set; } = Guid.NewGuid().ToString();
 
     [ProtectedPersonalData]
-    public virtual string PhoneNumber { get; set; }
+    public virtual string? PhoneNumber { get; set; }
 
     [PersonalData]
     public virtual bool PhoneNumberConfirmed { get; set; }
@@ -54,5 +52,5 @@ public class IdentityUser<TKey>
     public virtual int AccessFailedCount { get; set; }
 
     public override string ToString()
-        => UserName;
+        => UserName!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/ChangedChangingMonsterContext.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ChangedChangingMonsterContext.cs
@@ -11,8 +11,6 @@ using System.Runtime.CompilerServices;
 // ReSharper disable ConvertToAutoProperty
 namespace Microsoft.EntityFrameworkCore.TestModels;
 
-#nullable disable
-
 public class ChangedChangingMonsterContext(DbContextOptions options) : MonsterContext<
     ChangedChangingMonsterContext.Customer, ChangedChangingMonsterContext.Barcode, ChangedChangingMonsterContext.IncorrectScan,
     ChangedChangingMonsterContext.BarcodeDetail, ChangedChangingMonsterContext.Complaint, ChangedChangingMonsterContext.Resolution,
@@ -31,8 +29,8 @@ public class ChangedChangingMonsterContext(DbContextOptions options) : MonsterCo
 {
     public class NotificationEntity : INotifyPropertyChanged, INotifyPropertyChanging
     {
-        public event PropertyChangedEventHandler PropertyChanged;
-        public event PropertyChangingEventHandler PropertyChanging;
+        public event PropertyChangedEventHandler? PropertyChanged;
+        public event PropertyChangingEventHandler? PropertyChanging;
 
         private void NotifyChanged(string propertyName)
             => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
@@ -55,7 +53,7 @@ public class ChangedChangingMonsterContext(DbContextOptions options) : MonsterCo
 
     public class BackOrderLine : OrderLine, IBackOrderLine
     {
-        private ISupplier _supplier;
+        private ISupplier _supplier = null!;
         private int _supplierId;
         private DateTime _eta;
 
@@ -83,8 +81,8 @@ public class ChangedChangingMonsterContext(DbContextOptions options) : MonsterCo
 
     public class BarcodeDetail : NotificationEntity, IBarcodeDetail
     {
-        private byte[] _code;
-        private string _registeredTo;
+        private byte[] _code = null!;
+        private string _registeredTo = null!;
 
         public byte[] Code
         {
@@ -101,12 +99,12 @@ public class ChangedChangingMonsterContext(DbContextOptions options) : MonsterCo
 
     public class Barcode : NotificationEntity, IBarcode
     {
-        private byte[] _code;
+        private byte[] _code = null!;
         private int _productId;
-        private string _text;
-        private IProduct _product;
-        private ICollection<IIncorrectScan> _badScans;
-        private IBarcodeDetail _detail;
+        private string _text = null!;
+        private IProduct _product = null!;
+        private ICollection<IIncorrectScan> _badScans = null!;
+        private IBarcodeDetail _detail = null!;
 
         public void InitializeCollections()
             => BadScans ??= new ObservableCollection<IIncorrectScan>();
@@ -150,13 +148,13 @@ public class ChangedChangingMonsterContext(DbContextOptions options) : MonsterCo
 
     public class Complaint : NotificationEntity, IComplaint
     {
-        private ICustomer _customer;
-        private IResolution _resolution;
+        private ICustomer _customer = null!;
+        private IResolution _resolution = null!;
         private int _complaintId;
         private int _alternateId;
         private int? _customerId;
         private DateTime _logged;
-        private string _details;
+        private string _details = null!;
 
         public int ComplaintId
         {
@@ -204,13 +202,13 @@ public class ChangedChangingMonsterContext(DbContextOptions options) : MonsterCo
     public class ComputerDetail : NotificationEntity, IComputerDetail
     {
         private int _computerDetailId;
-        private string _manufacturer;
-        private string _model;
-        private string _serial;
-        private string _specifications;
+        private string _manufacturer = null!;
+        private string _model = null!;
+        private string _serial = null!;
+        private string _specifications = null!;
         private DateTime _purchaseDate;
-        private IDimensions _dimensions;
-        private IComputer _computer;
+        private IDimensions _dimensions = null!;
+        private IComputer _computer = null!;
 
         public ComputerDetail()
             => Dimensions = new Dimensions();
@@ -267,8 +265,8 @@ public class ChangedChangingMonsterContext(DbContextOptions options) : MonsterCo
     public class Computer : NotificationEntity, IComputer
     {
         private int _computerId;
-        private string _name;
-        private IComputerDetail _computerDetail;
+        private string _name = null!;
+        private IComputerDetail _computerDetail = null!;
 
         public int ComputerId
         {
@@ -292,7 +290,7 @@ public class ChangedChangingMonsterContext(DbContextOptions options) : MonsterCo
     public class ConcurrencyInfo : NotificationEntity, IConcurrencyInfo
     {
         private bool _active;
-        private string _token;
+        private string? _token;
         private DateTime? _queriedDateTime;
 
         public bool Active
@@ -301,7 +299,7 @@ public class ChangedChangingMonsterContext(DbContextOptions options) : MonsterCo
             set => SetWithNotify(value, ref _active);
         }
 
-        public string Token
+        public string? Token
         {
             get => _token;
             set => SetWithNotify(value, ref _token);
@@ -317,10 +315,10 @@ public class ChangedChangingMonsterContext(DbContextOptions options) : MonsterCo
     public class ContactDetails : NotificationEntity, IContactDetails
     {
         private bool _active;
-        private string _email;
-        private IPhone _homePhone;
-        private IPhone _workPhone;
-        private IPhone _mobilePhone;
+        private string? _email;
+        private IPhone _homePhone = null!;
+        private IPhone _workPhone = null!;
+        private IPhone _mobilePhone = null!;
 
         public ContactDetails()
         {
@@ -335,7 +333,7 @@ public class ChangedChangingMonsterContext(DbContextOptions options) : MonsterCo
             set => SetWithNotify(value, ref _active);
         }
 
-        public string Email
+        public string? Email
         {
             get => _email;
             set => SetWithNotify(value, ref _email);
@@ -363,7 +361,7 @@ public class ChangedChangingMonsterContext(DbContextOptions options) : MonsterCo
     public class CustomerInfo : NotificationEntity, ICustomerInfo
     {
         private int _customerInfoId;
-        private string _information;
+        private string _information = null!;
 
         public int CustomerInfoId
         {
@@ -405,7 +403,7 @@ public class ChangedChangingMonsterContext(DbContextOptions options) : MonsterCo
 
     public class DiscontinuedProduct : Product, IDiscontinuedProduct
     {
-        private IProduct _replacedBy;
+        private IProduct _replacedBy = null!;
         private DateTime _discontinued;
         private int? _replacementProductId;
 
@@ -430,9 +428,9 @@ public class ChangedChangingMonsterContext(DbContextOptions options) : MonsterCo
 
     public class Driver : NotificationEntity, IDriver
     {
-        private string _name;
+        private string _name = null!;
         private DateTime _birthDate;
-        private ILicense _license;
+        private ILicense _license = null!;
 
         public string Name
         {
@@ -456,12 +454,12 @@ public class ChangedChangingMonsterContext(DbContextOptions options) : MonsterCo
     public class IncorrectScan : NotificationEntity, IIncorrectScan
     {
         private int _incorrectScanId;
-        private byte[] _expectedCode;
-        private byte[] _actualCode;
+        private byte[]? _expectedCode;
+        private byte[]? _actualCode;
         private DateTime _scanDate;
-        private string _details;
-        private IBarcode _expectedBarcode;
-        private IBarcode _actualBarcode;
+        private string _details = null!;
+        private IBarcode? _expectedBarcode;
+        private IBarcode? _actualBarcode;
 
         public int IncorrectScanId
         {
@@ -469,13 +467,13 @@ public class ChangedChangingMonsterContext(DbContextOptions options) : MonsterCo
             set => SetWithNotify(value, ref _incorrectScanId);
         }
 
-        public byte[] ExpectedCode
+        public byte[]? ExpectedCode
         {
             get => _expectedCode;
             set => SetWithNotify(value, ref _expectedCode);
         }
 
-        public byte[] ActualCode
+        public byte[]? ActualCode
         {
             get => _actualCode;
             set => SetWithNotify(value, ref _actualCode);
@@ -493,13 +491,13 @@ public class ChangedChangingMonsterContext(DbContextOptions options) : MonsterCo
             set => SetWithNotify(value, ref _details);
         }
 
-        public virtual IBarcode ExpectedBarcode
+        public virtual IBarcode? ExpectedBarcode
         {
             get => _expectedBarcode;
             set => SetWithNotify(value, ref _expectedBarcode);
         }
 
-        public virtual IBarcode ActualBarcode
+        public virtual IBarcode? ActualBarcode
         {
             get => _actualBarcode;
             set => SetWithNotify(value, ref _actualBarcode);
@@ -508,11 +506,11 @@ public class ChangedChangingMonsterContext(DbContextOptions options) : MonsterCo
 
     public class LastLogin : NotificationEntity, ILastLogin
     {
-        private string _username;
+        private string _username = null!;
         private DateTime _loggedIn;
         private DateTime? _loggedOut;
-        private string _smartcardUsername;
-        private ILogin _login;
+        private string? _smartcardUsername;
+        private ILogin _login = null!;
 
         public string Username
         {
@@ -532,7 +530,7 @@ public class ChangedChangingMonsterContext(DbContextOptions options) : MonsterCo
             set => SetWithNotify(value, ref _loggedOut);
         }
 
-        public string SmartcardUsername
+        public string? SmartcardUsername
         {
             get => _smartcardUsername;
             set => SetWithNotify(value, ref _smartcardUsername);
@@ -547,13 +545,13 @@ public class ChangedChangingMonsterContext(DbContextOptions options) : MonsterCo
 
     public class License : NotificationEntity, ILicense
     {
-        private string _name;
-        private string _licenseNumber;
-        private string _licenseClass;
-        private string _restrictions;
+        private string _name = null!;
+        private string _licenseNumber = null!;
+        private string _licenseClass = null!;
+        private string _restrictions = null!;
         private DateTime _expirationDate;
         private LicenseState? _state;
-        private IDriver _driver;
+        private IDriver _driver = null!;
 
         public License()
             => LicenseClass = "C";
@@ -604,14 +602,14 @@ public class ChangedChangingMonsterContext(DbContextOptions options) : MonsterCo
     public class Message : NotificationEntity, IMessage
     {
         private int _messageId;
-        private string _fromUsername;
-        private string _toUsername;
+        private string _fromUsername = null!;
+        private string? _toUsername;
         private DateTime _sent;
-        private string _subject;
-        private string _body;
+        private string _subject = null!;
+        private string _body = null!;
         private bool _isRead;
-        private ILogin _sender;
-        private ILogin _recipient;
+        private ILogin _sender = null!;
+        private ILogin? _recipient;
 
         public int MessageId
         {
@@ -625,7 +623,7 @@ public class ChangedChangingMonsterContext(DbContextOptions options) : MonsterCo
             set => SetWithNotify(value, ref _fromUsername);
         }
 
-        public string ToUsername
+        public string? ToUsername
         {
             get => _toUsername;
             set => SetWithNotify(value, ref _toUsername);
@@ -661,7 +659,7 @@ public class ChangedChangingMonsterContext(DbContextOptions options) : MonsterCo
             set => SetWithNotify(value, ref _sender);
         }
 
-        public virtual ILogin Recipient
+        public virtual ILogin? Recipient
         {
             get => _recipient;
             set => SetWithNotify(value, ref _recipient);
@@ -673,9 +671,9 @@ public class ChangedChangingMonsterContext(DbContextOptions options) : MonsterCo
         private int _orderId;
         private int _productId;
         private int _quantity;
-        private string _concurrencyToken;
-        private IAnOrder _order;
-        private IProduct _product;
+        private string? _concurrencyToken;
+        private IAnOrder _order = null!;
+        private IProduct _product = null!;
 
         public OrderLine()
             => Quantity = 1;
@@ -698,7 +696,7 @@ public class ChangedChangingMonsterContext(DbContextOptions options) : MonsterCo
             set => SetWithNotify(value, ref _quantity);
         }
 
-        public string ConcurrencyToken
+        public string? ConcurrencyToken
         {
             get => _concurrencyToken;
             set => SetWithNotify(value, ref _concurrencyToken);
@@ -722,12 +720,12 @@ public class ChangedChangingMonsterContext(DbContextOptions options) : MonsterCo
         private int _anOrderId;
         private int _alternateId;
         private int? _customerId;
-        private IConcurrencyInfo _concurrency;
-        private ICustomer _customer;
-        private ICollection<IOrderLine> _orderLines;
-        private ICollection<IOrderNote> _notes;
-        private string _username;
-        private ILogin _login;
+        private IConcurrencyInfo _concurrency = null!;
+        private ICustomer _customer = null!;
+        private ICollection<IOrderLine> _orderLines = null!;
+        private ICollection<IOrderNote> _notes = null!;
+        private string _username = null!;
+        private ILogin _login = null!;
 
         public AnOrder()
             => Concurrency = new ConcurrencyInfo();
@@ -796,9 +794,9 @@ public class ChangedChangingMonsterContext(DbContextOptions options) : MonsterCo
     public class OrderNote : NotificationEntity, IOrderNote
     {
         private int _noteId;
-        private string _note;
+        private string _note = null!;
         private int _orderId;
-        private IAnOrder _order;
+        private IAnOrder _order = null!;
 
         public int NoteId
         {
@@ -828,9 +826,9 @@ public class ChangedChangingMonsterContext(DbContextOptions options) : MonsterCo
     public class OrderQualityCheck : NotificationEntity, IOrderQualityCheck
     {
         private int _orderId;
-        private string _checkedBy;
+        private string _checkedBy = null!;
         private DateTime _checkedDateTime;
-        private IAnOrder _order;
+        private IAnOrder _order = null!;
 
         public int OrderId
         {
@@ -860,10 +858,10 @@ public class ChangedChangingMonsterContext(DbContextOptions options) : MonsterCo
     public class PageView : NotificationEntity, IPageView
     {
         private int _pageViewId;
-        private string _username;
+        private string _username = null!;
         private DateTime _viewed;
-        private string _pageUrl;
-        private ILogin _login;
+        private string _pageUrl = null!;
+        private ILogin _login = null!;
 
         public int PageViewId
         {
@@ -899,10 +897,10 @@ public class ChangedChangingMonsterContext(DbContextOptions options) : MonsterCo
     public class PasswordReset : NotificationEntity, IPasswordReset
     {
         private int _resetNo;
-        private string _username;
-        private string _tempPassword;
-        private string _emailedTo;
-        private ILogin _login;
+        private string _username = null!;
+        private string _tempPassword = null!;
+        private string _emailedTo = null!;
+        private ILogin _login = null!;
 
         public int ResetNo
         {
@@ -938,8 +936,8 @@ public class ChangedChangingMonsterContext(DbContextOptions options) : MonsterCo
     public class ProductDetail : NotificationEntity, IProductDetail
     {
         private int _productId;
-        private string _details;
-        private IProduct _product;
+        private string _details = null!;
+        private IProduct _product = null!;
 
         public int ProductId
         {
@@ -963,17 +961,17 @@ public class ChangedChangingMonsterContext(DbContextOptions options) : MonsterCo
     public class Product : NotificationEntity, IProduct
     {
         private int _productId;
-        private string _description;
-        private string _baseConcurrency;
-        private IDimensions _dimensions;
-        private IConcurrencyInfo _complexConcurrency;
-        private IAuditInfo _nestedComplexConcurrency;
-        private ICollection<ISupplier> _suppliers;
-        private IProductDetail _detail;
-        private ICollection<IProductReview> _reviews;
-        private ICollection<IProductPhoto> _photos;
-        private ICollection<IBarcode> _barcodes;
-        private ICollection<IDiscontinuedProduct> _replaces;
+        private string _description = null!;
+        private string _baseConcurrency = null!;
+        private IDimensions _dimensions = null!;
+        private IConcurrencyInfo _complexConcurrency = null!;
+        private IAuditInfo _nestedComplexConcurrency = null!;
+        private ICollection<ISupplier> _suppliers = null!;
+        private IProductDetail _detail = null!;
+        private ICollection<IProductReview> _reviews = null!;
+        private ICollection<IProductPhoto> _photos = null!;
+        private ICollection<IBarcode> _barcodes = null!;
+        private ICollection<IDiscontinuedProduct> _replaces = null!;
 
         public Product()
         {
@@ -1065,7 +1063,7 @@ public class ChangedChangingMonsterContext(DbContextOptions options) : MonsterCo
 
     public class ProductPageView : PageView, IProductPageView
     {
-        private IProduct _product;
+        private IProduct _product = null!;
         private int _productId;
 
         public int ProductId
@@ -1085,8 +1083,8 @@ public class ChangedChangingMonsterContext(DbContextOptions options) : MonsterCo
     {
         private int _productId;
         private int _photoId;
-        private byte[] _photo;
-        private ICollection<IProductWebFeature> _features;
+        private byte[] _photo = null!;
+        private ICollection<IProductWebFeature> _features = null!;
 
         public void InitializeCollections()
             => Features ??= new ObservableCollection<IProductWebFeature>();
@@ -1120,9 +1118,9 @@ public class ChangedChangingMonsterContext(DbContextOptions options) : MonsterCo
     {
         private int _productId;
         private int _reviewId;
-        private string _review;
-        private IProduct _product;
-        private ICollection<IProductWebFeature> _features;
+        private string _review = null!;
+        private IProduct _product = null!;
+        private ICollection<IProductWebFeature> _features = null!;
 
         public void InitializeCollections()
             => Features ??= new ObservableCollection<IProductWebFeature>();
@@ -1164,9 +1162,9 @@ public class ChangedChangingMonsterContext(DbContextOptions options) : MonsterCo
         private int? _productId;
         private int? _photoId;
         private int _reviewId;
-        private string _heading;
-        private IProductReview _review;
-        private IProductPhoto _photo;
+        private string _heading = null!;
+        private IProductReview _review = null!;
+        private IProductPhoto _photo = null!;
 
         public int FeatureId
         {
@@ -1214,8 +1212,8 @@ public class ChangedChangingMonsterContext(DbContextOptions options) : MonsterCo
     public class Resolution : NotificationEntity, IResolution
     {
         private int _resolutionId;
-        private string _details;
-        private IComplaint _complaint;
+        private string _details = null!;
+        private IComplaint _complaint = null!;
 
         public int ResolutionId
         {
@@ -1238,10 +1236,10 @@ public class ChangedChangingMonsterContext(DbContextOptions options) : MonsterCo
 
     public class RsaToken : NotificationEntity, IRsaToken
     {
-        private string _serial;
+        private string _serial = null!;
         private DateTime _issued;
-        private string _username;
-        private ILogin _login;
+        private string _username = null!;
+        private ILogin _login = null!;
 
         public string Serial
         {
@@ -1270,11 +1268,11 @@ public class ChangedChangingMonsterContext(DbContextOptions options) : MonsterCo
 
     public class SmartCard : NotificationEntity, ISmartCard
     {
-        private string _username;
-        private string _cardSerial;
+        private string _username = null!;
+        private string _cardSerial = null!;
         private DateTime _issued;
-        private ILogin _login;
-        private ILastLogin _lastLogin;
+        private ILogin _login = null!;
+        private ILastLogin? _lastLogin;
 
         public string Username
         {
@@ -1300,7 +1298,7 @@ public class ChangedChangingMonsterContext(DbContextOptions options) : MonsterCo
             set => SetWithNotify(value, ref _login);
         }
 
-        public virtual ILastLogin LastLogin
+        public virtual ILastLogin? LastLogin
         {
             get => _lastLogin;
             set => SetWithNotify(value, ref _lastLogin);
@@ -1310,9 +1308,9 @@ public class ChangedChangingMonsterContext(DbContextOptions options) : MonsterCo
     public class SupplierInfo : NotificationEntity, ISupplierInfo
     {
         private int _supplierInfoId;
-        private string _information;
+        private string _information = null!;
         private int _supplierId;
-        private ISupplier _supplier;
+        private ISupplier _supplier = null!;
 
         public int SupplierInfoId
         {
@@ -1342,7 +1340,7 @@ public class ChangedChangingMonsterContext(DbContextOptions options) : MonsterCo
     public class SupplierLogo : NotificationEntity, ISupplierLogo
     {
         private int _supplierId;
-        private byte[] _logo;
+        private byte[] _logo = null!;
 
         public int SupplierId
         {
@@ -1360,10 +1358,10 @@ public class ChangedChangingMonsterContext(DbContextOptions options) : MonsterCo
     public class Supplier : NotificationEntity, ISupplier
     {
         private int _supplierId;
-        private string _name;
-        private ICollection<IProduct> _products;
-        private ISupplierLogo _logo;
-        private ICollection<IBackOrderLine> _backOrderLines;
+        private string _name = null!;
+        private ICollection<IProduct> _products = null!;
+        private ISupplierLogo _logo = null!;
+        private ICollection<IBackOrderLine> _backOrderLines = null!;
 
         public void InitializeCollections()
         {
@@ -1405,8 +1403,8 @@ public class ChangedChangingMonsterContext(DbContextOptions options) : MonsterCo
     public class SuspiciousActivity : NotificationEntity, ISuspiciousActivity
     {
         private int _suspiciousActivityId;
-        private string _activity;
-        private string _username;
+        private string _activity = null!;
+        private string _username = null!;
 
         public int SuspiciousActivityId
         {
@@ -1430,8 +1428,8 @@ public class ChangedChangingMonsterContext(DbContextOptions options) : MonsterCo
     public class AuditInfo : NotificationEntity, IAuditInfo
     {
         private DateTime _modifiedDate;
-        private string _modifiedBy;
-        private IConcurrencyInfo _concurrency;
+        private string? _modifiedBy;
+        private IConcurrencyInfo _concurrency = null!;
 
         public AuditInfo()
         {
@@ -1445,7 +1443,7 @@ public class ChangedChangingMonsterContext(DbContextOptions options) : MonsterCo
             set => SetWithNotify(value, ref _modifiedDate);
         }
 
-        public string ModifiedBy
+        public string? ModifiedBy
         {
             get => _modifiedBy;
             set => SetWithNotify(value, ref _modifiedBy);
@@ -1462,14 +1460,14 @@ public class ChangedChangingMonsterContext(DbContextOptions options) : MonsterCo
     {
         private int _customerId;
         private int? _husbandId;
-        private string _name;
-        private IContactDetails _contactInfo;
-        private IAuditInfo _auditing;
-        private ICollection<IAnOrder> _orders;
-        private ICollection<ILogin> _logins;
-        private ICustomer _husband;
-        private ICustomer _wife;
-        private ICustomerInfo _info;
+        private string _name = null!;
+        private IContactDetails _contactInfo = null!;
+        private IAuditInfo _auditing = null!;
+        private ICollection<IAnOrder> _orders = null!;
+        private ICollection<ILogin> _logins = null!;
+        private ICustomer _husband = null!;
+        private ICustomer _wife = null!;
+        private ICustomerInfo _info = null!;
 
         public Customer()
         {
@@ -1546,14 +1544,14 @@ public class ChangedChangingMonsterContext(DbContextOptions options) : MonsterCo
 
     public class Login : NotificationEntity, ILogin
     {
-        private string _username;
-        private string _alternateUsername;
+        private string _username = null!;
+        private string _alternateUsername = null!;
         private int _customerId;
-        private ICustomer _customer;
-        private ILastLogin _lastLogin;
-        private ICollection<IMessage> _sentMessages;
-        private ICollection<IMessage> _receivedMessages;
-        private ICollection<IAnOrder> _orders;
+        private ICustomer _customer = null!;
+        private ILastLogin _lastLogin = null!;
+        private ICollection<IMessage> _sentMessages = null!;
+        private ICollection<IMessage> _receivedMessages = null!;
+        private ICollection<IAnOrder> _orders = null!;
 
         public void InitializeCollections()
         {
@@ -1614,13 +1612,13 @@ public class ChangedChangingMonsterContext(DbContextOptions options) : MonsterCo
     public class Phone : NotificationEntity, IPhone
     {
         private PhoneType _phoneType;
-        private string _extension;
-        private string _phoneNumber;
+        private string _extension = null!;
+        private string? _phoneNumber;
 
         public Phone()
             => Extension = "None";
 
-        public string PhoneNumber
+        public string? PhoneNumber
         {
             get => _phoneNumber;
             set => SetWithNotify(value, ref _phoneNumber);

--- a/test/EFCore.Specification.Tests/TestModels/ChangedOnlyMonsterContext.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ChangedOnlyMonsterContext.cs
@@ -11,8 +11,6 @@ using System.Runtime.CompilerServices;
 // ReSharper disable ConvertToAutoProperty
 namespace Microsoft.EntityFrameworkCore.TestModels;
 
-#nullable disable
-
 public class ChangedOnlyMonsterContext(DbContextOptions options) : MonsterContext<
     ChangedOnlyMonsterContext.Customer, ChangedOnlyMonsterContext.Barcode, ChangedOnlyMonsterContext.IncorrectScan,
     ChangedOnlyMonsterContext.BarcodeDetail, ChangedOnlyMonsterContext.Complaint, ChangedOnlyMonsterContext.Resolution,
@@ -31,7 +29,7 @@ public class ChangedOnlyMonsterContext(DbContextOptions options) : MonsterContex
 {
     public class NotificationEntity : INotifyPropertyChanged
     {
-        public event PropertyChangedEventHandler PropertyChanged;
+        public event PropertyChangedEventHandler? PropertyChanged;
 
         private void NotifyChanged(string propertyName)
             => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
@@ -50,7 +48,7 @@ public class ChangedOnlyMonsterContext(DbContextOptions options) : MonsterContex
 
     public class BackOrderLine : OrderLine, IBackOrderLine
     {
-        private ISupplier _supplier;
+        private ISupplier _supplier = null!;
         private int _supplierId;
         private DateTime _eta;
 
@@ -78,8 +76,8 @@ public class ChangedOnlyMonsterContext(DbContextOptions options) : MonsterContex
 
     public class BarcodeDetail : NotificationEntity, IBarcodeDetail
     {
-        private byte[] _code;
-        private string _registeredTo;
+        private byte[] _code = null!;
+        private string _registeredTo = null!;
 
         public byte[] Code
         {
@@ -96,12 +94,12 @@ public class ChangedOnlyMonsterContext(DbContextOptions options) : MonsterContex
 
     public class Barcode : NotificationEntity, IBarcode
     {
-        private byte[] _code;
+        private byte[] _code = null!;
         private int _productId;
-        private string _text;
-        private IProduct _product;
-        private ICollection<IIncorrectScan> _badScans;
-        private IBarcodeDetail _detail;
+        private string _text = null!;
+        private IProduct _product = null!;
+        private ICollection<IIncorrectScan> _badScans = null!;
+        private IBarcodeDetail _detail = null!;
 
         public void InitializeCollections()
             => BadScans ??= new ObservableCollection<IIncorrectScan>();
@@ -145,13 +143,13 @@ public class ChangedOnlyMonsterContext(DbContextOptions options) : MonsterContex
 
     public class Complaint : NotificationEntity, IComplaint
     {
-        private ICustomer _customer;
-        private IResolution _resolution;
+        private ICustomer _customer = null!;
+        private IResolution _resolution = null!;
         private int _complaintId;
         private int _alternateId;
         private int? _customerId;
         private DateTime _logged;
-        private string _details;
+        private string _details = null!;
 
         public int ComplaintId
         {
@@ -199,13 +197,13 @@ public class ChangedOnlyMonsterContext(DbContextOptions options) : MonsterContex
     public class ComputerDetail : NotificationEntity, IComputerDetail
     {
         private int _computerDetailId;
-        private string _manufacturer;
-        private string _model;
-        private string _serial;
-        private string _specifications;
+        private string _manufacturer = null!;
+        private string _model = null!;
+        private string _serial = null!;
+        private string _specifications = null!;
         private DateTime _purchaseDate;
-        private IDimensions _dimensions;
-        private IComputer _computer;
+        private IDimensions _dimensions = null!;
+        private IComputer _computer = null!;
 
         public ComputerDetail()
             => Dimensions = new Dimensions();
@@ -262,8 +260,8 @@ public class ChangedOnlyMonsterContext(DbContextOptions options) : MonsterContex
     public class Computer : NotificationEntity, IComputer
     {
         private int _computerId;
-        private string _name;
-        private IComputerDetail _computerDetail;
+        private string _name = null!;
+        private IComputerDetail _computerDetail = null!;
 
         public int ComputerId
         {
@@ -287,7 +285,7 @@ public class ChangedOnlyMonsterContext(DbContextOptions options) : MonsterContex
     public class ConcurrencyInfo : NotificationEntity, IConcurrencyInfo
     {
         private bool _active;
-        private string _token;
+        private string? _token;
         private DateTime? _queriedDateTime;
 
         public bool Active
@@ -296,7 +294,7 @@ public class ChangedOnlyMonsterContext(DbContextOptions options) : MonsterContex
             set => SetWithNotify(value, ref _active);
         }
 
-        public string Token
+        public string? Token
         {
             get => _token;
             set => SetWithNotify(value, ref _token);
@@ -312,10 +310,10 @@ public class ChangedOnlyMonsterContext(DbContextOptions options) : MonsterContex
     public class ContactDetails : NotificationEntity, IContactDetails
     {
         private bool _active;
-        private string _email;
-        private IPhone _homePhone;
-        private IPhone _workPhone;
-        private IPhone _mobilePhone;
+        private string? _email;
+        private IPhone _homePhone = null!;
+        private IPhone _workPhone = null!;
+        private IPhone _mobilePhone = null!;
 
         public ContactDetails()
         {
@@ -330,7 +328,7 @@ public class ChangedOnlyMonsterContext(DbContextOptions options) : MonsterContex
             set => SetWithNotify(value, ref _active);
         }
 
-        public string Email
+        public string? Email
         {
             get => _email;
             set => SetWithNotify(value, ref _email);
@@ -358,7 +356,7 @@ public class ChangedOnlyMonsterContext(DbContextOptions options) : MonsterContex
     public class CustomerInfo : NotificationEntity, ICustomerInfo
     {
         private int _customerInfoId;
-        private string _information;
+        private string _information = null!;
 
         public int CustomerInfoId
         {
@@ -400,7 +398,7 @@ public class ChangedOnlyMonsterContext(DbContextOptions options) : MonsterContex
 
     public class DiscontinuedProduct : Product, IDiscontinuedProduct
     {
-        private IProduct _replacedBy;
+        private IProduct _replacedBy = null!;
         private DateTime _discontinued;
         private int? _replacementProductId;
 
@@ -425,9 +423,9 @@ public class ChangedOnlyMonsterContext(DbContextOptions options) : MonsterContex
 
     public class Driver : NotificationEntity, IDriver
     {
-        private string _name;
+        private string _name = null!;
         private DateTime _birthDate;
-        private ILicense _license;
+        private ILicense _license = null!;
 
         public string Name
         {
@@ -451,12 +449,12 @@ public class ChangedOnlyMonsterContext(DbContextOptions options) : MonsterContex
     public class IncorrectScan : NotificationEntity, IIncorrectScan
     {
         private int _incorrectScanId;
-        private byte[] _expectedCode;
-        private byte[] _actualCode;
+        private byte[]? _expectedCode;
+        private byte[]? _actualCode;
         private DateTime _scanDate;
-        private string _details;
-        private IBarcode _expectedBarcode;
-        private IBarcode _actualBarcode;
+        private string _details = null!;
+        private IBarcode? _expectedBarcode;
+        private IBarcode? _actualBarcode;
 
         public int IncorrectScanId
         {
@@ -464,13 +462,13 @@ public class ChangedOnlyMonsterContext(DbContextOptions options) : MonsterContex
             set => SetWithNotify(value, ref _incorrectScanId);
         }
 
-        public byte[] ExpectedCode
+        public byte[]? ExpectedCode
         {
             get => _expectedCode;
             set => SetWithNotify(value, ref _expectedCode);
         }
 
-        public byte[] ActualCode
+        public byte[]? ActualCode
         {
             get => _actualCode;
             set => SetWithNotify(value, ref _actualCode);
@@ -488,13 +486,13 @@ public class ChangedOnlyMonsterContext(DbContextOptions options) : MonsterContex
             set => SetWithNotify(value, ref _details);
         }
 
-        public virtual IBarcode ExpectedBarcode
+        public virtual IBarcode? ExpectedBarcode
         {
             get => _expectedBarcode;
             set => SetWithNotify(value, ref _expectedBarcode);
         }
 
-        public virtual IBarcode ActualBarcode
+        public virtual IBarcode? ActualBarcode
         {
             get => _actualBarcode;
             set => SetWithNotify(value, ref _actualBarcode);
@@ -503,11 +501,11 @@ public class ChangedOnlyMonsterContext(DbContextOptions options) : MonsterContex
 
     public class LastLogin : NotificationEntity, ILastLogin
     {
-        private string _username;
+        private string _username = null!;
         private DateTime _loggedIn;
         private DateTime? _loggedOut;
-        private string _smartcardUsername;
-        private ILogin _login;
+        private string? _smartcardUsername;
+        private ILogin _login = null!;
 
         public string Username
         {
@@ -527,7 +525,7 @@ public class ChangedOnlyMonsterContext(DbContextOptions options) : MonsterContex
             set => SetWithNotify(value, ref _loggedOut);
         }
 
-        public string SmartcardUsername
+        public string? SmartcardUsername
         {
             get => _smartcardUsername;
             set => SetWithNotify(value, ref _smartcardUsername);
@@ -542,13 +540,13 @@ public class ChangedOnlyMonsterContext(DbContextOptions options) : MonsterContex
 
     public class License : NotificationEntity, ILicense
     {
-        private string _name;
-        private string _licenseNumber;
-        private string _licenseClass;
-        private string _restrictions;
+        private string _name = null!;
+        private string _licenseNumber = null!;
+        private string _licenseClass = null!;
+        private string _restrictions = null!;
         private DateTime _expirationDate;
         private LicenseState? _state;
-        private IDriver _driver;
+        private IDriver _driver = null!;
 
         public License()
             => LicenseClass = "C";
@@ -599,14 +597,14 @@ public class ChangedOnlyMonsterContext(DbContextOptions options) : MonsterContex
     public class Message : NotificationEntity, IMessage
     {
         private int _messageId;
-        private string _fromUsername;
-        private string _toUsername;
+        private string _fromUsername = null!;
+        private string? _toUsername;
         private DateTime _sent;
-        private string _subject;
-        private string _body;
+        private string _subject = null!;
+        private string _body = null!;
         private bool _isRead;
-        private ILogin _sender;
-        private ILogin _recipient;
+        private ILogin _sender = null!;
+        private ILogin? _recipient;
 
         public int MessageId
         {
@@ -620,7 +618,7 @@ public class ChangedOnlyMonsterContext(DbContextOptions options) : MonsterContex
             set => SetWithNotify(value, ref _fromUsername);
         }
 
-        public string ToUsername
+        public string? ToUsername
         {
             get => _toUsername;
             set => SetWithNotify(value, ref _toUsername);
@@ -656,7 +654,7 @@ public class ChangedOnlyMonsterContext(DbContextOptions options) : MonsterContex
             set => SetWithNotify(value, ref _sender);
         }
 
-        public virtual ILogin Recipient
+        public virtual ILogin? Recipient
         {
             get => _recipient;
             set => SetWithNotify(value, ref _recipient);
@@ -668,9 +666,9 @@ public class ChangedOnlyMonsterContext(DbContextOptions options) : MonsterContex
         private int _orderId;
         private int _productId;
         private int _quantity;
-        private string _concurrencyToken;
-        private IAnOrder _order;
-        private IProduct _product;
+        private string? _concurrencyToken;
+        private IAnOrder _order = null!;
+        private IProduct _product = null!;
 
         public OrderLine()
             => Quantity = 1;
@@ -693,7 +691,7 @@ public class ChangedOnlyMonsterContext(DbContextOptions options) : MonsterContex
             set => SetWithNotify(value, ref _quantity);
         }
 
-        public string ConcurrencyToken
+        public string? ConcurrencyToken
         {
             get => _concurrencyToken;
             set => SetWithNotify(value, ref _concurrencyToken);
@@ -717,12 +715,12 @@ public class ChangedOnlyMonsterContext(DbContextOptions options) : MonsterContex
         private int _anOrderId;
         private int _alternateId;
         private int? _customerId;
-        private IConcurrencyInfo _concurrency;
-        private ICustomer _customer;
-        private ICollection<IOrderLine> _orderLines;
-        private ICollection<IOrderNote> _notes;
-        private string _username;
-        private ILogin _login;
+        private IConcurrencyInfo _concurrency = null!;
+        private ICustomer _customer = null!;
+        private ICollection<IOrderLine> _orderLines = null!;
+        private ICollection<IOrderNote> _notes = null!;
+        private string _username = null!;
+        private ILogin _login = null!;
 
         public AnOrder()
             => Concurrency = new ConcurrencyInfo();
@@ -791,9 +789,9 @@ public class ChangedOnlyMonsterContext(DbContextOptions options) : MonsterContex
     public class OrderNote : NotificationEntity, IOrderNote
     {
         private int _noteId;
-        private string _note;
+        private string _note = null!;
         private int _orderId;
-        private IAnOrder _order;
+        private IAnOrder _order = null!;
 
         public int NoteId
         {
@@ -823,9 +821,9 @@ public class ChangedOnlyMonsterContext(DbContextOptions options) : MonsterContex
     public class OrderQualityCheck : NotificationEntity, IOrderQualityCheck
     {
         private int _orderId;
-        private string _checkedBy;
+        private string _checkedBy = null!;
         private DateTime _checkedDateTime;
-        private IAnOrder _order;
+        private IAnOrder _order = null!;
 
         public int OrderId
         {
@@ -855,10 +853,10 @@ public class ChangedOnlyMonsterContext(DbContextOptions options) : MonsterContex
     public class PageView : NotificationEntity, IPageView
     {
         private int _pageViewId;
-        private string _username;
+        private string _username = null!;
         private DateTime _viewed;
-        private string _pageUrl;
-        private ILogin _login;
+        private string _pageUrl = null!;
+        private ILogin _login = null!;
 
         public int PageViewId
         {
@@ -894,10 +892,10 @@ public class ChangedOnlyMonsterContext(DbContextOptions options) : MonsterContex
     public class PasswordReset : NotificationEntity, IPasswordReset
     {
         private int _resetNo;
-        private string _username;
-        private string _tempPassword;
-        private string _emailedTo;
-        private ILogin _login;
+        private string _username = null!;
+        private string _tempPassword = null!;
+        private string _emailedTo = null!;
+        private ILogin _login = null!;
 
         public int ResetNo
         {
@@ -933,8 +931,8 @@ public class ChangedOnlyMonsterContext(DbContextOptions options) : MonsterContex
     public class ProductDetail : NotificationEntity, IProductDetail
     {
         private int _productId;
-        private string _details;
-        private IProduct _product;
+        private string _details = null!;
+        private IProduct _product = null!;
 
         public int ProductId
         {
@@ -958,17 +956,17 @@ public class ChangedOnlyMonsterContext(DbContextOptions options) : MonsterContex
     public class Product : NotificationEntity, IProduct
     {
         private int _productId;
-        private string _description;
-        private string _baseConcurrency;
-        private IDimensions _dimensions;
-        private IConcurrencyInfo _complexConcurrency;
-        private IAuditInfo _nestedComplexConcurrency;
-        private ICollection<ISupplier> _suppliers;
-        private IProductDetail _detail;
-        private ICollection<IProductReview> _reviews;
-        private ICollection<IProductPhoto> _photos;
-        private ICollection<IBarcode> _barcodes;
-        private ICollection<IDiscontinuedProduct> _replaces;
+        private string _description = null!;
+        private string _baseConcurrency = null!;
+        private IDimensions _dimensions = null!;
+        private IConcurrencyInfo _complexConcurrency = null!;
+        private IAuditInfo _nestedComplexConcurrency = null!;
+        private ICollection<ISupplier> _suppliers = null!;
+        private IProductDetail _detail = null!;
+        private ICollection<IProductReview> _reviews = null!;
+        private ICollection<IProductPhoto> _photos = null!;
+        private ICollection<IBarcode> _barcodes = null!;
+        private ICollection<IDiscontinuedProduct> _replaces = null!;
 
         public Product()
         {
@@ -1060,7 +1058,7 @@ public class ChangedOnlyMonsterContext(DbContextOptions options) : MonsterContex
 
     public class ProductPageView : PageView, IProductPageView
     {
-        private IProduct _product;
+        private IProduct _product = null!;
         private int _productId;
 
         public int ProductId
@@ -1080,8 +1078,8 @@ public class ChangedOnlyMonsterContext(DbContextOptions options) : MonsterContex
     {
         private int _productId;
         private int _photoId;
-        private byte[] _photo;
-        private ICollection<IProductWebFeature> _features;
+        private byte[] _photo = null!;
+        private ICollection<IProductWebFeature> _features = null!;
 
         public void InitializeCollections()
             => Features ??= new ObservableCollection<IProductWebFeature>();
@@ -1115,9 +1113,9 @@ public class ChangedOnlyMonsterContext(DbContextOptions options) : MonsterContex
     {
         private int _productId;
         private int _reviewId;
-        private string _review;
-        private IProduct _product;
-        private ICollection<IProductWebFeature> _features;
+        private string _review = null!;
+        private IProduct _product = null!;
+        private ICollection<IProductWebFeature> _features = null!;
 
         public void InitializeCollections()
             => Features ??= new ObservableCollection<IProductWebFeature>();
@@ -1159,9 +1157,9 @@ public class ChangedOnlyMonsterContext(DbContextOptions options) : MonsterContex
         private int? _productId;
         private int? _photoId;
         private int _reviewId;
-        private string _heading;
-        private IProductReview _review;
-        private IProductPhoto _photo;
+        private string _heading = null!;
+        private IProductReview _review = null!;
+        private IProductPhoto _photo = null!;
 
         public int FeatureId
         {
@@ -1209,8 +1207,8 @@ public class ChangedOnlyMonsterContext(DbContextOptions options) : MonsterContex
     public class Resolution : NotificationEntity, IResolution
     {
         private int _resolutionId;
-        private string _details;
-        private IComplaint _complaint;
+        private string _details = null!;
+        private IComplaint _complaint = null!;
 
         public int ResolutionId
         {
@@ -1233,10 +1231,10 @@ public class ChangedOnlyMonsterContext(DbContextOptions options) : MonsterContex
 
     public class RsaToken : NotificationEntity, IRsaToken
     {
-        private string _serial;
+        private string _serial = null!;
         private DateTime _issued;
-        private string _username;
-        private ILogin _login;
+        private string _username = null!;
+        private ILogin _login = null!;
 
         public string Serial
         {
@@ -1265,11 +1263,11 @@ public class ChangedOnlyMonsterContext(DbContextOptions options) : MonsterContex
 
     public class SmartCard : NotificationEntity, ISmartCard
     {
-        private string _username;
-        private string _cardSerial;
+        private string _username = null!;
+        private string _cardSerial = null!;
         private DateTime _issued;
-        private ILogin _login;
-        private ILastLogin _lastLogin;
+        private ILogin _login = null!;
+        private ILastLogin? _lastLogin;
 
         public string Username
         {
@@ -1295,7 +1293,7 @@ public class ChangedOnlyMonsterContext(DbContextOptions options) : MonsterContex
             set => SetWithNotify(value, ref _login);
         }
 
-        public virtual ILastLogin LastLogin
+        public virtual ILastLogin? LastLogin
         {
             get => _lastLogin;
             set => SetWithNotify(value, ref _lastLogin);
@@ -1305,9 +1303,9 @@ public class ChangedOnlyMonsterContext(DbContextOptions options) : MonsterContex
     public class SupplierInfo : NotificationEntity, ISupplierInfo
     {
         private int _supplierInfoId;
-        private string _information;
+        private string _information = null!;
         private int _supplierId;
-        private ISupplier _supplier;
+        private ISupplier _supplier = null!;
 
         public int SupplierInfoId
         {
@@ -1337,7 +1335,7 @@ public class ChangedOnlyMonsterContext(DbContextOptions options) : MonsterContex
     public class SupplierLogo : NotificationEntity, ISupplierLogo
     {
         private int _supplierId;
-        private byte[] _logo;
+        private byte[] _logo = null!;
 
         public int SupplierId
         {
@@ -1355,10 +1353,10 @@ public class ChangedOnlyMonsterContext(DbContextOptions options) : MonsterContex
     public class Supplier : NotificationEntity, ISupplier
     {
         private int _supplierId;
-        private string _name;
-        private ICollection<IProduct> _products;
-        private ISupplierLogo _logo;
-        private ICollection<IBackOrderLine> _backOrderLines;
+        private string _name = null!;
+        private ICollection<IProduct> _products = null!;
+        private ISupplierLogo _logo = null!;
+        private ICollection<IBackOrderLine> _backOrderLines = null!;
 
         public void InitializeCollections()
         {
@@ -1400,8 +1398,8 @@ public class ChangedOnlyMonsterContext(DbContextOptions options) : MonsterContex
     public class SuspiciousActivity : NotificationEntity, ISuspiciousActivity
     {
         private int _suspiciousActivityId;
-        private string _activity;
-        private string _username;
+        private string _activity = null!;
+        private string _username = null!;
 
         public int SuspiciousActivityId
         {
@@ -1425,8 +1423,8 @@ public class ChangedOnlyMonsterContext(DbContextOptions options) : MonsterContex
     public class AuditInfo : NotificationEntity, IAuditInfo
     {
         private DateTime _modifiedDate;
-        private string _modifiedBy;
-        private IConcurrencyInfo _concurrency;
+        private string? _modifiedBy;
+        private IConcurrencyInfo _concurrency = null!;
 
         public AuditInfo()
         {
@@ -1440,7 +1438,7 @@ public class ChangedOnlyMonsterContext(DbContextOptions options) : MonsterContex
             set => SetWithNotify(value, ref _modifiedDate);
         }
 
-        public string ModifiedBy
+        public string? ModifiedBy
         {
             get => _modifiedBy;
             set => SetWithNotify(value, ref _modifiedBy);
@@ -1457,14 +1455,14 @@ public class ChangedOnlyMonsterContext(DbContextOptions options) : MonsterContex
     {
         private int _customerId;
         private int? _husbandId;
-        private string _name;
-        private IContactDetails _contactInfo;
-        private IAuditInfo _auditing;
-        private ICollection<IAnOrder> _orders;
-        private ICollection<ILogin> _logins;
-        private ICustomer _husband;
-        private ICustomer _wife;
-        private ICustomerInfo _info;
+        private string _name = null!;
+        private IContactDetails _contactInfo = null!;
+        private IAuditInfo _auditing = null!;
+        private ICollection<IAnOrder> _orders = null!;
+        private ICollection<ILogin> _logins = null!;
+        private ICustomer _husband = null!;
+        private ICustomer _wife = null!;
+        private ICustomerInfo _info = null!;
 
         public Customer()
         {
@@ -1541,14 +1539,14 @@ public class ChangedOnlyMonsterContext(DbContextOptions options) : MonsterContex
 
     public class Login : NotificationEntity, ILogin
     {
-        private string _username;
-        private string _alternateUsername;
+        private string _username = null!;
+        private string _alternateUsername = null!;
         private int _customerId;
-        private ICustomer _customer;
-        private ILastLogin _lastLogin;
-        private ICollection<IMessage> _sentMessages;
-        private ICollection<IMessage> _receivedMessages;
-        private ICollection<IAnOrder> _orders;
+        private ICustomer _customer = null!;
+        private ILastLogin _lastLogin = null!;
+        private ICollection<IMessage> _sentMessages = null!;
+        private ICollection<IMessage> _receivedMessages = null!;
+        private ICollection<IAnOrder> _orders = null!;
 
         public void InitializeCollections()
         {
@@ -1609,13 +1607,13 @@ public class ChangedOnlyMonsterContext(DbContextOptions options) : MonsterContex
     public class Phone : NotificationEntity, IPhone
     {
         private PhoneType _phoneType;
-        private string _extension;
-        private string _phoneNumber;
+        private string _extension = null!;
+        private string? _phoneNumber;
 
         public Phone()
             => Extension = "None";
 
-        public string PhoneNumber
+        public string? PhoneNumber
         {
             get => _phoneNumber;
             set => SetWithNotify(value, ref _phoneNumber);

--- a/test/EFCore.Specification.Tests/TestModels/ComplexNavigationsModel/ComplexNavigationField.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ComplexNavigationsModel/ComplexNavigationField.cs
@@ -3,11 +3,9 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ComplexNavigationsModel;
 
-#nullable disable
-
 public class ComplexNavigationField
 {
-    public string Name { get; set; }
-    public ComplexNavigationString Label { get; set; }
-    public ComplexNavigationString Placeholder { get; set; }
+    public string Name { get; set; } = null!;
+    public ComplexNavigationString? Label { get; set; }
+    public ComplexNavigationString? Placeholder { get; set; }
 }

--- a/test/EFCore.Specification.Tests/TestModels/ComplexNavigationsModel/ComplexNavigationGlobalization.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ComplexNavigationsModel/ComplexNavigationGlobalization.cs
@@ -3,10 +3,8 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ComplexNavigationsModel;
 
-#nullable disable
-
 public class ComplexNavigationGlobalization
 {
-    public string Text { get; set; }
-    public ComplexNavigationLanguage Language { get; set; }
+    public string Text { get; set; } = null!;
+    public ComplexNavigationLanguage? Language { get; set; }
 }

--- a/test/EFCore.Specification.Tests/TestModels/ComplexNavigationsModel/ComplexNavigationLanguage.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ComplexNavigationsModel/ComplexNavigationLanguage.cs
@@ -3,10 +3,8 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ComplexNavigationsModel;
 
-#nullable disable
-
 public class ComplexNavigationLanguage
 {
-    public string Name { get; set; }
-    public string CultureString { get; set; }
+    public string Name { get; set; } = null!;
+    public string? CultureString { get; set; }
 }

--- a/test/EFCore.Specification.Tests/TestModels/ComplexNavigationsModel/ComplexNavigationString.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ComplexNavigationsModel/ComplexNavigationString.cs
@@ -3,10 +3,8 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ComplexNavigationsModel;
 
-#nullable disable
-
 public class ComplexNavigationString
 {
-    public string DefaultText { get; set; }
-    public IList<ComplexNavigationGlobalization> Globalizations { get; set; }
+    public string DefaultText { get; set; } = null!;
+    public IList<ComplexNavigationGlobalization> Globalizations { get; set; } = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/ComplexNavigationsModel/ComplexNavigationsContext.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ComplexNavigationsModel/ComplexNavigationsContext.cs
@@ -3,22 +3,20 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ComplexNavigationsModel;
 
-#nullable disable
-
 public class ComplexNavigationsContext(DbContextOptions options) : PoolableDbContext(options)
 {
-    public DbSet<Level1> LevelOne { get; set; }
-    public DbSet<Level2> LevelTwo { get; set; }
-    public DbSet<Level3> LevelThree { get; set; }
-    public DbSet<Level4> LevelFour { get; set; }
+    public DbSet<Level1> LevelOne { get; set; } = null!;
+    public DbSet<Level2> LevelTwo { get; set; } = null!;
+    public DbSet<Level3> LevelThree { get; set; } = null!;
+    public DbSet<Level4> LevelFour { get; set; } = null!;
 
-    public DbSet<ComplexNavigationField> Fields { get; set; }
-    public DbSet<ComplexNavigationString> MultilingualStrings { get; set; }
-    public DbSet<ComplexNavigationGlobalization> Globalizations { get; set; }
-    public DbSet<ComplexNavigationLanguage> Languages { get; set; }
+    public DbSet<ComplexNavigationField> Fields { get; set; } = null!;
+    public DbSet<ComplexNavigationString> MultilingualStrings { get; set; } = null!;
+    public DbSet<ComplexNavigationGlobalization> Globalizations { get; set; } = null!;
+    public DbSet<ComplexNavigationLanguage> Languages { get; set; } = null!;
 
-    public DbSet<InheritanceBase1> InheritanceOne { get; set; }
-    public DbSet<InheritanceBase2> InheritanceTwo { get; set; }
-    public DbSet<InheritanceLeaf1> InheritanceLeafOne { get; set; }
-    public DbSet<InheritanceLeaf2> InheritanceLeafTwo { get; set; }
+    public DbSet<InheritanceBase1> InheritanceOne { get; set; } = null!;
+    public DbSet<InheritanceBase2> InheritanceTwo { get; set; } = null!;
+    public DbSet<InheritanceLeaf1> InheritanceLeafOne { get; set; } = null!;
+    public DbSet<InheritanceLeaf2> InheritanceLeafTwo { get; set; } = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/ComplexNavigationsModel/InheritanceBase1.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ComplexNavigationsModel/InheritanceBase1.cs
@@ -3,11 +3,9 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ComplexNavigationsModel;
 
-#nullable disable
-
 public class InheritanceBase1
 {
     public int Id { get; set; }
 
-    public string Name { get; set; }
+    public string? Name { get; set; }
 }

--- a/test/EFCore.Specification.Tests/TestModels/ComplexNavigationsModel/InheritanceBase2.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ComplexNavigationsModel/InheritanceBase2.cs
@@ -3,14 +3,12 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ComplexNavigationsModel;
 
-#nullable disable
-
 public class InheritanceBase2
 {
     public int Id { get; set; }
 
-    public string Name { get; set; }
+    public string? Name { get; set; }
 
-    public InheritanceBase1 Reference { get; set; }
-    public List<InheritanceBase1> Collection { get; set; }
+    public InheritanceBase1? Reference { get; set; }
+    public List<InheritanceBase1> Collection { get; set; } = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/ComplexNavigationsModel/InheritanceDerived1.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ComplexNavigationsModel/InheritanceDerived1.cs
@@ -3,12 +3,10 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ComplexNavigationsModel;
 
-#nullable disable
-
 public class InheritanceDerived1 : InheritanceBase1
 {
-    public InheritanceLeaf1 ReferenceSameType { get; set; }
-    public InheritanceLeaf1 ReferenceDifferentType { get; set; }
-    public List<InheritanceLeaf1> CollectionSameType { get; set; }
-    public List<InheritanceLeaf1> CollectionDifferentType { get; set; }
+    public InheritanceLeaf1? ReferenceSameType { get; set; }
+    public InheritanceLeaf1? ReferenceDifferentType { get; set; }
+    public List<InheritanceLeaf1> CollectionSameType { get; set; } = null!;
+    public List<InheritanceLeaf1> CollectionDifferentType { get; set; } = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/ComplexNavigationsModel/InheritanceDerived2.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ComplexNavigationsModel/InheritanceDerived2.cs
@@ -3,12 +3,10 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ComplexNavigationsModel;
 
-#nullable disable
-
 public class InheritanceDerived2 : InheritanceBase1
 {
-    public InheritanceLeaf1 ReferenceSameType { get; set; }
-    public InheritanceLeaf2 ReferenceDifferentType { get; set; }
-    public List<InheritanceLeaf1> CollectionSameType { get; set; }
-    public List<InheritanceLeaf2> CollectionDifferentType { get; set; }
+    public InheritanceLeaf1? ReferenceSameType { get; set; }
+    public InheritanceLeaf2? ReferenceDifferentType { get; set; }
+    public List<InheritanceLeaf1> CollectionSameType { get; set; } = null!;
+    public List<InheritanceLeaf2> CollectionDifferentType { get; set; } = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/ComplexNavigationsModel/InheritanceLeaf1.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ComplexNavigationsModel/InheritanceLeaf1.cs
@@ -3,10 +3,8 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ComplexNavigationsModel;
 
-#nullable disable
-
 public class InheritanceLeaf1
 {
     public int Id { get; set; }
-    public string Name { get; set; }
+    public string Name { get; set; } = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/ComplexNavigationsModel/InheritanceLeaf2.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ComplexNavigationsModel/InheritanceLeaf2.cs
@@ -3,12 +3,10 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ComplexNavigationsModel;
 
-#nullable disable
-
 public class InheritanceLeaf2
 {
     public int Id { get; set; }
-    public string Name { get; set; }
+    public string Name { get; set; } = null!;
 
-    public List<InheritanceBase2> BaseCollection { get; set; }
+    public List<InheritanceBase2> BaseCollection { get; set; } = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/ComplexNavigationsModel/Level1.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ComplexNavigationsModel/Level1.cs
@@ -5,31 +5,29 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ComplexNavigationsModel;
 
-#nullable disable
-
 public class Level1
 {
     public int Id { get; set; }
-    public string Name { get; set; }
+    public string? Name { get; set; }
     public DateTime Date { get; set; }
 
-    public Level2 OneToOne_Required_PK1 { get; set; }
-    public Level2 OneToOne_Optional_PK1 { get; set; }
+    public Level2 OneToOne_Required_PK1 { get; set; } = null!;
+    public Level2? OneToOne_Optional_PK1 { get; set; }
 
-    public Level2 OneToOne_Required_FK1 { get; set; }
-    public Level2 OneToOne_Optional_FK1 { get; set; }
+    public Level2 OneToOne_Required_FK1 { get; set; } = null!;
+    public Level2? OneToOne_Optional_FK1 { get; set; }
 
-    public ICollection<Level2> OneToMany_Required1 { get; set; }
-    public ICollection<Level2> OneToMany_Optional1 { get; set; }
+    public ICollection<Level2> OneToMany_Required1 { get; set; } = null!;
+    public ICollection<Level2> OneToMany_Optional1 { get; set; } = null!;
 
-    public Level1 OneToOne_Optional_Self1 { get; set; }
+    public Level1? OneToOne_Optional_Self1 { get; set; }
 
-    public ICollection<Level1> OneToMany_Required_Self1 { get; set; }
-    public ICollection<Level1> OneToMany_Optional_Self1 { get; set; }
-    public Level1 OneToMany_Required_Self_Inverse1 { get; set; }
-    public Level1 OneToMany_Optional_Self_Inverse1 { get; set; }
+    public ICollection<Level1> OneToMany_Required_Self1 { get; set; } = null!;
+    public ICollection<Level1> OneToMany_Optional_Self1 { get; set; } = null!;
+    public Level1 OneToMany_Required_Self_Inverse1 { get; set; } = null!;
+    public Level1? OneToMany_Optional_Self_Inverse1 { get; set; }
 
-    public override bool Equals(object obj)
+    public override bool Equals(object? obj)
         => obj is not null && (ReferenceEquals(this, obj) || (obj.GetType() == GetType() && Equals((Level1)obj)));
 
     private bool Equals(Level1 other)

--- a/test/EFCore.Specification.Tests/TestModels/ComplexNavigationsModel/Level2.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ComplexNavigationsModel/Level2.cs
@@ -5,42 +5,40 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ComplexNavigationsModel;
 
-#nullable disable
-
 public class Level2
 {
     public int Id { get; set; }
-    public string Name { get; set; }
+    public string? Name { get; set; }
     public DateTime Date { get; set; }
 
     public int Level1_Required_Id { get; set; }
     public int? Level1_Optional_Id { get; set; }
 
-    public Level3 OneToOne_Required_PK2 { get; set; }
-    public Level3 OneToOne_Optional_PK2 { get; set; }
+    public Level3 OneToOne_Required_PK2 { get; set; } = null!;
+    public Level3? OneToOne_Optional_PK2 { get; set; }
 
-    public Level3 OneToOne_Required_FK2 { get; set; }
-    public Level3 OneToOne_Optional_FK2 { get; set; }
+    public Level3 OneToOne_Required_FK2 { get; set; } = null!;
+    public Level3? OneToOne_Optional_FK2 { get; set; }
 
-    public ICollection<Level3> OneToMany_Required2 { get; set; }
-    public ICollection<Level3> OneToMany_Optional2 { get; set; }
+    public ICollection<Level3> OneToMany_Required2 { get; set; } = null!;
+    public ICollection<Level3> OneToMany_Optional2 { get; set; } = null!;
 
-    public Level1 OneToOne_Required_PK_Inverse2 { get; set; }
-    public Level1 OneToOne_Optional_PK_Inverse2 { get; set; }
-    public Level1 OneToOne_Required_FK_Inverse2 { get; set; }
-    public Level1 OneToOne_Optional_FK_Inverse2 { get; set; }
+    public Level1 OneToOne_Required_PK_Inverse2 { get; set; } = null!;
+    public Level1? OneToOne_Optional_PK_Inverse2 { get; set; }
+    public Level1 OneToOne_Required_FK_Inverse2 { get; set; } = null!;
+    public Level1? OneToOne_Optional_FK_Inverse2 { get; set; }
 
-    public Level1 OneToMany_Required_Inverse2 { get; set; }
-    public Level1 OneToMany_Optional_Inverse2 { get; set; }
+    public Level1 OneToMany_Required_Inverse2 { get; set; } = null!;
+    public Level1? OneToMany_Optional_Inverse2 { get; set; }
 
-    public Level2 OneToOne_Optional_Self2 { get; set; }
+    public Level2? OneToOne_Optional_Self2 { get; set; }
 
-    public ICollection<Level2> OneToMany_Required_Self2 { get; set; }
-    public ICollection<Level2> OneToMany_Optional_Self2 { get; set; }
-    public Level2 OneToMany_Required_Self_Inverse2 { get; set; }
-    public Level2 OneToMany_Optional_Self_Inverse2 { get; set; }
+    public ICollection<Level2> OneToMany_Required_Self2 { get; set; } = null!;
+    public ICollection<Level2> OneToMany_Optional_Self2 { get; set; } = null!;
+    public Level2 OneToMany_Required_Self_Inverse2 { get; set; } = null!;
+    public Level2? OneToMany_Optional_Self_Inverse2 { get; set; }
 
-    public override bool Equals(object obj)
+    public override bool Equals(object? obj)
         => obj is not null && (ReferenceEquals(this, obj) || (obj.GetType() == GetType() && Equals((Level2)obj)));
 
     private bool Equals(Level2 other)

--- a/test/EFCore.Specification.Tests/TestModels/ComplexNavigationsModel/Level3.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ComplexNavigationsModel/Level3.cs
@@ -5,41 +5,39 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ComplexNavigationsModel;
 
-#nullable disable
-
 public class Level3
 {
     public int Id { get; set; }
-    public string Name { get; set; }
+    public string? Name { get; set; }
 
     public int Level2_Required_Id { get; set; }
     public int? Level2_Optional_Id { get; set; }
 
-    public Level4 OneToOne_Required_PK3 { get; set; }
-    public Level4 OneToOne_Optional_PK3 { get; set; }
+    public Level4 OneToOne_Required_PK3 { get; set; } = null!;
+    public Level4? OneToOne_Optional_PK3 { get; set; }
 
-    public Level4 OneToOne_Required_FK3 { get; set; }
-    public Level4 OneToOne_Optional_FK3 { get; set; }
+    public Level4 OneToOne_Required_FK3 { get; set; } = null!;
+    public Level4? OneToOne_Optional_FK3 { get; set; }
 
-    public ICollection<Level4> OneToMany_Required3 { get; set; }
-    public ICollection<Level4> OneToMany_Optional3 { get; set; }
+    public ICollection<Level4> OneToMany_Required3 { get; set; } = null!;
+    public ICollection<Level4> OneToMany_Optional3 { get; set; } = null!;
 
-    public Level2 OneToOne_Required_PK_Inverse3 { get; set; }
-    public Level2 OneToOne_Optional_PK_Inverse3 { get; set; }
-    public Level2 OneToOne_Required_FK_Inverse3 { get; set; }
-    public Level2 OneToOne_Optional_FK_Inverse3 { get; set; }
+    public Level2 OneToOne_Required_PK_Inverse3 { get; set; } = null!;
+    public Level2? OneToOne_Optional_PK_Inverse3 { get; set; }
+    public Level2 OneToOne_Required_FK_Inverse3 { get; set; } = null!;
+    public Level2? OneToOne_Optional_FK_Inverse3 { get; set; }
 
-    public Level2 OneToMany_Required_Inverse3 { get; set; }
-    public Level2 OneToMany_Optional_Inverse3 { get; set; }
+    public Level2 OneToMany_Required_Inverse3 { get; set; } = null!;
+    public Level2? OneToMany_Optional_Inverse3 { get; set; }
 
-    public Level3 OneToOne_Optional_Self3 { get; set; }
+    public Level3? OneToOne_Optional_Self3 { get; set; }
 
-    public ICollection<Level3> OneToMany_Required_Self3 { get; set; }
-    public ICollection<Level3> OneToMany_Optional_Self3 { get; set; }
-    public Level3 OneToMany_Required_Self_Inverse3 { get; set; }
-    public Level3 OneToMany_Optional_Self_Inverse3 { get; set; }
+    public ICollection<Level3> OneToMany_Required_Self3 { get; set; } = null!;
+    public ICollection<Level3> OneToMany_Optional_Self3 { get; set; } = null!;
+    public Level3 OneToMany_Required_Self_Inverse3 { get; set; } = null!;
+    public Level3? OneToMany_Optional_Self_Inverse3 { get; set; }
 
-    public override bool Equals(object obj)
+    public override bool Equals(object? obj)
         => obj is not null && (ReferenceEquals(this, obj) || (obj.GetType() == GetType() && Equals((Level3)obj)));
 
     protected bool Equals(Level3 other)

--- a/test/EFCore.Specification.Tests/TestModels/ComplexNavigationsModel/Level4.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ComplexNavigationsModel/Level4.cs
@@ -5,32 +5,30 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ComplexNavigationsModel;
 
-#nullable disable
-
 public class Level4
 {
     public int Id { get; set; }
-    public string Name { get; set; }
+    public string? Name { get; set; }
 
     public int Level3_Required_Id { get; set; }
     public int? Level3_Optional_Id { get; set; }
 
-    public Level3 OneToOne_Required_PK_Inverse4 { get; set; }
-    public Level3 OneToOne_Optional_PK_Inverse4 { get; set; }
-    public Level3 OneToOne_Required_FK_Inverse4 { get; set; }
-    public Level3 OneToOne_Optional_FK_Inverse4 { get; set; }
+    public Level3 OneToOne_Required_PK_Inverse4 { get; set; } = null!;
+    public Level3? OneToOne_Optional_PK_Inverse4 { get; set; }
+    public Level3 OneToOne_Required_FK_Inverse4 { get; set; } = null!;
+    public Level3? OneToOne_Optional_FK_Inverse4 { get; set; }
 
-    public Level3 OneToMany_Required_Inverse4 { get; set; }
-    public Level3 OneToMany_Optional_Inverse4 { get; set; }
+    public Level3 OneToMany_Required_Inverse4 { get; set; } = null!;
+    public Level3? OneToMany_Optional_Inverse4 { get; set; }
 
-    public Level4 OneToOne_Optional_Self4 { get; set; }
+    public Level4? OneToOne_Optional_Self4 { get; set; }
 
-    public ICollection<Level4> OneToMany_Required_Self4 { get; set; }
-    public ICollection<Level4> OneToMany_Optional_Self4 { get; set; }
-    public Level4 OneToMany_Required_Self_Inverse4 { get; set; }
-    public Level4 OneToMany_Optional_Self_Inverse4 { get; set; }
+    public ICollection<Level4> OneToMany_Required_Self4 { get; set; } = null!;
+    public ICollection<Level4> OneToMany_Optional_Self4 { get; set; } = null!;
+    public Level4 OneToMany_Required_Self_Inverse4 { get; set; } = null!;
+    public Level4? OneToMany_Optional_Self_Inverse4 { get; set; }
 
-    public override bool Equals(object obj)
+    public override bool Equals(object? obj)
         => obj is not null && (ReferenceEquals(this, obj) || (obj.GetType() == GetType() && Equals((Level4)obj)));
 
     protected bool Equals(Level4 other)

--- a/test/EFCore.Specification.Tests/TestModels/CompositeKeysModel/CompositeFour.cs
+++ b/test/EFCore.Specification.Tests/TestModels/CompositeKeysModel/CompositeFour.cs
@@ -3,37 +3,35 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.CompositeKeysModel;
 
-#nullable disable
-
 public class CompositeFour
 {
-    public string Id1 { get; set; }
+    public string Id1 { get; set; } = null!;
     public int Id2 { get; set; }
 
-    public string Name { get; set; }
+    public string Name { get; set; } = null!;
 
-    public string Level3_Required_Id1 { get; set; }
+    public string Level3_Required_Id1 { get; set; } = null!;
     public int Level3_Required_Id2 { get; set; }
 
-    public string Level3_Optional_Id1 { get; set; }
+    public string? Level3_Optional_Id1 { get; set; }
     public int? Level3_Optional_Id2 { get; set; }
 
-    public CompositeThree OneToOne_Required_PK_Inverse4 { get; set; }
-    public CompositeThree OneToOne_Optional_PK_Inverse4 { get; set; }
-    public CompositeThree OneToOne_Required_FK_Inverse4 { get; set; }
-    public CompositeThree OneToOne_Optional_FK_Inverse4 { get; set; }
+    public CompositeThree OneToOne_Required_PK_Inverse4 { get; set; } = null!;
+    public CompositeThree? OneToOne_Optional_PK_Inverse4 { get; set; }
+    public CompositeThree OneToOne_Required_FK_Inverse4 { get; set; } = null!;
+    public CompositeThree? OneToOne_Optional_FK_Inverse4 { get; set; }
 
-    public CompositeThree OneToMany_Required_Inverse4 { get; set; }
-    public CompositeThree OneToMany_Optional_Inverse4 { get; set; }
+    public CompositeThree OneToMany_Required_Inverse4 { get; set; } = null!;
+    public CompositeThree? OneToMany_Optional_Inverse4 { get; set; }
 
-    public CompositeFour OneToOne_Optional_Self4 { get; set; }
+    public CompositeFour? OneToOne_Optional_Self4 { get; set; }
 
-    public ICollection<CompositeFour> OneToMany_Required_Self4 { get; set; }
-    public ICollection<CompositeFour> OneToMany_Optional_Self4 { get; set; }
-    public CompositeFour OneToMany_Required_Self_Inverse4 { get; set; }
-    public CompositeFour OneToMany_Optional_Self_Inverse4 { get; set; }
+    public ICollection<CompositeFour> OneToMany_Required_Self4 { get; set; } = null!;
+    public ICollection<CompositeFour> OneToMany_Optional_Self4 { get; set; } = null!;
+    public CompositeFour OneToMany_Required_Self_Inverse4 { get; set; } = null!;
+    public CompositeFour? OneToMany_Optional_Self_Inverse4 { get; set; }
 
-    public override bool Equals(object obj)
+    public override bool Equals(object? obj)
         => obj is not null && (ReferenceEquals(this, obj) || (obj.GetType() == GetType() && Equals((CompositeFour)obj)));
 
     protected bool Equals(CompositeFour other)

--- a/test/EFCore.Specification.Tests/TestModels/CompositeKeysModel/CompositeKeysContext.cs
+++ b/test/EFCore.Specification.Tests/TestModels/CompositeKeysModel/CompositeKeysContext.cs
@@ -3,12 +3,10 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.CompositeKeysModel;
 
-#nullable disable
-
 public class CompositeKeysContext(DbContextOptions options) : PoolableDbContext(options)
 {
-    public DbSet<CompositeOne> CompositeOnes { get; set; }
-    public DbSet<CompositeTwo> CompositeTwos { get; set; }
-    public DbSet<CompositeThree> CompositeThrees { get; set; }
-    public DbSet<CompositeFour> CompositeFours { get; set; }
+    public DbSet<CompositeOne> CompositeOnes { get; set; } = null!;
+    public DbSet<CompositeTwo> CompositeTwos { get; set; } = null!;
+    public DbSet<CompositeThree> CompositeThrees { get; set; } = null!;
+    public DbSet<CompositeFour> CompositeFours { get; set; } = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/CompositeKeysModel/CompositeOne.cs
+++ b/test/EFCore.Specification.Tests/TestModels/CompositeKeysModel/CompositeOne.cs
@@ -3,33 +3,31 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.CompositeKeysModel;
 
-#nullable disable
-
 public class CompositeOne
 {
-    public string Id1 { get; set; }
+    public string Id1 { get; set; } = null!;
     public int Id2 { get; set; }
 
-    public string Name { get; set; }
+    public string Name { get; set; } = null!;
     public DateTime Date { get; set; }
 
-    public CompositeTwo OneToOne_Required_PK1 { get; set; }
-    public CompositeTwo OneToOne_Optional_PK1 { get; set; }
+    public CompositeTwo OneToOne_Required_PK1 { get; set; } = null!;
+    public CompositeTwo? OneToOne_Optional_PK1 { get; set; }
 
-    public CompositeTwo OneToOne_Required_FK1 { get; set; }
-    public CompositeTwo OneToOne_Optional_FK1 { get; set; }
+    public CompositeTwo OneToOne_Required_FK1 { get; set; } = null!;
+    public CompositeTwo? OneToOne_Optional_FK1 { get; set; }
 
-    public ICollection<CompositeTwo> OneToMany_Required1 { get; set; }
-    public ICollection<CompositeTwo> OneToMany_Optional1 { get; set; }
+    public ICollection<CompositeTwo> OneToMany_Required1 { get; set; } = null!;
+    public ICollection<CompositeTwo> OneToMany_Optional1 { get; set; } = null!;
 
-    public CompositeOne OneToOne_Optional_Self1 { get; set; }
+    public CompositeOne? OneToOne_Optional_Self1 { get; set; }
 
-    public ICollection<CompositeOne> OneToMany_Required_Self1 { get; set; }
-    public ICollection<CompositeOne> OneToMany_Optional_Self1 { get; set; }
-    public CompositeOne OneToMany_Required_Self_Inverse1 { get; set; }
-    public CompositeOne OneToMany_Optional_Self_Inverse1 { get; set; }
+    public ICollection<CompositeOne> OneToMany_Required_Self1 { get; set; } = null!;
+    public ICollection<CompositeOne> OneToMany_Optional_Self1 { get; set; } = null!;
+    public CompositeOne OneToMany_Required_Self_Inverse1 { get; set; } = null!;
+    public CompositeOne? OneToMany_Optional_Self_Inverse1 { get; set; }
 
-    public override bool Equals(object obj)
+    public override bool Equals(object? obj)
         => obj is not null && (ReferenceEquals(this, obj) || (obj.GetType() == GetType() && Equals((CompositeOne)obj)));
 
     private bool Equals(CompositeOne other)

--- a/test/EFCore.Specification.Tests/TestModels/CompositeKeysModel/CompositeThree.cs
+++ b/test/EFCore.Specification.Tests/TestModels/CompositeKeysModel/CompositeThree.cs
@@ -3,45 +3,43 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.CompositeKeysModel;
 
-#nullable disable
-
 public class CompositeThree
 {
-    public string Id1 { get; set; }
+    public string Id1 { get; set; } = null!;
     public int Id2 { get; set; }
 
-    public string Name { get; set; }
+    public string Name { get; set; } = null!;
 
-    public string Level2_Required_Id1 { get; set; }
+    public string Level2_Required_Id1 { get; set; } = null!;
     public int Level2_Required_Id2 { get; set; }
-    public string Level2_Optional_Id1 { get; set; }
+    public string? Level2_Optional_Id1 { get; set; }
     public int? Level2_Optional_Id2 { get; set; }
 
-    public CompositeFour OneToOne_Required_PK3 { get; set; }
-    public CompositeFour OneToOne_Optional_PK3 { get; set; }
+    public CompositeFour OneToOne_Required_PK3 { get; set; } = null!;
+    public CompositeFour? OneToOne_Optional_PK3 { get; set; }
 
-    public CompositeFour OneToOne_Required_FK3 { get; set; }
-    public CompositeFour OneToOne_Optional_FK3 { get; set; }
+    public CompositeFour OneToOne_Required_FK3 { get; set; } = null!;
+    public CompositeFour? OneToOne_Optional_FK3 { get; set; }
 
-    public ICollection<CompositeFour> OneToMany_Required3 { get; set; }
-    public ICollection<CompositeFour> OneToMany_Optional3 { get; set; }
+    public ICollection<CompositeFour> OneToMany_Required3 { get; set; } = null!;
+    public ICollection<CompositeFour> OneToMany_Optional3 { get; set; } = null!;
 
-    public CompositeTwo OneToOne_Required_PK_Inverse3 { get; set; }
-    public CompositeTwo OneToOne_Optional_PK_Inverse3 { get; set; }
-    public CompositeTwo OneToOne_Required_FK_Inverse3 { get; set; }
-    public CompositeTwo OneToOne_Optional_FK_Inverse3 { get; set; }
+    public CompositeTwo OneToOne_Required_PK_Inverse3 { get; set; } = null!;
+    public CompositeTwo? OneToOne_Optional_PK_Inverse3 { get; set; }
+    public CompositeTwo OneToOne_Required_FK_Inverse3 { get; set; } = null!;
+    public CompositeTwo? OneToOne_Optional_FK_Inverse3 { get; set; }
 
-    public CompositeTwo OneToMany_Required_Inverse3 { get; set; }
-    public CompositeTwo OneToMany_Optional_Inverse3 { get; set; }
+    public CompositeTwo OneToMany_Required_Inverse3 { get; set; } = null!;
+    public CompositeTwo? OneToMany_Optional_Inverse3 { get; set; }
 
-    public CompositeThree OneToOne_Optional_Self3 { get; set; }
+    public CompositeThree? OneToOne_Optional_Self3 { get; set; }
 
-    public ICollection<CompositeThree> OneToMany_Required_Self3 { get; set; }
-    public ICollection<CompositeThree> OneToMany_Optional_Self3 { get; set; }
-    public CompositeThree OneToMany_Required_Self_Inverse3 { get; set; }
-    public CompositeThree OneToMany_Optional_Self_Inverse3 { get; set; }
+    public ICollection<CompositeThree> OneToMany_Required_Self3 { get; set; } = null!;
+    public ICollection<CompositeThree> OneToMany_Optional_Self3 { get; set; } = null!;
+    public CompositeThree OneToMany_Required_Self_Inverse3 { get; set; } = null!;
+    public CompositeThree? OneToMany_Optional_Self_Inverse3 { get; set; }
 
-    public override bool Equals(object obj)
+    public override bool Equals(object? obj)
         => obj is not null && (ReferenceEquals(this, obj) || (obj.GetType() == GetType() && Equals((CompositeThree)obj)));
 
     protected bool Equals(CompositeThree other)

--- a/test/EFCore.Specification.Tests/TestModels/CompositeKeysModel/CompositeTwo.cs
+++ b/test/EFCore.Specification.Tests/TestModels/CompositeKeysModel/CompositeTwo.cs
@@ -3,47 +3,45 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.CompositeKeysModel;
 
-#nullable disable
-
 public class CompositeTwo
 {
-    public string Id1 { get; set; }
+    public string Id1 { get; set; } = null!;
     public int Id2 { get; set; }
 
-    public string Name { get; set; }
+    public string Name { get; set; } = null!;
     public DateTime Date { get; set; }
 
-    public string Level1_Required_Id1 { get; set; }
+    public string Level1_Required_Id1 { get; set; } = null!;
     public int Level1_Required_Id2 { get; set; }
 
-    public string Level1_Optional_Id1 { get; set; }
+    public string? Level1_Optional_Id1 { get; set; }
     public int? Level1_Optional_Id2 { get; set; }
 
-    public CompositeThree OneToOne_Required_PK2 { get; set; }
-    public CompositeThree OneToOne_Optional_PK2 { get; set; }
+    public CompositeThree OneToOne_Required_PK2 { get; set; } = null!;
+    public CompositeThree? OneToOne_Optional_PK2 { get; set; }
 
-    public CompositeThree OneToOne_Required_FK2 { get; set; }
-    public CompositeThree OneToOne_Optional_FK2 { get; set; }
+    public CompositeThree OneToOne_Required_FK2 { get; set; } = null!;
+    public CompositeThree? OneToOne_Optional_FK2 { get; set; }
 
-    public ICollection<CompositeThree> OneToMany_Required2 { get; set; }
-    public ICollection<CompositeThree> OneToMany_Optional2 { get; set; }
+    public ICollection<CompositeThree> OneToMany_Required2 { get; set; } = null!;
+    public ICollection<CompositeThree> OneToMany_Optional2 { get; set; } = null!;
 
-    public CompositeOne OneToOne_Required_PK_Inverse2 { get; set; }
-    public CompositeOne OneToOne_Optional_PK_Inverse2 { get; set; }
-    public CompositeOne OneToOne_Required_FK_Inverse2 { get; set; }
-    public CompositeOne OneToOne_Optional_FK_Inverse2 { get; set; }
+    public CompositeOne OneToOne_Required_PK_Inverse2 { get; set; } = null!;
+    public CompositeOne? OneToOne_Optional_PK_Inverse2 { get; set; }
+    public CompositeOne OneToOne_Required_FK_Inverse2 { get; set; } = null!;
+    public CompositeOne? OneToOne_Optional_FK_Inverse2 { get; set; }
 
-    public CompositeOne OneToMany_Required_Inverse2 { get; set; }
-    public CompositeOne OneToMany_Optional_Inverse2 { get; set; }
+    public CompositeOne OneToMany_Required_Inverse2 { get; set; } = null!;
+    public CompositeOne? OneToMany_Optional_Inverse2 { get; set; }
 
-    public CompositeTwo OneToOne_Optional_Self2 { get; set; }
+    public CompositeTwo? OneToOne_Optional_Self2 { get; set; }
 
-    public ICollection<CompositeTwo> OneToMany_Required_Self2 { get; set; }
-    public ICollection<CompositeTwo> OneToMany_Optional_Self2 { get; set; }
-    public CompositeTwo OneToMany_Required_Self_Inverse2 { get; set; }
-    public CompositeTwo OneToMany_Optional_Self_Inverse2 { get; set; }
+    public ICollection<CompositeTwo> OneToMany_Required_Self2 { get; set; } = null!;
+    public ICollection<CompositeTwo> OneToMany_Optional_Self2 { get; set; } = null!;
+    public CompositeTwo OneToMany_Required_Self_Inverse2 { get; set; } = null!;
+    public CompositeTwo? OneToMany_Optional_Self_Inverse2 { get; set; }
 
-    public override bool Equals(object obj)
+    public override bool Equals(object? obj)
         => obj is not null && (ReferenceEquals(this, obj) || (obj.GetType() == GetType() && Equals((CompositeTwo)obj)));
 
     private bool Equals(CompositeTwo other)

--- a/test/EFCore.Specification.Tests/TestModels/ConcurrencyModel/Chassis.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ConcurrencyModel/Chassis.cs
@@ -3,8 +3,6 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ConcurrencyModel;
 
-#nullable disable
-
 public class Chassis
 {
     public class ChassisProxy(
@@ -18,8 +16,8 @@ public class Chassis
         public bool InitializedCalled { get; set; }
     }
 
-    private readonly ILazyLoader _loader;
-    private Team _team;
+    private readonly ILazyLoader _loader = null!;
+    private Team? _team;
 
     public Chassis()
     {
@@ -38,11 +36,11 @@ public class Chassis
     }
 
     public int TeamId { get; set; }
-    public string Name { get; set; }
+    public string Name { get; set; } = null!;
 
     public virtual Team Team
     {
-        get => _loader.Load(this, ref _team);
+        get => _loader.Load(this, ref _team)!;
         set => _team = value;
     }
 }

--- a/test/EFCore.Specification.Tests/TestModels/ConcurrencyModel/Circuit.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ConcurrencyModel/Circuit.cs
@@ -6,8 +6,6 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ConcurrencyModel;
 
-#nullable disable
-
 public interface IStreetCircuit<TCity>
 {
     public string Name { get; set; }
@@ -17,11 +15,11 @@ public interface IStreetCircuit<TCity>
 public abstract class Circuit
 {
     public int Id { get; set; }
-    public string Name { get; set; }
+    public string Name { get; set; } = null!;
     public ulong ULongVersion { get; init; }
 
     [NotMapped]
-    public List<byte> BinaryVersion { get; init; }
+    public List<byte> BinaryVersion { get; init; } = null!;
 }
 
 public class StreetCircuit : Circuit, IStreetCircuit<City>
@@ -36,7 +34,7 @@ public class StreetCircuit : Circuit, IStreetCircuit<City>
     public int Length { get; set; }
 
     [Required]
-    public City City { get; set; }
+    public City City { get; set; } = null!;
 }
 
 public class OvalCircuit : Circuit

--- a/test/EFCore.Specification.Tests/TestModels/ConcurrencyModel/CircuitTpc.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ConcurrencyModel/CircuitTpc.cs
@@ -6,16 +6,14 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ConcurrencyModel;
 
-#nullable disable
-
 public abstract class CircuitTpc
 {
     public int Id { get; set; }
-    public string Name { get; set; }
+    public string Name { get; set; } = null!;
     public ulong ULongVersion { get; init; }
 
     [NotMapped]
-    public List<byte> BinaryVersion { get; init; }
+    public List<byte> BinaryVersion { get; init; } = null!;
 }
 
 public class StreetCircuitTpc : CircuitTpc, IStreetCircuit<CityTpc>
@@ -30,7 +28,7 @@ public class StreetCircuitTpc : CircuitTpc, IStreetCircuit<CityTpc>
     public int Length { get; set; }
 
     [Required]
-    public CityTpc City { get; set; }
+    public CityTpc City { get; set; } = null!;
 }
 
 public class OvalCircuitTpc : CircuitTpc

--- a/test/EFCore.Specification.Tests/TestModels/ConcurrencyModel/CircuitTpt.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ConcurrencyModel/CircuitTpt.cs
@@ -6,16 +6,14 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ConcurrencyModel;
 
-#nullable disable
-
 public abstract class CircuitTpt
 {
     public int Id { get; set; }
-    public string Name { get; set; }
+    public string Name { get; set; } = null!;
     public ulong ULongVersion { get; init; }
 
     [NotMapped]
-    public List<byte> BinaryVersion { get; init; }
+    public List<byte> BinaryVersion { get; init; } = null!;
 }
 
 public class StreetCircuitTpt : CircuitTpt, IStreetCircuit<CityTpt>
@@ -30,7 +28,7 @@ public class StreetCircuitTpt : CircuitTpt, IStreetCircuit<CityTpt>
     public int Length { get; set; }
 
     [Required]
-    public CityTpt City { get; set; }
+    public CityTpt City { get; set; } = null!;
 }
 
 public class OvalCircuitTpt : CircuitTpt

--- a/test/EFCore.Specification.Tests/TestModels/ConcurrencyModel/City.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ConcurrencyModel/City.cs
@@ -5,8 +5,6 @@ using System.ComponentModel.DataAnnotations;
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ConcurrencyModel;
 
-#nullable disable
-
 public interface ICity
 {
     public string Name { get; set; }
@@ -24,7 +22,7 @@ public class City : ICity
     public int Id { get; set; }
 
     [Required]
-    public string Name { get; set; }
+    public string Name { get; set; } = null!;
 }
 
 public class CityTpt : ICity
@@ -39,7 +37,7 @@ public class CityTpt : ICity
     public int Id { get; set; }
 
     [Required]
-    public string Name { get; set; }
+    public string Name { get; set; } = null!;
 }
 
 public class CityTpc : ICity
@@ -54,5 +52,5 @@ public class CityTpc : ICity
     public int Id { get; set; }
 
     [Required]
-    public string Name { get; set; }
+    public string Name { get; set; } = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/ConcurrencyModel/Driver.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ConcurrencyModel/Driver.cs
@@ -3,8 +3,6 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ConcurrencyModel;
 
-#nullable disable
-
 public class Driver
 {
     public class DriverProxy(
@@ -25,8 +23,8 @@ public class Driver
         public bool InitializedCalled { get; set; }
     }
 
-    private readonly ILazyLoader _loader;
-    private Team _team;
+    private readonly ILazyLoader _loader = null!;
+    private Team? _team;
 
     public Driver()
     {
@@ -62,7 +60,7 @@ public class Driver
     }
 
     public int Id { get; set; }
-    public string Name { get; set; }
+    public string Name { get; set; } = null!;
     public int? CarNumber { get; set; }
     public int Championships { get; set; }
     public int Races { get; set; }
@@ -73,7 +71,7 @@ public class Driver
 
     public virtual Team Team
     {
-        get => _loader.Load(this, ref _team);
+        get => _loader.Load(this, ref _team)!;
         set => _team = value;
     }
 

--- a/test/EFCore.Specification.Tests/TestModels/ConcurrencyModel/Engine.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ConcurrencyModel/Engine.cs
@@ -3,8 +3,6 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ConcurrencyModel;
 
-#nullable disable
-
 public class Engine
 {
     public class EngineProxy(
@@ -17,10 +15,10 @@ public class Engine
         public bool InitializedCalled { get; set; }
     }
 
-    private readonly ILazyLoader _loader;
-    private EngineSupplier _engineSupplier;
-    private ICollection<Team> _teams;
-    private ICollection<Gearbox> _gearboxes;
+    private readonly ILazyLoader _loader = null!;
+    private EngineSupplier? _engineSupplier;
+    private ICollection<Team>? _teams;
+    private ICollection<Gearbox>? _gearboxes;
 
     public Engine()
     {
@@ -36,27 +34,27 @@ public class Engine
     }
 
     public int Id { get; set; }
-    public string Name { get; set; }
+    public string? Name { get; set; }
 
-    public Location StorageLocation { get; set; }
+    public Location? StorageLocation { get; set; }
 
-    public string EngineSupplierId { get; set; }
+    public string? EngineSupplierId { get; set; }
 
     public virtual EngineSupplier EngineSupplier
     {
-        get => _loader.Load(this, ref _engineSupplier);
+        get => _loader.Load(this, ref _engineSupplier)!;
         set => _engineSupplier = value;
     }
 
     public virtual ICollection<Team> Teams
     {
-        get => _loader.Load(this, ref _teams);
+        get => _loader.Load(this, ref _teams)!;
         set => _teams = value;
     }
 
     public virtual ICollection<Gearbox> Gearboxes
     {
-        get => _loader.Load(this, ref _gearboxes);
+        get => _loader.Load(this, ref _gearboxes)!;
         set => _gearboxes = value;
     }
 }

--- a/test/EFCore.Specification.Tests/TestModels/ConcurrencyModel/EngineSupplier.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ConcurrencyModel/EngineSupplier.cs
@@ -3,8 +3,6 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ConcurrencyModel;
 
-#nullable disable
-
 public class EngineSupplier
 {
     public class EngineSupplierProxy(
@@ -16,8 +14,8 @@ public class EngineSupplier
         public bool InitializedCalled { get; set; }
     }
 
-    private readonly ILazyLoader _loader;
-    private ICollection<Engine> _engines;
+    private readonly ILazyLoader _loader = null!;
+    private ICollection<Engine>? _engines;
 
     public EngineSupplier()
     {
@@ -31,11 +29,11 @@ public class EngineSupplier
         Assert.IsType<EngineSupplierProxy>(this);
     }
 
-    public string Name { get; set; }
+    public string Name { get; set; } = null!;
 
     public virtual ICollection<Engine> Engines
     {
-        get => _loader.Load(this, ref _engines);
+        get => _loader.Load(this, ref _engines)!;
         set => _engines = value;
     }
 }

--- a/test/EFCore.Specification.Tests/TestModels/ConcurrencyModel/F1Context.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ConcurrencyModel/F1Context.cs
@@ -3,19 +3,17 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ConcurrencyModel;
 
-#nullable disable
-
 public class F1Context(DbContextOptions options) : PoolableDbContext(options)
 {
-    public DbSet<Team> Teams { get; set; }
-    public DbSet<Driver> Drivers { get; set; }
-    public DbSet<Sponsor> Sponsors { get; set; }
-    public DbSet<Engine> Engines { get; set; }
-    public DbSet<EngineSupplier> EngineSuppliers { get; set; }
-    public DbSet<Fan> Fans { get; set; }
-    public DbSet<FanTpt> FanTpts { get; set; }
-    public DbSet<FanTpc> FanTpcs { get; set; }
-    public DbSet<Circuit> Circuits { get; set; }
+    public DbSet<Team> Teams { get; set; } = null!;
+    public DbSet<Driver> Drivers { get; set; } = null!;
+    public DbSet<Sponsor> Sponsors { get; set; } = null!;
+    public DbSet<Engine> Engines { get; set; } = null!;
+    public DbSet<EngineSupplier> EngineSuppliers { get; set; } = null!;
+    public DbSet<Fan> Fans { get; set; } = null!;
+    public DbSet<FanTpt> FanTpts { get; set; } = null!;
+    public DbSet<FanTpc> FanTpcs { get; set; } = null!;
+    public DbSet<Circuit> Circuits { get; set; } = null!;
 
     public static void AddSeedData(F1Context context)
     {

--- a/test/EFCore.Specification.Tests/TestModels/ConcurrencyModel/Fan.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ConcurrencyModel/Fan.cs
@@ -5,8 +5,6 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ConcurrencyModel;
 
-#nullable disable
-
 public interface ISuperFan
 {
     public string Name { get; set; }
@@ -16,11 +14,11 @@ public interface ISuperFan
 public abstract class Fan
 {
     public int Id { get; set; }
-    public string Name { get; set; }
+    public string Name { get; set; } = null!;
     public ulong ULongVersion { get; init; }
 
     [NotMapped]
-    public List<byte> BinaryVersion { get; init; }
+    public List<byte> BinaryVersion { get; init; } = null!;
 }
 
 public class MegaFan : Fan
@@ -32,8 +30,8 @@ public class MegaFan : Fan
         public bool InitializedCalled { get; set; }
     }
 
-    public string MegaStatus { get; set; }
-    public SwagBag Swag { get; set; }
+    public string? MegaStatus { get; set; }
+    public SwagBag Swag { get; set; } = null!;
 }
 
 public class SuperFan : Fan, ISuperFan
@@ -45,6 +43,6 @@ public class SuperFan : Fan, ISuperFan
         public bool InitializedCalled { get; set; }
     }
 
-    public string SuperStatus { get; set; }
-    public SwagBag Swag { get; set; }
+    public string? SuperStatus { get; set; }
+    public SwagBag Swag { get; set; } = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/ConcurrencyModel/FanTpc.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ConcurrencyModel/FanTpc.cs
@@ -5,16 +5,14 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ConcurrencyModel;
 
-#nullable disable
-
 public abstract class FanTpc
 {
     public int Id { get; set; }
-    public string Name { get; set; }
+    public string Name { get; set; } = null!;
     public ulong ULongVersion { get; init; }
 
     [NotMapped]
-    public List<byte> BinaryVersion { get; init; }
+    public List<byte> BinaryVersion { get; init; } = null!;
 }
 
 public class MegaFanTpc : FanTpc
@@ -26,8 +24,8 @@ public class MegaFanTpc : FanTpc
         public bool InitializedCalled { get; set; }
     }
 
-    public string MegaStatus { get; set; }
-    public SwagBag Swag { get; set; }
+    public string? MegaStatus { get; set; }
+    public SwagBag Swag { get; set; } = null!;
 }
 
 public class SuperFanTpc : FanTpc, ISuperFan
@@ -39,6 +37,6 @@ public class SuperFanTpc : FanTpc, ISuperFan
         public bool InitializedCalled { get; set; }
     }
 
-    public string SuperStatus { get; set; }
-    public SwagBag Swag { get; set; }
+    public string? SuperStatus { get; set; }
+    public SwagBag Swag { get; set; } = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/ConcurrencyModel/FanTpt.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ConcurrencyModel/FanTpt.cs
@@ -5,16 +5,14 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ConcurrencyModel;
 
-#nullable disable
-
 public abstract class FanTpt
 {
     public int Id { get; set; }
-    public string Name { get; set; }
+    public string Name { get; set; } = null!;
     public ulong ULongVersion { get; init; }
 
     [NotMapped]
-    public List<byte> BinaryVersion { get; init; }
+    public List<byte> BinaryVersion { get; init; } = null!;
 }
 
 public class MegaFanTpt : FanTpt
@@ -26,8 +24,8 @@ public class MegaFanTpt : FanTpt
         public bool InitializedCalled { get; set; }
     }
 
-    public string MegaStatus { get; set; }
-    public SwagBag Swag { get; set; }
+    public string? MegaStatus { get; set; }
+    public SwagBag Swag { get; set; } = null!;
 }
 
 public class SuperFanTpt : FanTpt, ISuperFan
@@ -39,6 +37,6 @@ public class SuperFanTpt : FanTpt, ISuperFan
         public bool InitializedCalled { get; set; }
     }
 
-    public string SuperStatus { get; set; }
-    public SwagBag Swag { get; set; }
+    public string? SuperStatus { get; set; }
+    public SwagBag Swag { get; set; } = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/ConcurrencyModel/Gearbox.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ConcurrencyModel/Gearbox.cs
@@ -3,8 +3,6 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ConcurrencyModel;
 
-#nullable disable
-
 public class Gearbox
 {
     public class GearboxProxy(
@@ -29,5 +27,5 @@ public class Gearbox
     }
 
     public int Id { get; set; }
-    public string Name { get; set; }
+    public string Name { get; set; } = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/ConcurrencyModel/Sponsor.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ConcurrencyModel/Sponsor.cs
@@ -5,8 +5,6 @@ using System.Collections.ObjectModel;
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ConcurrencyModel;
 
-#nullable disable
-
 public class Sponsor
 {
     public class SponsorDoubleProxy : SponsorProxy
@@ -33,7 +31,7 @@ public class Sponsor
     private readonly ObservableCollection<Team> _teams = [];
 
     public int Id { get; set; }
-    public string Name { get; set; }
+    public string Name { get; set; } = null!;
 
     public virtual ICollection<Team> Teams
         => _teams;

--- a/test/EFCore.Specification.Tests/TestModels/ConcurrencyModel/SwagBag.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ConcurrencyModel/SwagBag.cs
@@ -5,8 +5,6 @@ using System.ComponentModel.DataAnnotations;
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ConcurrencyModel;
 
-#nullable disable
-
 [Owned]
 public class SwagBag
 {
@@ -18,5 +16,5 @@ public class SwagBag
     }
 
     [Required]
-    public string Stuff { get; set; }
+    public string Stuff { get; set; } = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/ConcurrencyModel/Team.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ConcurrencyModel/Team.cs
@@ -5,8 +5,6 @@ using System.Collections.ObjectModel;
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ConcurrencyModel;
 
-#nullable disable
-
 public class Team
 {
     public class TeamProxy(
@@ -32,12 +30,12 @@ public class Team
         public bool InitializedCalled { get; set; }
     }
 
-    private readonly ILazyLoader _loader;
+    private readonly ILazyLoader _loader = null!;
     private readonly ObservableCollection<Driver> _drivers = new ObservableCollectionListSource<Driver>();
     private readonly ObservableCollection<Sponsor> _sponsors = [];
-    private Engine _engine;
-    private Chassis _chassis;
-    private Gearbox _gearbox;
+    private Engine? _engine;
+    private Chassis? _chassis;
+    private Gearbox? _gearbox;
 
     public Team()
     {
@@ -76,10 +74,10 @@ public class Team
     }
 
     public int Id { get; set; }
-    public string Name { get; set; }
-    public string Constructor { get; set; }
-    public string Tire { get; set; }
-    public string Principal { get; set; }
+    public string Name { get; set; } = null!;
+    public string? Constructor { get; set; }
+    public string? Tire { get; set; }
+    public string? Principal { get; set; }
     public int ConstructorsChampionships { get; set; }
     public int DriversChampionships { get; set; }
     public int Races { get; set; }
@@ -89,13 +87,13 @@ public class Team
 
     public virtual Engine Engine
     {
-        get => _loader.Load(this, ref _engine);
+        get => _loader.Load(this, ref _engine)!;
         set => _engine = value;
     }
 
     public virtual Chassis Chassis
     {
-        get => _loader.Load(this, ref _chassis);
+        get => _loader.Load(this, ref _chassis)!;
         set => _chassis = value;
     }
 
@@ -115,7 +113,7 @@ public class Team
 
     public virtual Gearbox Gearbox
     {
-        get => _loader.Load(this, ref _gearbox);
+        get => _loader.Load(this, ref _gearbox)!;
         set => _gearbox = value;
     }
 

--- a/test/EFCore.Specification.Tests/TestModels/ConcurrencyModel/TeamSponsor.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ConcurrencyModel/TeamSponsor.cs
@@ -3,8 +3,6 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ConcurrencyModel;
 
-#nullable disable
-
 public class TeamSponsor
 {
     public class TeamSponsorProxy : TeamSponsor, IF1Proxy
@@ -17,6 +15,6 @@ public class TeamSponsor
     public int TeamId { get; set; }
     public int SponsorId { get; set; }
 
-    public virtual Team Team { get; set; }
-    public virtual Sponsor Sponsor { get; set; }
+    public virtual Team Team { get; set; } = null!;
+    public virtual Sponsor Sponsor { get; set; } = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/ConcurrencyModel/TitleSponsor.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ConcurrencyModel/TitleSponsor.cs
@@ -3,8 +3,6 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ConcurrencyModel;
 
-#nullable disable
-
 public class TitleSponsor : Sponsor
 {
     public class TitleSponsorProxy(ILazyLoader loader) : TitleSponsor(loader), IF1Proxy
@@ -14,7 +12,7 @@ public class TitleSponsor : Sponsor
         public bool InitializedCalled { get; set; }
     }
 
-    private readonly ILazyLoader _loader;
+    private readonly ILazyLoader _loader = null!;
 
     public TitleSponsor()
     {
@@ -29,7 +27,7 @@ public class TitleSponsor : Sponsor
 
     public SponsorDetails Details
     {
-        get => _loader.Load(this, ref field);
+        get => _loader.Load(this, ref field)!;
         set;
     }
 }

--- a/test/EFCore.Specification.Tests/TestModels/ConferencePlanner/ApplicationDbContext.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ConferencePlanner/ApplicationDbContext.cs
@@ -3,8 +3,6 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ConferencePlanner;
 
-#nullable disable
-
 public class ApplicationDbContext(DbContextOptions<ApplicationDbContext> options) : DbContext(options)
 {
     protected override void OnModelCreating(ModelBuilder modelBuilder)
@@ -22,11 +20,11 @@ public class ApplicationDbContext(DbContextOptions<ApplicationDbContext> options
             .HasKey(ss => new { ss.SessionId, ss.SpeakerId });
     }
 
-    public DbSet<Session> Sessions { get; set; }
+    public DbSet<Session> Sessions { get; set; } = null!;
 
-    public DbSet<Track> Tracks { get; set; }
+    public DbSet<Track> Tracks { get; set; } = null!;
 
-    public DbSet<Speaker> Speakers { get; set; }
+    public DbSet<Speaker> Speakers { get; set; } = null!;
 
-    public DbSet<Attendee> Attendees { get; set; }
+    public DbSet<Attendee> Attendees { get; set; } = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/ConferencePlanner/Attendee.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ConferencePlanner/Attendee.cs
@@ -3,9 +3,7 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ConferencePlanner;
 
-#nullable disable
-
 public class Attendee : ConferenceDTO.Attendee
 {
-    public virtual ICollection<SessionAttendee> SessionsAttendees { get; set; }
+    public virtual ICollection<SessionAttendee> SessionsAttendees { get; set; } = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/ConferencePlanner/ConferenceDTO/Attendee.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ConferencePlanner/ConferenceDTO/Attendee.cs
@@ -5,21 +5,19 @@ using System.ComponentModel.DataAnnotations;
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ConferencePlanner.ConferenceDTO;
 
-#nullable disable
-
 public class Attendee
 {
     public int Id { get; set; }
 
     [Required, StringLength(200)]
-    public virtual string FirstName { get; set; }
+    public virtual string FirstName { get; set; } = null!;
 
     [Required, StringLength(200)]
-    public virtual string LastName { get; set; }
+    public virtual string LastName { get; set; } = null!;
 
     [Required, StringLength(200)]
-    public string UserName { get; set; }
+    public string UserName { get; set; } = null!;
 
     [StringLength(256)]
-    public virtual string EmailAddress { get; set; }
+    public virtual string EmailAddress { get; set; } = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/ConferencePlanner/ConferenceDTO/AttendeeResponse.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ConferencePlanner/ConferenceDTO/AttendeeResponse.cs
@@ -5,5 +5,5 @@ namespace Microsoft.EntityFrameworkCore.TestModels.ConferencePlanner.ConferenceD
 
 public class AttendeeResponse : Attendee
 {
-    public ICollection<Session> Sessions { get; set; } = [];
+    public ICollection<Session>? Sessions { get; set; }
 }

--- a/test/EFCore.Specification.Tests/TestModels/ConferencePlanner/ConferenceDTO/SearchResult.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ConferencePlanner/ConferenceDTO/SearchResult.cs
@@ -3,13 +3,11 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ConferencePlanner.ConferenceDTO;
 
-#nullable disable
-
 public class SearchResult
 {
     public SearchResultType Type { get; set; }
 
-    public SessionResponse Session { get; set; }
+    public SessionResponse Session { get; set; } = null!;
 
-    public SpeakerResponse Speaker { get; set; }
+    public SpeakerResponse Speaker { get; set; } = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/ConferencePlanner/ConferenceDTO/SearchTerm.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ConferencePlanner/ConferenceDTO/SearchTerm.cs
@@ -3,9 +3,7 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ConferencePlanner.ConferenceDTO;
 
-#nullable disable
-
 public class SearchTerm
 {
-    public string Query { get; set; }
+    public string Query { get; set; } = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/ConferencePlanner/ConferenceDTO/Session.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ConferencePlanner/ConferenceDTO/Session.cs
@@ -5,17 +5,15 @@ using System.ComponentModel.DataAnnotations;
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ConferencePlanner.ConferenceDTO;
 
-#nullable disable
-
 public class Session
 {
     public int Id { get; set; }
 
     [Required, StringLength(200)]
-    public string Title { get; set; }
+    public string Title { get; set; } = null!;
 
     [StringLength(4000)]
-    public virtual string Abstract { get; set; }
+    public virtual string Abstract { get; set; } = null!;
 
     public virtual DateTimeOffset? StartTime { get; set; }
 

--- a/test/EFCore.Specification.Tests/TestModels/ConferencePlanner/ConferenceDTO/SessionResponse.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ConferencePlanner/ConferenceDTO/SessionResponse.cs
@@ -3,11 +3,9 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ConferencePlanner.ConferenceDTO;
 
-#nullable disable
-
 public class SessionResponse : Session
 {
-    public Track Track { get; set; }
+    public Track Track { get; set; } = null!;
 
-    public List<Speaker> Speakers { get; set; } = [];
+    public List<Speaker>? Speakers { get; set; }
 }

--- a/test/EFCore.Specification.Tests/TestModels/ConferencePlanner/ConferenceDTO/Speaker.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ConferencePlanner/ConferenceDTO/Speaker.cs
@@ -5,18 +5,16 @@ using System.ComponentModel.DataAnnotations;
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ConferencePlanner.ConferenceDTO;
 
-#nullable disable
-
 public class Speaker
 {
     public int Id { get; set; }
 
     [Required, StringLength(200)]
-    public string Name { get; set; }
+    public string Name { get; set; } = null!;
 
     [StringLength(4000)]
-    public string Bio { get; set; }
+    public string? Bio { get; set; }
 
     [StringLength(1000)]
-    public virtual string WebSite { get; set; }
+    public virtual string? WebSite { get; set; }
 }

--- a/test/EFCore.Specification.Tests/TestModels/ConferencePlanner/ConferenceDTO/SpeakerResponse.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ConferencePlanner/ConferenceDTO/SpeakerResponse.cs
@@ -6,5 +6,5 @@ namespace Microsoft.EntityFrameworkCore.TestModels.ConferencePlanner.ConferenceD
 public class SpeakerResponse : Speaker
 {
     // TODO: Set order of JSON proeprties so this shows up last not first
-    public ICollection<Session> Sessions { get; set; } = [];
+    public ICollection<Session>? Sessions { get; set; }
 }

--- a/test/EFCore.Specification.Tests/TestModels/ConferencePlanner/ConferenceDTO/Track.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ConferencePlanner/ConferenceDTO/Track.cs
@@ -5,12 +5,10 @@ using System.ComponentModel.DataAnnotations;
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ConferencePlanner.ConferenceDTO;
 
-#nullable disable
-
 public class Track
 {
     public int Id { get; set; }
 
-    [Required, StringLength(200)]
-    public string Name { get; set; }
+    [StringLength(200)]
+    public string? Name { get; set; }
 }

--- a/test/EFCore.Specification.Tests/TestModels/ConferencePlanner/EntityExtensions.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ConferencePlanner/EntityExtensions.cs
@@ -5,8 +5,6 @@ using Microsoft.EntityFrameworkCore.TestModels.ConferencePlanner.ConferenceDTO;
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ConferencePlanner;
 
-#nullable disable
-
 public static class EntityExtensions
 {
     public static SessionResponse MapSessionResponse(this Session session)
@@ -17,10 +15,10 @@ public static class EntityExtensions
             StartTime = session.StartTime,
             EndTime = session.EndTime,
             Speakers = session.SessionSpeakers?
-                .Select(ss => new ConferenceDTO.Speaker { Id = ss.SpeakerId, Name = ss.Speaker.Name })
+                .Select(ss => new ConferenceDTO.Speaker { Id = ss.SpeakerId, Name = ss.Speaker!.Name })
                 .ToList(),
             TrackId = session.TrackId,
-            Track = new ConferenceDTO.Track { Id = session?.TrackId ?? 0, Name = session.Track?.Name },
+            Track = new ConferenceDTO.Track { Id = session.TrackId ?? 0, Name = session.Track?.Name },
             Abstract = session.Abstract
         };
 
@@ -54,6 +52,6 @@ public static class EntityExtensions
                         StartTime = sa.Session.StartTime,
                         EndTime = sa.Session.EndTime
                     })
-                .ToList()
+                    .ToList()
         };
 }

--- a/test/EFCore.Specification.Tests/TestModels/ConferencePlanner/Session.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ConferencePlanner/Session.cs
@@ -3,13 +3,11 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ConferencePlanner;
 
-#nullable disable
-
 public class Session : ConferenceDTO.Session
 {
-    public virtual ICollection<SessionSpeaker> SessionSpeakers { get; set; }
+    public virtual ICollection<SessionSpeaker> SessionSpeakers { get; set; } = null!;
 
-    public virtual ICollection<SessionAttendee> SessionAttendees { get; set; }
+    public virtual ICollection<SessionAttendee> SessionAttendees { get; set; } = null!;
 
-    public Track Track { get; set; }
+    public Track Track { get; set; } = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/ConferencePlanner/SessionAttendee.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ConferencePlanner/SessionAttendee.cs
@@ -3,15 +3,13 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ConferencePlanner;
 
-#nullable disable
-
 public class SessionAttendee
 {
     public int SessionId { get; set; }
 
-    public Session Session { get; set; }
+    public Session Session { get; set; } = null!;
 
     public int AttendeeId { get; set; }
 
-    public Attendee Attendee { get; set; }
+    public Attendee Attendee { get; set; } = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/ConferencePlanner/SessionSpeaker.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ConferencePlanner/SessionSpeaker.cs
@@ -3,15 +3,13 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ConferencePlanner;
 
-#nullable disable
-
 public class SessionSpeaker
 {
     public int SessionId { get; set; }
 
-    public Session Session { get; set; }
+    public Session Session { get; set; } = null!;
 
     public int SpeakerId { get; set; }
 
-    public Speaker Speaker { get; set; }
+    public Speaker Speaker { get; set; } = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/ConferencePlanner/Track.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ConferencePlanner/Track.cs
@@ -3,9 +3,7 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ConferencePlanner;
 
-#nullable disable
-
 public class Track : ConferenceDTO.Track
 {
-    public virtual ICollection<Session> Sessions { get; set; }
+    public virtual ICollection<Session> Sessions { get; set; } = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/FunkyDataModel/FunkyCustomer.cs
+++ b/test/EFCore.Specification.Tests/TestModels/FunkyDataModel/FunkyCustomer.cs
@@ -3,13 +3,11 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.FunkyDataModel;
 
-#nullable disable
-
 public class FunkyCustomer
 {
     public int Id { get; set; }
-    public string FirstName { get; set; }
-    public string LastName { get; set; }
+    public string? FirstName { get; set; }
+    public string? LastName { get; set; }
 
     public bool? NullableBool { get; set; }
 }

--- a/test/EFCore.Specification.Tests/TestModels/FunkyDataModel/FunkyDataContext.cs
+++ b/test/EFCore.Specification.Tests/TestModels/FunkyDataModel/FunkyDataContext.cs
@@ -3,11 +3,9 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.FunkyDataModel;
 
-#nullable disable
-
 public class FunkyDataContext(DbContextOptions options) : PoolableDbContext(options)
 {
-    public DbSet<FunkyCustomer> FunkyCustomers { get; set; }
+    public DbSet<FunkyCustomer> FunkyCustomers { get; set; } = null!;
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
         => modelBuilder.Entity<FunkyCustomer>().Property(e => e.Id).ValueGeneratedNever();

--- a/test/EFCore.Specification.Tests/TestModels/FunkyDataModel/FunkyDataData.cs
+++ b/test/EFCore.Specification.Tests/TestModels/FunkyDataModel/FunkyDataData.cs
@@ -3,8 +3,6 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.FunkyDataModel;
 
-#nullable disable
-
 public class FunkyDataData : ISetSource
 {
     public static readonly FunkyDataData Instance = new();

--- a/test/EFCore.Specification.Tests/TestModels/GearsOfWarModel/City.cs
+++ b/test/EFCore.Specification.Tests/TestModels/GearsOfWarModel/City.cs
@@ -3,17 +3,15 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.GearsOfWarModel;
 
-#nullable disable
-
 public class City
 {
     // non-integer key with not conventional name
-    public string Name { get; set; }
+    public string Name { get; set; } = null!;
 
-    public string Location { get; set; }
+    public string? Location { get; set; }
 
-    public string Nation { get; set; }
+    public string? Nation { get; set; }
 
-    public List<Gear> BornGears { get; set; }
-    public List<Gear> StationedGears { get; set; }
+    public List<Gear> BornGears { get; set; } = null!;
+    public List<Gear> StationedGears { get; set; } = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/GearsOfWarModel/CogTag.cs
+++ b/test/EFCore.Specification.Tests/TestModels/GearsOfWarModel/CogTag.cs
@@ -3,17 +3,15 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.GearsOfWarModel;
 
-#nullable disable
-
 public class CogTag
 {
     // auto generated key (identity for now)
     public Guid Id { get; set; }
 
-    public string Note { get; set; }
+    public string? Note { get; set; }
 
-    public string GearNickName { get; set; }
+    public string? GearNickName { get; set; }
     public int? GearSquadId { get; set; }
-    public virtual Gear Gear { get; set; }
+    public virtual Gear? Gear { get; set; }
     public DateTime IssueDate { get; set; }
 }

--- a/test/EFCore.Specification.Tests/TestModels/GearsOfWarModel/Faction.cs
+++ b/test/EFCore.Specification.Tests/TestModels/GearsOfWarModel/Faction.cs
@@ -5,14 +5,12 @@ using System.Net;
 
 namespace Microsoft.EntityFrameworkCore.TestModels.GearsOfWarModel;
 
-#nullable disable
-
 public abstract class Faction
 {
     public int Id { get; set; }
-    public string Name { get; set; }
-    public IPAddress ServerAddress { get; set; }
+    public string? Name { get; set; }
+    public IPAddress? ServerAddress { get; set; }
 
-    public string CapitalName { get; set; }
-    public City Capital { get; set; }
+    public string? CapitalName { get; set; }
+    public City? Capital { get; set; }
 }

--- a/test/EFCore.Specification.Tests/TestModels/GearsOfWarModel/Gear.cs
+++ b/test/EFCore.Specification.Tests/TestModels/GearsOfWarModel/Gear.cs
@@ -5,35 +5,33 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace Microsoft.EntityFrameworkCore.TestModels.GearsOfWarModel;
 
-#nullable disable
-
 public class Gear
 {
     public Gear()
         => Weapons = [];
 
     // composite key
-    public string Nickname { get; set; }
+    public string Nickname { get; set; } = null!;
 
     public int SquadId { get; set; }
 
-    public string FullName { get; set; }
+    public string FullName { get; set; } = null!;
 
-    public string CityOfBirthName { get; set; }
-    public virtual City CityOfBirth { get; set; }
+    public string CityOfBirthName { get; set; } = null!;
+    public virtual City CityOfBirth { get; set; } = null!;
 
-    public virtual City AssignedCity { get; set; }
+    public virtual City? AssignedCity { get; set; }
 
     public MilitaryRank Rank { get; set; }
 
     public virtual CogTag Tag { get; set; } = new(); // Initialized to test #23851
 
-    public virtual Squad Squad { get; set; }
+    public virtual Squad Squad { get; set; } = null!;
 
     // TODO: make this many to many - not supported at the moment
     public virtual ICollection<Weapon> Weapons { get; set; }
 
-    public string LeaderNickname { get; set; }
+    public string? LeaderNickname { get; set; }
     public int LeaderSquadId { get; set; }
 
     public bool HasSoulPatch { get; set; }

--- a/test/EFCore.Specification.Tests/TestModels/GearsOfWarModel/GearsOfWarContext.cs
+++ b/test/EFCore.Specification.Tests/TestModels/GearsOfWarModel/GearsOfWarContext.cs
@@ -3,21 +3,19 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.GearsOfWarModel;
 
-#nullable disable
-
 public class GearsOfWarContext(DbContextOptions options) : PoolableDbContext(options)
 {
-    public DbSet<Gear> Gears { get; set; }
-    public DbSet<Officer> Officers { get; set; }
-    public DbSet<Squad> Squads { get; set; }
-    public DbSet<CogTag> Tags { get; set; }
-    public DbSet<Weapon> Weapons { get; set; }
-    public DbSet<City> Cities { get; set; }
-    public DbSet<Mission> Missions { get; set; }
-    public DbSet<SquadMission> SquadMissions { get; set; }
-    public DbSet<Faction> Factions { get; set; }
-    public DbSet<LocustLeader> LocustLeaders { get; set; }
-    public DbSet<LocustHighCommand> LocustHighCommands { get; set; }
+    public DbSet<Gear> Gears { get; set; } = null!;
+    public DbSet<Officer> Officers { get; set; } = null!;
+    public DbSet<Squad> Squads { get; set; } = null!;
+    public DbSet<CogTag> Tags { get; set; } = null!;
+    public DbSet<Weapon> Weapons { get; set; } = null!;
+    public DbSet<City> Cities { get; set; } = null!;
+    public DbSet<Mission> Missions { get; set; } = null!;
+    public DbSet<SquadMission> SquadMissions { get; set; } = null!;
+    public DbSet<Faction> Factions { get; set; } = null!;
+    public DbSet<LocustLeader> LocustLeaders { get; set; } = null!;
+    public DbSet<LocustHighCommand> LocustHighCommands { get; set; } = null!;
 
     public static async Task SeedAsync(GearsOfWarContext context)
     {

--- a/test/EFCore.Specification.Tests/TestModels/GearsOfWarModel/LocustCommander.cs
+++ b/test/EFCore.Specification.Tests/TestModels/GearsOfWarModel/LocustCommander.cs
@@ -3,16 +3,14 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.GearsOfWarModel;
 
-#nullable disable
-
 public class LocustCommander : LocustLeader
 {
-    public LocustHorde CommandingFaction { get; set; }
+    public LocustHorde CommandingFaction { get; set; } = null!;
 
-    public string DefeatedByNickname { get; set; }
+    public string? DefeatedByNickname { get; set; }
     public int? DefeatedBySquadId { get; set; }
-    public Gear DefeatedBy { get; set; }
+    public Gear? DefeatedBy { get; set; }
 
-    public LocustHighCommand HighCommand { get; set; }
+    public LocustHighCommand HighCommand { get; set; } = null!;
     public int HighCommandId { get; set; }
 }

--- a/test/EFCore.Specification.Tests/TestModels/GearsOfWarModel/LocustHighCommand.cs
+++ b/test/EFCore.Specification.Tests/TestModels/GearsOfWarModel/LocustHighCommand.cs
@@ -3,14 +3,12 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.GearsOfWarModel;
 
-#nullable disable
-
 public class LocustHighCommand
 {
     public int Id { get; set; }
 
-    public string Name { get; set; }
+    public string? Name { get; set; }
     public bool IsOperational { get; set; }
 
-    public List<LocustCommander> Commanders { get; set; }
+    public List<LocustCommander> Commanders { get; set; } = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/GearsOfWarModel/LocustHorde.cs
+++ b/test/EFCore.Specification.Tests/TestModels/GearsOfWarModel/LocustHorde.cs
@@ -3,14 +3,12 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.GearsOfWarModel;
 
-#nullable disable
-
 public class LocustHorde : Faction
 {
-    public LocustCommander Commander { get; set; }
-    public LocustLeader DeputyCommander { get; set; }
-    public List<LocustLeader> Leaders { get; set; }
+    public LocustCommander? Commander { get; set; }
+    public LocustLeader? DeputyCommander { get; set; }
+    public List<LocustLeader> Leaders { get; set; } = null!;
 
-    public string CommanderName { get; set; }
+    public string? CommanderName { get; set; }
     public bool? Eradicated { get; set; }
 }

--- a/test/EFCore.Specification.Tests/TestModels/GearsOfWarModel/LocustLeader.cs
+++ b/test/EFCore.Specification.Tests/TestModels/GearsOfWarModel/LocustLeader.cs
@@ -3,11 +3,9 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.GearsOfWarModel;
 
-#nullable disable
-
 public class LocustLeader
 {
-    public string Name { get; set; }
+    public string Name { get; set; } = null!;
     public short ThreatLevel { get; set; }
     public byte ThreatLevelByte { get; set; }
     public byte? ThreatLevelNullableByte { get; set; }

--- a/test/EFCore.Specification.Tests/TestModels/GearsOfWarModel/Mission.cs
+++ b/test/EFCore.Specification.Tests/TestModels/GearsOfWarModel/Mission.cs
@@ -3,13 +3,11 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.GearsOfWarModel;
 
-#nullable disable
-
 public class Mission
 {
     public int Id { get; set; }
 
-    public string CodeName { get; set; }
+    public string? CodeName { get; set; }
     public double? Rating { get; set; }
     public DateTimeOffset Timeline { get; set; }
     public TimeSpan Duration { get; set; }
@@ -17,5 +15,5 @@ public class Mission
     public TimeOnly Time { get; set; }
     public MissionDifficulty Difficulty { get; set; }
 
-    public virtual ICollection<SquadMission> ParticipatingSquads { get; set; }
+    public virtual ICollection<SquadMission> ParticipatingSquads { get; set; } = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/GearsOfWarModel/Squad.cs
+++ b/test/EFCore.Specification.Tests/TestModels/GearsOfWarModel/Squad.cs
@@ -3,8 +3,6 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.GearsOfWarModel;
 
-#nullable disable
-
 public class Squad
 {
     public Squad()
@@ -13,15 +11,15 @@ public class Squad
     // non-auto generated key
     public int Id { get; set; }
 
-    public string Name { get; set; }
+    public string? Name { get; set; }
 
     // auto-generated non-key (sequence)
     public int InternalNumber { get; set; }
 
-    public virtual byte[] Banner { get; set; }
+    public virtual byte[] Banner { get; set; } = null!;
 
-    public virtual byte[] Banner5 { get; set; }
+    public virtual byte[] Banner5 { get; set; } = null!;
 
     public virtual ICollection<Gear> Members { get; set; }
-    public virtual ICollection<SquadMission> Missions { get; set; }
+    public virtual ICollection<SquadMission> Missions { get; set; } = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/GearsOfWarModel/SquadMission.cs
+++ b/test/EFCore.Specification.Tests/TestModels/GearsOfWarModel/SquadMission.cs
@@ -3,13 +3,11 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.GearsOfWarModel;
 
-#nullable disable
-
 public class SquadMission
 {
-    public Squad Squad { get; set; }
+    public Squad Squad { get; set; } = null!;
     public int MissionId { get; set; }
 
     public int SquadId { get; set; }
-    public Mission Mission { get; set; }
+    public Mission Mission { get; set; } = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/GearsOfWarModel/Weapon.cs
+++ b/test/EFCore.Specification.Tests/TestModels/GearsOfWarModel/Weapon.cs
@@ -3,22 +3,20 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.GearsOfWarModel;
 
-#nullable disable
-
 public class Weapon
 {
     // auto generated key (sequence) TODO: make nullable when issue #478 is fixed
     public int Id { get; set; }
 
-    public string Name { get; set; }
+    public string? Name { get; set; }
     public AmmunitionType? AmmunitionType { get; set; }
     public bool IsAutomatic { get; set; }
 
     // 1 - 1 self reference
     public int? SynergyWithId { get; set; }
 
-    public virtual Weapon SynergyWith { get; set; }
+    public virtual Weapon? SynergyWith { get; set; }
 
-    public string OwnerFullName { get; set; }
-    public Gear Owner { get; set; }
+    public string? OwnerFullName { get; set; }
+    public Gear? Owner { get; set; }
 }

--- a/test/EFCore.Specification.Tests/TestModels/InheritanceModel/Animal.cs
+++ b/test/EFCore.Specification.Tests/TestModels/InheritanceModel/Animal.cs
@@ -3,18 +3,16 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.InheritanceModel;
 
-#nullable disable
-
 public abstract class Animal
 {
     public int Id { get; set; }
-    public string Species { get; set; }
-    public string Name { get; set; }
+    public string? Species { get; set; }
+    public string? Name { get; set; }
     public int CountryId { get; set; }
 }
 
 public abstract class AnimalQuery
 {
-    public string Name { get; set; }
+    public string? Name { get; set; }
     public int CountryId { get; set; }
 }

--- a/test/EFCore.Specification.Tests/TestModels/InheritanceModel/Country.cs
+++ b/test/EFCore.Specification.Tests/TestModels/InheritanceModel/Country.cs
@@ -3,13 +3,11 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.InheritanceModel;
 
-#nullable disable
-
 public class Country
 {
     public int Id { get; set; }
-    public string Name { get; set; }
+    public string Name { get; set; } = null!;
 
     public IList<Animal> Animals { get; set; } = [];
-    public IList<Plant> Plants { get; set; }
+    public IList<Plant> Plants { get; set; } = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/InheritanceModel/InheritanceContext.cs
+++ b/test/EFCore.Specification.Tests/TestModels/InheritanceModel/InheritanceContext.cs
@@ -3,18 +3,16 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.InheritanceModel;
 
-#nullable disable
-
 public class InheritanceContext(DbContextOptions options) : PoolableDbContext(options)
 {
-    public DbSet<Animal> Animals { get; set; }
-    public DbSet<AnimalQuery> AnimalQueries { get; set; }
-    public DbSet<Country> Countries { get; set; }
-    public DbSet<Drink> Drinks { get; set; }
-    public DbSet<Coke> Coke { get; set; }
-    public DbSet<Lilt> Lilt { get; set; }
-    public DbSet<Tea> Tea { get; set; }
-    public DbSet<Plant> Plants { get; set; }
+    public DbSet<Animal> Animals { get; set; } = null!;
+    public DbSet<AnimalQuery> AnimalQueries { get; set; } = null!;
+    public DbSet<Country> Countries { get; set; } = null!;
+    public DbSet<Drink> Drinks { get; set; } = null!;
+    public DbSet<Coke> Coke { get; set; } = null!;
+    public DbSet<Lilt> Lilt { get; set; } = null!;
+    public DbSet<Tea> Tea { get; set; } = null!;
+    public DbSet<Plant> Plants { get; set; } = null!;
 
     public static Task SeedAsync(InheritanceContext context, bool useGeneratedKeys)
     {

--- a/test/EFCore.Specification.Tests/TestModels/InheritanceModel/Plant.cs
+++ b/test/EFCore.Specification.Tests/TestModels/InheritanceModel/Plant.cs
@@ -3,11 +3,9 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.InheritanceModel;
 
-#nullable disable
-
 public abstract class Plant
 {
     public PlantGenus Genus { get; set; }
-    public string Species { get; set; }
-    public string Name { get; set; }
+    public string Species { get; set; } = null!;
+    public string Name { get; set; } = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/InheritanceRelationshipsModel/BaseCollectionOnBase.cs
+++ b/test/EFCore.Specification.Tests/TestModels/InheritanceRelationshipsModel/BaseCollectionOnBase.cs
@@ -3,18 +3,16 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.InheritanceRelationshipsModel;
 
-#nullable disable
-
 public class BaseCollectionOnBase
 {
     public int Id { get; set; }
 
-    public string Name { get; set; }
+    public string? Name { get; set; }
 
     public int? BaseParentId { get; set; }
-    public BaseInheritanceRelationshipEntity BaseParent { get; set; }
+    public BaseInheritanceRelationshipEntity? BaseParent { get; set; }
 
-    public NestedReferenceBase NestedReference { get; set; }
+    public NestedReferenceBase? NestedReference { get; set; }
 
-    public List<NestedCollectionBase> NestedCollection { get; set; }
+    public List<NestedCollectionBase> NestedCollection { get; set; } = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/InheritanceRelationshipsModel/BaseCollectionOnDerived.cs
+++ b/test/EFCore.Specification.Tests/TestModels/InheritanceRelationshipsModel/BaseCollectionOnDerived.cs
@@ -3,14 +3,12 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.InheritanceRelationshipsModel;
 
-#nullable disable
-
 public class BaseCollectionOnDerived
 {
     public int Id { get; set; }
 
-    public string Name { get; set; }
+    public string? Name { get; set; }
 
     public int? ParentId { get; set; }
-    public DerivedInheritanceRelationshipEntity BaseParent { get; set; }
+    public DerivedInheritanceRelationshipEntity? BaseParent { get; set; }
 }

--- a/test/EFCore.Specification.Tests/TestModels/InheritanceRelationshipsModel/BaseInheritanceRelationshipEntity.cs
+++ b/test/EFCore.Specification.Tests/TestModels/InheritanceRelationshipsModel/BaseInheritanceRelationshipEntity.cs
@@ -3,20 +3,18 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.InheritanceRelationshipsModel;
 
-#nullable disable
-
 public class BaseInheritanceRelationshipEntity
 {
     public int Id { get; set; }
 
-    public string Name { get; set; }
+    public string? Name { get; set; }
 
-    public DerivedInheritanceRelationshipEntity DerivedSefReferenceOnBase { get; set; }
-    public BaseReferenceOnBase BaseReferenceOnBase { get; set; }
-    public ReferenceOnBase ReferenceOnBase { get; set; }
-    public OwnedEntity OwnedReferenceOnBase { get; set; }
+    public DerivedInheritanceRelationshipEntity? DerivedSefReferenceOnBase { get; set; }
+    public BaseReferenceOnBase? BaseReferenceOnBase { get; set; }
+    public ReferenceOnBase? ReferenceOnBase { get; set; }
+    public OwnedEntity? OwnedReferenceOnBase { get; set; }
 
-    public List<BaseCollectionOnBase> BaseCollectionOnBase { get; set; }
-    public List<CollectionOnBase> CollectionOnBase { get; set; }
-    public List<OwnedEntity> OwnedCollectionOnBase { get; set; }
+    public List<BaseCollectionOnBase> BaseCollectionOnBase { get; set; } = null!;
+    public List<CollectionOnBase> CollectionOnBase { get; set; } = null!;
+    public List<OwnedEntity> OwnedCollectionOnBase { get; set; } = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/InheritanceRelationshipsModel/BaseReferenceOnBase.cs
+++ b/test/EFCore.Specification.Tests/TestModels/InheritanceRelationshipsModel/BaseReferenceOnBase.cs
@@ -3,18 +3,16 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.InheritanceRelationshipsModel;
 
-#nullable disable
-
 public class BaseReferenceOnBase
 {
     public int Id { get; set; }
 
-    public string Name { get; set; }
+    public string? Name { get; set; }
 
     public int? BaseParentId { get; set; }
-    public BaseInheritanceRelationshipEntity BaseParent { get; set; }
+    public BaseInheritanceRelationshipEntity? BaseParent { get; set; }
 
-    public NestedReferenceBase NestedReference { get; set; }
+    public NestedReferenceBase? NestedReference { get; set; }
 
-    public List<NestedCollectionBase> NestedCollection { get; set; }
+    public List<NestedCollectionBase> NestedCollection { get; set; } = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/InheritanceRelationshipsModel/BaseReferenceOnDerived.cs
+++ b/test/EFCore.Specification.Tests/TestModels/InheritanceRelationshipsModel/BaseReferenceOnDerived.cs
@@ -3,14 +3,12 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.InheritanceRelationshipsModel;
 
-#nullable disable
-
 public class BaseReferenceOnDerived
 {
     public int Id { get; set; }
 
-    public string Name { get; set; }
+    public string? Name { get; set; }
 
     public int? BaseParentId { get; set; }
-    public DerivedInheritanceRelationshipEntity BaseParent { get; set; }
+    public DerivedInheritanceRelationshipEntity? BaseParent { get; set; }
 }

--- a/test/EFCore.Specification.Tests/TestModels/InheritanceRelationshipsModel/CollectionOnBase.cs
+++ b/test/EFCore.Specification.Tests/TestModels/InheritanceRelationshipsModel/CollectionOnBase.cs
@@ -3,13 +3,11 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.InheritanceRelationshipsModel;
 
-#nullable disable
-
 public class CollectionOnBase
 {
     public int Id { get; set; }
-    public string Name { get; set; }
+    public string? Name { get; set; }
 
     public int? ParentId { get; set; }
-    public BaseInheritanceRelationshipEntity Parent { get; set; }
+    public BaseInheritanceRelationshipEntity? Parent { get; set; }
 }

--- a/test/EFCore.Specification.Tests/TestModels/InheritanceRelationshipsModel/CollectionOnDerived.cs
+++ b/test/EFCore.Specification.Tests/TestModels/InheritanceRelationshipsModel/CollectionOnDerived.cs
@@ -3,13 +3,11 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.InheritanceRelationshipsModel;
 
-#nullable disable
-
 public class CollectionOnDerived
 {
     public int Id { get; set; }
-    public string Name { get; set; }
+    public string? Name { get; set; }
 
     public int? ParentId { get; set; }
-    public DerivedInheritanceRelationshipEntity Parent { get; set; }
+    public DerivedInheritanceRelationshipEntity? Parent { get; set; }
 }

--- a/test/EFCore.Specification.Tests/TestModels/InheritanceRelationshipsModel/DerivedInheritanceRelationshipEntity.cs
+++ b/test/EFCore.Specification.Tests/TestModels/InheritanceRelationshipsModel/DerivedInheritanceRelationshipEntity.cs
@@ -3,20 +3,18 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.InheritanceRelationshipsModel;
 
-#nullable disable
-
 public class DerivedInheritanceRelationshipEntity : BaseInheritanceRelationshipEntity
 {
     public int? BaseId { get; set; }
 
-    public BaseReferenceOnDerived BaseReferenceOnDerived { get; set; }
-    public DerivedReferenceOnDerived DerivedReferenceOnDerived { get; set; }
-    public ReferenceOnDerived ReferenceOnDerived { get; set; }
-    public BaseInheritanceRelationshipEntity BaseSelfReferenceOnDerived { get; set; }
-    public OwnedEntity OwnedReferenceOnDerived { get; set; }
+    public BaseReferenceOnDerived? BaseReferenceOnDerived { get; set; }
+    public DerivedReferenceOnDerived? DerivedReferenceOnDerived { get; set; }
+    public ReferenceOnDerived? ReferenceOnDerived { get; set; }
+    public BaseInheritanceRelationshipEntity? BaseSelfReferenceOnDerived { get; set; }
+    public OwnedEntity? OwnedReferenceOnDerived { get; set; }
 
-    public List<BaseCollectionOnDerived> BaseCollectionOnDerived { get; set; }
-    public List<DerivedCollectionOnDerived> DerivedCollectionOnDerived { get; set; }
-    public List<CollectionOnDerived> CollectionOnDerived { get; set; }
-    public List<OwnedEntity> OwnedCollectionOnDerived { get; set; }
+    public List<BaseCollectionOnDerived> BaseCollectionOnDerived { get; set; } = null!;
+    public List<DerivedCollectionOnDerived> DerivedCollectionOnDerived { get; set; } = null!;
+    public List<CollectionOnDerived> CollectionOnDerived { get; set; } = null!;
+    public List<OwnedEntity> OwnedCollectionOnDerived { get; set; } = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/InheritanceRelationshipsModel/InheritanceRelationshipsContext.cs
+++ b/test/EFCore.Specification.Tests/TestModels/InheritanceRelationshipsModel/InheritanceRelationshipsContext.cs
@@ -3,25 +3,23 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.InheritanceRelationshipsModel;
 
-#nullable disable
-
 public class InheritanceRelationshipsContext(DbContextOptions options) : PoolableDbContext(options)
 {
     public static readonly string StoreName = "InheritanceRelationships";
 
-    public DbSet<BaseCollectionOnBase> BaseCollectionsOnBase { get; set; }
-    public DbSet<BaseCollectionOnDerived> BaseCollectionsOnDerived { get; set; }
-    public DbSet<BaseInheritanceRelationshipEntity> BaseEntities { get; set; }
-    public DbSet<BaseReferenceOnBase> BaseReferencesOnBase { get; set; }
-    public DbSet<BaseReferenceOnDerived> BaseReferencesOnDerived { get; set; }
-    public DbSet<CollectionOnBase> CollectionsOnBase { get; set; }
-    public DbSet<CollectionOnDerived> CollectionsOnDerived { get; set; }
-    public DbSet<NestedCollectionBase> NestedCollections { get; set; }
-    public DbSet<NestedReferenceBase> NestedReferences { get; set; }
-    public DbSet<PrincipalEntity> PrincipalEntities { get; set; }
-    public DbSet<ReferencedEntity> ReferencedEntities { get; set; }
-    public DbSet<ReferenceOnBase> ReferencesOnBase { get; set; }
-    public DbSet<ReferenceOnDerived> ReferencesOnDerived { get; set; }
+    public DbSet<BaseCollectionOnBase> BaseCollectionsOnBase { get; set; } = null!;
+    public DbSet<BaseCollectionOnDerived> BaseCollectionsOnDerived { get; set; } = null!;
+    public DbSet<BaseInheritanceRelationshipEntity> BaseEntities { get; set; } = null!;
+    public DbSet<BaseReferenceOnBase> BaseReferencesOnBase { get; set; } = null!;
+    public DbSet<BaseReferenceOnDerived> BaseReferencesOnDerived { get; set; } = null!;
+    public DbSet<CollectionOnBase> CollectionsOnBase { get; set; } = null!;
+    public DbSet<CollectionOnDerived> CollectionsOnDerived { get; set; } = null!;
+    public DbSet<NestedCollectionBase> NestedCollections { get; set; } = null!;
+    public DbSet<NestedReferenceBase> NestedReferences { get; set; } = null!;
+    public DbSet<PrincipalEntity> PrincipalEntities { get; set; } = null!;
+    public DbSet<ReferencedEntity> ReferencedEntities { get; set; } = null!;
+    public DbSet<ReferenceOnBase> ReferencesOnBase { get; set; } = null!;
+    public DbSet<ReferenceOnDerived> ReferencesOnDerived { get; set; } = null!;
 
     public static Task SeedAsync(InheritanceRelationshipsContext context)
     {

--- a/test/EFCore.Specification.Tests/TestModels/InheritanceRelationshipsModel/NestedCollectionBase.cs
+++ b/test/EFCore.Specification.Tests/TestModels/InheritanceRelationshipsModel/NestedCollectionBase.cs
@@ -3,17 +3,15 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.InheritanceRelationshipsModel;
 
-#nullable disable
-
 public class NestedCollectionBase
 {
     public int Id { get; set; }
 
-    public string Name { get; set; }
+    public string? Name { get; set; }
 
     public int? ParentReferenceId { get; set; }
-    public BaseReferenceOnBase ParentReference { get; set; }
+    public BaseReferenceOnBase? ParentReference { get; set; }
 
     public int? ParentCollectionId { get; set; }
-    public BaseCollectionOnBase ParentCollection { get; set; }
+    public BaseCollectionOnBase? ParentCollection { get; set; }
 }

--- a/test/EFCore.Specification.Tests/TestModels/InheritanceRelationshipsModel/NestedReferenceBase.cs
+++ b/test/EFCore.Specification.Tests/TestModels/InheritanceRelationshipsModel/NestedReferenceBase.cs
@@ -3,17 +3,15 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.InheritanceRelationshipsModel;
 
-#nullable disable
-
 public class NestedReferenceBase
 {
     public int Id { get; set; }
 
-    public string Name { get; set; }
+    public string? Name { get; set; }
 
     public int? ParentReferenceId { get; set; }
-    public BaseReferenceOnBase ParentReference { get; set; }
+    public BaseReferenceOnBase? ParentReference { get; set; }
 
     public int? ParentCollectionId { get; set; }
-    public BaseCollectionOnBase ParentCollection { get; set; }
+    public BaseCollectionOnBase? ParentCollection { get; set; }
 }

--- a/test/EFCore.Specification.Tests/TestModels/InheritanceRelationshipsModel/NonEntityBase.cs
+++ b/test/EFCore.Specification.Tests/TestModels/InheritanceRelationshipsModel/NonEntityBase.cs
@@ -3,12 +3,10 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.InheritanceRelationshipsModel;
 
-#nullable disable
-
 public class NonEntityBase
 {
     public int Id { get; set; }
-    public string Name { get; set; }
+    public string? Name { get; set; }
 
-    public ReferencedEntity Reference { get; set; }
+    public ReferencedEntity? Reference { get; set; }
 }

--- a/test/EFCore.Specification.Tests/TestModels/InheritanceRelationshipsModel/OwnedEntity.cs
+++ b/test/EFCore.Specification.Tests/TestModels/InheritanceRelationshipsModel/OwnedEntity.cs
@@ -3,10 +3,8 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.InheritanceRelationshipsModel;
 
-#nullable disable
-
 public class OwnedEntity
 {
     public int Id { get; set; }
-    public string Name { get; set; }
+    public string? Name { get; set; }
 }

--- a/test/EFCore.Specification.Tests/TestModels/InheritanceRelationshipsModel/ReferenceOnBase.cs
+++ b/test/EFCore.Specification.Tests/TestModels/InheritanceRelationshipsModel/ReferenceOnBase.cs
@@ -3,13 +3,11 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.InheritanceRelationshipsModel;
 
-#nullable disable
-
 public class ReferenceOnBase
 {
     public int Id { get; set; }
-    public string Name { get; set; }
+    public string? Name { get; set; }
 
     public int? ParentId { get; set; }
-    public BaseInheritanceRelationshipEntity Parent { get; set; }
+    public BaseInheritanceRelationshipEntity? Parent { get; set; }
 }

--- a/test/EFCore.Specification.Tests/TestModels/InheritanceRelationshipsModel/ReferenceOnDerived.cs
+++ b/test/EFCore.Specification.Tests/TestModels/InheritanceRelationshipsModel/ReferenceOnDerived.cs
@@ -3,13 +3,11 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.InheritanceRelationshipsModel;
 
-#nullable disable
-
 public class ReferenceOnDerived
 {
     public int Id { get; set; }
-    public string Name { get; set; }
+    public string? Name { get; set; }
 
     public int? ParentId { get; set; }
-    public DerivedInheritanceRelationshipEntity Parent { get; set; }
+    public DerivedInheritanceRelationshipEntity? Parent { get; set; }
 }

--- a/test/EFCore.Specification.Tests/TestModels/InheritanceRelationshipsModel/ReferencedEntity.cs
+++ b/test/EFCore.Specification.Tests/TestModels/InheritanceRelationshipsModel/ReferencedEntity.cs
@@ -3,12 +3,10 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.InheritanceRelationshipsModel;
 
-#nullable disable
-
 public class ReferencedEntity
 {
     public int Id { get; set; }
-    public string Name { get; set; }
+    public string? Name { get; set; }
 
-    public ICollection<PrincipalEntity> Principals { get; set; }
+    public ICollection<PrincipalEntity> Principals { get; set; } = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/JsonQuery/AJsonEntityHasComplexChildForReferenceForReference.cs
+++ b/test/EFCore.Specification.Tests/TestModels/JsonQuery/AJsonEntityHasComplexChildForReferenceForReference.cs
@@ -3,13 +3,11 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.JsonQuery;
 
-#nullable disable
-
 public class AJsonEntityHasComplexChildForReferenceForReference
 {
     public int Id { get; set; }
-    public string Name { get; set; }
+    public string Name { get; set; } = null!;
 
     public int? ParentId { get; set; }
-    public JsonEntityHasComplexChildForReference Parent { get; set; }
+    public JsonEntityHasComplexChildForReference Parent { get; set; } = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/JsonQuery/EntityBasic.cs
+++ b/test/EFCore.Specification.Tests/TestModels/JsonQuery/EntityBasic.cs
@@ -3,11 +3,9 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.JsonQuery;
 
-#nullable disable
-
 public class EntityBasic
 {
     public int Id { get; set; }
-    public string Name { get; set; }
-    public List<JsonEntityBasic> JsonEntityBasics { get; set; }
+    public string Name { get; set; } = null!;
+    public List<JsonEntityBasic> JsonEntityBasics { get; set; } = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/JsonQuery/JsonEntityAllTypes.cs
+++ b/test/EFCore.Specification.Tests/TestModels/JsonQuery/JsonEntityAllTypes.cs
@@ -7,58 +7,56 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace Microsoft.EntityFrameworkCore.TestModels.JsonQuery;
 
-#nullable disable
-
 public class JsonEntityAllTypes
 {
-    private ObservableCollection<int?> _testNullableInt32CollectionX = [99];
-    private Collection<JsonEnum?> _testNullableEnumCollectionX = [];
-    private Collection<JsonEnum?> _testNullableEnumWithIntConverterCollectionX = [JsonEnum.Three];
+    private ObservableCollection<int?>? _testNullableInt32CollectionX = [99];
+    private Collection<JsonEnum?>? _testNullableEnumCollectionX = [];
+    private Collection<JsonEnum?>? _testNullableEnumWithIntConverterCollectionX = [JsonEnum.Three];
 
-    public List<List<long>> TestInt64CollectionCollection { get; set; } = [];
-    public IReadOnlyList<double[]> TestDoubleCollectionCollection { get; set; } = new List<double[]>();
-    public List<float>[] TestSingleCollectionCollection { get; set; } = [[1.1f, 1.2f]];
-    public bool[][] TestBooleanCollectionCollection { get; set; } = [];
-    public ObservableCollection<ReadOnlyCollection<char>> TestCharacterCollectionCollection { get; set; } = [];
+    public List<List<long>?> TestInt64CollectionCollection { get; set; } = [];
+    public IReadOnlyList<double[]?> TestDoubleCollectionCollection { get; set; } = new List<double[]?>();
+    public List<float>?[] TestSingleCollectionCollection { get; set; } = [[1.1f, 1.2f]];
+    public bool[]?[] TestBooleanCollectionCollection { get; set; } = [];
+    public ObservableCollection<ReadOnlyCollection<char>?> TestCharacterCollectionCollection { get; set; } = [];
 
     public int Id { get; set; }
-    public JsonOwnedAllTypes Reference { get; init; }
-    public List<JsonOwnedAllTypes> Collection { get; init; }
+    public JsonOwnedAllTypes? Reference { get; init; }
+    public List<JsonOwnedAllTypes> Collection { get; init; } = null!;
 
-    public string[] TestDefaultStringCollection { get; init; }
-    public List<string> TestMaxLengthStringCollection { get; init; }
-    public IList<short> TestInt16Collection { get; set; }
+    public string[]? TestDefaultStringCollection { get; init; }
+    public List<string>? TestMaxLengthStringCollection { get; init; }
+    public IList<short>? TestInt16Collection { get; set; }
 
-    public string[][] TestDefaultStringCollectionCollection { get; init; }
-    public List<IReadOnlyList<string>> TestMaxLengthStringCollectionCollection { get; init; }
-    public IReadOnlyList<IReadOnlyList<short>> TestInt16CollectionCollection { get; set; }
+    public string?[]?[] TestDefaultStringCollectionCollection { get; init; } = null!;
+    public List<IReadOnlyList<string?>?> TestMaxLengthStringCollectionCollection { get; init; } = null!;
+    public IReadOnlyList<IReadOnlyList<short>?> TestInt16CollectionCollection { get; set; } = null!;
 
-    public int[] TestInt32Collection { get; set; } = [];
+    public int[]? TestInt32Collection { get; set; } = [];
 
-    public int[][] TestInt32CollectionCollection { get; set; } = [];
+    public int[]?[] TestInt32CollectionCollection { get; set; } = [];
 
-    public decimal[] TestDecimalCollection { get; set; }
-    public List<DateTime> TestDateTimeCollection { get; set; }
-    public IList<DateTimeOffset> TestDateTimeOffsetCollection { get; set; }
-    public TimeSpan[] TestTimeSpanCollection { get; set; } = [new(1, 1, 1)];
+    public decimal[]? TestDecimalCollection { get; set; }
+    public List<DateTime>? TestDateTimeCollection { get; set; }
+    public IList<DateTimeOffset>? TestDateTimeOffsetCollection { get; set; }
+    public TimeSpan[]? TestTimeSpanCollection { get; set; } = [new(1, 1, 1)];
 
-    public ReadOnlyCollection<long> TestInt64Collection { get; set; } = new([]);
-    public IList<double> TestDoubleCollection { get; set; } = new List<double>();
-    public IReadOnlyList<float> TestSingleCollection { get; set; } = [1.1f, 1.2f];
-    public IList<bool> TestBooleanCollection { get; set; } = new List<bool> { true };
-    public ObservableCollection<char> TestCharacterCollection { get; set; } = [];
-    public byte[] TestByteCollection { get; set; }
+    public ReadOnlyCollection<long>? TestInt64Collection { get; set; } = new([]);
+    public IList<double>? TestDoubleCollection { get; set; } = new List<double>();
+    public IReadOnlyList<float>? TestSingleCollection { get; set; } = [1.1f, 1.2f];
+    public IList<bool>? TestBooleanCollection { get; set; } = new List<bool> { true };
+    public ObservableCollection<char>? TestCharacterCollection { get; set; } = [];
+    public byte[]? TestByteCollection { get; set; }
 
     [Required]
-    public ReadOnlyCollection<Guid> TestGuidCollection { get; set; }
+    public ReadOnlyCollection<Guid> TestGuidCollection { get; set; } = null!;
 
-    public IList<ushort> TestUnsignedInt16Collection { get; set; }
-    public uint[] TestUnsignedInt32Collection { get; set; }
-    public ObservableCollection<ulong> TestUnsignedInt64Collection { get; set; }
+    public IList<ushort>? TestUnsignedInt16Collection { get; set; }
+    public uint[]? TestUnsignedInt32Collection { get; set; }
+    public ObservableCollection<ulong>? TestUnsignedInt64Collection { get; set; }
 
-    public sbyte[] TestSignedByteCollection { get; set; }
+    public sbyte[]? TestSignedByteCollection { get; set; }
 
-    public ObservableCollection<int?> TestNullableInt32Collection
+    public ObservableCollection<int?>? TestNullableInt32Collection
     {
         get => _testNullableInt32CollectionX;
         set
@@ -68,10 +66,10 @@ public class JsonEntityAllTypes
         }
     }
 
-    public IList<JsonEnum> TestEnumCollection { get; set; }
-    public JsonEnum[] TestEnumWithIntConverterCollection { get; set; }
+    public IList<JsonEnum>? TestEnumCollection { get; set; }
+    public JsonEnum[]? TestEnumWithIntConverterCollection { get; set; }
 
-    public Collection<JsonEnum?> TestNullableEnumCollection
+    public Collection<JsonEnum?>? TestNullableEnumCollection
     {
         get => _testNullableEnumCollectionX;
         set
@@ -81,7 +79,7 @@ public class JsonEntityAllTypes
         }
     }
 
-    public Collection<JsonEnum?> TestNullableEnumWithIntConverterCollection
+    public Collection<JsonEnum?>? TestNullableEnumWithIntConverterCollection
     {
         get => _testNullableEnumWithIntConverterCollectionX;
         set
@@ -91,10 +89,10 @@ public class JsonEntityAllTypes
         }
     }
 
-    public ObservableCollection<int?[]> TestNullableInt32CollectionCollection { get; set; } = [[99]];
-    public ICollection<List<Collection<JsonEnum?>>> TestNullableEnumCollectionCollection { get; set; } = [];
-    public JsonEnum?[][][] TestNullableEnumWithIntConverterCollectionCollection { get; set; } = [[[JsonEnum.Three]]];
-    public JsonEnum?[] TestNullableEnumWithConverterThatHandlesNullsCollection { get; set; }
+    public ObservableCollection<int?[]?> TestNullableInt32CollectionCollection { get; set; } = [[99]];
+    public ICollection<List<Collection<JsonEnum?>?>?> TestNullableEnumCollectionCollection { get; set; } = [];
+    public JsonEnum?[]?[]?[] TestNullableEnumWithIntConverterCollectionCollection { get; set; } = [[[JsonEnum.Three]]];
+    public JsonEnum?[]? TestNullableEnumWithConverterThatHandlesNullsCollection { get; set; }
 
     [NotMapped]
     public bool NewCollectionSet { get; private set; }

--- a/test/EFCore.Specification.Tests/TestModels/JsonQuery/JsonEntityBasic.cs
+++ b/test/EFCore.Specification.Tests/TestModels/JsonQuery/JsonEntityBasic.cs
@@ -3,16 +3,14 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.JsonQuery;
 
-#nullable disable
-
 public class JsonEntityBasic
 {
     public int Id { get; set; }
-    public string Name { get; set; }
+    public string Name { get; set; } = null!;
 
-    public JsonOwnedRoot OwnedReferenceRoot { get; set; }
-    public List<JsonOwnedRoot> OwnedCollectionRoot { get; set; }
+    public JsonOwnedRoot OwnedReferenceRoot { get; set; } = null!;
+    public List<JsonOwnedRoot> OwnedCollectionRoot { get; set; } = null!;
 
-    public JsonEntityBasicForReference EntityReference { get; set; }
-    public List<JsonEntityBasicForCollection> EntityCollection { get; set; }
+    public JsonEntityBasicForReference EntityReference { get; set; } = null!;
+    public List<JsonEntityBasicForCollection> EntityCollection { get; set; } = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/JsonQuery/JsonEntityBasicForCollection.cs
+++ b/test/EFCore.Specification.Tests/TestModels/JsonQuery/JsonEntityBasicForCollection.cs
@@ -3,13 +3,11 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.JsonQuery;
 
-#nullable disable
-
 public class JsonEntityBasicForCollection
 {
     public int Id { get; init; }
-    public string Name { get; init; }
+    public string Name { get; init; } = null!;
 
     public int? ParentId { get; set; }
-    public JsonEntityBasic Parent { get; set; }
+    public JsonEntityBasic Parent { get; set; } = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/JsonQuery/JsonEntityBasicForReference.cs
+++ b/test/EFCore.Specification.Tests/TestModels/JsonQuery/JsonEntityBasicForReference.cs
@@ -6,16 +6,14 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.JsonQuery;
 
-#nullable disable
-
 public class JsonEntityBasicForReference
 {
     public int Id { get; private set; }
 
-    public string Name { get; private set; }
+    public string Name { get; private set; } = null!;
 
     public int? ParentId { get; set; }
-    public JsonEntityBasic Parent { get; set; }
+    public JsonEntityBasic Parent { get; set; } = null!;
 
     public void SetIdAndName(int id, string name)
     {

--- a/test/EFCore.Specification.Tests/TestModels/JsonQuery/JsonEntityConverters.cs
+++ b/test/EFCore.Specification.Tests/TestModels/JsonQuery/JsonEntityConverters.cs
@@ -3,10 +3,8 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.JsonQuery;
 
-#nullable disable
-
 public class JsonEntityConverters
 {
     public int Id { get; set; }
-    public JsonOwnedConverters Reference { get; set; }
+    public JsonOwnedConverters Reference { get; set; } = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/JsonQuery/JsonEntityCustomNaming.cs
+++ b/test/EFCore.Specification.Tests/TestModels/JsonQuery/JsonEntityCustomNaming.cs
@@ -5,17 +5,15 @@ using System.Text.Json.Serialization;
 
 namespace Microsoft.EntityFrameworkCore.TestModels.JsonQuery;
 
-#nullable disable
-
 public class JsonEntityCustomNaming
 {
     public int Id { get; set; }
 
-    public string Title { get; set; }
+    public string Title { get; set; } = null!;
 
     [JsonPropertyName("CustomOwnedReferenceRoot")]
-    public JsonOwnedCustomNameRoot OwnedReferenceRoot { get; set; }
+    public JsonOwnedCustomNameRoot OwnedReferenceRoot { get; set; } = null!;
 
     [JsonPropertyName("CustomOwnedCollectionRoot")]
-    public List<JsonOwnedCustomNameRoot> OwnedCollectionRoot { get; set; }
+    public List<JsonOwnedCustomNameRoot> OwnedCollectionRoot { get; set; } = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/JsonQuery/JsonEntityHasComplexChild.cs
+++ b/test/EFCore.Specification.Tests/TestModels/JsonQuery/JsonEntityHasComplexChild.cs
@@ -3,12 +3,10 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.JsonQuery;
 
-#nullable disable
-
 public class JsonEntityHasComplexChild
 {
     public int Id { get; set; }
-    public string Name { get; set; }
+    public string Name { get; set; } = null!;
 
-    public JsonEntityHasComplexChildForReference EntityReference { get; set; }
+    public JsonEntityHasComplexChildForReference EntityReference { get; set; } = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/JsonQuery/JsonEntityHasComplexChildForReference.cs
+++ b/test/EFCore.Specification.Tests/TestModels/JsonQuery/JsonEntityHasComplexChildForReference.cs
@@ -3,16 +3,14 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.JsonQuery;
 
-#nullable disable
-
 public class JsonEntityHasComplexChildForReference
 {
     public int Id { get; set; }
-    public string Name { get; set; }
+    public string Name { get; set; } = null!;
 
     // A is required for sorting
-    public AJsonEntityHasComplexChildForReferenceForReference AEntityReference { get; set; }
+    public AJsonEntityHasComplexChildForReferenceForReference AEntityReference { get; set; } = null!;
 
     public int? ParentId { get; set; }
-    public JsonEntityHasComplexChild Parent { get; set; }
+    public JsonEntityHasComplexChild Parent { get; set; } = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/JsonQuery/JsonEntityInheritanceBase.cs
+++ b/test/EFCore.Specification.Tests/TestModels/JsonQuery/JsonEntityInheritanceBase.cs
@@ -3,13 +3,11 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.JsonQuery;
 
-#nullable disable
-
 public class JsonEntityInheritanceBase
 {
     public int Id { get; set; }
-    public string Name { get; set; }
+    public string Name { get; set; } = null!;
 
-    public JsonOwnedBranch ReferenceOnBase { get; set; }
-    public List<JsonOwnedBranch> CollectionOnBase { get; set; }
+    public JsonOwnedBranch ReferenceOnBase { get; set; } = null!;
+    public List<JsonOwnedBranch> CollectionOnBase { get; set; } = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/JsonQuery/JsonEntityInheritanceDerived.cs
+++ b/test/EFCore.Specification.Tests/TestModels/JsonQuery/JsonEntityInheritanceDerived.cs
@@ -3,11 +3,9 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.JsonQuery;
 
-#nullable disable
-
 public class JsonEntityInheritanceDerived : JsonEntityInheritanceBase
 {
     public double Fraction { get; set; }
-    public JsonOwnedBranch ReferenceOnDerived { get; set; }
-    public List<JsonOwnedBranch> CollectionOnDerived { get; set; }
+    public JsonOwnedBranch ReferenceOnDerived { get; set; } = null!;
+    public List<JsonOwnedBranch> CollectionOnDerived { get; set; } = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/JsonQuery/JsonEntitySingleOwned.cs
+++ b/test/EFCore.Specification.Tests/TestModels/JsonQuery/JsonEntitySingleOwned.cs
@@ -3,12 +3,10 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.JsonQuery;
 
-#nullable disable
-
 public class JsonEntitySingleOwned
 {
     public int Id { get; set; }
-    public string Name { get; set; }
+    public string Name { get; set; } = null!;
 
-    public List<JsonOwnedLeaf> OwnedCollection { get; set; }
+    public List<JsonOwnedLeaf> OwnedCollection { get; set; } = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/JsonQuery/JsonEnum.cs
+++ b/test/EFCore.Specification.Tests/TestModels/JsonQuery/JsonEnum.cs
@@ -3,8 +3,6 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.JsonQuery;
 
-#nullable disable
-
 public enum JsonEnum
 {
     One = -1,

--- a/test/EFCore.Specification.Tests/TestModels/JsonQuery/JsonOwnedAllTypes.cs
+++ b/test/EFCore.Specification.Tests/TestModels/JsonQuery/JsonOwnedAllTypes.cs
@@ -6,21 +6,19 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace Microsoft.EntityFrameworkCore.TestModels.JsonQuery;
 
-#nullable disable
-
 public class JsonOwnedAllTypes
 {
     private List<long> _testInt64CollectionX = [];
     private IList<double> _testDoubleCollectionX = new List<double>();
     private List<float> _testSingleCollectionX = [1.1f, 1.2f];
     private IList<bool> _testBooleanCollectionX = new List<bool> { true };
-    private ObservableCollection<char> _testCharacterCollectionX = [];
-    private ObservableCollection<int?> _testNullableInt32CollectionX = [99];
-    private Collection<JsonEnum?> _testNullableEnumCollectionX = [];
-    private Collection<JsonEnum?> _testNullableEnumWithIntConverterCollectionX = [JsonEnum.Three];
+    private ObservableCollection<char>? _testCharacterCollectionX = [];
+    private ObservableCollection<int?>? _testNullableInt32CollectionX = [99];
+    private Collection<JsonEnum?>? _testNullableEnumCollectionX = [];
+    private Collection<JsonEnum?>? _testNullableEnumWithIntConverterCollectionX = [JsonEnum.Three];
 
-    public string TestDefaultString { get; set; }
-    public string TestMaxLengthString { get; set; }
+    public string TestDefaultString { get; set; } = null!;
+    public string TestMaxLengthString { get; set; } = null!;
     public short TestInt16 { get; set; }
     public int TestInt32 { get; set; }
     public long TestInt64 { get; set; }
@@ -34,7 +32,7 @@ public class JsonOwnedAllTypes
     public float TestSingle { get; set; }
     public bool TestBoolean { get; set; }
     public byte TestByte { get; set; }
-    public byte[] TestByteArray { get; set; }
+    public byte[]? TestByteArray { get; set; }
     public Guid TestGuid { get; set; }
     public ushort TestUnsignedInt16 { get; set; }
     public uint TestUnsignedInt32 { get; set; }
@@ -50,15 +48,15 @@ public class JsonOwnedAllTypes
     public JsonEnum? TestNullableEnumWithIntConverter { get; set; }
     public JsonEnum? TestNullableEnumWithConverterThatHandlesNulls { get; set; }
 
-    public List<List<long>> TestInt64CollectionCollection { get; set; } = [];
-    public List<double[]> TestDoubleCollectionCollection { get; set; } = [];
-    public List<float[]> TestSingleCollectionCollection { get; set; } = [( [1.1f, 1.2f])];
-    public bool[][] TestBooleanCollectionCollection { get; set; } = [];
-    public ObservableCollection<IReadOnlyCollection<char>> TestCharacterCollectionCollection { get; set; } = [];
+    public List<List<long>?> TestInt64CollectionCollection { get; set; } = [];
+    public List<double[]?> TestDoubleCollectionCollection { get; set; } = [];
+    public List<float[]?> TestSingleCollectionCollection { get; set; } = [( [1.1f, 1.2f])];
+    public bool[]?[] TestBooleanCollectionCollection { get; set; } = [];
+    public ObservableCollection<IReadOnlyCollection<char>?> TestCharacterCollectionCollection { get; set; } = [];
 
-    public string[] TestDefaultStringCollection { get; set; }
-    public ReadOnlyCollection<string> TestMaxLengthStringCollection { get; set; }
-    public IReadOnlyList<short> TestInt16Collection { get; set; }
+    public string[] TestDefaultStringCollection { get; set; } = null!;
+    public ReadOnlyCollection<string> TestMaxLengthStringCollection { get; set; } = null!;
+    public IReadOnlyList<short> TestInt16Collection { get; set; } = null!;
 
     public int[] TestInt32Collection { get; set; } = [];
 
@@ -82,22 +80,22 @@ public class JsonOwnedAllTypes
         }
     }
 
-    public decimal[] TestDecimalCollection { get; set; }
-    public List<DateTime> TestDateTimeCollection { get; set; }
-    public IList<DateTimeOffset> TestDateTimeOffsetCollection { get; set; }
+    public decimal[] TestDecimalCollection { get; set; } = null!;
+    public List<DateTime> TestDateTimeCollection { get; set; } = null!;
+    public IList<DateTimeOffset> TestDateTimeOffsetCollection { get; set; } = null!;
     public TimeSpan[] TestTimeSpanCollection { get; set; } = [new(1, 1, 1)];
-    public DateOnly[] TestDateOnlyCollection { get; set; }
-    public TimeOnly[] TestTimeOnlyCollection { get; set; }
+    public DateOnly[] TestDateOnlyCollection { get; set; } = null!;
+    public TimeOnly[] TestTimeOnlyCollection { get; set; } = null!;
 
-    public string[][] TestDefaultStringCollectionCollection { get; init; }
-    public List<ReadOnlyCollection<string>> TestMaxLengthStringCollectionCollection { get; init; }
-    public IList<IReadOnlyList<short>> TestInt16CollectionCollection { get; set; }
+    public string?[]?[] TestDefaultStringCollectionCollection { get; init; } = null!;
+    public List<ReadOnlyCollection<string?>?> TestMaxLengthStringCollectionCollection { get; init; } = null!;
+    public IList<IReadOnlyList<short>?> TestInt16CollectionCollection { get; set; } = null!;
 
-    public int[][] TestInt32CollectionCollection { get; set; } = [];
+    public int[]?[] TestInt32CollectionCollection { get; set; } = [];
 
-    public ObservableCollection<int?[]> TestNullableInt32CollectionCollection { get; set; } = [[99]];
-    public ICollection<List<Collection<JsonEnum?>>> TestNullableEnumCollectionCollection { get; set; } = [];
-    public JsonEnum?[][][] TestNullableEnumWithIntConverterCollectionCollection { get; set; } = [[[JsonEnum.Three]]];
+    public ObservableCollection<int?[]?> TestNullableInt32CollectionCollection { get; set; } = [[99]];
+    public ICollection<List<Collection<JsonEnum?>?>?> TestNullableEnumCollectionCollection { get; set; } = [];
+    public JsonEnum?[]?[]?[] TestNullableEnumWithIntConverterCollectionCollection { get; set; } = [[[JsonEnum.Three]]];
 
     public List<float> TestSingleCollection
     {
@@ -119,13 +117,13 @@ public class JsonOwnedAllTypes
         }
     }
 
-    public byte[] TestByteCollection { get; set; }
-    public List<Guid> TestGuidCollection { get; set; }
-    public IList<ushort> TestUnsignedInt16Collection { get; set; }
-    public uint[] TestUnsignedInt32Collection { get; set; }
-    public ObservableCollection<ulong> TestUnsignedInt64Collection { get; set; }
+    public byte[]? TestByteCollection { get; set; }
+    public List<Guid> TestGuidCollection { get; set; } = null!;
+    public IList<ushort> TestUnsignedInt16Collection { get; set; } = null!;
+    public uint[] TestUnsignedInt32Collection { get; set; } = null!;
+    public ObservableCollection<ulong> TestUnsignedInt64Collection { get; set; } = null!;
 
-    public ObservableCollection<char> TestCharacterCollection
+    public ObservableCollection<char>? TestCharacterCollection
     {
         get => _testCharacterCollectionX;
         set
@@ -135,9 +133,9 @@ public class JsonOwnedAllTypes
         }
     }
 
-    public sbyte[] TestSignedByteCollection { get; set; }
+    public sbyte[] TestSignedByteCollection { get; set; } = null!;
 
-    public ObservableCollection<int?> TestNullableInt32Collection
+    public ObservableCollection<int?>? TestNullableInt32Collection
     {
         get => _testNullableInt32CollectionX;
         set
@@ -147,10 +145,10 @@ public class JsonOwnedAllTypes
         }
     }
 
-    public IList<JsonEnum> TestEnumCollection { get; set; }
-    public JsonEnum[] TestEnumWithIntConverterCollection { get; set; }
+    public IList<JsonEnum> TestEnumCollection { get; set; } = null!;
+    public JsonEnum[] TestEnumWithIntConverterCollection { get; set; } = null!;
 
-    public Collection<JsonEnum?> TestNullableEnumCollection
+    public Collection<JsonEnum?>? TestNullableEnumCollection
     {
         get => _testNullableEnumCollectionX;
         set
@@ -160,7 +158,7 @@ public class JsonOwnedAllTypes
         }
     }
 
-    public Collection<JsonEnum?> TestNullableEnumWithIntConverterCollection
+    public Collection<JsonEnum?>? TestNullableEnumWithIntConverterCollection
     {
         get => _testNullableEnumWithIntConverterCollectionX;
         set
@@ -170,7 +168,7 @@ public class JsonOwnedAllTypes
         }
     }
 
-    public JsonEnum?[] TestNullableEnumWithConverterThatHandlesNullsCollection { get; set; }
+    public JsonEnum?[]? TestNullableEnumWithConverterThatHandlesNullsCollection { get; set; }
 
     [NotMapped]
     public bool NewCollectionSet { get; private set; }

--- a/test/EFCore.Specification.Tests/TestModels/JsonQuery/JsonOwnedBranch.cs
+++ b/test/EFCore.Specification.Tests/TestModels/JsonQuery/JsonOwnedBranch.cs
@@ -3,8 +3,6 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.JsonQuery;
 
-#nullable disable
-
 public class JsonOwnedBranch
 {
     public int Id { get; set; }
@@ -13,9 +11,9 @@ public class JsonOwnedBranch
 
     public JsonEnum Enum { get; set; }
     public JsonEnum? NullableEnum { get; init; }
-    public JsonEnum[] Enums { get; init; }
-    public JsonEnum?[] NullableEnums { get; init; }
+    public JsonEnum[]? Enums { get; init; }
+    public JsonEnum?[]? NullableEnums { get; init; }
 
-    public JsonOwnedLeaf OwnedReferenceLeaf { get; set; }
-    public List<JsonOwnedLeaf> OwnedCollectionLeaf { get; set; }
+    public JsonOwnedLeaf OwnedReferenceLeaf { get; set; } = null!;
+    public List<JsonOwnedLeaf> OwnedCollectionLeaf { get; set; } = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/JsonQuery/JsonOwnedConverters.cs
+++ b/test/EFCore.Specification.Tests/TestModels/JsonQuery/JsonOwnedConverters.cs
@@ -3,14 +3,12 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.JsonQuery;
 
-#nullable disable
-
 public class JsonOwnedConverters
 {
     public bool BoolConvertedToIntZeroOne { get; set; }
     public bool BoolConvertedToStringTrueFalse { get; set; }
     public bool BoolConvertedToStringYN { get; set; }
     public int IntZeroOneConvertedToBool { get; set; }
-    public string StringTrueFalseConvertedToBool { get; set; }
-    public string StringYNConvertedToBool { get; set; }
+    public string StringTrueFalseConvertedToBool { get; set; } = null!;
+    public string StringYNConvertedToBool { get; set; } = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/JsonQuery/JsonOwnedCustomNameBranch.cs
+++ b/test/EFCore.Specification.Tests/TestModels/JsonQuery/JsonOwnedCustomNameBranch.cs
@@ -5,8 +5,6 @@ using System.Text.Json.Serialization;
 
 namespace Microsoft.EntityFrameworkCore.TestModels.JsonQuery;
 
-#nullable disable
-
 public class JsonOwnedCustomNameBranch
 {
     [JsonPropertyName("CustomDate")]

--- a/test/EFCore.Specification.Tests/TestModels/JsonQuery/JsonOwnedCustomNameRoot.cs
+++ b/test/EFCore.Specification.Tests/TestModels/JsonQuery/JsonOwnedCustomNameRoot.cs
@@ -5,12 +5,10 @@ using System.Text.Json.Serialization;
 
 namespace Microsoft.EntityFrameworkCore.TestModels.JsonQuery;
 
-#nullable disable
-
 public class JsonOwnedCustomNameRoot
 {
     [JsonPropertyName("CustomName")]
-    public string Name { get; set; }
+    public string Name { get; set; } = null!;
 
     public int Number { get; set; }
 
@@ -18,8 +16,8 @@ public class JsonOwnedCustomNameRoot
     public JsonEnum Enum { get; set; }
 
     [JsonPropertyName("Custom#OwnedReferenceBranch`-=[]\\;',./~!@#$%^&*()_+{}|:\"<>?独角兽π獨角獸")]
-    public JsonOwnedCustomNameBranch OwnedReferenceBranch { get; set; }
+    public JsonOwnedCustomNameBranch? OwnedReferenceBranch { get; set; }
 
     [JsonPropertyName("CustomOwnedCollectionBranch")]
-    public List<JsonOwnedCustomNameBranch> OwnedCollectionBranch { get; set; }
+    public List<JsonOwnedCustomNameBranch> OwnedCollectionBranch { get; set; } = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/JsonQuery/JsonOwnedLeaf.cs
+++ b/test/EFCore.Specification.Tests/TestModels/JsonQuery/JsonOwnedLeaf.cs
@@ -3,11 +3,9 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.JsonQuery;
 
-#nullable disable
-
 public class JsonOwnedLeaf
 {
-    public string SomethingSomething { get; set; }
+    public string? SomethingSomething { get; set; }
 
-    public JsonOwnedBranch Parent { get; set; }
+    public JsonOwnedBranch Parent { get; set; } = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/JsonQuery/JsonOwnedRoot.cs
+++ b/test/EFCore.Specification.Tests/TestModels/JsonQuery/JsonOwnedRoot.cs
@@ -3,18 +3,16 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.JsonQuery;
 
-#nullable disable
-
 public class JsonOwnedRoot
 {
     public int Id { get; set; }
-    public string Name { get; set; }
+    public string Name { get; set; } = null!;
     public int Number { get; set; }
-    public string[] Names { get; set; }
-    public int[] Numbers { get; set; }
+    public string[]? Names { get; set; }
+    public int[]? Numbers { get; set; }
 
-    public JsonOwnedBranch OwnedReferenceBranch { get; set; }
-    public List<JsonOwnedBranch> OwnedCollectionBranch { get; set; }
+    public JsonOwnedBranch? OwnedReferenceBranch { get; set; }
+    public List<JsonOwnedBranch> OwnedCollectionBranch { get; set; } = null!;
 
-    public JsonEntityBasic Owner { get; set; }
+    public JsonEntityBasic Owner { get; set; } = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/JsonQuery/JsonQueryContext.cs
+++ b/test/EFCore.Specification.Tests/TestModels/JsonQuery/JsonQueryContext.cs
@@ -3,19 +3,17 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.JsonQuery;
 
-#nullable disable
-
 public class JsonQueryContext(DbContextOptions options) : DbContext(options)
 {
-    public DbSet<EntityBasic> EntitiesBasic { get; set; }
-    public DbSet<JsonEntityBasic> JsonEntitiesBasic { get; set; }
-    public DbSet<JsonEntityBasicForReference> JsonEntitiesBasicForReference { get; set; }
-    public DbSet<JsonEntityBasicForCollection> JsonEntitiesBasicForCollection { get; set; }
-    public DbSet<JsonEntityCustomNaming> JsonEntitiesCustomNaming { get; set; }
-    public DbSet<JsonEntitySingleOwned> JsonEntitiesSingleOwned { get; set; }
-    public DbSet<JsonEntityInheritanceBase> JsonEntitiesInheritance { get; set; }
-    public DbSet<JsonEntityAllTypes> JsonEntitiesAllTypes { get; set; }
-    public DbSet<JsonEntityConverters> JsonEntitiesConverters { get; set; }
+    public DbSet<EntityBasic> EntitiesBasic { get; set; } = null!;
+    public DbSet<JsonEntityBasic> JsonEntitiesBasic { get; set; } = null!;
+    public DbSet<JsonEntityBasicForReference> JsonEntitiesBasicForReference { get; set; } = null!;
+    public DbSet<JsonEntityBasicForCollection> JsonEntitiesBasicForCollection { get; set; } = null!;
+    public DbSet<JsonEntityCustomNaming> JsonEntitiesCustomNaming { get; set; } = null!;
+    public DbSet<JsonEntitySingleOwned> JsonEntitiesSingleOwned { get; set; } = null!;
+    public DbSet<JsonEntityInheritanceBase> JsonEntitiesInheritance { get; set; } = null!;
+    public DbSet<JsonEntityAllTypes> JsonEntitiesAllTypes { get; set; } = null!;
+    public DbSet<JsonEntityConverters> JsonEntitiesConverters { get; set; } = null!;
 
     public static Task SeedAsync(JsonQueryContext context)
     {

--- a/test/EFCore.Specification.Tests/TestModels/JsonQuery/JsonQueryData.cs
+++ b/test/EFCore.Specification.Tests/TestModels/JsonQuery/JsonQueryData.cs
@@ -5,8 +5,6 @@ using System.Collections.ObjectModel;
 
 namespace Microsoft.EntityFrameworkCore.TestModels.JsonQuery;
 
-#nullable disable
-
 public class JsonQueryData : ISetSource
 {
     public JsonQueryData()
@@ -826,7 +824,7 @@ public class JsonQueryData : ISetSource
             TestNullableEnumWithConverterThatHandlesNullsCollection = [JsonEnum.One, null, (JsonEnum)(-7)],
             TestDefaultStringCollectionCollection = [["S11", "S12", "S13"], null, ["S21", null, "S23"]],
             TestMaxLengthStringCollectionCollection =
-                [new ReadOnlyCollection<string>(["S11", "S12", "S13"]), null, new ReadOnlyCollection<string>(["S21", null, "S23"])],
+                [new ReadOnlyCollection<string?>(["S11", "S12", "S13"]), null, new ReadOnlyCollection<string?>(["S21", null, "S23"])],
             TestBooleanCollectionCollection = [[true], null, [true, false]],
             TestCharacterCollectionCollection = [['A', 'B', 'C'], null, ['D', 'E', 'F']],
             TestDoubleCollectionCollection = [[-1.23456789, -1.23456789], null, [1.23456789]],
@@ -950,7 +948,7 @@ public class JsonQueryData : ISetSource
             TestNullableEnumWithConverterThatHandlesNullsCollection = [JsonEnum.One, null, (JsonEnum)(-7)],
             TestDefaultStringCollectionCollection = [["S11", "S12", "S13"], null, ["S21", null, "S23"]],
             TestMaxLengthStringCollectionCollection =
-                [new ReadOnlyCollection<string>(["S11", "S12", "S13"]), null, new ReadOnlyCollection<string>(["S21", null, "S23"])],
+                [new ReadOnlyCollection<string?>(["S11", "S12", "S13"]), null, new ReadOnlyCollection<string?>(["S21", null, "S23"])],
             TestBooleanCollectionCollection = [[true], null, [true, false]],
             TestCharacterCollectionCollection = [['A', 'B', 'C'], null, ['D', 'E', 'F']],
             TestDoubleCollectionCollection = [[-1.23456789, -1.23456789], null, [1.23456789]],
@@ -1076,7 +1074,7 @@ public class JsonQueryData : ISetSource
             TestNullableEnumWithConverterThatHandlesNullsCollection = [JsonEnum.One, null, (JsonEnum)(-7)],
             TestDefaultStringCollectionCollection = [["S11", "S12", "S13"], null, ["S21", null, "S23"]],
             TestMaxLengthStringCollectionCollection =
-                [new ReadOnlyCollection<string>(["S11", "S12", "S13"]), null, new ReadOnlyCollection<string>(["S21", null, "S23"])],
+                [new ReadOnlyCollection<string?>(["S11", "S12", "S13"]), null, new ReadOnlyCollection<string?>(["S21", null, "S23"])],
             TestBooleanCollectionCollection = [[true], null, [true, false]],
             TestCharacterCollectionCollection = [['A', 'B', 'C'], null, ['D', 'E', 'F']],
             TestDoubleCollectionCollection = [[-1.23456789, -1.23456789], null, [1.23456789]],
@@ -1200,7 +1198,7 @@ public class JsonQueryData : ISetSource
             TestNullableEnumWithConverterThatHandlesNullsCollection = [JsonEnum.One, null, (JsonEnum)(-7)],
             TestDefaultStringCollectionCollection = [["S11", "S12", "S13"], null, ["S21", null, "S23"]],
             TestMaxLengthStringCollectionCollection =
-                [new ReadOnlyCollection<string>(["S11", "S12", "S13"]), null, new ReadOnlyCollection<string>(["S21", null, "S23"])],
+                [new ReadOnlyCollection<string?>(["S11", "S12", "S13"]), null, new ReadOnlyCollection<string?>(["S21", null, "S23"])],
             TestBooleanCollectionCollection = [[true], null, [true, false]],
             TestCharacterCollectionCollection = [['A', 'B', 'C'], null, ['D', 'E', 'F']],
             TestDoubleCollectionCollection = [[-1.23456789, -1.23456789], null, [1.23456789]],

--- a/test/EFCore.Specification.Tests/TestModels/ManyToManyFieldsModel/EntityBranch.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ManyToManyFieldsModel/EntityBranch.cs
@@ -3,11 +3,9 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ManyToManyFieldsModel;
 
-#nullable disable
-
 public class EntityBranch : EntityRoot
 {
     public long Number;
-    public ICollection<EntityOne> OneSkip;
-    public ICollection<EntityRoot> RootSkipShared;
+    public ICollection<EntityOne> OneSkip = null!;
+    public ICollection<EntityRoot> RootSkipShared = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/ManyToManyFieldsModel/EntityCompositeKey.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ManyToManyFieldsModel/EntityCompositeKey.cs
@@ -3,20 +3,18 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ManyToManyFieldsModel;
 
-#nullable disable
-
 public class EntityCompositeKey
 {
     public int Key1;
-    public string Key2;
+    public string Key2 = null!;
     public DateTime Key3;
 
-    public string Name;
+    public string? Name;
 
-    public ICollection<EntityTwo> TwoSkipShared;
-    public ICollection<EntityThree> ThreeSkipFull;
-    public ICollection<JoinThreeToCompositeKeyFull> JoinThreeFull;
-    public ICollection<EntityRoot> RootSkipShared;
-    public ICollection<EntityLeaf> LeafSkipFull;
-    public ICollection<JoinCompositeKeyToLeaf> JoinLeafFull;
+    public ICollection<EntityTwo> TwoSkipShared = null!;
+    public ICollection<EntityThree> ThreeSkipFull = null!;
+    public ICollection<JoinThreeToCompositeKeyFull> JoinThreeFull = null!;
+    public ICollection<EntityRoot> RootSkipShared = null!;
+    public ICollection<EntityLeaf> LeafSkipFull = null!;
+    public ICollection<JoinCompositeKeyToLeaf> JoinLeafFull = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/ManyToManyFieldsModel/EntityLeaf.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ManyToManyFieldsModel/EntityLeaf.cs
@@ -3,12 +3,10 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ManyToManyFieldsModel;
 
-#nullable disable
-
 public class EntityLeaf : EntityBranch
 {
     public bool? IsGreen;
 
-    public ICollection<EntityCompositeKey> CompositeKeySkipFull;
-    public ICollection<JoinCompositeKeyToLeaf> JoinCompositeKeyFull;
+    public ICollection<EntityCompositeKey> CompositeKeySkipFull = null!;
+    public ICollection<JoinCompositeKeyToLeaf> JoinCompositeKeyFull = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/ManyToManyFieldsModel/EntityOne.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ManyToManyFieldsModel/EntityOne.cs
@@ -3,24 +3,22 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ManyToManyFieldsModel;
 
-#nullable disable
-
 public class EntityOne
 {
     public int Id;
-    public string Name;
+    public string? Name;
 
-    public EntityTwo Reference;
-    public ICollection<EntityTwo> Collection;
-    public ICollection<EntityTwo> TwoSkip;
-    public ICollection<EntityThree> ThreeSkipPayloadFull;
-    public ICollection<JoinOneToThreePayloadFull> JoinThreePayloadFull;
-    public ICollection<EntityTwo> TwoSkipShared;
-    public ICollection<EntityThree> ThreeSkipPayloadFullShared;
-    public ICollection<Dictionary<string, object>> JoinThreePayloadFullShared;
-    public ICollection<EntityOne> SelfSkipPayloadLeft;
-    public ICollection<JoinOneSelfPayload> JoinSelfPayloadLeft;
-    public ICollection<EntityOne> SelfSkipPayloadRight;
-    public ICollection<JoinOneSelfPayload> JoinSelfPayloadRight;
-    public ICollection<EntityBranch> BranchSkip;
+    public EntityTwo Reference = null!;
+    public ICollection<EntityTwo> Collection = null!;
+    public ICollection<EntityTwo> TwoSkip = null!;
+    public ICollection<EntityThree> ThreeSkipPayloadFull = null!;
+    public ICollection<JoinOneToThreePayloadFull> JoinThreePayloadFull = null!;
+    public ICollection<EntityTwo> TwoSkipShared = null!;
+    public ICollection<EntityThree> ThreeSkipPayloadFullShared = null!;
+    public ICollection<Dictionary<string, object>> JoinThreePayloadFullShared = null!;
+    public ICollection<EntityOne> SelfSkipPayloadLeft = null!;
+    public ICollection<JoinOneSelfPayload> JoinSelfPayloadLeft = null!;
+    public ICollection<EntityOne> SelfSkipPayloadRight = null!;
+    public ICollection<JoinOneSelfPayload> JoinSelfPayloadRight = null!;
+    public ICollection<EntityBranch> BranchSkip = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/ManyToManyFieldsModel/EntityRoot.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ManyToManyFieldsModel/EntityRoot.cs
@@ -3,13 +3,11 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ManyToManyFieldsModel;
 
-#nullable disable
-
 public class EntityRoot
 {
     public int Id;
-    public string Name;
-    public ICollection<EntityThree> ThreeSkipShared;
-    public ICollection<EntityCompositeKey> CompositeKeySkipShared;
-    public ICollection<EntityBranch> BranchSkipShared;
+    public string? Name;
+    public ICollection<EntityThree> ThreeSkipShared = null!;
+    public ICollection<EntityCompositeKey> CompositeKeySkipShared = null!;
+    public ICollection<EntityBranch> BranchSkipShared = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/ManyToManyFieldsModel/EntityThree.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ManyToManyFieldsModel/EntityThree.cs
@@ -3,26 +3,24 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ManyToManyFieldsModel;
 
-#nullable disable
-
 public class EntityThree
 {
     public int Id;
-    public string Name;
+    public string? Name;
 
     public int? ReferenceInverseId;
-    public EntityTwo ReferenceInverse;
+    public EntityTwo? ReferenceInverse;
 
     public int? CollectionInverseId;
-    public EntityTwo CollectionInverse;
+    public EntityTwo? CollectionInverse;
 
-    public ICollection<EntityOne> OneSkipPayloadFull;
-    public ICollection<JoinOneToThreePayloadFull> JoinOnePayloadFull;
-    public ICollection<EntityTwo> TwoSkipFull;
-    public ICollection<JoinTwoToThree> JoinTwoFull;
-    public ICollection<EntityOne> OneSkipPayloadFullShared;
-    public ICollection<Dictionary<string, object>> JoinOnePayloadFullShared;
-    public ICollection<EntityCompositeKey> CompositeKeySkipFull;
-    public ICollection<JoinThreeToCompositeKeyFull> JoinCompositeKeyFull;
-    public ICollection<EntityRoot> RootSkipShared;
+    public ICollection<EntityOne> OneSkipPayloadFull = null!;
+    public ICollection<JoinOneToThreePayloadFull> JoinOnePayloadFull = null!;
+    public ICollection<EntityTwo> TwoSkipFull = null!;
+    public ICollection<JoinTwoToThree> JoinTwoFull = null!;
+    public ICollection<EntityOne> OneSkipPayloadFullShared = null!;
+    public ICollection<Dictionary<string, object>> JoinOnePayloadFullShared = null!;
+    public ICollection<EntityCompositeKey> CompositeKeySkipFull = null!;
+    public ICollection<JoinThreeToCompositeKeyFull> JoinCompositeKeyFull = null!;
+    public ICollection<EntityRoot> RootSkipShared = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/ManyToManyFieldsModel/EntityTwo.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ManyToManyFieldsModel/EntityTwo.cs
@@ -5,29 +5,27 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ManyToManyFieldsModel;
 
-#nullable disable
-
 public class EntityTwo
 {
     public int Id;
-    public string Name;
+    public string? Name;
 
     public int? ReferenceInverseId;
-    public EntityOne ReferenceInverse;
+    public EntityOne? ReferenceInverse;
 
     public int? CollectionInverseId;
-    public EntityOne CollectionInverse;
+    public EntityOne? CollectionInverse;
 
-    public EntityThree Reference;
-    public ICollection<EntityThree> Collection;
-    public ICollection<EntityOne> OneSkip;
-    public ICollection<EntityThree> ThreeSkipFull;
-    public ICollection<JoinTwoToThree> JoinThreeFull;
-    public ICollection<EntityTwo> SelfSkipSharedLeft;
-    public ICollection<EntityTwo> SelfSkipSharedRight;
+    public EntityThree Reference = null!;
+    public ICollection<EntityThree> Collection = null!;
+    public ICollection<EntityOne> OneSkip = null!;
+    public ICollection<EntityThree> ThreeSkipFull = null!;
+    public ICollection<JoinTwoToThree> JoinThreeFull = null!;
+    public ICollection<EntityTwo> SelfSkipSharedLeft = null!;
+    public ICollection<EntityTwo> SelfSkipSharedRight = null!;
 
     [InverseProperty("TwoSkipShared")]
-    public ICollection<EntityOne> OneSkipShared;
+    public ICollection<EntityOne> OneSkipShared = null!;
 
-    public ICollection<EntityCompositeKey> CompositeKeySkipShared;
+    public ICollection<EntityCompositeKey> CompositeKeySkipShared = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/ManyToManyFieldsModel/GeneratedKeysLeft.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ManyToManyFieldsModel/GeneratedKeysLeft.cs
@@ -5,12 +5,10 @@ using System.Collections.ObjectModel;
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ManyToManyFieldsModel;
 
-#nullable disable
-
 public class GeneratedKeysLeft
 {
     public int Id;
-    public string Name;
+    public string? Name;
 
     public ICollection<GeneratedKeysRight> Rights = new ObservableCollection<GeneratedKeysRight>();
 }

--- a/test/EFCore.Specification.Tests/TestModels/ManyToManyFieldsModel/GeneratedKeysRight.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ManyToManyFieldsModel/GeneratedKeysRight.cs
@@ -5,12 +5,10 @@ using System.Collections.ObjectModel;
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ManyToManyFieldsModel;
 
-#nullable disable
-
 public class GeneratedKeysRight
 {
     public int Id;
-    public string Name;
+    public string? Name;
 
     public ICollection<GeneratedKeysLeft> Lefts = new ObservableCollection<GeneratedKeysLeft>();
 }

--- a/test/EFCore.Specification.Tests/TestModels/ManyToManyFieldsModel/ImplicitManyToManyA.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ManyToManyFieldsModel/ImplicitManyToManyA.cs
@@ -5,12 +5,10 @@ using System.Collections.ObjectModel;
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ManyToManyFieldsModel;
 
-#nullable disable
-
 public class ImplicitManyToManyA
 {
     public int Id;
-    public string Name;
+    public string? Name;
 
     public ICollection<ImplicitManyToManyB> Bs = new ObservableCollection<ImplicitManyToManyB>();
 }

--- a/test/EFCore.Specification.Tests/TestModels/ManyToManyFieldsModel/ImplicitManyToManyB.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ManyToManyFieldsModel/ImplicitManyToManyB.cs
@@ -5,12 +5,10 @@ using System.Collections.ObjectModel;
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ManyToManyFieldsModel;
 
-#nullable disable
-
 public class ImplicitManyToManyB
 {
     public int Id;
-    public string Name;
+    public string? Name;
 
     public ICollection<ImplicitManyToManyA> As = new ObservableCollection<ImplicitManyToManyA>();
 }

--- a/test/EFCore.Specification.Tests/TestModels/ManyToManyFieldsModel/JoinCompositeKeyToLeaf.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ManyToManyFieldsModel/JoinCompositeKeyToLeaf.cs
@@ -3,15 +3,13 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ManyToManyFieldsModel;
 
-#nullable disable
-
 public class JoinCompositeKeyToLeaf
 {
     public int CompositeId1;
-    public string CompositeId2;
+    public string CompositeId2 = null!;
     public DateTime CompositeId3;
     public int LeafId;
 
-    public EntityCompositeKey Composite;
-    public EntityLeaf Leaf;
+    public EntityCompositeKey Composite = null!;
+    public EntityLeaf Leaf = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/ManyToManyFieldsModel/JoinOneSelfPayload.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ManyToManyFieldsModel/JoinOneSelfPayload.cs
@@ -3,13 +3,11 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ManyToManyFieldsModel;
 
-#nullable disable
-
 public class JoinOneSelfPayload
 {
     public int LeftId;
     public int RightId;
     public DateTime Payload;
-    public EntityOne Right;
-    public EntityOne Left;
+    public EntityOne Right = null!;
+    public EntityOne Left = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/ManyToManyFieldsModel/JoinOneToThreePayloadFull.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ManyToManyFieldsModel/JoinOneToThreePayloadFull.cs
@@ -3,14 +3,12 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ManyToManyFieldsModel;
 
-#nullable disable
-
 public class JoinOneToThreePayloadFull
 {
     public int OneId;
     public int ThreeId;
-    public EntityOne One;
-    public EntityThree Three;
+    public EntityOne One = null!;
+    public EntityThree Three = null!;
 
-    public string Payload;
+    public string? Payload;
 }

--- a/test/EFCore.Specification.Tests/TestModels/ManyToManyFieldsModel/JoinThreeToCompositeKeyFull.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ManyToManyFieldsModel/JoinThreeToCompositeKeyFull.cs
@@ -3,16 +3,14 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ManyToManyFieldsModel;
 
-#nullable disable
-
 public class JoinThreeToCompositeKeyFull
 {
     public Guid Id;
     public int ThreeId;
     public int CompositeId1;
-    public string CompositeId2;
+    public string CompositeId2 = null!;
     public DateTime CompositeId3;
 
-    public EntityThree Three;
-    public EntityCompositeKey Composite;
+    public EntityThree Three = null!;
+    public EntityCompositeKey Composite = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/ManyToManyFieldsModel/JoinTwoToThree.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ManyToManyFieldsModel/JoinTwoToThree.cs
@@ -3,12 +3,10 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ManyToManyFieldsModel;
 
-#nullable disable
-
 public class JoinTwoToThree
 {
     public int TwoId;
     public int ThreeId;
-    public EntityTwo Two;
-    public EntityThree Three;
+    public EntityTwo Two = null!;
+    public EntityThree Three = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/ManyToManyFieldsModel/ManyToManyContext.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ManyToManyFieldsModel/ManyToManyContext.cs
@@ -5,24 +5,22 @@ using Microsoft.EntityFrameworkCore.Proxies.Internal;
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ManyToManyFieldsModel;
 
-#nullable disable
-
 public class ManyToManyContext(DbContextOptions options) : PoolableDbContext(options)
 {
-    public DbSet<EntityOne> EntityOnes { get; set; }
-    public DbSet<EntityTwo> EntityTwos { get; set; }
-    public DbSet<EntityThree> EntityThrees { get; set; }
-    public DbSet<EntityCompositeKey> EntityCompositeKeys { get; set; }
-    public DbSet<EntityRoot> EntityRoots { get; set; }
-    public DbSet<ImplicitManyToManyA> ImplicitManyToManyAs { get; set; }
-    public DbSet<ImplicitManyToManyB> ImplicitManyToManyBs { get; set; }
-    public DbSet<GeneratedKeysLeft> GeneratedKeysLefts { get; set; }
-    public DbSet<GeneratedKeysRight> GeneratedKeysRights { get; set; }
+    public DbSet<EntityOne> EntityOnes { get; set; } = null!;
+    public DbSet<EntityTwo> EntityTwos { get; set; } = null!;
+    public DbSet<EntityThree> EntityThrees { get; set; } = null!;
+    public DbSet<EntityCompositeKey> EntityCompositeKeys { get; set; } = null!;
+    public DbSet<EntityRoot> EntityRoots { get; set; } = null!;
+    public DbSet<ImplicitManyToManyA> ImplicitManyToManyAs { get; set; } = null!;
+    public DbSet<ImplicitManyToManyB> ImplicitManyToManyBs { get; set; } = null!;
+    public DbSet<GeneratedKeysLeft> GeneratedKeysLefts { get; set; } = null!;
+    public DbSet<GeneratedKeysRight> GeneratedKeysRights { get; set; } = null!;
 }
 
 public static class ManyToManyContextExtensions
 {
-    public static TEntity CreateInstance<TEntity>(this DbSet<TEntity> set, Action<TEntity, bool> configureEntity = null)
+    public static TEntity CreateInstance<TEntity>(this DbSet<TEntity> set, Action<TEntity, bool>? configureEntity = null)
         where TEntity : class, new()
     {
         var isProxy = set.GetService<IDbContextOptions>().FindExtension<ProxiesOptionsExtension>()?.UseChangeTrackingProxies == true;

--- a/test/EFCore.Specification.Tests/TestModels/ManyToManyFieldsModel/ManyToManyData.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ManyToManyFieldsModel/ManyToManyData.cs
@@ -5,8 +5,6 @@ using System.Collections.ObjectModel;
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ManyToManyFieldsModel;
 
-#nullable disable
-
 public class ManyToManyData : ISetSource
 {
     private readonly bool _useGeneratedKeys;
@@ -157,8 +155,8 @@ public class ManyToManyData : ISetSource
         ManyToManyContext context,
         int id,
         string name,
-        EntityOne referenceInverse,
-        EntityOne collectionInverse)
+        EntityOne? referenceInverse,
+        EntityOne? collectionInverse)
         => CreateInstance(
             context?.EntityTwos, (e, p) =>
             {
@@ -205,8 +203,8 @@ public class ManyToManyData : ISetSource
         ManyToManyContext context,
         int id,
         string name,
-        EntityTwo referenceInverse,
-        EntityTwo collectionInverse)
+        EntityTwo? referenceInverse,
+        EntityTwo? collectionInverse)
         => CreateInstance(
             context?.EntityThrees, (e, p) =>
             {
@@ -1253,7 +1251,7 @@ public class ManyToManyData : ISetSource
                 e["CompositeKeySkipSharedKey3"] = composite.Key3;
             });
 
-    private static TEntity CreateInstance<TEntity>(DbSet<TEntity> set, Action<TEntity, bool> configureEntity)
+    private static TEntity CreateInstance<TEntity>(DbSet<TEntity>? set, Action<TEntity, bool> configureEntity)
         where TEntity : class, new()
     {
         if (set != null)

--- a/test/EFCore.Specification.Tests/TestModels/ManyToManyFieldsModel/ProxyableSharedType.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ManyToManyFieldsModel/ProxyableSharedType.cs
@@ -3,15 +3,13 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ManyToManyFieldsModel;
 
-#nullable disable
-
 public class ProxyableSharedType
 {
     private readonly Dictionary<string, object> _keyValueStore = [];
 
-    public virtual object this[string key]
+    public virtual object? this[string key]
     {
         get => _keyValueStore.TryGetValue(key, out var value) ? value : default;
-        set => _keyValueStore[key] = value;
+        set => _keyValueStore[key] = value!;
     }
 }

--- a/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/EntityBranch.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/EntityBranch.cs
@@ -3,11 +3,9 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ManyToManyModel;
 
-#nullable disable
-
 public class EntityBranch : EntityRoot
 {
     public virtual long Number { get; set; }
-    public virtual ICollection<EntityOne> OneSkip { get; set; }
-    public virtual ICollection<EntityRoot> RootSkipShared { get; set; }
+    public virtual ICollection<EntityOne> OneSkip { get; set; } = null!;
+    public virtual ICollection<EntityRoot> RootSkipShared { get; set; } = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/EntityBranch2.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/EntityBranch2.cs
@@ -3,13 +3,11 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ManyToManyModel;
 
-#nullable disable
-
 public abstract class EntityBranch2 : EntityRoot
 {
     public virtual long Slumber { get; set; }
-    public virtual ICollection<EntityLeaf2> Leaf2SkipShared { get; set; }
+    public virtual ICollection<EntityLeaf2> Leaf2SkipShared { get; set; } = null!;
 
-    public virtual ICollection<EntityBranch2> SelfSkipSharedLeft { get; set; }
-    public virtual ICollection<EntityBranch2> SelfSkipSharedRight { get; set; }
+    public virtual ICollection<EntityBranch2> SelfSkipSharedLeft { get; set; } = null!;
+    public virtual ICollection<EntityBranch2> SelfSkipSharedRight { get; set; } = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/EntityCompositeKey.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/EntityCompositeKey.cs
@@ -3,20 +3,18 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ManyToManyModel;
 
-#nullable disable
-
 public class EntityCompositeKey
 {
     public virtual int Key1 { get; set; }
-    public virtual string Key2 { get; set; }
+    public virtual string Key2 { get; set; } = null!;
     public virtual DateTime Key3 { get; set; }
 
-    public virtual string Name { get; set; }
+    public virtual string? Name { get; set; }
 
-    public virtual ICollection<EntityTwo> TwoSkipShared { get; set; }
-    public virtual ICollection<EntityThree> ThreeSkipFull { get; set; }
-    public virtual ICollection<JoinThreeToCompositeKeyFull> JoinThreeFull { get; set; }
-    public virtual ICollection<EntityRoot> RootSkipShared { get; set; }
-    public virtual ICollection<EntityLeaf> LeafSkipFull { get; set; }
-    public virtual ICollection<JoinCompositeKeyToLeaf> JoinLeafFull { get; set; }
+    public virtual ICollection<EntityTwo> TwoSkipShared { get; set; } = null!;
+    public virtual ICollection<EntityThree> ThreeSkipFull { get; set; } = null!;
+    public virtual ICollection<JoinThreeToCompositeKeyFull> JoinThreeFull { get; set; } = null!;
+    public virtual ICollection<EntityRoot> RootSkipShared { get; set; } = null!;
+    public virtual ICollection<EntityLeaf> LeafSkipFull { get; set; } = null!;
+    public virtual ICollection<JoinCompositeKeyToLeaf> JoinLeafFull { get; set; } = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/EntityLeaf.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/EntityLeaf.cs
@@ -3,12 +3,10 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ManyToManyModel;
 
-#nullable disable
-
 public class EntityLeaf : EntityBranch
 {
     public virtual bool? IsGreen { get; set; }
 
-    public virtual ICollection<EntityCompositeKey> CompositeKeySkipFull { get; set; }
-    public virtual ICollection<JoinCompositeKeyToLeaf> JoinCompositeKeyFull { get; set; }
+    public virtual ICollection<EntityCompositeKey> CompositeKeySkipFull { get; set; } = null!;
+    public virtual ICollection<JoinCompositeKeyToLeaf> JoinCompositeKeyFull { get; set; } = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/EntityLeaf2.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/EntityLeaf2.cs
@@ -3,10 +3,8 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ManyToManyModel;
 
-#nullable disable
-
 public class EntityLeaf2 : EntityBranch2
 {
     public virtual bool? IsBrown { get; set; }
-    public virtual ICollection<EntityBranch2> Branch2SkipShared { get; set; }
+    public virtual ICollection<EntityBranch2> Branch2SkipShared { get; set; } = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/EntityOne.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/EntityOne.cs
@@ -5,27 +5,25 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ManyToManyModel;
 
-#nullable disable
-
 public class EntityOne
 {
     public virtual int Id { get; set; }
-    public virtual string Name { get; set; }
+    public virtual string? Name { get; set; }
 
-    public virtual EntityTwo Reference { get; set; }
-    public virtual ICollection<EntityTwo> Collection { get; set; }
-    public virtual ICollection<EntityTwo> TwoSkip { get; set; }
-    public virtual ICollection<EntityThree> ThreeSkipPayloadFull { get; set; }
-    public virtual ICollection<JoinOneToThreePayloadFull> JoinThreePayloadFull { get; set; }
+    public virtual EntityTwo Reference { get; set; } = null!;
+    public virtual ICollection<EntityTwo> Collection { get; set; } = null!;
+    public virtual ICollection<EntityTwo> TwoSkip { get; set; } = null!;
+    public virtual ICollection<EntityThree> ThreeSkipPayloadFull { get; set; } = null!;
+    public virtual ICollection<JoinOneToThreePayloadFull> JoinThreePayloadFull { get; set; } = null!;
 
     [InverseProperty("OneSkipShared")]
-    public virtual ICollection<EntityTwo> TwoSkipShared { get; set; }
+    public virtual ICollection<EntityTwo> TwoSkipShared { get; set; } = null!;
 
-    public virtual ICollection<EntityThree> ThreeSkipPayloadFullShared { get; set; }
-    public virtual ICollection<Dictionary<string, object>> JoinThreePayloadFullShared { get; set; }
-    public virtual ICollection<EntityOne> SelfSkipPayloadLeft { get; set; }
-    public virtual ICollection<JoinOneSelfPayload> JoinSelfPayloadLeft { get; set; }
-    public virtual ICollection<EntityOne> SelfSkipPayloadRight { get; set; }
-    public virtual ICollection<JoinOneSelfPayload> JoinSelfPayloadRight { get; set; }
-    public virtual ICollection<EntityBranch> BranchSkip { get; set; }
+    public virtual ICollection<EntityThree> ThreeSkipPayloadFullShared { get; set; } = null!;
+    public virtual ICollection<Dictionary<string, object>> JoinThreePayloadFullShared { get; set; } = null!;
+    public virtual ICollection<EntityOne> SelfSkipPayloadLeft { get; set; } = null!;
+    public virtual ICollection<JoinOneSelfPayload> JoinSelfPayloadLeft { get; set; } = null!;
+    public virtual ICollection<EntityOne> SelfSkipPayloadRight { get; set; } = null!;
+    public virtual ICollection<JoinOneSelfPayload> JoinSelfPayloadRight { get; set; } = null!;
+    public virtual ICollection<EntityBranch> BranchSkip { get; set; } = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/EntityRoot.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/EntityRoot.cs
@@ -3,13 +3,11 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ManyToManyModel;
 
-#nullable disable
-
 public class EntityRoot
 {
     public virtual int Id { get; set; }
-    public virtual string Name { get; set; }
-    public virtual ICollection<EntityThree> ThreeSkipShared { get; set; }
-    public virtual ICollection<EntityCompositeKey> CompositeKeySkipShared { get; set; }
-    public virtual ICollection<EntityBranch> BranchSkipShared { get; set; }
+    public virtual string? Name { get; set; }
+    public virtual ICollection<EntityThree> ThreeSkipShared { get; set; } = null!;
+    public virtual ICollection<EntityCompositeKey> CompositeKeySkipShared { get; set; } = null!;
+    public virtual ICollection<EntityBranch> BranchSkipShared { get; set; } = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/EntityTableSharing1.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/EntityTableSharing1.cs
@@ -3,11 +3,9 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ManyToManyModel;
 
-#nullable disable
-
 public class EntityTableSharing1
 {
     public virtual int Id { get; set; }
-    public virtual string Name { get; set; }
-    public virtual ICollection<EntityTableSharing2> TableSharing2Shared { get; set; }
+    public virtual string Name { get; set; } = null!;
+    public virtual ICollection<EntityTableSharing2> TableSharing2Shared { get; set; } = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/EntityTableSharing2.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/EntityTableSharing2.cs
@@ -3,11 +3,9 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ManyToManyModel;
 
-#nullable disable
-
 public class EntityTableSharing2
 {
     public virtual int Id { get; set; }
     public virtual long Cucumber { get; set; }
-    public virtual ICollection<EntityTableSharing1> TableSharing1Shared { get; set; }
+    public virtual ICollection<EntityTableSharing1> TableSharing1Shared { get; set; } = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/EntityThree.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/EntityThree.cs
@@ -5,28 +5,26 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ManyToManyModel;
 
-#nullable disable
-
 public class EntityThree
 {
     public virtual int Id { get; set; }
-    public virtual string Name { get; set; }
+    public virtual string? Name { get; set; }
 
     public virtual int? ReferenceInverseId { get; set; }
-    public virtual EntityTwo ReferenceInverse { get; set; }
+    public virtual EntityTwo? ReferenceInverse { get; set; }
 
     public virtual int? CollectionInverseId { get; set; }
-    public virtual EntityTwo CollectionInverse { get; set; }
+    public virtual EntityTwo? CollectionInverse { get; set; }
 
-    public virtual ICollection<EntityOne> OneSkipPayloadFull { get; set; }
-    public virtual ICollection<JoinOneToThreePayloadFull> JoinOnePayloadFull { get; set; }
-    public virtual ICollection<EntityTwo> TwoSkipFull { get; set; }
-    public virtual ICollection<JoinTwoToThree> JoinTwoFull { get; set; }
-    public virtual ICollection<EntityOne> OneSkipPayloadFullShared { get; set; }
-    public virtual ICollection<Dictionary<string, object>> JoinOnePayloadFullShared { get; set; }
-    public virtual ICollection<EntityCompositeKey> CompositeKeySkipFull { get; set; }
-    public virtual ICollection<JoinThreeToCompositeKeyFull> JoinCompositeKeyFull { get; set; }
+    public virtual ICollection<EntityOne> OneSkipPayloadFull { get; set; } = null!;
+    public virtual ICollection<JoinOneToThreePayloadFull> JoinOnePayloadFull { get; set; } = null!;
+    public virtual ICollection<EntityTwo> TwoSkipFull { get; set; } = null!;
+    public virtual ICollection<JoinTwoToThree> JoinTwoFull { get; set; } = null!;
+    public virtual ICollection<EntityOne> OneSkipPayloadFullShared { get; set; } = null!;
+    public virtual ICollection<Dictionary<string, object>> JoinOnePayloadFullShared { get; set; } = null!;
+    public virtual ICollection<EntityCompositeKey> CompositeKeySkipFull { get; set; } = null!;
+    public virtual ICollection<JoinThreeToCompositeKeyFull> JoinCompositeKeyFull { get; set; } = null!;
 
     [InverseProperty("ThreeSkipShared")]
-    public virtual ICollection<EntityRoot> RootSkipShared { get; set; }
+    public virtual ICollection<EntityRoot> RootSkipShared { get; set; } = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/EntityTwo.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/EntityTwo.cs
@@ -5,32 +5,30 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ManyToManyModel;
 
-#nullable disable
-
 public class EntityTwo
 {
     public virtual int Id { get; set; }
-    public virtual string Name { get; set; }
+    public virtual string? Name { get; set; }
 
     public virtual int? ReferenceInverseId { get; set; }
-    public virtual EntityOne ReferenceInverse { get; set; }
+    public virtual EntityOne? ReferenceInverse { get; set; }
 
     public virtual int? CollectionInverseId { get; set; }
-    public virtual EntityOne CollectionInverse { get; set; }
+    public virtual EntityOne? CollectionInverse { get; set; }
 
-    public virtual EntityThree Reference { get; set; }
-    public virtual ICollection<EntityThree> Collection { get; set; }
-    public virtual ICollection<EntityOne> OneSkip { get; set; }
-    public virtual ICollection<EntityThree> ThreeSkipFull { get; set; }
-    public virtual ICollection<JoinTwoToThree> JoinThreeFull { get; set; }
-    public virtual ICollection<EntityTwo> SelfSkipSharedLeft { get; set; }
-    public virtual ICollection<EntityTwo> SelfSkipSharedRight { get; set; }
+    public virtual EntityThree Reference { get; set; } = null!;
+    public virtual ICollection<EntityThree> Collection { get; set; } = null!;
+    public virtual ICollection<EntityOne> OneSkip { get; set; } = null!;
+    public virtual ICollection<EntityThree> ThreeSkipFull { get; set; } = null!;
+    public virtual ICollection<JoinTwoToThree> JoinThreeFull { get; set; } = null!;
+    public virtual ICollection<EntityTwo> SelfSkipSharedLeft { get; set; } = null!;
+    public virtual ICollection<EntityTwo> SelfSkipSharedRight { get; set; } = null!;
 
     [InverseProperty("TwoSkipShared")]
-    public virtual ICollection<EntityOne> OneSkipShared { get; set; }
+    public virtual ICollection<EntityOne> OneSkipShared { get; set; } = null!;
 
-    public virtual ICollection<EntityCompositeKey> CompositeKeySkipShared { get; set; }
+    public virtual ICollection<EntityCompositeKey> CompositeKeySkipShared { get; set; } = null!;
 
     public virtual int? ExtraId { get; set; }
-    public virtual JoinOneToTwoExtra Extra { get; set; }
+    public virtual JoinOneToTwoExtra? Extra { get; set; }
 }

--- a/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/GeneratedKeysLeft.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/GeneratedKeysLeft.cs
@@ -5,12 +5,10 @@ using System.Collections.ObjectModel;
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ManyToManyModel;
 
-#nullable disable
-
 public class GeneratedKeysLeft
 {
     public virtual int Id { get; set; }
-    public virtual string Name { get; set; }
+    public virtual string? Name { get; set; }
 
     public virtual ICollection<GeneratedKeysRight> Rights { get; } = new ObservableCollection<GeneratedKeysRight>();
 }

--- a/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/GeneratedKeysRight.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/GeneratedKeysRight.cs
@@ -5,12 +5,10 @@ using System.Collections.ObjectModel;
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ManyToManyModel;
 
-#nullable disable
-
 public class GeneratedKeysRight
 {
     public virtual int Id { get; set; }
-    public virtual string Name { get; set; }
+    public virtual string? Name { get; set; }
 
     public virtual ICollection<GeneratedKeysLeft> Lefts { get; } = new ObservableCollection<GeneratedKeysLeft>();
 }

--- a/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/ImplicitManyToManyA.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/ImplicitManyToManyA.cs
@@ -6,14 +6,12 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ManyToManyModel;
 
-#nullable disable
-
 public class ImplicitManyToManyA
 {
     [DatabaseGenerated(DatabaseGeneratedOption.None)]
     public virtual int Id { get; set; }
 
-    public virtual string Name { get; set; }
+    public virtual string? Name { get; set; }
 
     public virtual ICollection<ImplicitManyToManyB> Bs { get; } = new ObservableCollection<ImplicitManyToManyB>();
 }

--- a/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/ImplicitManyToManyB.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/ImplicitManyToManyB.cs
@@ -6,14 +6,12 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ManyToManyModel;
 
-#nullable disable
-
 public class ImplicitManyToManyB
 {
     [DatabaseGenerated(DatabaseGeneratedOption.None)]
     public virtual int Id { get; set; }
 
-    public virtual string Name { get; set; }
+    public virtual string? Name { get; set; }
 
     public virtual ICollection<ImplicitManyToManyA> As { get; } = new ObservableCollection<ImplicitManyToManyA>();
 }

--- a/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/JoinCompositeKeyToLeaf.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/JoinCompositeKeyToLeaf.cs
@@ -3,15 +3,13 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ManyToManyModel;
 
-#nullable disable
-
 public class JoinCompositeKeyToLeaf
 {
     public virtual int CompositeId1 { get; set; }
-    public virtual string CompositeId2 { get; set; }
+    public virtual string CompositeId2 { get; set; } = null!;
     public virtual DateTime CompositeId3 { get; set; }
     public virtual int LeafId { get; set; }
 
-    public virtual EntityCompositeKey Composite { get; set; }
-    public virtual EntityLeaf Leaf { get; set; }
+    public virtual EntityCompositeKey Composite { get; set; } = null!;
+    public virtual EntityLeaf Leaf { get; set; } = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/JoinOneSelfPayload.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/JoinOneSelfPayload.cs
@@ -3,13 +3,11 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ManyToManyModel;
 
-#nullable disable
-
 public class JoinOneSelfPayload
 {
     public virtual int LeftId { get; set; }
     public virtual int RightId { get; set; }
     public virtual DateTime Payload { get; set; }
-    public virtual EntityOne Right { get; set; }
-    public virtual EntityOne Left { get; set; }
+    public virtual EntityOne Right { get; set; } = null!;
+    public virtual EntityOne Left { get; set; } = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/JoinOneToThreePayloadFull.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/JoinOneToThreePayloadFull.cs
@@ -3,14 +3,12 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ManyToManyModel;
 
-#nullable disable
-
 public class JoinOneToThreePayloadFull
 {
     public virtual int OneId { get; set; }
     public virtual int ThreeId { get; set; }
-    public virtual EntityOne One { get; set; }
-    public virtual EntityThree Three { get; set; }
+    public virtual EntityOne One { get; set; } = null!;
+    public virtual EntityThree Three { get; set; } = null!;
 
-    public virtual string Payload { get; set; }
+    public virtual string? Payload { get; set; }
 }

--- a/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/JoinOneToTwo.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/JoinOneToTwo.cs
@@ -3,13 +3,11 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ManyToManyModel;
 
-#nullable disable
-
 public class JoinOneToTwo
 {
     public virtual int OneId { get; set; }
     public virtual int TwoId { get; set; }
 
-    public virtual EntityOne One { get; set; }
-    public virtual EntityTwo Two { get; set; }
+    public virtual EntityOne One { get; set; } = null!;
+    public virtual EntityTwo Two { get; set; } = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/JoinOneToTwoExtra.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/JoinOneToTwoExtra.cs
@@ -3,12 +3,10 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ManyToManyModel;
 
-#nullable disable
-
 public class JoinOneToTwoExtra
 {
     public virtual int Id { get; set; }
-    public virtual string Name { get; set; }
+    public virtual string? Name { get; set; }
 
-    public virtual ICollection<JoinOneToTwo> JoinEntities { get; set; }
+    public virtual ICollection<JoinOneToTwo> JoinEntities { get; set; } = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/JoinThreeToCompositeKeyFull.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/JoinThreeToCompositeKeyFull.cs
@@ -3,16 +3,14 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ManyToManyModel;
 
-#nullable disable
-
 public class JoinThreeToCompositeKeyFull
 {
     public virtual Guid Id { get; set; }
     public virtual int ThreeId { get; set; }
     public virtual int CompositeId1 { get; set; }
-    public virtual string CompositeId2 { get; set; }
+    public virtual string CompositeId2 { get; set; } = null!;
     public virtual DateTime CompositeId3 { get; set; }
 
-    public virtual EntityThree Three { get; set; }
-    public virtual EntityCompositeKey Composite { get; set; }
+    public virtual EntityThree Three { get; set; } = null!;
+    public virtual EntityCompositeKey Composite { get; set; } = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/JoinTwoToThree.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/JoinTwoToThree.cs
@@ -3,12 +3,10 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ManyToManyModel;
 
-#nullable disable
-
 public class JoinTwoToThree
 {
     public virtual int TwoId { get; set; }
     public virtual int ThreeId { get; set; }
-    public virtual EntityTwo Two { get; set; }
-    public virtual EntityThree Three { get; set; }
+    public virtual EntityTwo Two { get; set; } = null!;
+    public virtual EntityThree Three { get; set; } = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/ManyToManyContext.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/ManyToManyContext.cs
@@ -5,33 +5,31 @@ using Microsoft.EntityFrameworkCore.Proxies.Internal;
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ManyToManyModel;
 
-#nullable disable
-
 public class ManyToManyContext(DbContextOptions options) : PoolableDbContext(options)
 {
-    public DbSet<EntityOne> EntityOnes { get; set; }
-    public DbSet<EntityTwo> EntityTwos { get; set; }
-    public DbSet<EntityThree> EntityThrees { get; set; }
-    public DbSet<EntityCompositeKey> EntityCompositeKeys { get; set; }
-    public DbSet<EntityRoot> EntityRoots { get; set; }
-    public DbSet<EntityTableSharing1> EntityTableSharing1s { get; set; }
-    public DbSet<EntityTableSharing2> EntityTableSharing2s { get; set; }
-    public DbSet<ImplicitManyToManyA> ImplicitManyToManyAs { get; set; }
-    public DbSet<ImplicitManyToManyB> ImplicitManyToManyBs { get; set; }
-    public DbSet<GeneratedKeysLeft> GeneratedKeysLefts { get; set; }
-    public DbSet<GeneratedKeysRight> GeneratedKeysRights { get; set; }
-    public DbSet<UnidirectionalEntityOne> UnidirectionalEntityOnes { get; set; }
-    public DbSet<UnidirectionalEntityTwo> UnidirectionalEntityTwos { get; set; }
-    public DbSet<UnidirectionalEntityThree> UnidirectionalEntityThrees { get; set; }
-    public DbSet<UnidirectionalEntityCompositeKey> UnidirectionalEntityCompositeKeys { get; set; }
-    public DbSet<UnidirectionalEntityRoot> UnidirectionalEntityRoots { get; set; }
-    public DbSet<UnidirectionalGeneratedKeysLeft> UnidirectionalGeneratedKeysLefts { get; set; }
-    public DbSet<UnidirectionalGeneratedKeysRight> UnidirectionalGeneratedKeysRights { get; set; }
+    public DbSet<EntityOne> EntityOnes { get; set; } = null!;
+    public DbSet<EntityTwo> EntityTwos { get; set; } = null!;
+    public DbSet<EntityThree> EntityThrees { get; set; } = null!;
+    public DbSet<EntityCompositeKey> EntityCompositeKeys { get; set; } = null!;
+    public DbSet<EntityRoot> EntityRoots { get; set; } = null!;
+    public DbSet<EntityTableSharing1> EntityTableSharing1s { get; set; } = null!;
+    public DbSet<EntityTableSharing2> EntityTableSharing2s { get; set; } = null!;
+    public DbSet<ImplicitManyToManyA> ImplicitManyToManyAs { get; set; } = null!;
+    public DbSet<ImplicitManyToManyB> ImplicitManyToManyBs { get; set; } = null!;
+    public DbSet<GeneratedKeysLeft> GeneratedKeysLefts { get; set; } = null!;
+    public DbSet<GeneratedKeysRight> GeneratedKeysRights { get; set; } = null!;
+    public DbSet<UnidirectionalEntityOne> UnidirectionalEntityOnes { get; set; } = null!;
+    public DbSet<UnidirectionalEntityTwo> UnidirectionalEntityTwos { get; set; } = null!;
+    public DbSet<UnidirectionalEntityThree> UnidirectionalEntityThrees { get; set; } = null!;
+    public DbSet<UnidirectionalEntityCompositeKey> UnidirectionalEntityCompositeKeys { get; set; } = null!;
+    public DbSet<UnidirectionalEntityRoot> UnidirectionalEntityRoots { get; set; } = null!;
+    public DbSet<UnidirectionalGeneratedKeysLeft> UnidirectionalGeneratedKeysLefts { get; set; } = null!;
+    public DbSet<UnidirectionalGeneratedKeysRight> UnidirectionalGeneratedKeysRights { get; set; } = null!;
 }
 
 public static class ManyToManyContextExtensions
 {
-    public static TEntity CreateInstance<TEntity>(this DbSet<TEntity> set, Action<TEntity, bool> configureEntity = null)
+    public static TEntity CreateInstance<TEntity>(this DbSet<TEntity> set, Action<TEntity, bool>? configureEntity = null)
         where TEntity : class, new()
     {
         var isProxy = set.GetService<IDbContextOptions>().FindExtension<ProxiesOptionsExtension>()?.UseChangeTrackingProxies == true;

--- a/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/ManyToManyData.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/ManyToManyData.cs
@@ -5,8 +5,6 @@ using System.Collections.ObjectModel;
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ManyToManyModel;
 
-#nullable disable
-
 public class ManyToManyData : ISetSource
 {
     private readonly bool _useGeneratedKeys;
@@ -184,8 +182,8 @@ public class ManyToManyData : ISetSource
         ManyToManyContext context,
         int id,
         string name,
-        EntityOne referenceInverse,
-        EntityOne collectionInverse)
+        EntityOne? referenceInverse,
+        EntityOne? collectionInverse)
         => CreateInstance(
             context?.EntityTwos, (e, p) =>
             {
@@ -232,8 +230,8 @@ public class ManyToManyData : ISetSource
         ManyToManyContext context,
         int id,
         string name,
-        EntityTwo referenceInverse,
-        EntityTwo collectionInverse)
+        EntityTwo? referenceInverse,
+        EntityTwo? collectionInverse)
         => CreateInstance(
             context?.EntityThrees, (e, p) =>
             {
@@ -1360,8 +1358,8 @@ public class ManyToManyData : ISetSource
         ManyToManyContext context,
         int id,
         string name,
-        UnidirectionalEntityOne referenceInverse,
-        UnidirectionalEntityOne collectionInverse)
+        UnidirectionalEntityOne? referenceInverse,
+        UnidirectionalEntityOne? collectionInverse)
         => CreateInstance(
             context?.UnidirectionalEntityTwos, (e, p) =>
             {
@@ -1414,8 +1412,8 @@ public class ManyToManyData : ISetSource
         ManyToManyContext context,
         int id,
         string name,
-        UnidirectionalEntityTwo referenceInverse,
-        UnidirectionalEntityTwo collectionInverse)
+        UnidirectionalEntityTwo? referenceInverse,
+        UnidirectionalEntityTwo? collectionInverse)
         => CreateInstance(
             context?.UnidirectionalEntityThrees, (e, p) =>
             {
@@ -2568,7 +2566,7 @@ public class ManyToManyData : ISetSource
     private static ICollection<TEntity> CreateCollection<TEntity>(bool proxy)
         => proxy ? new ObservableCollection<TEntity>() : new List<TEntity>();
 
-    private static TEntity CreateInstance<TEntity>(DbSet<TEntity> set, Action<TEntity, bool> configureEntity)
+    private static TEntity CreateInstance<TEntity>(DbSet<TEntity>? set, Action<TEntity, bool> configureEntity)
         where TEntity : class, new()
     {
         if (set != null)

--- a/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/ProxyableSharedType.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/ProxyableSharedType.cs
@@ -3,15 +3,13 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ManyToManyModel;
 
-#nullable disable
-
 public class ProxyableSharedType
 {
     private readonly Dictionary<string, object> _keyValueStore = [];
 
-    public virtual object this[string key]
+    public virtual object? this[string key]
     {
         get => _keyValueStore.TryGetValue(key, out var value) ? value : default;
-        set => _keyValueStore[key] = value;
+        set => _keyValueStore[key] = value!;
     }
 }

--- a/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/UnidirectionalEntityCompositeKey.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/UnidirectionalEntityCompositeKey.cs
@@ -3,19 +3,17 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ManyToManyModel;
 
-#nullable disable
-
 public class UnidirectionalEntityCompositeKey
 {
     public virtual int Key1 { get; set; }
-    public virtual string Key2 { get; set; }
+    public virtual string Key2 { get; set; } = null!;
     public virtual DateTime Key3 { get; set; }
 
-    public virtual string Name { get; set; }
+    public virtual string? Name { get; set; }
 
-    public virtual ICollection<UnidirectionalEntityTwo> TwoSkipShared { get; set; }
-    public virtual ICollection<UnidirectionalEntityThree> ThreeSkipFull { get; set; }
-    public virtual ICollection<UnidirectionalJoinThreeToCompositeKeyFull> JoinThreeFull { get; set; }
-    public virtual ICollection<UnidirectionalEntityRoot> RootSkipShared { get; set; }
-    public virtual ICollection<UnidirectionalJoinCompositeKeyToLeaf> JoinLeafFull { get; set; }
+    public virtual ICollection<UnidirectionalEntityTwo> TwoSkipShared { get; set; } = null!;
+    public virtual ICollection<UnidirectionalEntityThree> ThreeSkipFull { get; set; } = null!;
+    public virtual ICollection<UnidirectionalJoinThreeToCompositeKeyFull> JoinThreeFull { get; set; } = null!;
+    public virtual ICollection<UnidirectionalEntityRoot> RootSkipShared { get; set; } = null!;
+    public virtual ICollection<UnidirectionalJoinCompositeKeyToLeaf> JoinLeafFull { get; set; } = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/UnidirectionalEntityLeaf.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/UnidirectionalEntityLeaf.cs
@@ -3,12 +3,10 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ManyToManyModel;
 
-#nullable disable
-
 public class UnidirectionalEntityLeaf : UnidirectionalEntityBranch
 {
     public virtual bool? IsGreen { get; set; }
 
-    public virtual ICollection<UnidirectionalEntityCompositeKey> CompositeKeySkipFull { get; set; }
-    public virtual ICollection<UnidirectionalJoinCompositeKeyToLeaf> JoinCompositeKeyFull { get; set; }
+    public virtual ICollection<UnidirectionalEntityCompositeKey> CompositeKeySkipFull { get; set; } = null!;
+    public virtual ICollection<UnidirectionalJoinCompositeKeyToLeaf> JoinCompositeKeyFull { get; set; } = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/UnidirectionalEntityOne.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/UnidirectionalEntityOne.cs
@@ -3,24 +3,22 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ManyToManyModel;
 
-#nullable disable
-
 public class UnidirectionalEntityOne
 {
     public virtual int Id { get; set; }
-    public virtual string Name { get; set; }
+    public virtual string? Name { get; set; }
 
-    public virtual UnidirectionalEntityTwo Reference { get; set; }
-    public virtual ICollection<UnidirectionalEntityTwo> Collection { get; set; }
-    public virtual ICollection<UnidirectionalEntityTwo> TwoSkip { get; set; }
-    public virtual ICollection<UnidirectionalJoinOneToThreePayloadFull> JoinThreePayloadFull { get; set; }
+    public virtual UnidirectionalEntityTwo Reference { get; set; } = null!;
+    public virtual ICollection<UnidirectionalEntityTwo> Collection { get; set; } = null!;
+    public virtual ICollection<UnidirectionalEntityTwo> TwoSkip { get; set; } = null!;
+    public virtual ICollection<UnidirectionalJoinOneToThreePayloadFull> JoinThreePayloadFull { get; set; } = null!;
 
-    public virtual ICollection<UnidirectionalEntityTwo> TwoSkipShared { get; set; }
+    public virtual ICollection<UnidirectionalEntityTwo> TwoSkipShared { get; set; } = null!;
 
-    public virtual ICollection<UnidirectionalEntityThree> ThreeSkipPayloadFullShared { get; set; }
-    public virtual ICollection<Dictionary<string, object>> JoinThreePayloadFullShared { get; set; }
-    public virtual ICollection<UnidirectionalEntityOne> SelfSkipPayloadLeft { get; set; }
-    public virtual ICollection<UnidirectionalJoinOneSelfPayload> JoinSelfPayloadLeft { get; set; }
-    public virtual ICollection<UnidirectionalJoinOneSelfPayload> JoinSelfPayloadRight { get; set; }
-    public virtual ICollection<UnidirectionalEntityBranch> BranchSkip { get; set; }
+    public virtual ICollection<UnidirectionalEntityThree> ThreeSkipPayloadFullShared { get; set; } = null!;
+    public virtual ICollection<Dictionary<string, object>> JoinThreePayloadFullShared { get; set; } = null!;
+    public virtual ICollection<UnidirectionalEntityOne> SelfSkipPayloadLeft { get; set; } = null!;
+    public virtual ICollection<UnidirectionalJoinOneSelfPayload> JoinSelfPayloadLeft { get; set; } = null!;
+    public virtual ICollection<UnidirectionalJoinOneSelfPayload> JoinSelfPayloadRight { get; set; } = null!;
+    public virtual ICollection<UnidirectionalEntityBranch> BranchSkip { get; set; } = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/UnidirectionalEntityRoot.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/UnidirectionalEntityRoot.cs
@@ -3,12 +3,10 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ManyToManyModel;
 
-#nullable disable
-
 public class UnidirectionalEntityRoot
 {
     public virtual int Id { get; set; }
-    public virtual string Name { get; set; }
-    public virtual ICollection<UnidirectionalEntityThree> ThreeSkipShared { get; set; }
-    public virtual ICollection<UnidirectionalEntityBranch> BranchSkipShared { get; set; }
+    public virtual string? Name { get; set; }
+    public virtual ICollection<UnidirectionalEntityThree> ThreeSkipShared { get; set; } = null!;
+    public virtual ICollection<UnidirectionalEntityBranch> BranchSkipShared { get; set; } = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/UnidirectionalEntityThree.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/UnidirectionalEntityThree.cs
@@ -3,22 +3,20 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ManyToManyModel;
 
-#nullable disable
-
 public class UnidirectionalEntityThree
 {
     public virtual int Id { get; set; }
-    public virtual string Name { get; set; }
+    public virtual string? Name { get; set; }
 
     public virtual int? ReferenceInverseId { get; set; }
-    public virtual UnidirectionalEntityTwo ReferenceInverse { get; set; }
+    public virtual UnidirectionalEntityTwo? ReferenceInverse { get; set; }
 
     public virtual int? CollectionInverseId { get; set; }
-    public virtual UnidirectionalEntityTwo CollectionInverse { get; set; }
+    public virtual UnidirectionalEntityTwo? CollectionInverse { get; set; }
 
-    public virtual ICollection<UnidirectionalJoinOneToThreePayloadFull> JoinOnePayloadFull { get; set; }
-    public virtual ICollection<UnidirectionalEntityTwo> TwoSkipFull { get; set; }
-    public virtual ICollection<UnidirectionalJoinTwoToThree> JoinTwoFull { get; set; }
-    public virtual ICollection<Dictionary<string, object>> JoinOnePayloadFullShared { get; set; }
-    public virtual ICollection<UnidirectionalJoinThreeToCompositeKeyFull> JoinCompositeKeyFull { get; set; }
+    public virtual ICollection<UnidirectionalJoinOneToThreePayloadFull> JoinOnePayloadFull { get; set; } = null!;
+    public virtual ICollection<UnidirectionalEntityTwo> TwoSkipFull { get; set; } = null!;
+    public virtual ICollection<UnidirectionalJoinTwoToThree> JoinTwoFull { get; set; } = null!;
+    public virtual ICollection<Dictionary<string, object>> JoinOnePayloadFullShared { get; set; } = null!;
+    public virtual ICollection<UnidirectionalJoinThreeToCompositeKeyFull> JoinCompositeKeyFull { get; set; } = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/UnidirectionalEntityTwo.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/UnidirectionalEntityTwo.cs
@@ -3,24 +3,22 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ManyToManyModel;
 
-#nullable disable
-
 public class UnidirectionalEntityTwo
 {
     public virtual int Id { get; set; }
-    public virtual string Name { get; set; }
+    public virtual string? Name { get; set; }
 
     public virtual int? ReferenceInverseId { get; set; }
-    public virtual UnidirectionalEntityOne ReferenceInverse { get; set; }
+    public virtual UnidirectionalEntityOne? ReferenceInverse { get; set; }
 
     public virtual int? CollectionInverseId { get; set; }
-    public virtual UnidirectionalEntityOne CollectionInverse { get; set; }
+    public virtual UnidirectionalEntityOne? CollectionInverse { get; set; }
 
-    public virtual UnidirectionalEntityThree Reference { get; set; }
-    public virtual ICollection<UnidirectionalEntityThree> Collection { get; set; }
-    public virtual ICollection<UnidirectionalJoinTwoToThree> JoinThreeFull { get; set; }
-    public virtual ICollection<UnidirectionalEntityTwo> SelfSkipSharedRight { get; set; }
+    public virtual UnidirectionalEntityThree Reference { get; set; } = null!;
+    public virtual ICollection<UnidirectionalEntityThree> Collection { get; set; } = null!;
+    public virtual ICollection<UnidirectionalJoinTwoToThree> JoinThreeFull { get; set; } = null!;
+    public virtual ICollection<UnidirectionalEntityTwo> SelfSkipSharedRight { get; set; } = null!;
 
     public virtual int? ExtraId { get; set; }
-    public virtual UnidirectionalJoinOneToTwoExtra Extra { get; set; }
+    public virtual UnidirectionalJoinOneToTwoExtra? Extra { get; set; }
 }

--- a/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/UnidirectionalGeneratedKeysLeft.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/UnidirectionalGeneratedKeysLeft.cs
@@ -5,12 +5,10 @@ using System.Collections.ObjectModel;
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ManyToManyModel;
 
-#nullable disable
-
 public class UnidirectionalGeneratedKeysLeft
 {
     public virtual int Id { get; set; }
-    public virtual string Name { get; set; }
+    public virtual string Name { get; set; } = null!;
 
     public virtual ICollection<UnidirectionalGeneratedKeysRight> Rights { get; } =
         new ObservableCollection<UnidirectionalGeneratedKeysRight>();

--- a/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/UnidirectionalGeneratedKeysRight.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/UnidirectionalGeneratedKeysRight.cs
@@ -5,12 +5,10 @@ using System.Collections.ObjectModel;
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ManyToManyModel;
 
-#nullable disable
-
 public class UnidirectionalGeneratedKeysRight
 {
     public virtual int Id { get; set; }
-    public virtual string Name { get; set; }
+    public virtual string? Name { get; set; }
 
     public virtual ICollection<UnidirectionalGeneratedKeysLeft> Lefts { get; } =
         new ObservableCollection<UnidirectionalGeneratedKeysLeft>();

--- a/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/UnidirectionalJoinCompositeKeyToLeaf.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/UnidirectionalJoinCompositeKeyToLeaf.cs
@@ -3,15 +3,13 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ManyToManyModel;
 
-#nullable disable
-
 public class UnidirectionalJoinCompositeKeyToLeaf
 {
     public virtual int CompositeId1 { get; set; }
-    public virtual string CompositeId2 { get; set; }
+    public virtual string CompositeId2 { get; set; } = null!;
     public virtual DateTime CompositeId3 { get; set; }
     public virtual int LeafId { get; set; }
 
-    public virtual UnidirectionalEntityCompositeKey Composite { get; set; }
-    public virtual UnidirectionalEntityLeaf Leaf { get; set; }
+    public virtual UnidirectionalEntityCompositeKey Composite { get; set; } = null!;
+    public virtual UnidirectionalEntityLeaf Leaf { get; set; } = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/UnidirectionalJoinOneSelfPayload.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/UnidirectionalJoinOneSelfPayload.cs
@@ -3,13 +3,11 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ManyToManyModel;
 
-#nullable disable
-
 public class UnidirectionalJoinOneSelfPayload
 {
     public virtual int LeftId { get; set; }
     public virtual int RightId { get; set; }
     public virtual DateTime Payload { get; set; }
-    public virtual UnidirectionalEntityOne Right { get; set; }
-    public virtual UnidirectionalEntityOne Left { get; set; }
+    public virtual UnidirectionalEntityOne Right { get; set; } = null!;
+    public virtual UnidirectionalEntityOne Left { get; set; } = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/UnidirectionalJoinOneToThreePayloadFull.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/UnidirectionalJoinOneToThreePayloadFull.cs
@@ -3,14 +3,12 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ManyToManyModel;
 
-#nullable disable
-
 public class UnidirectionalJoinOneToThreePayloadFull
 {
     public virtual int OneId { get; set; }
     public virtual int ThreeId { get; set; }
-    public virtual UnidirectionalEntityOne One { get; set; }
-    public virtual UnidirectionalEntityThree Three { get; set; }
+    public virtual UnidirectionalEntityOne One { get; set; } = null!;
+    public virtual UnidirectionalEntityThree Three { get; set; } = null!;
 
-    public virtual string Payload { get; set; }
+    public virtual string Payload { get; set; } = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/UnidirectionalJoinOneToTwo.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/UnidirectionalJoinOneToTwo.cs
@@ -3,13 +3,11 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ManyToManyModel;
 
-#nullable disable
-
 public class UnidirectionalJoinOneToTwo
 {
     public virtual int OneId { get; set; }
     public virtual int TwoId { get; set; }
 
-    public virtual UnidirectionalEntityOne One { get; set; }
-    public virtual UnidirectionalEntityTwo Two { get; set; }
+    public virtual UnidirectionalEntityOne One { get; set; } = null!;
+    public virtual UnidirectionalEntityTwo Two { get; set; } = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/UnidirectionalJoinOneToTwoExtra.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/UnidirectionalJoinOneToTwoExtra.cs
@@ -3,12 +3,10 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ManyToManyModel;
 
-#nullable disable
-
 public class UnidirectionalJoinOneToTwoExtra
 {
     public virtual int Id { get; set; }
-    public virtual string Name { get; set; }
+    public virtual string? Name { get; set; }
 
-    public virtual ICollection<UnidirectionalJoinOneToTwo> JoinEntities { get; set; }
+    public virtual ICollection<UnidirectionalJoinOneToTwo> JoinEntities { get; set; } = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/UnidirectionalJoinThreeToCompositeKeyFull.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/UnidirectionalJoinThreeToCompositeKeyFull.cs
@@ -3,16 +3,14 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ManyToManyModel;
 
-#nullable disable
-
 public class UnidirectionalJoinThreeToCompositeKeyFull
 {
     public virtual Guid Id { get; set; }
     public virtual int ThreeId { get; set; }
     public virtual int CompositeId1 { get; set; }
-    public virtual string CompositeId2 { get; set; }
+    public virtual string CompositeId2 { get; set; } = null!;
     public virtual DateTime CompositeId3 { get; set; }
 
-    public virtual UnidirectionalEntityThree Three { get; set; }
-    public virtual UnidirectionalEntityCompositeKey Composite { get; set; }
+    public virtual UnidirectionalEntityThree Three { get; set; } = null!;
+    public virtual UnidirectionalEntityCompositeKey Composite { get; set; } = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/UnidirectionalJoinTwoToThree.cs
+++ b/test/EFCore.Specification.Tests/TestModels/ManyToManyModel/UnidirectionalJoinTwoToThree.cs
@@ -3,12 +3,10 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.ManyToManyModel;
 
-#nullable disable
-
 public class UnidirectionalJoinTwoToThree
 {
     public virtual int TwoId { get; set; }
     public virtual int ThreeId { get; set; }
-    public virtual UnidirectionalEntityTwo Two { get; set; }
-    public virtual UnidirectionalEntityThree Three { get; set; }
+    public virtual UnidirectionalEntityTwo Two { get; set; } = null!;
+    public virtual UnidirectionalEntityThree Three { get; set; } = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/MonsterContext`.cs
+++ b/test/EFCore.Specification.Tests/TestModels/MonsterContext`.cs
@@ -5,8 +5,6 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels;
 
-#nullable disable
-
 public class MonsterContext<
     TCustomer, TBarcode, TIncorrectScan, TBarcodeDetail, TComplaint, TResolution, TLogin, TSuspiciousActivity,
     TSmartCard, TRsaToken, TPasswordReset, TPageView, TLastLogin, TMessage, TAnOrder, TOrderNote, TOrderQualityCheck,
@@ -274,15 +272,15 @@ public class MonsterContext<
             b.HasMany(e => (IEnumerable<TMessage>)e.SentMessages).WithOne(e => (TLogin)e.Sender)
                 .HasForeignKey(e => e.FromUsername);
 
-            b.HasMany(e => (IEnumerable<TMessage>)e.ReceivedMessages).WithOne(e => (TLogin)e.Recipient)
+            b.HasMany(e => (IEnumerable<TMessage>)e.ReceivedMessages).WithOne(e => (TLogin?)e.Recipient)
                 .HasForeignKey(e => e.ToUsername);
 
             b.HasMany(e => (IEnumerable<TAnOrder>)e.Orders).WithOne(e => (TLogin)e.Login)
                 .HasForeignKey(e => e.Username);
 
             var entityType = b.Metadata;
-            var activityEntityType = entityType.Model.FindEntityType(typeof(TSuspiciousActivity));
-            activityEntityType.AddForeignKey(activityEntityType.FindProperty("Username"), key.Metadata, entityType);
+            var activityEntityType = entityType.Model.FindEntityType(typeof(TSuspiciousActivity))!;
+            activityEntityType.AddForeignKey(activityEntityType.FindProperty("Username")!, key.Metadata, entityType);
 
             b.HasOne(e => (TLastLogin)e.LastLogin).WithOne(e => (TLogin)e.Login)
                 .HasForeignKey<TLastLogin>(e => e.Username);
@@ -304,14 +302,14 @@ public class MonsterContext<
         {
             b.HasKey(e => e.Code);
 
-            b.HasMany(e => (IEnumerable<TIncorrectScan>)e.BadScans).WithOne(e => (TBarcode)e.ExpectedBarcode)
+            b.HasMany(e => (IEnumerable<TIncorrectScan>)e.BadScans).WithOne(e => (TBarcode)e.ExpectedBarcode!)
                 .HasForeignKey(e => e.ExpectedCode);
 
             b.HasOne(e => (TBarcodeDetail)e.Detail).WithOne()
                 .HasForeignKey<TBarcodeDetail>(e => e.Code);
         });
 
-        modelBuilder.Entity<TIncorrectScan>().HasOne(e => (TBarcode)e.ActualBarcode).WithMany()
+        modelBuilder.Entity<TIncorrectScan>().HasOne(e => (TBarcode)e.ActualBarcode!).WithMany()
             .HasForeignKey(e => e.ActualCode);
 
         modelBuilder.Entity<TSupplierInfo>().HasOne(e => (TSupplier)e.Supplier).WithMany();
@@ -335,7 +333,7 @@ public class MonsterContext<
             b.HasOne(e => (TLogin)e.Login).WithOne()
                 .HasForeignKey<TSmartCard>(e => e.Username);
 
-            b.HasOne(e => (TLastLogin)e.LastLogin).WithOne()
+            b.HasOne(e => (TLastLogin)e.LastLogin!).WithOne()
                 .HasForeignKey<TLastLogin>(e => e.SmartcardUsername);
         });
 
@@ -878,7 +876,7 @@ public class MonsterContext<
             new TCustomer { Name = "Tarquin Tiger" }).Entity;
 
         var customer2 = Add(
-            new TCustomer { Name = "Sue Pandy", Husband = dependentNavs ? customer0 : null }).Entity;
+            new TCustomer { Name = "Sue Pandy", Husband = dependentNavs ? customer0 : null! }).Entity;
         if (principalNavs)
         {
             customer0.Wife = customer2;
@@ -914,7 +912,7 @@ public class MonsterContext<
                 new TBarcode
                 {
                     Code = [1, 2, 3, 4],
-                    Product = dependentNavs ? product1 : null,
+                    Product = dependentNavs ? product1 : null!,
                     Text = "Barcode 1 2 3 4"
                 })
             .Entity;
@@ -922,7 +920,7 @@ public class MonsterContext<
                 new TBarcode
                 {
                     Code = [2, 2, 3, 4],
-                    Product = dependentNavs ? product2 : null,
+                    Product = dependentNavs ? product2 : null!,
                     Text = "Barcode 2 2 3 4"
                 })
             .Entity;
@@ -930,7 +928,7 @@ public class MonsterContext<
                 new TBarcode
                 {
                     Code = [3, 2, 3, 4],
-                    Product = dependentNavs ? product3 : null,
+                    Product = dependentNavs ? product3 : null!,
                     Text = "Barcode 3 2 3 4"
                 })
             .Entity;
@@ -960,7 +958,7 @@ public class MonsterContext<
                 ScanDate = new DateTime(2014, 5, 28, 19, 9, 6),
                 Details = "Treats not Donuts",
                 ActualBarcode = barcode3,
-                ExpectedBarcode = dependentNavs ? barcode2 : null
+                ExpectedBarcode = dependentNavs ? barcode2 : null!
             }).Entity;
         if (principalNavs)
         {
@@ -974,7 +972,7 @@ public class MonsterContext<
                 ScanDate = new DateTime(2014, 5, 28, 19, 15, 31),
                 Details = "Wot no waffles?",
                 ActualBarcode = barcode2,
-                ExpectedBarcode = dependentNavs ? barcode1 : null
+                ExpectedBarcode = dependentNavs ? barcode1 : null!
             }).Entity;
         if (principalNavs)
         {
@@ -1001,7 +999,7 @@ public class MonsterContext<
             }).Entity;
 
         var resolution = Add(
-                new TResolution { Complaint = dependentNavs ? complaint2 : null, Details = "Destroyed all coffee in Redmond area." })
+                new TResolution { Complaint = dependentNavs ? complaint2 : null!, Details = "Destroyed all coffee in Redmond area." })
             .Entity;
         if (principalNavs)
         {
@@ -1011,21 +1009,21 @@ public class MonsterContext<
         var login1 = Add(
             new TLogin
             {
-                Customer = dependentNavs ? customer1 : null,
+                Customer = dependentNavs ? customer1 : null!,
                 Username = "MrsKoalie73",
                 AlternateUsername = "Sheila"
             }).Entity;
         var login2 = Add(
             new TLogin
             {
-                Customer = dependentNavs ? customer2 : null,
+                Customer = dependentNavs ? customer2 : null!,
                 Username = "MrsBossyPants",
                 AlternateUsername = "Sue"
             }).Entity;
         var login3 = Add(
                 new TLogin
                 {
-                    Customer = dependentNavs ? customer3 : null,
+                    Customer = dependentNavs ? customer3 : null!,
                     Username = "TheStripedMenace",
                     AlternateUsername = "Tarquin"
                 })
@@ -1156,7 +1154,7 @@ public class MonsterContext<
                 Body = "Fancy a cup of tea?",
                 FromUsername = Entry(login1).Property(e => e.Username).CurrentValue,
                 Sender = login1,
-                Recipient = dependentNavs ? login2 : null,
+                Recipient = dependentNavs ? login2 : null!,
                 Sent = DateTime.Now
             }).Entity;
         if (principalNavs)
@@ -1174,7 +1172,7 @@ public class MonsterContext<
                 Body = "Love one!",
                 FromUsername = Entry(login2).Property(e => e.Username).CurrentValue,
                 Sender = login2,
-                Recipient = dependentNavs ? login1 : null,
+                Recipient = dependentNavs ? login1 : null!,
                 Sent = DateTime.Now
             }).Entity;
         if (principalNavs)
@@ -1190,7 +1188,7 @@ public class MonsterContext<
                 Body = "I'll put the kettle on.",
                 FromUsername = Entry(login1).Property(e => e.Username).CurrentValue,
                 Sender = login1,
-                Recipient = dependentNavs ? login2 : null,
+                Recipient = dependentNavs ? login2 : null!,
                 Sent = DateTime.Now
             }).Entity;
         if (principalNavs)
@@ -1202,24 +1200,24 @@ public class MonsterContext<
         var order1 = Add(
                 new TAnOrder
                 {
-                    Customer = dependentNavs ? customer1 : null,
-                    Login = dependentNavs ? login1 : null,
+                    Customer = dependentNavs ? customer1 : null!,
+                    Login = dependentNavs ? login1 : null!,
                     AlternateId = 77
                 })
             .Entity;
         var order2 = Add(
                 new TAnOrder
                 {
-                    Customer = dependentNavs ? customer2 : null,
-                    Login = dependentNavs ? login2 : null,
+                    Customer = dependentNavs ? customer2 : null!,
+                    Login = dependentNavs ? login2 : null!,
                     AlternateId = 78
                 })
             .Entity;
         var order3 = Add(
                 new TAnOrder
                 {
-                    Customer = dependentNavs ? customer3 : null,
-                    Login = dependentNavs ? login3 : null,
+                    Customer = dependentNavs ? customer3 : null!,
+                    Login = dependentNavs ? login3 : null!,
                     AlternateId = 79
                 })
             .Entity;
@@ -1235,11 +1233,11 @@ public class MonsterContext<
         }
 
         var orderNote1 = Add(
-            new TOrderNote { Note = "Must have tea!", Order = dependentNavs ? order1 : null }).Entity;
+            new TOrderNote { Note = "Must have tea!", Order = dependentNavs ? order1 : null! }).Entity;
         var orderNote2 = Add(
-            new TOrderNote { Note = "And donuts!", Order = dependentNavs ? order1 : null }).Entity;
+            new TOrderNote { Note = "And donuts!", Order = dependentNavs ? order1 : null! }).Entity;
         var orderNote3 = Add(
-            new TOrderNote { Note = "But no coffee. :-(", Order = dependentNavs ? order1 : null }).Entity;
+            new TOrderNote { Note = "But no coffee. :-(", Order = dependentNavs ? order1 : null! }).Entity;
         if (principalNavs)
         {
             order1.InitializeCollections();
@@ -1335,11 +1333,11 @@ public class MonsterContext<
         }
 
         var productReview1 = Add(
-            new TProductReview { Product = dependentNavs ? product1 : null, Review = "Better than Tarqies!" }).Entity;
+            new TProductReview { Product = dependentNavs ? product1 : null!, Review = "Better than Tarqies!" }).Entity;
         var productReview2 = Add(
-            new TProductReview { Product = dependentNavs ? product1 : null, Review = "Good with maple syrup." }).Entity;
+            new TProductReview { Product = dependentNavs ? product1 : null!, Review = "Good with maple syrup." }).Entity;
         var productReview3 = Add(
-            new TProductReview { Product = dependentNavs ? product2 : null, Review = "Eeky says yes!" }).Entity;
+            new TProductReview { Product = dependentNavs ? product2 : null!, Review = "Eeky says yes!" }).Entity;
         if (principalNavs)
         {
             product1.Reviews.Add(productReview1);
@@ -1367,9 +1365,9 @@ public class MonsterContext<
             new TProductWebFeature
             {
                 Heading = "Waffle Style",
-                Photo = dependentNavs ? productPhoto1 : null,
+                Photo = dependentNavs ? productPhoto1 : null!,
                 ProductId = Entry(product1).Property(e => e.ProductId).CurrentValue,
-                Review = dependentNavs ? productReview1 : null
+                Review = dependentNavs ? productReview1 : null!
             }).Entity;
         if (principalNavs)
         {
@@ -1384,7 +1382,7 @@ public class MonsterContext<
             {
                 Heading = "What does the waffle say?",
                 ProductId = Entry(product2).Property(e => e.ProductId).CurrentValue,
-                Review = dependentNavs ? productReview3 : null
+                Review = dependentNavs ? productReview3 : null!
             }).Entity;
         if (principalNavs)
         {
@@ -1980,7 +1978,7 @@ internal static class Adder
 {
     public static TValue AddEx<TValue>(this List<object> list, TValue value)
     {
-        list.Add(value);
+        list.Add(value!);
         return value;
     }
 }

--- a/test/EFCore.Specification.Tests/TestModels/MonsterModel.cs
+++ b/test/EFCore.Specification.Tests/TestModels/MonsterModel.cs
@@ -60,14 +60,14 @@ public interface IComputer
 public interface IConcurrencyInfo
 {
     public bool Active { get; set; }
-    public string Token { get; set; }
+    public string? Token { get; set; }
     public DateTime? QueriedDateTime { get; set; }
 }
 
 public interface IContactDetails
 {
     public bool Active { get; set; }
-    public string Email { get; set; }
+    public string? Email { get; set; }
 
     public IPhone HomePhone { get; set; }
     public IPhone WorkPhone { get; set; }
@@ -104,12 +104,12 @@ public interface IDriver
 public interface IIncorrectScan
 {
     public int IncorrectScanId { get; set; }
-    public byte[] ExpectedCode { get; set; }
-    public byte[] ActualCode { get; set; }
+    public byte[]? ExpectedCode { get; set; }
+    public byte[]? ActualCode { get; set; }
     public DateTime ScanDate { get; set; }
     public string Details { get; set; }
-    public IBarcode ExpectedBarcode { get; set; }
-    public IBarcode ActualBarcode { get; set; }
+    public IBarcode? ExpectedBarcode { get; set; }
+    public IBarcode? ActualBarcode { get; set; }
 }
 
 public interface ILastLogin
@@ -117,7 +117,7 @@ public interface ILastLogin
     public string Username { get; set; }
     public DateTime LoggedIn { get; set; }
     public DateTime? LoggedOut { get; set; }
-    public string SmartcardUsername { get; set; }
+    public string? SmartcardUsername { get; set; }
     public ILogin Login { get; set; }
 }
 
@@ -136,13 +136,13 @@ public interface IMessage
 {
     public int MessageId { get; set; }
     public string FromUsername { get; set; }
-    public string ToUsername { get; set; }
+    public string? ToUsername { get; set; }
     public DateTime Sent { get; set; }
     public string Subject { get; set; }
     public string Body { get; set; }
     public bool IsRead { get; set; }
     public ILogin Sender { get; set; }
-    public ILogin Recipient { get; set; }
+    public ILogin? Recipient { get; set; }
 }
 
 public interface IOrderLine
@@ -150,7 +150,7 @@ public interface IOrderLine
     public int OrderId { get; set; }
     public int ProductId { get; set; }
     public int Quantity { get; set; }
-    public string ConcurrencyToken { get; set; }
+    public string? ConcurrencyToken { get; set; }
     public IAnOrder Order { get; set; }
     public IProduct Product { get; set; }
 }
@@ -284,7 +284,7 @@ public interface ISmartCard
     public string CardSerial { get; set; }
     public DateTime Issued { get; set; }
     public ILogin Login { get; set; }
-    public ILastLogin LastLogin { get; set; }
+    public ILastLogin? LastLogin { get; set; }
 }
 
 public interface ISupplierInfo
@@ -321,7 +321,7 @@ public interface ISuspiciousActivity
 public interface IAuditInfo
 {
     public DateTime ModifiedDate { get; set; }
-    public string ModifiedBy { get; set; }
+    public string? ModifiedBy { get; set; }
 
     public IConcurrencyInfo Concurrency { get; set; }
 }
@@ -363,7 +363,7 @@ public interface ILogin
 
 public interface IPhone
 {
-    public string PhoneNumber { get; set; }
+    public string? PhoneNumber { get; set; }
     public string Extension { get; set; }
     public PhoneType PhoneType { get; set; }
 }

--- a/test/EFCore.Specification.Tests/TestModels/MusicStore/Album.cs
+++ b/test/EFCore.Specification.Tests/TestModels/MusicStore/Album.cs
@@ -6,8 +6,6 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace Microsoft.EntityFrameworkCore.TestModels.MusicStore;
 
-#nullable disable
-
 public class Album
 {
     [ScaffoldColumn(false)]
@@ -18,17 +16,17 @@ public class Album
     public int ArtistId { get; set; }
 
     [Required, StringLength(160, MinimumLength = 2)]
-    public string Title { get; set; }
+    public string Title { get; set; } = null!;
 
     [Required, Range(0.01, 100.00), DataType(DataType.Currency), Column(TypeName = "decimal(18,2)")]
     public decimal Price { get; set; }
 
     [Display(Name = "Album Art URL"), StringLength(1024)]
-    public string AlbumArtUrl { get; set; }
+    public string? AlbumArtUrl { get; set; }
 
-    public virtual Genre Genre { get; set; }
-    public virtual Artist Artist { get; set; }
-    public virtual List<OrderDetail> OrderDetails { get; set; }
+    public virtual Genre Genre { get; set; } = null!;
+    public virtual Artist Artist { get; set; } = null!;
+    public virtual List<OrderDetail> OrderDetails { get; set; } = null!;
 
     [ScaffoldColumn(false), Required]
     public DateTime Created { get; set; } = DateTime.UtcNow;

--- a/test/EFCore.Specification.Tests/TestModels/MusicStore/Artist.cs
+++ b/test/EFCore.Specification.Tests/TestModels/MusicStore/Artist.cs
@@ -5,12 +5,10 @@ using System.ComponentModel.DataAnnotations;
 
 namespace Microsoft.EntityFrameworkCore.TestModels.MusicStore;
 
-#nullable disable
-
 public class Artist
 {
     public int ArtistId { get; set; }
 
     [Required]
-    public string Name { get; set; }
+    public string Name { get; set; } = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/MusicStore/CartItem.cs
+++ b/test/EFCore.Specification.Tests/TestModels/MusicStore/CartItem.cs
@@ -5,15 +5,13 @@ using System.ComponentModel.DataAnnotations;
 
 namespace Microsoft.EntityFrameworkCore.TestModels.MusicStore;
 
-#nullable disable
-
 public class CartItem
 {
     [Key]
     public int CartItemId { get; set; }
 
     [Required]
-    public string CartId { get; set; }
+    public string CartId { get; set; } = null!;
 
     public int AlbumId { get; set; }
     public int Count { get; set; }
@@ -21,5 +19,5 @@ public class CartItem
     [DataType(DataType.DateTime)]
     public DateTime DateCreated { get; set; }
 
-    public virtual Album Album { get; set; }
+    public virtual Album Album { get; set; } = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/MusicStore/Genre.cs
+++ b/test/EFCore.Specification.Tests/TestModels/MusicStore/Genre.cs
@@ -5,16 +5,14 @@ using System.ComponentModel.DataAnnotations;
 
 namespace Microsoft.EntityFrameworkCore.TestModels.MusicStore;
 
-#nullable disable
-
 public class Genre
 {
     public int GenreId { get; set; }
 
     [Required]
-    public string Name { get; set; }
+    public string Name { get; set; } = null!;
 
-    public string Description { get; set; }
+    public string? Description { get; set; }
 
-    public List<Album> Albums { get; set; }
+    public List<Album> Albums { get; set; } = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/MusicStore/MusicStoreContext.cs
+++ b/test/EFCore.Specification.Tests/TestModels/MusicStore/MusicStoreContext.cs
@@ -5,14 +5,12 @@ using Microsoft.EntityFrameworkCore.TestModels.AspNetIdentity;
 
 namespace Microsoft.EntityFrameworkCore.TestModels.MusicStore;
 
-#nullable disable
-
 public class MusicStoreContext(DbContextOptions<MusicStoreContext> options) : IdentityDbContext<ApplicationUser>(options)
 {
-    public DbSet<Album> Albums { get; set; }
-    public DbSet<Artist> Artists { get; set; }
-    public DbSet<Order> Orders { get; set; }
-    public DbSet<Genre> Genres { get; set; }
-    public DbSet<CartItem> CartItems { get; set; }
-    public DbSet<OrderDetail> OrderDetails { get; set; }
+    public DbSet<Album> Albums { get; set; } = null!;
+    public DbSet<Artist> Artists { get; set; } = null!;
+    public DbSet<Order> Orders { get; set; } = null!;
+    public DbSet<Genre> Genres { get; set; } = null!;
+    public DbSet<CartItem> CartItems { get; set; } = null!;
+    public DbSet<OrderDetail> OrderDetails { get; set; } = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/MusicStore/Order.cs
+++ b/test/EFCore.Specification.Tests/TestModels/MusicStore/Order.cs
@@ -6,8 +6,6 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace Microsoft.EntityFrameworkCore.TestModels.MusicStore;
 
-#nullable disable
-
 public class Order
 {
     [ScaffoldColumn(false)]
@@ -17,39 +15,39 @@ public class Order
     public DateTime OrderDate { get; set; }
 
     [ScaffoldColumn(false)]
-    public string Username { get; set; }
+    public string Username { get; set; } = null!;
 
     [Required, Display(Name = "First Name"), StringLength(160)]
-    public string FirstName { get; set; }
+    public string FirstName { get; set; } = null!;
 
     [Required, Display(Name = "Last Name"), StringLength(160)]
-    public string LastName { get; set; }
+    public string LastName { get; set; } = null!;
 
     [Required, StringLength(70, MinimumLength = 3)]
-    public string Address { get; set; }
+    public string Address { get; set; } = null!;
 
     [Required, StringLength(40)]
-    public string City { get; set; }
+    public string City { get; set; } = null!;
 
     [Required, StringLength(40)]
-    public string State { get; set; }
+    public string State { get; set; } = null!;
 
     [Required, Display(Name = "Postal Code"), StringLength(10, MinimumLength = 5)]
-    public string PostalCode { get; set; }
+    public string PostalCode { get; set; } = null!;
 
     [Required, StringLength(40)]
-    public string Country { get; set; }
+    public string Country { get; set; } = null!;
 
     [Required, StringLength(24), DataType(DataType.PhoneNumber)]
-    public string Phone { get; set; }
+    public string Phone { get; set; } = null!;
 
     [Required, Display(Name = "Email Address"), RegularExpression(
          @"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,4}",
          ErrorMessage = "Email is not valid."), DataType(DataType.EmailAddress)]
-    public string Email { get; set; }
+    public string Email { get; set; } = null!;
 
     [ScaffoldColumn(false), Column(TypeName = "decimal(18,2)")]
     public decimal Total { get; set; }
 
-    public List<OrderDetail> OrderDetails { get; set; }
+    public List<OrderDetail> OrderDetails { get; set; } = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/MusicStore/OrderDetail.cs
+++ b/test/EFCore.Specification.Tests/TestModels/MusicStore/OrderDetail.cs
@@ -5,8 +5,6 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace Microsoft.EntityFrameworkCore.TestModels.MusicStore;
 
-#nullable disable
-
 public class OrderDetail
 {
     public int OrderDetailId { get; set; }
@@ -17,6 +15,6 @@ public class OrderDetail
     [Column(TypeName = "decimal(18,2)")]
     public decimal UnitPrice { get; set; }
 
-    public virtual Album Album { get; set; }
-    public virtual Order Order { get; set; }
+    public virtual Album Album { get; set; } = null!;
+    public virtual Order Order { get; set; } = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/MusicStore/ShoppingCartRemoveViewModel.cs
+++ b/test/EFCore.Specification.Tests/TestModels/MusicStore/ShoppingCartRemoveViewModel.cs
@@ -3,11 +3,9 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.MusicStore;
 
-#nullable disable
-
 public class ShoppingCartRemoveViewModel
 {
-    public string Message { get; set; }
+    public string Message { get; set; } = null!;
     public decimal CartTotal { get; set; }
     public int CartCount { get; set; }
     public int ItemCount { get; set; }

--- a/test/EFCore.Specification.Tests/TestModels/MusicStore/ShoppingCartViewModel.cs
+++ b/test/EFCore.Specification.Tests/TestModels/MusicStore/ShoppingCartViewModel.cs
@@ -3,10 +3,8 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.MusicStore;
 
-#nullable disable
-
 public class ShoppingCartViewModel
 {
-    public List<CartItem> CartItems { get; set; }
+    public List<CartItem> CartItems { get; set; } = null!;
     public decimal CartTotal { get; set; }
 }

--- a/test/EFCore.Specification.Tests/TestModels/Northwind/CustomerQuery.cs
+++ b/test/EFCore.Specification.Tests/TestModels/Northwind/CustomerQuery.cs
@@ -5,15 +5,13 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace Microsoft.EntityFrameworkCore.TestModels.Northwind;
 
-#nullable disable
-
 public class CustomerQuery
 {
-    public string CompanyName { get; set; }
-    public string ContactName { get; set; }
-    public string ContactTitle { get; set; }
-    public string Address { get; set; }
-    public string City { get; set; }
+    public string CompanyName { get; set; } = null!;
+    public string? ContactName { get; set; }
+    public string? ContactTitle { get; set; }
+    public string? Address { get; set; }
+    public string? City { get; set; }
 
     [NotMapped]
     public bool IsLondon
@@ -22,7 +20,7 @@ public class CustomerQuery
     protected bool Equals(CustomerQuery other)
         => string.Equals(CompanyName, other.CompanyName);
 
-    public override bool Equals(object obj)
+    public override bool Equals(object? obj)
         => obj is not null
             && (ReferenceEquals(this, obj)
                 || (obj.GetType() == GetType()

--- a/test/EFCore.Specification.Tests/TestModels/Northwind/CustomerQueryWithQueryFilter.cs
+++ b/test/EFCore.Specification.Tests/TestModels/Northwind/CustomerQueryWithQueryFilter.cs
@@ -3,11 +3,9 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.Northwind;
 
-#nullable disable
-
 public class CustomerQueryWithQueryFilter
 {
-    public string CompanyName { get; set; }
+    public string CompanyName { get; set; } = null!;
     public int OrderCount { get; set; }
-    public string SearchTerm { get; set; }
+    public string SearchTerm { get; set; } = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/Northwind/Employee.cs
+++ b/test/EFCore.Specification.Tests/TestModels/Northwind/Employee.cs
@@ -5,8 +5,6 @@ using System.ComponentModel.DataAnnotations;
 
 namespace Microsoft.EntityFrameworkCore.TestModels.Northwind;
 
-#nullable disable
-
 public class Employee
 {
     private uint? _employeeId;
@@ -18,54 +16,54 @@ public class Employee
     }
 
     [MaxLength(20), Required]
-    public string LastName { get; set; }
+    public string LastName { get; set; } = null!;
 
     [MaxLength(10), Required]
-    public string FirstName { get; set; }
+    public string FirstName { get; set; } = null!;
 
     [MaxLength(30)]
-    public string Title { get; set; }
+    public string? Title { get; set; }
 
     [MaxLength(25)]
-    public string TitleOfCourtesy { get; set; }
+    public string? TitleOfCourtesy { get; set; }
 
     public DateTime? BirthDate { get; set; }
     public DateTime? HireDate { get; set; }
 
     [MaxLength(60)]
-    public string Address { get; set; }
+    public string? Address { get; set; }
 
     [MaxLength(15)]
-    public string City { get; set; }
+    public string? City { get; set; }
 
     [MaxLength(15)]
-    public string Region { get; set; }
+    public string? Region { get; set; }
 
     [MaxLength(10)]
-    public string PostalCode { get; set; }
+    public string? PostalCode { get; set; }
 
     [MaxLength(15)]
-    public string Country { get; set; }
+    public string? Country { get; set; }
 
     [MaxLength(24)]
-    public string HomePhone { get; set; }
+    public string? HomePhone { get; set; }
 
     [MaxLength(4)]
-    public string Extension { get; set; }
+    public string? Extension { get; set; }
 
-    public byte[] Photo { get; set; }
-    public string Notes { get; set; }
+    public byte[]? Photo { get; set; }
+    public string? Notes { get; set; }
     public uint? ReportsTo { get; set; }
 
     [MaxLength(255)]
-    public string PhotoPath { get; set; }
+    public string? PhotoPath { get; set; }
 
-    public Employee Manager { get; set; }
+    public Employee? Manager { get; set; }
 
     protected bool Equals(Employee other)
         => EmployeeID == other.EmployeeID;
 
-    public override bool Equals(object obj)
+    public override bool Equals(object? obj)
         => obj is not null
             && (ReferenceEquals(this, obj)
                 || (obj.GetType() == GetType()

--- a/test/EFCore.Specification.Tests/TestModels/Northwind/NorthwindContext.cs
+++ b/test/EFCore.Specification.Tests/TestModels/Northwind/NorthwindContext.cs
@@ -5,16 +5,14 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.Northwind;
 
-#nullable disable
-
 public class NorthwindContext(DbContextOptions options) : PoolableDbContext(options)
 {
-    public virtual DbSet<Customer> Customers { get; set; }
-    public virtual DbSet<Employee> Employees { get; set; }
-    public virtual DbSet<Order> Orders { get; set; }
-    public virtual DbSet<OrderDetail> OrderDetails { get; set; }
-    public virtual DbSet<Product> Products { get; set; }
-    public virtual DbSet<CustomerQuery> CustomerQueries { get; set; }
+    public virtual DbSet<Customer> Customers { get; set; } = null!;
+    public virtual DbSet<Employee> Employees { get; set; } = null!;
+    public virtual DbSet<Order> Orders { get; set; } = null!;
+    public virtual DbSet<OrderDetail> OrderDetails { get; set; } = null!;
+    public virtual DbSet<Product> Products { get; set; } = null!;
+    public virtual DbSet<CustomerQuery> CustomerQueries { get; set; } = null!;
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -92,7 +90,7 @@ public class NorthwindContext(DbContextOptions options) : PoolableDbContext(opti
         modelBuilder.Entity<Customer>().HasQueryFilter(c => c.CompanyName.StartsWith(TenantPrefix));
         modelBuilder.Entity<Order>().HasQueryFilter(o => o.Customer != null && o.Customer.CompanyName != null);
         modelBuilder.Entity<OrderDetail>().HasQueryFilter(od => od.Order != null && EF.Property<short>(od, "Quantity") > _quantity);
-        modelBuilder.Entity<Employee>().HasQueryFilter(e => e.Address.StartsWith("A"));
+        modelBuilder.Entity<Employee>().HasQueryFilter(e => e.Address!.StartsWith("A"));
         modelBuilder.Entity<Product>().HasQueryFilter(p => ClientMethod(p));
         modelBuilder.Entity<CustomerQueryWithQueryFilter>().HasQueryFilter(cq => cq.CompanyName.StartsWith(SearchTerm));
     }

--- a/test/EFCore.Specification.Tests/TestModels/Northwind/NorthwindData.cs
+++ b/test/EFCore.Specification.Tests/TestModels/Northwind/NorthwindData.cs
@@ -3,8 +3,6 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.Northwind;
 
-#nullable disable
-
 public partial class NorthwindData : ISetSource
 {
     public static readonly NorthwindData Instance = new();
@@ -15,9 +13,9 @@ public partial class NorthwindData : ISetSource
     public Employee[] Employees { get; }
     public Product[] Products { get; }
     public ProductQuery[] ProductQueries { get; }
-    public ProductView[] ProductViews { get; }
+    public ProductView[] ProductViews { get; } = [];
     public Order[] Orders { get; }
-    public OrderQuery[] OrderQueries { get; }
+    public OrderQuery[] OrderQueries { get; } = [];
     public OrderDetail[] OrderDetails { get; }
 
     private readonly Dictionary<int, string> _categoryNameMap = new()

--- a/test/EFCore.Specification.Tests/TestModels/Northwind/Order.cs
+++ b/test/EFCore.Specification.Tests/TestModels/Northwind/Order.cs
@@ -5,8 +5,6 @@ using System.ComponentModel.DataAnnotations;
 
 namespace Microsoft.EntityFrameworkCore.TestModels.Northwind;
 
-#nullable disable
-
 public class Order
 {
     private int? _orderId;
@@ -18,7 +16,7 @@ public class Order
     }
 
     [MaxLength(5)]
-    public string CustomerID { get; set; }
+    public string? CustomerID { get; set; }
 
     public uint? EmployeeID { get; set; }
     public DateTime? OrderDate { get; set; }
@@ -28,31 +26,31 @@ public class Order
     public decimal? Freight { get; set; }
 
     [MaxLength(40)]
-    public string ShipName { get; set; }
+    public string? ShipName { get; set; }
 
     [MaxLength(60)]
-    public string ShipAddress { get; set; }
+    public string? ShipAddress { get; set; }
 
     [MaxLength(15)]
-    public string ShipCity { get; set; }
+    public string? ShipCity { get; set; }
 
     [MaxLength(15)]
-    public string ShipRegion { get; set; }
+    public string? ShipRegion { get; set; }
 
     [MaxLength(10)]
-    public string ShipPostalCode { get; set; }
+    public string? ShipPostalCode { get; set; }
 
     [MaxLength(15)]
-    public string ShipCountry { get; set; }
+    public string? ShipCountry { get; set; }
 
-    public Customer Customer { get; set; } = new(); // Initialized to test #23851
+    public Customer? Customer { get; set; } = new(); // Initialized to test #23851
 
-    public virtual ICollection<OrderDetail> OrderDetails { get; set; }
+    public virtual ICollection<OrderDetail> OrderDetails { get; set; } = null!;
 
     protected bool Equals(Order other)
         => OrderID == other.OrderID;
 
-    public override bool Equals(object obj)
+    public override bool Equals(object? obj)
         => obj is not null
             && (ReferenceEquals(this, obj)
                 || (obj.GetType() == GetType()

--- a/test/EFCore.Specification.Tests/TestModels/Northwind/OrderDetail.cs
+++ b/test/EFCore.Specification.Tests/TestModels/Northwind/OrderDetail.cs
@@ -3,8 +3,6 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.Northwind;
 
-#nullable disable
-
 public class OrderDetail : IComparable<OrderDetail>
 {
     private int? _orderId;
@@ -26,14 +24,14 @@ public class OrderDetail : IComparable<OrderDetail>
     public short Quantity { get; set; }
     public float Discount { get; set; }
 
-    public virtual Product Product { get; set; }
-    public virtual Order Order { get; set; }
+    public virtual Product Product { get; set; } = null!;
+    public virtual Order Order { get; set; } = null!;
 
     protected bool Equals(OrderDetail other)
         => OrderID == other.OrderID
             && ProductID == other.ProductID;
 
-    public override bool Equals(object obj)
+    public override bool Equals(object? obj)
         => obj is not null
             && (ReferenceEquals(this, obj)
                 || (obj.GetType() == GetType()
@@ -42,7 +40,7 @@ public class OrderDetail : IComparable<OrderDetail>
     public override int GetHashCode()
         => HashCode.Combine(OrderID, ProductID);
 
-    public int CompareTo(OrderDetail other)
+    public int CompareTo(OrderDetail? other)
     {
         if (other == null)
         {

--- a/test/EFCore.Specification.Tests/TestModels/Northwind/OrderQuery.cs
+++ b/test/EFCore.Specification.Tests/TestModels/Northwind/OrderQuery.cs
@@ -3,8 +3,6 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.Northwind;
 
-#nullable disable
-
 public class OrderQuery
 {
     public OrderQuery()
@@ -14,14 +12,14 @@ public class OrderQuery
     public OrderQuery(string customerID)
         => CustomerID = customerID;
 
-    public string CustomerID { get; set; }
+    public string? CustomerID { get; set; }
 
-    public Customer Customer { get; set; }
+    public Customer? Customer { get; set; }
 
     protected bool Equals(OrderQuery other)
         => string.Equals(CustomerID, other.CustomerID);
 
-    public override bool Equals(object obj)
+    public override bool Equals(object? obj)
         => obj is not null
             && (ReferenceEquals(this, obj)
                 || (obj.GetType() == GetType()
@@ -34,7 +32,7 @@ public class OrderQuery
         => !Equals(left, right);
 
     public override int GetHashCode()
-        => CustomerID.GetHashCode();
+        => CustomerID?.GetHashCode() ?? 0;
 
     public override string ToString()
         => "OrderView " + CustomerID;

--- a/test/EFCore.Specification.Tests/TestModels/Northwind/Product.cs
+++ b/test/EFCore.Specification.Tests/TestModels/Northwind/Product.cs
@@ -5,8 +5,6 @@ using System.ComponentModel.DataAnnotations;
 
 namespace Microsoft.EntityFrameworkCore.TestModels.Northwind;
 
-#nullable disable
-
 public class Product
 {
     private int? _productId;
@@ -21,13 +19,13 @@ public class Product
     }
 
     [MaxLength(40), Required]
-    public string ProductName { get; set; }
+    public string ProductName { get; set; } = null!;
 
     public int? SupplierID { get; set; }
     public int? CategoryID { get; set; }
 
     [MaxLength(20)]
-    public string QuantityPerUnit { get; set; }
+    public string? QuantityPerUnit { get; set; }
 
     public decimal? UnitPrice { get; set; }
     public ushort UnitsInStock { get; set; }
@@ -40,7 +38,7 @@ public class Product
     protected bool Equals(Product other)
         => Equals(ProductID, other.ProductID);
 
-    public override bool Equals(object obj)
+    public override bool Equals(object? obj)
         => obj is not null
             && (ReferenceEquals(this, obj)
                 || (obj.GetType() == GetType()

--- a/test/EFCore.Specification.Tests/TestModels/Northwind/ProductQuery.cs
+++ b/test/EFCore.Specification.Tests/TestModels/Northwind/ProductQuery.cs
@@ -3,11 +3,9 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.Northwind;
 
-#nullable disable
-
 public class ProductQuery
 {
     public int ProductID { get; set; }
-    public string ProductName { get; set; }
-    public string CategoryName { get; set; }
+    public string ProductName { get; set; } = null!;
+    public string CategoryName { get; set; } = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/Northwind/ProductView.cs
+++ b/test/EFCore.Specification.Tests/TestModels/Northwind/ProductView.cs
@@ -3,11 +3,9 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.Northwind;
 
-#nullable disable
-
 public class ProductView
 {
     public int ProductID { get; set; }
-    public string ProductName { get; set; }
-    public string CategoryName { get; set; }
+    public string ProductName { get; set; } = null!;
+    public string CategoryName { get; set; } = null!;
 }

--- a/test/EFCore.Specification.Tests/TestModels/Northwind/UnmappedEmployee.cs
+++ b/test/EFCore.Specification.Tests/TestModels/Northwind/UnmappedEmployee.cs
@@ -5,54 +5,52 @@ using System.ComponentModel.DataAnnotations;
 
 namespace Microsoft.EntityFrameworkCore.TestModels.Northwind;
 
-#nullable disable
-
 public class UnmappedEmployee
 {
     public int EmployeeID { get; set; }
 
     [MaxLength(20), Required]
-    public string LastName { get; set; }
+    public string LastName { get; set; } = null!;
 
     [MaxLength(10), Required]
-    public string FirstName { get; set; }
+    public string FirstName { get; set; } = null!;
 
     [MaxLength(30)]
-    public string Title { get; set; }
+    public string? Title { get; set; }
 
     [MaxLength(25)]
-    public string TitleOfCourtesy { get; set; }
+    public string? TitleOfCourtesy { get; set; }
 
     public DateTime? BirthDate { get; set; }
     public DateTime? HireDate { get; set; }
 
     [MaxLength(60)]
-    public string Address { get; set; }
+    public string? Address { get; set; }
 
     [MaxLength(15)]
-    public string City { get; set; }
+    public string? City { get; set; }
 
     [MaxLength(15)]
-    public string Region { get; set; }
+    public string? Region { get; set; }
 
     [MaxLength(10)]
-    public string PostalCode { get; set; }
+    public string? PostalCode { get; set; }
 
     [MaxLength(15)]
-    public string Country { get; set; }
+    public string? Country { get; set; }
 
     [MaxLength(24)]
-    public string HomePhone { get; set; }
+    public string? HomePhone { get; set; }
 
     [MaxLength(4)]
-    public string Extension { get; set; }
+    public string? Extension { get; set; }
 
-    public byte[] Photo { get; set; }
-    public string Notes { get; set; }
+    public byte[]? Photo { get; set; }
+    public string? Notes { get; set; }
     public int? ReportsTo { get; set; }
 
     [MaxLength(255)]
-    public string PhotoPath { get; set; }
+    public string? PhotoPath { get; set; }
 
     public static UnmappedEmployee FromEmployee(Employee employee)
         => new()

--- a/test/EFCore.Specification.Tests/TestModels/Northwind/UnmappedOrder.cs
+++ b/test/EFCore.Specification.Tests/TestModels/Northwind/UnmappedOrder.cs
@@ -6,15 +6,13 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace Microsoft.EntityFrameworkCore.TestModels.Northwind;
 
-#nullable disable
-
 [Table("Orders")]
 public class UnmappedOrder
 {
     public int OrderID { get; set; }
 
     [MaxLength(5)]
-    public string CustomerID { get; set; }
+    public string? CustomerID { get; set; }
 
     public int? EmployeeID { get; set; }
     public DateTime? OrderDate { get; set; }
@@ -26,29 +24,29 @@ public class UnmappedOrder
     public decimal? Freight { get; set; }
 
     [MaxLength(40)]
-    public string ShipName { get; set; }
+    public string? ShipName { get; set; }
 
     [MaxLength(60)]
-    public string ShipAddress { get; set; }
+    public string? ShipAddress { get; set; }
 
     [MaxLength(15)]
-    public string ShipCity { get; set; }
+    public string? ShipCity { get; set; }
 
     [MaxLength(15)]
-    public string ShipRegion { get; set; }
+    public string? ShipRegion { get; set; }
 
     [MaxLength(10)]
-    public string ShipPostalCode { get; set; }
+    public string? ShipPostalCode { get; set; }
 
     [MaxLength(15)]
-    public string ShipCountry { get; set; }
+    public string? ShipCountry { get; set; }
 
     public static UnmappedOrder FromOrder(Order order)
         => new()
         {
             OrderID = order.OrderID,
             CustomerID = order.CustomerID,
-            EmployeeID = (int)order.EmployeeID,
+            EmployeeID = (int?)order.EmployeeID,
             OrderDate = order.OrderDate,
             RequiredDate = order.RequiredDate,
             ShippedDate = order.ShippedDate,

--- a/test/EFCore.Specification.Tests/TestModels/Northwind/UnmappedProduct.cs
+++ b/test/EFCore.Specification.Tests/TestModels/Northwind/UnmappedProduct.cs
@@ -5,12 +5,10 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace Microsoft.EntityFrameworkCore.TestModels.Northwind;
 
-#nullable disable
-
 public class UnmappedProduct
 {
     public int ProductID { get; set; }
-    public string ProductName { get; set; }
+    public string ProductName { get; set; } = null!;
     public int? SupplierID { get; set; }
 
     [NotMapped]

--- a/test/EFCore.Specification.Tests/TestModels/NullSemanticsModel/NullSemanticsContext.cs
+++ b/test/EFCore.Specification.Tests/TestModels/NullSemanticsModel/NullSemanticsContext.cs
@@ -3,12 +3,10 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.NullSemanticsModel;
 
-#nullable disable
-
 public class NullSemanticsContext(DbContextOptions options) : PoolableDbContext(options)
 {
-    public DbSet<NullSemanticsEntity1> Entities1 { get; set; }
-    public DbSet<NullSemanticsEntity2> Entities2 { get; set; }
+    public DbSet<NullSemanticsEntity1> Entities1 { get; set; } = null!;
+    public DbSet<NullSemanticsEntity2> Entities2 { get; set; } = null!;
 
     public static Task SeedAsync(NullSemanticsContext context)
     {

--- a/test/EFCore.Specification.Tests/TestModels/NullSemanticsModel/NullSemanticsEntityBase.cs
+++ b/test/EFCore.Specification.Tests/TestModels/NullSemanticsModel/NullSemanticsEntityBase.cs
@@ -3,8 +3,6 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.NullSemanticsModel;
 
-#nullable disable
-
 public abstract class NullSemanticsEntityBase
 {
     public int Id { get; set; }
@@ -16,13 +14,13 @@ public abstract class NullSemanticsEntityBase
     public bool? NullableBoolB { get; set; }
     public bool? NullableBoolC { get; set; }
 
-    public string StringA { get; set; }
-    public string StringB { get; set; }
-    public string StringC { get; set; }
+    public string StringA { get; set; } = null!;
+    public string StringB { get; set; } = null!;
+    public string StringC { get; set; } = null!;
 
-    public string NullableStringA { get; set; }
-    public string NullableStringB { get; set; }
-    public string NullableStringC { get; set; }
+    public string? NullableStringA { get; set; }
+    public string? NullableStringB { get; set; }
+    public string? NullableStringC { get; set; }
 
     public int IntA { get; set; }
     public int IntB { get; set; }

--- a/test/EFCore.Specification.Tests/TestModels/QueryFilterFuncletizationContext.cs
+++ b/test/EFCore.Specification.Tests/TestModels/QueryFilterFuncletizationContext.cs
@@ -5,8 +5,6 @@
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
-#nullable disable
-
 public class QueryFilterFuncletizationContext(DbContextOptions options) : DbContext(options)
 {
     public static int AdminId = 1;
@@ -21,10 +19,10 @@ public class QueryFilterFuncletizationContext(DbContextOptions options) : DbCont
     public Indirection GetFlag()
         => new();
 
-    public List<int> TenantIds { get; set; }
-    public Indirection IndirectionFlag { get; set; }
+    public List<int> TenantIds { get; set; } = null!;
+    public Indirection IndirectionFlag { get; set; } = null!;
 
-    public DbSet<DependentSetFilter> Dependents { get; set; }
+    public DbSet<DependentSetFilter> Dependents { get; set; } = null!;
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -63,7 +61,7 @@ public class QueryFilterFuncletizationContext(DbContextOptions options) : DbCont
             .HasQueryFilter(b => b.IsEnabled == StaticMemberFilter.DefaultEnabled);
         var enabled = true;
         modelBuilder.Entity<LocalVariableFilter>().HasQueryFilter(e => e.IsEnabled == enabled);
-        Indirection flag = null;
+        Indirection flag = null!;
         modelBuilder.Entity<LocalVariableErrorFilter>().HasQueryFilter(e => e.IsEnabled == flag.Enabled);
         IncorrectFilter(modelBuilder.Entity<ParameterFilter>(), Tenant);
 
@@ -385,7 +383,7 @@ public class PrincipalSetFilter
 {
     public int Id { get; set; }
     public bool Filler { get; set; }
-    public ICollection<DependentSetFilter> Dependents { get; set; }
+    public ICollection<DependentSetFilter> Dependents { get; set; } = null!;
 }
 
 public class DependentSetFilter
@@ -405,8 +403,8 @@ public class DeDupeFilter1
 {
     public int Id { get; set; }
     public int Tenant { get; set; }
-    public ICollection<DeDupeFilter2> DeDupeFilter2s { get; set; }
-    public ICollection<DeDupeFilter3> DeDupeFilter3s { get; set; }
+    public ICollection<DeDupeFilter2> DeDupeFilter2s { get; set; } = null!;
+    public ICollection<DeDupeFilter3> DeDupeFilter3s { get; set; } = null!;
 }
 
 public class DeDupeFilter2
@@ -414,7 +412,7 @@ public class DeDupeFilter2
     public int Id { get; set; }
     public int TenantX { get; set; }
     public int? DeDupeFilter1Id { get; set; }
-    public DeDupeFilter1 DeDupeFilter1 { get; set; }
+    public DeDupeFilter1 DeDupeFilter1 { get; set; } = null!;
 }
 
 public class DeDupeFilter3
@@ -422,7 +420,7 @@ public class DeDupeFilter3
     public int Id { get; set; }
     public short Tenant { get; set; }
     public int? DeDupeFilter1Id { get; set; }
-    public DeDupeFilter1 DeDupeFilter1 { get; set; }
+    public DeDupeFilter1 DeDupeFilter1 { get; set; } = null!;
 }
 
 #endregion

--- a/test/EFCore.Specification.Tests/TestModels/SnapshotMonsterContext.cs
+++ b/test/EFCore.Specification.Tests/TestModels/SnapshotMonsterContext.cs
@@ -5,8 +5,6 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels;
 
-#nullable disable
-
 public class SnapshotMonsterContext(DbContextOptions options) : MonsterContext<
     SnapshotMonsterContext.Customer, SnapshotMonsterContext.Barcode, SnapshotMonsterContext.IncorrectScan,
     SnapshotMonsterContext.BarcodeDetail, SnapshotMonsterContext.Complaint, SnapshotMonsterContext.Resolution,
@@ -29,13 +27,13 @@ public class SnapshotMonsterContext(DbContextOptions options) : MonsterContext<
         public DateTime ETA { get; set; } = DateTime.Now;
 
         public int SupplierId { get; set; }
-        public virtual ISupplier Supplier { get; set; }
+        public virtual ISupplier Supplier { get; set; } = null!;
     }
 
     public class BarcodeDetail : IBarcodeDetail
     {
-        public byte[] Code { get; set; }
-        public string RegisteredTo { get; set; }
+        public byte[] Code { get; set; } = null!;
+        public string RegisteredTo { get; set; } = null!;
     }
 
     public class Barcode : IBarcode
@@ -43,13 +41,13 @@ public class SnapshotMonsterContext(DbContextOptions options) : MonsterContext<
         public void InitializeCollections()
             => BadScans ??= new HashSet<IIncorrectScan>();
 
-        public byte[] Code { get; set; }
+        public byte[] Code { get; set; } = null!;
         public int ProductId { get; set; }
-        public string Text { get; set; }
+        public string Text { get; set; } = null!;
 
-        public virtual IProduct Product { get; set; }
-        public virtual ICollection<IIncorrectScan> BadScans { get; set; }
-        public virtual IBarcodeDetail Detail { get; set; }
+        public virtual IProduct Product { get; set; } = null!;
+        public virtual ICollection<IIncorrectScan> BadScans { get; set; } = null!;
+        public virtual IBarcodeDetail Detail { get; set; } = null!;
     }
 
     public class Complaint : IComplaint
@@ -58,45 +56,45 @@ public class SnapshotMonsterContext(DbContextOptions options) : MonsterContext<
         public int AlternateId { get; set; }
         public int? CustomerId { get; set; }
         public DateTime Logged { get; set; }
-        public string Details { get; set; }
+        public string Details { get; set; } = null!;
 
-        public virtual ICustomer Customer { get; set; }
-        public virtual IResolution Resolution { get; set; }
+        public virtual ICustomer Customer { get; set; } = null!;
+        public virtual IResolution Resolution { get; set; } = null!;
     }
 
     public class ComputerDetail : IComputerDetail
     {
         public int ComputerDetailId { get; set; }
-        public string Manufacturer { get; set; }
-        public string Model { get; set; }
-        public string Serial { get; set; }
-        public string Specifications { get; set; }
+        public string Manufacturer { get; set; } = null!;
+        public string Model { get; set; } = null!;
+        public string Serial { get; set; } = null!;
+        public string Specifications { get; set; } = null!;
         public DateTime PurchaseDate { get; set; }
 
         public IDimensions Dimensions { get; set; } = new Dimensions();
 
-        public virtual IComputer Computer { get; set; }
+        public virtual IComputer Computer { get; set; } = null!;
     }
 
     public class Computer : IComputer
     {
         public int ComputerId { get; set; }
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
 
-        public virtual IComputerDetail ComputerDetail { get; set; }
+        public virtual IComputerDetail ComputerDetail { get; set; } = null!;
     }
 
     public class ConcurrencyInfo : IConcurrencyInfo
     {
         public bool Active { get; set; }
-        public string Token { get; set; }
+        public string? Token { get; set; }
         public DateTime? QueriedDateTime { get; set; }
     }
 
     public class ContactDetails : IContactDetails
     {
         public bool Active { get; set; }
-        public string Email { get; set; }
+        public string? Email { get; set; }
 
         public IPhone HomePhone { get; set; } = new Phone();
         public IPhone WorkPhone { get; set; } = new Phone();
@@ -106,7 +104,7 @@ public class SnapshotMonsterContext(DbContextOptions options) : MonsterContext<
     public class CustomerInfo : ICustomerInfo
     {
         public int CustomerInfoId { get; set; }
-        public string Information { get; set; }
+        public string Information { get; set; } = null!;
     }
 
     public class Dimensions : IDimensions
@@ -121,64 +119,64 @@ public class SnapshotMonsterContext(DbContextOptions options) : MonsterContext<
         public DateTime Discontinued { get; set; }
         public int? ReplacementProductId { get; set; }
 
-        public virtual IProduct ReplacedBy { get; set; }
+        public virtual IProduct ReplacedBy { get; set; } = null!;
     }
 
     public class Driver : IDriver
     {
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
         public DateTime BirthDate { get; set; }
 
-        public virtual ILicense License { get; set; }
+        public virtual ILicense License { get; set; } = null!;
     }
 
     public class IncorrectScan : IIncorrectScan
     {
         public int IncorrectScanId { get; set; }
-        public byte[] ExpectedCode { get; set; }
-        public byte[] ActualCode { get; set; }
+        public byte[]? ExpectedCode { get; set; }
+        public byte[]? ActualCode { get; set; }
         public DateTime ScanDate { get; set; }
-        public string Details { get; set; }
+        public string Details { get; set; } = null!;
 
-        public virtual IBarcode ExpectedBarcode { get; set; }
-        public virtual IBarcode ActualBarcode { get; set; }
+        public virtual IBarcode? ExpectedBarcode { get; set; }
+        public virtual IBarcode? ActualBarcode { get; set; }
     }
 
     public class LastLogin : ILastLogin
     {
-        public string Username { get; set; }
+        public string Username { get; set; } = null!;
         public DateTime LoggedIn { get; set; }
         public DateTime? LoggedOut { get; set; }
 
-        public string SmartcardUsername { get; set; }
+        public string? SmartcardUsername { get; set; }
 
-        public virtual ILogin Login { get; set; }
+        public virtual ILogin Login { get; set; } = null!;
     }
 
     public class License : ILicense
     {
-        public string Name { get; set; }
-        public string LicenseNumber { get; set; }
+        public string Name { get; set; } = null!;
+        public string LicenseNumber { get; set; } = null!;
         public string LicenseClass { get; set; } = "C";
-        public string Restrictions { get; set; }
+        public string Restrictions { get; set; } = null!;
         public DateTime ExpirationDate { get; set; }
         public LicenseState? State { get; set; }
 
-        public virtual IDriver Driver { get; set; }
+        public virtual IDriver Driver { get; set; } = null!;
     }
 
     public class Message : IMessage
     {
         public int MessageId { get; set; }
-        public string FromUsername { get; set; }
-        public string ToUsername { get; set; }
+        public string FromUsername { get; set; } = null!;
+        public string? ToUsername { get; set; }
         public DateTime Sent { get; set; }
-        public string Subject { get; set; }
-        public string Body { get; set; }
+        public string Subject { get; set; } = null!;
+        public string Body { get; set; } = null!;
         public bool IsRead { get; set; }
 
-        public virtual ILogin Sender { get; set; }
-        public virtual ILogin Recipient { get; set; }
+        public virtual ILogin Sender { get; set; } = null!;
+        public virtual ILogin? Recipient { get; set; }
     }
 
     public class OrderLine : IOrderLine
@@ -186,10 +184,10 @@ public class SnapshotMonsterContext(DbContextOptions options) : MonsterContext<
         public int OrderId { get; set; }
         public int ProductId { get; set; }
         public int Quantity { get; set; } = 1;
-        public string ConcurrencyToken { get; set; }
+        public string? ConcurrencyToken { get; set; }
 
-        public virtual IAnOrder Order { get; set; }
-        public virtual IProduct Product { get; set; }
+        public virtual IAnOrder Order { get; set; } = null!;
+        public virtual IProduct Product { get; set; } = null!;
     }
 
     public class AnOrder : IAnOrder
@@ -206,58 +204,58 @@ public class SnapshotMonsterContext(DbContextOptions options) : MonsterContext<
 
         public IConcurrencyInfo Concurrency { get; set; } = new ConcurrencyInfo();
 
-        public virtual ICustomer Customer { get; set; }
-        public virtual ICollection<IOrderLine> OrderLines { get; set; }
-        public virtual ICollection<IOrderNote> Notes { get; set; }
+        public virtual ICustomer Customer { get; set; } = null!;
+        public virtual ICollection<IOrderLine> OrderLines { get; set; } = null!;
+        public virtual ICollection<IOrderNote> Notes { get; set; } = null!;
 
-        public string Username { get; set; }
-        public virtual ILogin Login { get; set; }
+        public string Username { get; set; } = null!;
+        public virtual ILogin Login { get; set; } = null!;
     }
 
     public class OrderNote : IOrderNote
     {
         public int NoteId { get; set; }
-        public string Note { get; set; }
+        public string Note { get; set; } = null!;
 
         public int OrderId { get; set; }
-        public virtual IAnOrder Order { get; set; }
+        public virtual IAnOrder Order { get; set; } = null!;
     }
 
     public class OrderQualityCheck : IOrderQualityCheck
     {
         public int OrderId { get; set; }
-        public string CheckedBy { get; set; }
+        public string CheckedBy { get; set; } = null!;
         public DateTime CheckedDateTime { get; set; }
 
-        public virtual IAnOrder Order { get; set; }
+        public virtual IAnOrder Order { get; set; } = null!;
     }
 
     public class PageView : IPageView
     {
         public int PageViewId { get; set; }
-        public string Username { get; set; }
+        public string Username { get; set; } = null!;
         public DateTime Viewed { get; set; }
-        public string PageUrl { get; set; }
+        public string PageUrl { get; set; } = null!;
 
-        public virtual ILogin Login { get; set; }
+        public virtual ILogin Login { get; set; } = null!;
     }
 
     public class PasswordReset : IPasswordReset
     {
         public int ResetNo { get; set; }
-        public string Username { get; set; }
-        public string TempPassword { get; set; }
-        public string EmailedTo { get; set; }
+        public string Username { get; set; } = null!;
+        public string TempPassword { get; set; } = null!;
+        public string EmailedTo { get; set; } = null!;
 
-        public virtual ILogin Login { get; set; }
+        public virtual ILogin Login { get; set; } = null!;
     }
 
     public class ProductDetail : IProductDetail
     {
         public int ProductId { get; set; }
-        public string Details { get; set; }
+        public string Details { get; set; } = null!;
 
-        public virtual IProduct Product { get; set; }
+        public virtual IProduct Product { get; set; } = null!;
     }
 
     public class Product : IProduct
@@ -272,26 +270,26 @@ public class SnapshotMonsterContext(DbContextOptions options) : MonsterContext<
         }
 
         public int ProductId { get; set; }
-        public string Description { get; set; }
-        public string BaseConcurrency { get; set; }
+        public string Description { get; set; } = null!;
+        public string BaseConcurrency { get; set; } = null!;
 
-        public IDimensions Dimensions { get; set; }
+        public IDimensions Dimensions { get; set; } = null!;
         public IConcurrencyInfo ComplexConcurrency { get; set; } = new ConcurrencyInfo();
         public IAuditInfo NestedComplexConcurrency { get; set; } = new AuditInfo();
 
-        public virtual ICollection<ISupplier> Suppliers { get; set; }
-        public virtual ICollection<IDiscontinuedProduct> Replaces { get; set; }
-        public virtual IProductDetail Detail { get; set; }
-        public virtual ICollection<IProductReview> Reviews { get; set; }
-        public virtual ICollection<IProductPhoto> Photos { get; set; }
-        public virtual ICollection<IBarcode> Barcodes { get; set; }
+        public virtual ICollection<ISupplier> Suppliers { get; set; } = null!;
+        public virtual ICollection<IDiscontinuedProduct> Replaces { get; set; } = null!;
+        public virtual IProductDetail Detail { get; set; } = null!;
+        public virtual ICollection<IProductReview> Reviews { get; set; } = null!;
+        public virtual ICollection<IProductPhoto> Photos { get; set; } = null!;
+        public virtual ICollection<IBarcode> Barcodes { get; set; } = null!;
     }
 
     public class ProductPageView : PageView, IProductPageView
     {
         public int ProductId { get; set; }
 
-        public virtual IProduct Product { get; set; }
+        public virtual IProduct Product { get; set; } = null!;
     }
 
     public class ProductPhoto : IProductPhoto
@@ -301,9 +299,9 @@ public class SnapshotMonsterContext(DbContextOptions options) : MonsterContext<
 
         public int ProductId { get; set; }
         public int PhotoId { get; set; }
-        public byte[] Photo { get; set; }
+        public byte[] Photo { get; set; } = null!;
 
-        public virtual ICollection<IProductWebFeature> Features { get; set; }
+        public virtual ICollection<IProductWebFeature> Features { get; set; } = null!;
     }
 
     public class ProductReview : IProductReview
@@ -313,10 +311,10 @@ public class SnapshotMonsterContext(DbContextOptions options) : MonsterContext<
 
         public int ProductId { get; set; }
         public int ReviewId { get; set; }
-        public string Review { get; set; }
+        public string Review { get; set; } = null!;
 
-        public virtual IProduct Product { get; set; }
-        public virtual ICollection<IProductWebFeature> Features { get; set; }
+        public virtual IProduct Product { get; set; } = null!;
+        public virtual ICollection<IProductWebFeature> Features { get; set; } = null!;
     }
 
     public class ProductWebFeature : IProductWebFeature
@@ -325,52 +323,52 @@ public class SnapshotMonsterContext(DbContextOptions options) : MonsterContext<
         public int? ProductId { get; set; }
         public int? PhotoId { get; set; }
         public int ReviewId { get; set; }
-        public string Heading { get; set; }
+        public string Heading { get; set; } = null!;
 
-        public virtual IProductReview Review { get; set; }
-        public virtual IProductPhoto Photo { get; set; }
+        public virtual IProductReview Review { get; set; } = null!;
+        public virtual IProductPhoto Photo { get; set; } = null!;
     }
 
     public class Resolution : IResolution
     {
         public int ResolutionId { get; set; }
-        public string Details { get; set; }
+        public string Details { get; set; } = null!;
 
-        public virtual IComplaint Complaint { get; set; }
+        public virtual IComplaint Complaint { get; set; } = null!;
     }
 
     public class RsaToken : IRsaToken
     {
-        public string Serial { get; set; }
+        public string Serial { get; set; } = null!;
         public DateTime Issued { get; set; }
 
-        public string Username { get; set; }
-        public virtual ILogin Login { get; set; }
+        public string Username { get; set; } = null!;
+        public virtual ILogin Login { get; set; } = null!;
     }
 
     public class SmartCard : ISmartCard
     {
-        public string Username { get; set; }
-        public string CardSerial { get; set; }
+        public string Username { get; set; } = null!;
+        public string CardSerial { get; set; } = null!;
         public DateTime Issued { get; set; }
 
-        public virtual ILogin Login { get; set; }
-        public virtual ILastLogin LastLogin { get; set; }
+        public virtual ILogin Login { get; set; } = null!;
+        public virtual ILastLogin? LastLogin { get; set; }
     }
 
     public class SupplierInfo : ISupplierInfo
     {
         public int SupplierInfoId { get; set; }
-        public string Information { get; set; }
+        public string Information { get; set; } = null!;
 
         public int SupplierId { get; set; }
-        public virtual ISupplier Supplier { get; set; }
+        public virtual ISupplier Supplier { get; set; } = null!;
     }
 
     public class SupplierLogo : ISupplierLogo
     {
         public int SupplierId { get; set; }
-        public byte[] Logo { get; set; }
+        public byte[] Logo { get; set; } = null!;
     }
 
     public class Supplier : ISupplier
@@ -382,25 +380,25 @@ public class SnapshotMonsterContext(DbContextOptions options) : MonsterContext<
         }
 
         public int SupplierId { get; set; }
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
 
-        public virtual ICollection<IProduct> Products { get; set; }
-        public virtual ICollection<IBackOrderLine> BackOrderLines { get; set; }
-        public virtual ISupplierLogo Logo { get; set; }
+        public virtual ICollection<IProduct> Products { get; set; } = null!;
+        public virtual ICollection<IBackOrderLine> BackOrderLines { get; set; } = null!;
+        public virtual ISupplierLogo Logo { get; set; } = null!;
     }
 
     public class SuspiciousActivity : ISuspiciousActivity
     {
         public int SuspiciousActivityId { get; set; }
-        public string Activity { get; set; }
+        public string Activity { get; set; } = null!;
 
-        public string Username { get; set; }
+        public string Username { get; set; } = null!;
     }
 
     public class AuditInfo : IAuditInfo
     {
         public DateTime ModifiedDate { get; set; } = DateTime.Now;
-        public string ModifiedBy { get; set; }
+        public string? ModifiedBy { get; set; }
 
         public IConcurrencyInfo Concurrency { get; set; } = new ConcurrencyInfo();
     }
@@ -415,16 +413,16 @@ public class SnapshotMonsterContext(DbContextOptions options) : MonsterContext<
 
         public int CustomerId { get; set; }
         public int? HusbandId { get; set; }
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
 
         public IContactDetails ContactInfo { get; set; } = new ContactDetails();
         public IAuditInfo Auditing { get; set; } = new AuditInfo();
 
-        public virtual ICollection<IAnOrder> Orders { get; set; }
-        public virtual ICollection<ILogin> Logins { get; set; }
-        public virtual ICustomer Husband { get; set; }
-        public virtual ICustomer Wife { get; set; }
-        public virtual ICustomerInfo Info { get; set; }
+        public virtual ICollection<IAnOrder> Orders { get; set; } = null!;
+        public virtual ICollection<ILogin> Logins { get; set; } = null!;
+        public virtual ICustomer Husband { get; set; } = null!;
+        public virtual ICustomer Wife { get; set; } = null!;
+        public virtual ICustomerInfo Info { get; set; } = null!;
     }
 
     public class Login : ILogin
@@ -436,20 +434,20 @@ public class SnapshotMonsterContext(DbContextOptions options) : MonsterContext<
             Orders ??= new HashSet<IAnOrder>();
         }
 
-        public string Username { get; set; }
-        public string AlternateUsername { get; set; }
+        public string Username { get; set; } = null!;
+        public string AlternateUsername { get; set; } = null!;
         public int CustomerId { get; set; }
 
-        public virtual ICustomer Customer { get; set; }
-        public virtual ILastLogin LastLogin { get; set; }
-        public virtual ICollection<IMessage> SentMessages { get; set; }
-        public virtual ICollection<IMessage> ReceivedMessages { get; set; }
-        public virtual ICollection<IAnOrder> Orders { get; set; }
+        public virtual ICustomer Customer { get; set; } = null!;
+        public virtual ILastLogin LastLogin { get; set; } = null!;
+        public virtual ICollection<IMessage> SentMessages { get; set; } = null!;
+        public virtual ICollection<IMessage> ReceivedMessages { get; set; } = null!;
+        public virtual ICollection<IAnOrder> Orders { get; set; } = null!;
     }
 
     public class Phone : IPhone
     {
-        public string PhoneNumber { get; set; }
+        public string? PhoneNumber { get; set; }
         public string Extension { get; set; } = "None";
         public PhoneType PhoneType { get; set; }
     }

--- a/test/EFCore.Specification.Tests/TestModels/SpatialModel/GeoExtensions.cs
+++ b/test/EFCore.Specification.Tests/TestModels/SpatialModel/GeoExtensions.cs
@@ -5,16 +5,14 @@ using NetTopologySuite.Geometries;
 
 namespace Microsoft.EntityFrameworkCore.TestModels.SpatialModel;
 
-#nullable disable
-
 public static class GeoExtensions
 {
     public static double Distance(this GeoPoint x, GeoPoint y)
     {
         var converter = new GeoPointConverter();
 
-        var xPoint = (Point)converter.ConvertToProvider(x);
-        var yPoint = (Point)converter.ConvertToProvider(y);
+        var xPoint = (Point)converter.ConvertToProvider(x)!;
+        var yPoint = (Point)converter.ConvertToProvider(y)!;
 
         return yPoint.Distance(xPoint);
     }

--- a/test/EFCore.Specification.Tests/TestModels/SpatialModel/LineStringEntity.cs
+++ b/test/EFCore.Specification.Tests/TestModels/SpatialModel/LineStringEntity.cs
@@ -5,10 +5,8 @@ using NetTopologySuite.Geometries;
 
 namespace Microsoft.EntityFrameworkCore.TestModels.SpatialModel;
 
-#nullable disable
-
 public class LineStringEntity
 {
     public int Id { get; set; }
-    public LineString LineString { get; set; }
+    public LineString? LineString { get; set; }
 }

--- a/test/EFCore.Specification.Tests/TestModels/SpatialModel/MultiLineStringEntity.cs
+++ b/test/EFCore.Specification.Tests/TestModels/SpatialModel/MultiLineStringEntity.cs
@@ -5,10 +5,8 @@ using NetTopologySuite.Geometries;
 
 namespace Microsoft.EntityFrameworkCore.TestModels.SpatialModel;
 
-#nullable disable
-
 public class MultiLineStringEntity
 {
     public int Id { get; set; }
-    public MultiLineString MultiLineString { get; set; }
+    public MultiLineString? MultiLineString { get; set; }
 }

--- a/test/EFCore.Specification.Tests/TestModels/SpatialModel/PointEntity.cs
+++ b/test/EFCore.Specification.Tests/TestModels/SpatialModel/PointEntity.cs
@@ -5,17 +5,15 @@ using NetTopologySuite.Geometries;
 
 namespace Microsoft.EntityFrameworkCore.TestModels.SpatialModel;
 
-#nullable disable
-
 public class PointEntity
 {
     public static readonly Guid WellKnownId = Guid.Parse("2F39AADE-4D8D-42D2-88CE-775C84AB83B1");
 
     public Guid Id { get; set; }
-    public string Group { get; set; }
-    public Geometry Geometry { get; set; }
-    public Point Point { get; set; }
-    public Point PointZ { get; set; }
-    public Point PointM { get; set; }
-    public Point PointZM { get; set; }
+    public string? Group { get; set; }
+    public Geometry? Geometry { get; set; }
+    public Point? Point { get; set; }
+    public Point? PointZ { get; set; }
+    public Point? PointM { get; set; }
+    public Point? PointZM { get; set; }
 }

--- a/test/EFCore.Specification.Tests/TestModels/SpatialModel/PolygonEntity.cs
+++ b/test/EFCore.Specification.Tests/TestModels/SpatialModel/PolygonEntity.cs
@@ -5,10 +5,8 @@ using NetTopologySuite.Geometries;
 
 namespace Microsoft.EntityFrameworkCore.TestModels.SpatialModel;
 
-#nullable disable
-
 public class PolygonEntity
 {
     public Guid Id { get; set; }
-    public Polygon Polygon { get; set; }
+    public Polygon? Polygon { get; set; }
 }

--- a/test/EFCore.Specification.Tests/TestModels/SpatialModel/SpatialData.cs
+++ b/test/EFCore.Specification.Tests/TestModels/SpatialModel/SpatialData.cs
@@ -5,8 +5,6 @@ using NetTopologySuite.Geometries;
 
 namespace Microsoft.EntityFrameworkCore.TestModels.SpatialModel;
 
-#nullable disable
-
 public class SpatialData(GeometryFactory factory) : ISetSource
 {
     private readonly IReadOnlyList<PointEntity> _pointEntities = CreatePointEntities(factory);

--- a/test/EFCore.Specification.Tests/TestModels/TransportationModel/CombustionEngine.cs
+++ b/test/EFCore.Specification.Tests/TestModels/TransportationModel/CombustionEngine.cs
@@ -3,13 +3,11 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.TransportationModel;
 
-#nullable disable
-
 public abstract class CombustionEngine : Engine
 {
-    public FuelTank FuelTank { get; set; }
+    public FuelTank? FuelTank { get; set; }
 
-    public override bool Equals(object obj)
+    public override bool Equals(object? obj)
         => obj is CombustionEngine other
             && base.Equals(other)
             && Equals(FuelTank, other.FuelTank);

--- a/test/EFCore.Specification.Tests/TestModels/TransportationModel/CompositeVehicle.cs
+++ b/test/EFCore.Specification.Tests/TestModels/TransportationModel/CompositeVehicle.cs
@@ -3,13 +3,11 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.TransportationModel;
 
-#nullable disable
-
 public class CompositeVehicle : PoweredVehicle
 {
-    public Vehicle AttachedVehicle { get; set; }
+    public Vehicle? AttachedVehicle { get; set; }
 
-    public override bool Equals(object obj)
+    public override bool Equals(object? obj)
         => obj is CompositeVehicle other
             && base.Equals(other)
             && Equals(AttachedVehicle, other.AttachedVehicle);

--- a/test/EFCore.Specification.Tests/TestModels/TransportationModel/FuelTank.cs
+++ b/test/EFCore.Specification.Tests/TestModels/TransportationModel/FuelTank.cs
@@ -3,18 +3,16 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.TransportationModel;
 
-#nullable disable
-
 public class FuelTank
 {
-    public string VehicleName { get; set; }
-    public string FuelType { get; set; }
+    public string VehicleName { get; set; } = null!;
+    public string? FuelType { get; set; }
     public int Capacity { get; set; }
 
-    public PoweredVehicle Vehicle { get; set; }
-    public CombustionEngine Engine { get; set; }
+    public PoweredVehicle Vehicle { get; set; } = null!;
+    public CombustionEngine Engine { get; set; } = null!;
 
-    public override bool Equals(object obj)
+    public override bool Equals(object? obj)
         => obj is FuelTank other
             && VehicleName == other.VehicleName
             && FuelType == other.FuelType

--- a/test/EFCore.Specification.Tests/TestModels/TransportationModel/LicensedOperator.cs
+++ b/test/EFCore.Specification.Tests/TestModels/TransportationModel/LicensedOperator.cs
@@ -3,13 +3,11 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.TransportationModel;
 
-#nullable disable
-
 public class LicensedOperator : Operator
 {
-    public string LicenseType { get; set; }
+    public string? LicenseType { get; set; }
 
-    public override bool Equals(object obj)
+    public override bool Equals(object? obj)
         => obj is LicensedOperator other
             && base.Equals(other)
             && LicenseType == other.LicenseType;

--- a/test/EFCore.Specification.Tests/TestModels/TransportationModel/Operator.cs
+++ b/test/EFCore.Specification.Tests/TestModels/TransportationModel/Operator.cs
@@ -3,16 +3,14 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.TransportationModel;
 
-#nullable disable
-
 public class Operator
 {
-    public string VehicleName { get; set; }
-    public string Name { get; set; }
-    public Vehicle Vehicle { get; set; }
-    public OperatorDetails Details { get; set; }
+    public string? VehicleName { get; set; }
+    public string? Name { get; set; }
+    public Vehicle Vehicle { get; set; } = null!;
+    public OperatorDetails? Details { get; set; }
 
-    public override bool Equals(object obj)
+    public override bool Equals(object? obj)
         => obj is Operator other
             && VehicleName == other.VehicleName
             && Name == other.Name

--- a/test/EFCore.Specification.Tests/TestModels/TransportationModel/OperatorDetails.cs
+++ b/test/EFCore.Specification.Tests/TestModels/TransportationModel/OperatorDetails.cs
@@ -3,15 +3,13 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.TransportationModel;
 
-#nullable disable
-
 public class OperatorDetails
 {
-    public string VehicleName { get; set; }
-    public string Type { get; set; }
+    public string VehicleName { get; set; } = null!;
+    public string? Type { get; set; }
     public bool Active { get; set; }
 
-    public override bool Equals(object obj)
+    public override bool Equals(object? obj)
         => obj is OperatorDetails other
             && VehicleName == other.VehicleName
             && Type == other.Type

--- a/test/EFCore.Specification.Tests/TestModels/TransportationModel/PoweredVehicle.cs
+++ b/test/EFCore.Specification.Tests/TestModels/TransportationModel/PoweredVehicle.cs
@@ -7,7 +7,7 @@ public class PoweredVehicle : Vehicle
 {
     public Engine? Engine { get; set; }
 
-    public override bool Equals(object obj)
+    public override bool Equals(object? obj)
         => obj is PoweredVehicle other
             && base.Equals(other)
             && Equals(Engine, other.Engine);

--- a/test/EFCore.Specification.Tests/TestModels/TransportationModel/SolidFuelTank.cs
+++ b/test/EFCore.Specification.Tests/TestModels/TransportationModel/SolidFuelTank.cs
@@ -3,14 +3,12 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.TransportationModel;
 
-#nullable disable
-
 public class SolidFuelTank : FuelTank
 {
-    public string GrainGeometry { get; set; }
-    public SolidRocket Rocket { get; set; }
+    public string GrainGeometry { get; set; } = null!;
+    public SolidRocket Rocket { get; set; } = null!;
 
-    public override bool Equals(object obj)
+    public override bool Equals(object? obj)
         => obj is SolidFuelTank other
             && base.Equals(other)
             && GrainGeometry == other.GrainGeometry;

--- a/test/EFCore.Specification.Tests/TestModels/TransportationModel/SolidRocket.cs
+++ b/test/EFCore.Specification.Tests/TestModels/TransportationModel/SolidRocket.cs
@@ -3,13 +3,11 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.TransportationModel;
 
-#nullable disable
-
 public class SolidRocket : ContinuousCombustionEngine
 {
-    public SolidFuelTank SolidFuelTank { get; set; }
+    public SolidFuelTank SolidFuelTank { get; set; } = null!;
 
-    public override bool Equals(object obj)
+    public override bool Equals(object? obj)
         => obj is SolidRocket other
             && base.Equals(other);
 

--- a/test/EFCore.Specification.Tests/TestModels/TransportationModel/TransportationContext.cs
+++ b/test/EFCore.Specification.Tests/TestModels/TransportationModel/TransportationContext.cs
@@ -5,11 +5,9 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.TransportationModel;
 
-#nullable disable
-
 public class TransportationContext(DbContextOptions options) : PoolableDbContext(options)
 {
-    public DbSet<Vehicle> Vehicles { get; set; }
+    public DbSet<Vehicle> Vehicles { get; set; } = null!;
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -71,7 +69,7 @@ public class TransportationContext(DbContextOptions options) : PoolableDbContext
             .Include(v => v.Operator)
             .ThenInclude(v => v.Details)
             .Include(v => ((PoweredVehicle)v).Engine)
-            .ThenInclude(e => (e as CombustionEngine).FuelTank)
+            .ThenInclude(e => (e as CombustionEngine)!.FuelTank)
             .OrderBy(v => v.Name).ToList();
 
         Assert.Equal(expected, actual);

--- a/test/EFCore.Specification.Tests/TestModels/TransportationModel/Vehicle.cs
+++ b/test/EFCore.Specification.Tests/TestModels/TransportationModel/Vehicle.cs
@@ -3,15 +3,13 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.TransportationModel;
 
-#nullable disable
-
 public class Vehicle
 {
-    public string Name { get; set; }
+    public string Name { get; set; } = null!;
     public int SeatingCapacity { get; set; }
-    public Operator Operator { get; set; }
+    public Operator Operator { get; set; } = null!;
 
-    public override bool Equals(object obj)
+    public override bool Equals(object? obj)
         => obj is Vehicle other
             && Name == other.Name
             && SeatingCapacity == other.SeatingCapacity

--- a/test/EFCore.Specification.Tests/TestModels/UpdatesModel/Nougat.cs
+++ b/test/EFCore.Specification.Tests/TestModels/UpdatesModel/Nougat.cs
@@ -3,22 +3,20 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.UpdatesModel;
 
-#nullable disable
-
 public abstract class Nougat
 {
     public int Id { get; set; }
-    public string Name { get; set; }
+    public string Name { get; set; } = null!;
 }
 
 public class CrunchyNougat : Nougat
 {
-    public NougatFilling Filling { get; set; }
+    public NougatFilling? Filling { get; set; }
 }
 
 public class SoftNougat : Nougat
 {
-    public NougatFilling Filling { get; set; }
+    public NougatFilling? Filling { get; set; }
 }
 
 public class NougatFilling

--- a/test/EFCore.Specification.Tests/TestUtilities/BuildFileResult.cs
+++ b/test/EFCore.Specification.Tests/TestUtilities/BuildFileResult.cs
@@ -3,13 +3,11 @@
 
 namespace Microsoft.EntityFrameworkCore.TestUtilities;
 
-#nullable disable
-
 public class BuildFileResult(string targetPath)
 {
     public string TargetPath { get; } = targetPath;
 
-    public string TargetDir { get; } = Path.GetDirectoryName(targetPath);
+    public string TargetDir { get; } = Path.GetDirectoryName(targetPath)!;
 
     public string TargetName { get; } = Path.GetFileNameWithoutExtension(targetPath);
 }

--- a/test/EFCore.Specification.Tests/TestUtilities/BulkUpdatesAsserter.cs
+++ b/test/EFCore.Specification.Tests/TestUtilities/BulkUpdatesAsserter.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 namespace Microsoft.EntityFrameworkCore.TestUtilities;
 
 public class BulkUpdatesAsserter(IQueryFixtureBase queryFixture, Func<Expression, Expression> rewriteServerQueryExpression)

--- a/test/EFCore.Specification.Tests/TestUtilities/DataGenerator.cs
+++ b/test/EFCore.Specification.Tests/TestUtilities/DataGenerator.cs
@@ -5,8 +5,6 @@ using System.Collections.Concurrent;
 
 namespace Microsoft.EntityFrameworkCore.TestUtilities;
 
-#nullable disable
-
 public static class DataGenerator
 {
     private static readonly ConcurrentDictionary<Type, object[]> Values = new();
@@ -18,7 +16,7 @@ public static class DataGenerator
     static DataGenerator()
     {
         Values[typeof(bool)] = [false, true];
-        Values[typeof(bool?)] = [null, false, true];
+        Values[typeof(bool?)] = [null!, false, true];
     }
 
     public static object[][] GetCombinations(object[] set, int length)
@@ -39,7 +37,7 @@ public static class DataGenerator
                 var underlyingType = Nullable.GetUnderlyingType(type);
                 if (underlyingType != null && underlyingType.IsEnum)
                 {
-                    values = [null, .. Enum.GetValues(underlyingType).Cast<object>()];
+                    values = [null!, .. Enum.GetValues(underlyingType).Cast<object>()];
                     Values[type] = values;
                 }
                 else if (!type.IsDefined(typeof(FlagsAttribute), false))

--- a/test/EFCore.Specification.Tests/TestUtilities/ExpectedFilteredInclude.cs
+++ b/test/EFCore.Specification.Tests/TestUtilities/ExpectedFilteredInclude.cs
@@ -3,15 +3,13 @@
 
 namespace Microsoft.EntityFrameworkCore.TestUtilities;
 
-#nullable disable
-
 public class ExpectedFilteredInclude<TEntity, TIncluded>(
     Expression<Func<TEntity, IEnumerable<TIncluded>>> include,
     string navigationPath = "",
-    Func<IEnumerable<TIncluded>, IEnumerable<TIncluded>> includeFilter = null,
+    Func<IEnumerable<TIncluded>, IEnumerable<TIncluded>>? includeFilter = null,
     bool assertOrder = false) : ExpectedInclude<TEntity>(Convert(include), navigationPath)
 {
-    public Func<IEnumerable<TIncluded>, IEnumerable<TIncluded>> IncludeFilter { get; } = includeFilter;
+    public Func<IEnumerable<TIncluded>, IEnumerable<TIncluded>> IncludeFilter { get; } = includeFilter!;
 
     public bool AssertOrder { get; } = assertOrder;
 

--- a/test/EFCore.Specification.Tests/TestUtilities/MockMethodInfo.cs
+++ b/test/EFCore.Specification.Tests/TestUtilities/MockMethodInfo.cs
@@ -5,11 +5,9 @@ using System.Globalization;
 
 namespace Microsoft.EntityFrameworkCore.TestUtilities;
 
-#nullable disable
-
-public class MockMethodInfo(Type declaringType, Action<object[]> invoke = null) : MethodInfo
+public class MockMethodInfo(Type declaringType, Action<object?[]>? invoke = null) : MethodInfo
 {
-    private readonly Action<object[]> _invoke = invoke;
+    private readonly Action<object?[]>? _invoke = invoke;
 
     public override Type DeclaringType { get; } = declaringType;
 
@@ -43,9 +41,9 @@ public class MockMethodInfo(Type declaringType, Action<object[]> invoke = null) 
     public override ParameterInfo[] GetParameters()
         => new ParameterInfo[1];
 
-    public override object Invoke(object obj, BindingFlags invokeAttr, Binder binder, object[] parameters, CultureInfo culture)
+    public override object? Invoke(object? obj, BindingFlags invokeAttr, Binder? binder, object?[]? parameters, CultureInfo? culture)
     {
-        _invoke?.Invoke(parameters);
+        _invoke?.Invoke(parameters!);
 
         return null;
     }

--- a/test/EFCore.Specification.Tests/TestUtilities/QueryTestGeneration/InjectIncludeExpressionMutator.cs
+++ b/test/EFCore.Specification.Tests/TestUtilities/QueryTestGeneration/InjectIncludeExpressionMutator.cs
@@ -5,11 +5,9 @@ using Microsoft.EntityFrameworkCore.Query.Internal;
 
 namespace Microsoft.EntityFrameworkCore.TestUtilities.QueryTestGeneration;
 
-#nullable disable
-
 public class InjectIncludeExpressionMutator(DbContext context) : ExpressionMutator(context)
 {
-    private ExpressionFinder _expressionFinder;
+    private ExpressionFinder _expressionFinder = null!;
 
     public override bool IsValid(Expression expression)
     {

--- a/test/EFCore.Specification.Tests/TestUtilities/QueryTestGeneration/InjectWhereExpressionMutator.cs
+++ b/test/EFCore.Specification.Tests/TestUtilities/QueryTestGeneration/InjectWhereExpressionMutator.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.EntityFrameworkCore.TestUtilities.QueryTestGeneration;
@@ -40,17 +38,17 @@ public class InjectWhereExpressionMutator(DbContext context) : ExpressionMutator
         var boolProperties = properties.Where(p => p.PropertyType == typeof(bool)).ToList();
         if (boolProperties.Any())
         {
-            candidateExpressions.Add(Expression.Property(prm, random.Choose(boolProperties)));
+            candidateExpressions.Add(Expression.Property(prm, random.Choose(boolProperties)!));
         }
 
         // compare two properties
         var propertiesOfTheSameType = properties.GroupBy(p => p.PropertyType).Where(g => g.Count() > 1).ToList();
         if (propertiesOfTheSameType.Any())
         {
-            var propertyGroup = random.Choose(propertiesOfTheSameType).ToList();
+            var propertyGroup = random.Choose(propertiesOfTheSameType)!.ToList();
 
-            var firstProperty = random.Choose(propertyGroup);
-            var secondProperty = random.Choose(propertyGroup.Where(p => p != firstProperty).ToList());
+            var firstProperty = random.Choose(propertyGroup)!;
+            var secondProperty = random.Choose(propertyGroup.Where(p => p != firstProperty).ToList())!;
 
             candidateExpressions.Add(
                 Expression.NotEqual(Expression.Property(prm, firstProperty), Expression.Property(prm, secondProperty)));
@@ -59,7 +57,7 @@ public class InjectWhereExpressionMutator(DbContext context) : ExpressionMutator
         // compare property to constant
         if (properties.Any())
         {
-            var property = random.Choose(properties);
+            var property = random.Choose(properties)!;
             candidateExpressions.Add(
                 Expression.NotEqual(
                     Expression.Property(prm, property),
@@ -86,7 +84,7 @@ public class InjectWhereExpressionMutator(DbContext context) : ExpressionMutator
             }
         }
 
-        var lambdaBody = random.Choose(candidateExpressions);
+        var lambdaBody = random.Choose(candidateExpressions)!;
 
         var negated = random.Next(6) > 3;
         if (negated)
@@ -100,8 +98,6 @@ public class InjectWhereExpressionMutator(DbContext context) : ExpressionMutator
 
         return injector.Visit(expression);
     }
-
-#nullable restore
 
     private class ExpressionFinder(InjectWhereExpressionMutator mutator) : ExpressionVisitor
     {

--- a/test/EFCore.Specification.Tests/TestUtilities/QueryTestGeneration/ProceduralQueryExpressionGenerator.cs
+++ b/test/EFCore.Specification.Tests/TestUtilities/QueryTestGeneration/ProceduralQueryExpressionGenerator.cs
@@ -3,8 +3,6 @@
 
 namespace Microsoft.EntityFrameworkCore.TestUtilities.QueryTestGeneration;
 
-#nullable disable
-
 public class ProceduralQueryExpressionGenerator(DbContext context)
 {
     private readonly List<ExpressionMutator> _mutators =
@@ -300,7 +298,7 @@ public class ProcedurallyGeneratedQueryExecutor
         var depth = 2;
 
         IQueryable newQuery = query;
-        Expression newExpression = null;
+        Expression newExpression = null!;
         for (var i = 0; i < depth; i++)
         {
             var expression = newQuery.Expression;
@@ -321,7 +319,7 @@ public class ProcedurallyGeneratedQueryExecutor
         }
 
         // printed just for debugging purposes
-        var queryString = newExpression.Print();
+        var queryString = newExpression!.Print();
 
         try
         {

--- a/test/EFCore.Specification.Tests/TestUtilities/SingleThreadSynchronizationContext.cs
+++ b/test/EFCore.Specification.Tests/TestUtilities/SingleThreadSynchronizationContext.cs
@@ -5,11 +5,9 @@ using System.Collections.Concurrent;
 
 namespace Microsoft.EntityFrameworkCore.TestUtilities;
 
-#nullable disable
-
 public class SingleThreadSynchronizationContext : SynchronizationContext, IDisposable
 {
-    private readonly BlockingCollection<(SendOrPostCallback callback, object state)> _tasks = [];
+    private readonly BlockingCollection<(SendOrPostCallback callback, object? state)> _tasks = [];
 
     public Thread Thread { get; }
 
@@ -19,7 +17,7 @@ public class SingleThreadSynchronizationContext : SynchronizationContext, IDispo
         Thread.Start();
     }
 
-    public override void Post(SendOrPostCallback callback, object state)
+    public override void Post(SendOrPostCallback callback, object? state)
         => _tasks.Add((callback, state));
 
     public void Dispose()

--- a/test/EFCore.Specification.Tests/TestUtilities/TestDiagnosticSource.cs
+++ b/test/EFCore.Specification.Tests/TestUtilities/TestDiagnosticSource.cs
@@ -3,21 +3,19 @@
 
 namespace Microsoft.EntityFrameworkCore.TestUtilities;
 
-#nullable disable
-
 public class TestDiagnosticSource : DiagnosticSource
 {
-    public string EnableFor { get; set; }
-    public string LoggedEventName { get; set; }
-    public string LoggedMessage { get; set; }
+    public string EnableFor { get; set; } = null!;
+    public string LoggedEventName { get; set; } = null!;
+    public string LoggedMessage { get; set; } = null!;
 
-    public override void Write(string name, object value)
+    public override void Write(string name, object? value)
     {
         LoggedEventName = name;
 
         Assert.IsAssignableFrom<EventData>(value);
 
-        LoggedMessage = value.ToString();
+        LoggedMessage = value!.ToString()!;
 
         var exceptionProperty = value.GetType().GetTypeInfo().GetDeclaredProperty("Exception");
         if (exceptionProperty != null)

--- a/test/EFCore.Specification.Tests/TestUtilities/TestLoggerBase.cs
+++ b/test/EFCore.Specification.Tests/TestUtilities/TestLoggerBase.cs
@@ -3,14 +3,12 @@
 
 namespace Microsoft.EntityFrameworkCore.TestUtilities;
 
-#nullable disable
-
 public abstract class TestLoggerBase
 {
     public LogLevel EnabledFor { get; set; }
     public LogLevel? LoggedAt { get; set; }
     public EventId LoggedEvent { get; set; }
-    public string Message { get; set; }
+    public string Message { get; set; } = null!;
 
     public IDbContextLogger DbContextLogger { get; } = new TestDbContextLogger();
 

--- a/test/EFCore.Specification.Tests/TestUtilities/TestServiceFactory.cs
+++ b/test/EFCore.Specification.Tests/TestUtilities/TestServiceFactory.cs
@@ -7,8 +7,6 @@ using Microsoft.EntityFrameworkCore.Internal;
 
 namespace Microsoft.EntityFrameworkCore.TestUtilities;
 
-#nullable disable
-
 public class TestServiceFactory
 {
     public static readonly TestServiceFactory Instance = new();
@@ -38,7 +36,7 @@ public class TestServiceFactory
         return _factories.GetOrAdd(
                 typeof(TService),
                 t => AddType([], typeof(TService), exceptions).BuildServiceProvider(validateScopes: true))
-            .GetService<TService>();
+            .GetService<TService>()!;
     }
 
     private static ServiceCollection AddType(
@@ -110,7 +108,7 @@ public class TestServiceFactory
             : (IList<(Type ServiceType, Type ImplementationType)>)implementationTypes.Select(t => (elementType, t)).ToList();
     }
 
-    private static Type TryGetEnumerableType(Type type)
+    private static Type? TryGetEnumerableType(Type type)
         => !type.IsGenericTypeDefinition
             && type.IsGenericType
             && type.GetGenericTypeDefinition() == typeof(IEnumerable<>)

--- a/test/EFCore.Specification.Tests/TestUtilities/Xunit/UseCultureAttribute.cs
+++ b/test/EFCore.Specification.Tests/TestUtilities/Xunit/UseCultureAttribute.cs
@@ -8,13 +8,11 @@ using Xunit.v3;
 
 namespace Microsoft.EntityFrameworkCore.TestUtilities.Xunit;
 
-#nullable disable
-
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
 public sealed class UseCultureAttribute(string culture, string uiCulture) : BeforeAfterTestAttribute
 {
-    private CultureInfo _originalCulture;
-    private CultureInfo _originalUiCulture;
+    private CultureInfo _originalCulture = null!;
+    private CultureInfo _originalUiCulture = null!;
 
     public UseCultureAttribute(string culture)
         : this(culture, culture)

--- a/test/EFCore.Specification.Tests/UnidirectionalManyToManyLoadTestBase.cs
+++ b/test/EFCore.Specification.Tests/UnidirectionalManyToManyLoadTestBase.cs
@@ -6,8 +6,6 @@ using Microsoft.EntityFrameworkCore.TestModels.ManyToManyModel;
 
 namespace Microsoft.EntityFrameworkCore;
 
-#nullable disable
-
 public abstract partial class ManyToManyLoadTestBase<TFixture>
 {
     [Theory, InlineData(EntityState.Unchanged, QueryTrackingBehavior.TrackAll, true),
@@ -38,15 +36,15 @@ public abstract partial class ManyToManyLoadTestBase<TFixture>
 
         ClearLog();
 
-        var collectionEntry = context.Entry(left).Collection(e => e.TwoSkip);
+        var collectionEntry = context.Entry(left!).Collection(e => e.TwoSkip);
 
-        context.Entry(left).State = state;
+        context.Entry(left!).State = state;
 
         Assert.False(collectionEntry.IsLoaded);
 
         if (ExpectLazyLoading)
         {
-            Assert.Equal(7, left.TwoSkip.Count);
+            Assert.Equal(7, left!.TwoSkip.Count);
         }
         else
         {
@@ -61,7 +59,7 @@ public abstract partial class ManyToManyLoadTestBase<TFixture>
         }
 
         Assert.True(collectionEntry.IsLoaded);
-        foreach (var entityTwo in left.TwoSkip)
+        foreach (var entityTwo in left!.TwoSkip)
         {
             Assert.False(context.Entry(entityTwo).Collection("UnidirectionalEntityOne1").IsLoaded);
         }
@@ -72,7 +70,7 @@ public abstract partial class ManyToManyLoadTestBase<TFixture>
         Assert.Equal(7, left.TwoSkip.Count);
         foreach (var right in left.TwoSkip)
         {
-            Assert.Contains(left, ((IEnumerable<object>)context.Entry(right).Collection("UnidirectionalEntityOne1").CurrentValue)!);
+            Assert.Contains(left, ((IEnumerable<object>)context.Entry(right).Collection("UnidirectionalEntityOne1").CurrentValue!)!);
         }
 
         Assert.Equal(1 + 7 + 7, context.ChangeTracker.Entries().Count());
@@ -89,9 +87,9 @@ public abstract partial class ManyToManyLoadTestBase<TFixture>
 
         ClearLog();
 
-        var collectionEntry = context.Entry(left).Collection(e => e.TwoSkipShared);
+        var collectionEntry = context.Entry(left!).Collection(e => e.TwoSkipShared);
 
-        context.Entry(left).State = state;
+        context.Entry(left!).State = state;
 
         Assert.False(collectionEntry.IsLoaded);
 
@@ -100,7 +98,7 @@ public abstract partial class ManyToManyLoadTestBase<TFixture>
             : collectionEntry.Query().ToList();
 
         Assert.False(collectionEntry.IsLoaded);
-        foreach (var entityTwo in left.TwoSkipShared)
+        foreach (var entityTwo in left!.TwoSkipShared)
         {
             Assert.False(context.Entry(entityTwo).Collection("UnidirectionalEntityOne").IsLoaded);
         }
@@ -274,7 +272,7 @@ public abstract partial class ManyToManyLoadTestBase<TFixture>
         Assert.Equal(7, left.TwoSkip.Count);
         foreach (var right in left.TwoSkip)
         {
-            Assert.Contains(left, ((IEnumerable<object>)context.Entry(right).Navigation("UnidirectionalEntityOne1").CurrentValue)!);
+            Assert.Contains(left, ((IEnumerable<object>)context.Entry(right).Navigation("UnidirectionalEntityOne1").CurrentValue!)!);
         }
 
         Assert.Equal(children, left.TwoSkip.ToList());
@@ -293,15 +291,15 @@ public abstract partial class ManyToManyLoadTestBase<TFixture>
 
         ClearLog();
 
-        var navigationEntry = context.Entry(left).Navigation("TwoSkip");
+        var navigationEntry = context.Entry(left!).Navigation("TwoSkip");
 
-        context.Entry(left).State = state;
+        context.Entry(left!).State = state;
 
         Assert.False(navigationEntry.IsLoaded);
 
         if (ExpectLazyLoading)
         {
-            Assert.Equal(7, left.TwoSkip.Count);
+            Assert.Equal(7, left!.TwoSkip.Count);
         }
         else
         {
@@ -316,7 +314,7 @@ public abstract partial class ManyToManyLoadTestBase<TFixture>
         }
 
         Assert.True(navigationEntry.IsLoaded);
-        foreach (var entityTwo in left.TwoSkip)
+        foreach (var entityTwo in left!.TwoSkip)
         {
             Assert.False(context.Entry((object)entityTwo).Collection("UnidirectionalEntityOne1").IsLoaded);
         }
@@ -327,7 +325,7 @@ public abstract partial class ManyToManyLoadTestBase<TFixture>
         Assert.Equal(7, left.TwoSkip.Count);
         foreach (var right in left.TwoSkip)
         {
-            Assert.Contains(left, ((IEnumerable<object>)context.Entry(right).Member("UnidirectionalEntityOne1").CurrentValue)!);
+            Assert.Contains(left, ((IEnumerable<object>)context.Entry(right).Member("UnidirectionalEntityOne1").CurrentValue!)!);
         }
 
         Assert.Equal(1 + 7 + 7, context.ChangeTracker.Entries().Count());
@@ -344,9 +342,9 @@ public abstract partial class ManyToManyLoadTestBase<TFixture>
 
         ClearLog();
 
-        var collectionEntry = context.Entry(left).Navigation("TwoSkipShared");
+        var collectionEntry = context.Entry(left!).Navigation("TwoSkipShared");
 
-        context.Entry(left).State = state;
+        context.Entry(left!).State = state;
 
         Assert.False(collectionEntry.IsLoaded);
 
@@ -355,7 +353,7 @@ public abstract partial class ManyToManyLoadTestBase<TFixture>
             : collectionEntry.Query().ToList<object>();
 
         Assert.False(collectionEntry.IsLoaded);
-        foreach (var entityTwo in left.TwoSkipShared)
+        foreach (var entityTwo in left!.TwoSkipShared)
         {
             Assert.False(context.Entry((object)entityTwo).Collection("UnidirectionalEntityOne").IsLoaded);
         }
@@ -563,7 +561,7 @@ public abstract partial class ManyToManyLoadTestBase<TFixture>
         Assert.Equal(7, left.TwoSkip.Count);
         foreach (var right in left.TwoSkip)
         {
-            Assert.Contains(left, ((IEnumerable<object>)context.Entry(right).Collection("UnidirectionalEntityOne1").CurrentValue)!);
+            Assert.Contains(left, ((IEnumerable<object>)context.Entry(right).Collection("UnidirectionalEntityOne1").CurrentValue!)!);
         }
 
         Assert.Equal(children, left.TwoSkip.ToList());
@@ -582,15 +580,15 @@ public abstract partial class ManyToManyLoadTestBase<TFixture>
 
         ClearLog();
 
-        var collectionEntry = context.Entry(left).Collection(e => e.ThreeSkipFull);
+        var collectionEntry = context.Entry(left!).Collection(e => e.ThreeSkipFull);
 
-        context.Entry(left).State = state;
+        context.Entry(left!).State = state;
 
         Assert.False(collectionEntry.IsLoaded);
 
         if (ExpectLazyLoading)
         {
-            Assert.Equal(2, left.ThreeSkipFull.Count);
+            Assert.Equal(2, left!.ThreeSkipFull.Count);
         }
         else
         {
@@ -605,7 +603,7 @@ public abstract partial class ManyToManyLoadTestBase<TFixture>
         }
 
         Assert.True(collectionEntry.IsLoaded);
-        foreach (var entityTwo in left.ThreeSkipFull)
+        foreach (var entityTwo in left!.ThreeSkipFull)
         {
             Assert.False(context.Entry(entityTwo).Collection("UnidirectionalEntityCompositeKey").IsLoaded);
         }
@@ -633,9 +631,9 @@ public abstract partial class ManyToManyLoadTestBase<TFixture>
 
         ClearLog();
 
-        var collectionEntry = context.Entry(left).Collection(e => e.ThreeSkipFull);
+        var collectionEntry = context.Entry(left!).Collection(e => e.ThreeSkipFull);
 
-        context.Entry(left).State = state;
+        context.Entry(left!).State = state;
 
         Assert.False(collectionEntry.IsLoaded);
 
@@ -648,7 +646,7 @@ public abstract partial class ManyToManyLoadTestBase<TFixture>
         RecordLog();
         context.ChangeTracker.LazyLoadingEnabled = false;
 
-        Assert.Equal(2, left.ThreeSkipFull.Count);
+        Assert.Equal(2, left!.ThreeSkipFull.Count);
         Assert.Equal(children, left.ThreeSkipFull.ToList());
         Assert.Equal(1 + 2 + 2, context.ChangeTracker.Entries().Count());
     }
@@ -706,7 +704,7 @@ public abstract partial class ManyToManyLoadTestBase<TFixture>
 
         ClearLog();
 
-        var collectionEntry = context.Entry(left).Collection(e => e.TwoSkipShared);
+        var collectionEntry = context.Entry(left!).Collection(e => e.TwoSkipShared);
 
         Assert.False(collectionEntry.IsLoaded);
 
@@ -715,7 +713,7 @@ public abstract partial class ManyToManyLoadTestBase<TFixture>
             : collectionEntry.Query().Include("UnidirectionalEntityThree").ToList();
 
         Assert.False(collectionEntry.IsLoaded);
-        foreach (var entityTwo in left.TwoSkipShared)
+        foreach (var entityTwo in left!.TwoSkipShared)
         {
             var threeNav = context.Entry(entityTwo).Collection<UnidirectionalEntityThree>("UnidirectionalEntityThree");
             Assert.True(threeNav.IsLoaded);
@@ -751,7 +749,7 @@ public abstract partial class ManyToManyLoadTestBase<TFixture>
 
         ClearLog();
 
-        var collectionEntry = context.Entry(left).Collection(e => e.TwoSkipShared);
+        var collectionEntry = context.Entry(left!).Collection(e => e.TwoSkipShared);
 
         Assert.False(collectionEntry.IsLoaded);
 
@@ -761,7 +759,7 @@ public abstract partial class ManyToManyLoadTestBase<TFixture>
             : queryable.ToList();
 
         Assert.False(collectionEntry.IsLoaded);
-        foreach (var entityTwo in left.TwoSkipShared)
+        foreach (var entityTwo in left!.TwoSkipShared)
         {
             Assert.True(context.Entry(entityTwo).Collection("UnidirectionalEntityOne").IsLoaded);
         }
@@ -790,7 +788,7 @@ public abstract partial class ManyToManyLoadTestBase<TFixture>
 
         ClearLog();
 
-        var collectionEntry = context.Entry(left).Collection(e => e.TwoSkipShared);
+        var collectionEntry = context.Entry(left!).Collection(e => e.TwoSkipShared);
 
         Assert.False(collectionEntry.IsLoaded);
 
@@ -803,7 +801,7 @@ public abstract partial class ManyToManyLoadTestBase<TFixture>
                     .Where(e => e.Id == 13 || e.Id == 11)).ToList();
 
         Assert.False(collectionEntry.IsLoaded);
-        foreach (var entityTwo in left.TwoSkipShared)
+        foreach (var entityTwo in left!.TwoSkipShared)
         {
             Assert.False(context.Entry(entityTwo).Collection("UnidirectionalEntityOne").IsLoaded);
             Assert.True(context.Entry(entityTwo).Collection("UnidirectionalEntityThree").IsLoaded);
@@ -843,7 +841,7 @@ public abstract partial class ManyToManyLoadTestBase<TFixture>
 
         ClearLog();
 
-        var collectionEntry = context.Entry(left).Collection(e => e.TwoSkipShared);
+        var collectionEntry = context.Entry(left!).Collection(e => e.TwoSkipShared);
 
         Assert.False(collectionEntry.IsLoaded);
 
@@ -865,7 +863,7 @@ public abstract partial class ManyToManyLoadTestBase<TFixture>
         RecordLog();
         context.ChangeTracker.LazyLoadingEnabled = false;
         Assert.False(collectionEntry.IsLoaded);
-        Assert.Empty(left.TwoSkipShared);
+        Assert.Empty(left!.TwoSkipShared);
         Assert.Single(context.ChangeTracker.Entries());
 
         Assert.Equal(3, projected.Count);
@@ -889,7 +887,7 @@ public abstract partial class ManyToManyLoadTestBase<TFixture>
 
         ClearLog();
 
-        var collectionEntry = context.Entry(left).Collection(e => e.TwoSkipShared);
+        var collectionEntry = context.Entry(left!).Collection(e => e.TwoSkipShared);
 
         Assert.False(collectionEntry.IsLoaded);
 

--- a/test/EFCore.Specification.Tests/UnidirectionalManyToManyTrackingTestBase.cs
+++ b/test/EFCore.Specification.Tests/UnidirectionalManyToManyTrackingTestBase.cs
@@ -6,14 +6,12 @@ using Microsoft.EntityFrameworkCore.TestModels.ManyToManyModel;
 
 namespace Microsoft.EntityFrameworkCore;
 
-#nullable disable
-
 public abstract partial class ManyToManyTrackingTestBase<TFixture>
 {
     [Theory, InlineData(false), InlineData(true)]
     public virtual async Task Can_insert_many_to_many_composite_with_navs_unidirectional(bool async)
     {
-        List<int> leftKeys = null;
+        List<int> leftKeys = null!;
 
         await ExecuteWithStrategyInTransactionAsync(
             async context =>
@@ -84,8 +82,8 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>
             },
             async context =>
             {
-                var queryable = context.Set<UnidirectionalEntityCompositeKey>().Where(e => leftKeys.Contains(e.Key1));
-                context.Set<UnidirectionalJoinCompositeKeyToLeaf>().Where(e => leftKeys.Contains(e.CompositeId1)).Include(e => e.Leaf)
+                var queryable = context.Set<UnidirectionalEntityCompositeKey>().Where(e => leftKeys!.Contains(e.Key1));
+                context.Set<UnidirectionalJoinCompositeKeyToLeaf>().Where(e => leftKeys!.Contains(e.CompositeId1)).Include(e => e.Leaf)
                     .Load();
 
                 var results = async ? await queryable.ToListAsync() : queryable.ToList();
@@ -427,7 +425,7 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>
     [Theory, InlineData(false), InlineData(true)]
     public virtual async Task Can_insert_many_to_many_composite_additional_pk_with_navs_unidirectional(bool async)
     {
-        List<string> keys = null;
+        List<string> keys = null!;
 
         await ExecuteWithStrategyInTransactionAsync(
             async context =>
@@ -510,7 +508,7 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>
             },
             async context =>
             {
-                var queryable = context.Set<UnidirectionalEntityCompositeKey>().Where(e => keys.Contains(e.Key2))
+                var queryable = context.Set<UnidirectionalEntityCompositeKey>().Where(e => keys!.Contains(e.Key2))
                     .Include(e => e.ThreeSkipFull);
                 var results = async ? await queryable.ToListAsync() : queryable.ToList();
                 Assert.Equal(3, results.Count);
@@ -571,7 +569,7 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>
     [Fact]
     public virtual Task Can_update_many_to_many_composite_additional_pk_with_navs_unidirectional()
     {
-        List<int> threeIds = null;
+        List<int> threeIds = null!;
 
         return ExecuteWithStrategyInTransactionAsync(
             async context =>
@@ -695,9 +693,9 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>
             Assert.Equal(joinCount, context.ChangeTracker.Entries<UnidirectionalJoinThreeToCompositeKeyFull>().Count());
             Assert.Equal(leftCount + rightCount + joinCount, context.ChangeTracker.Entries().Count());
 
-            Assert.Contains(leftEntities[0].ThreeSkipFull, e => context.Entry(e).Property(e => e.Id).CurrentValue == threeIds[0]);
-            Assert.Contains(leftEntities[0].ThreeSkipFull, e => context.Entry(e).Property(e => e.Id).CurrentValue == threeIds[1]);
-            Assert.Contains(leftEntities[0].ThreeSkipFull, e => context.Entry(e).Property(e => e.Id).CurrentValue == threeIds[2]);
+            Assert.Contains(leftEntities[0].ThreeSkipFull, e => context.Entry(e).Property(e => e.Id).CurrentValue == threeIds![0]);
+            Assert.Contains(leftEntities[0].ThreeSkipFull, e => context.Entry(e).Property(e => e.Id).CurrentValue == threeIds![1]);
+            Assert.Contains(leftEntities[0].ThreeSkipFull, e => context.Entry(e).Property(e => e.Id).CurrentValue == threeIds![2]);
 
             var rightNav0 = context.Entry(rightEntities[0])
                 .Collection<UnidirectionalEntityCompositeKey>("UnidirectionalEntityCompositeKey").CurrentValue!;
@@ -714,7 +712,7 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>
             }
 
             Assert.DoesNotContain(leftEntities[3].ThreeSkipFull, e => e.Name == "EntityThree 23");
-            Assert.Contains(leftEntities[3].ThreeSkipFull, e => context.Entry(e).Property(e => e.Id).CurrentValue == threeIds[3]);
+            Assert.Contains(leftEntities[3].ThreeSkipFull, e => context.Entry(e).Property(e => e.Id).CurrentValue == threeIds![3]);
 
             var rightNav2 = context.Entry(rightEntities[2])
                 .Collection<UnidirectionalEntityCompositeKey>("UnidirectionalEntityCompositeKey").CurrentValue!;
@@ -758,7 +756,7 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>
 
                     if (rightNav?.Contains(left) == true)
                     {
-                        Assert.Contains(right, left.ThreeSkipFull);
+                        Assert.Contains(right, left.ThreeSkipFull!);
                         count++;
                     }
                 }
@@ -927,8 +925,8 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>
     [Theory, InlineData(false), InlineData(true)]
     public virtual async Task Can_insert_many_to_many_self_shared_unidirectional(bool async)
     {
-        List<int> leftKeys = null;
-        List<int> rightKeys = null;
+        List<int> leftKeys = null!;
+        List<int> rightKeys = null!;
 
         await ExecuteWithStrategyInTransactionAsync(
             async context =>
@@ -990,7 +988,7 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>
             async context =>
             {
                 var queryable = context.Set<UnidirectionalEntityTwo>()
-                    .Where(e => leftKeys.Contains(e.Id) || rightKeys.Contains(e.Id))
+                    .Where(e => leftKeys!.Contains(e.Id) || rightKeys!.Contains(e.Id))
                     .Include("UnidirectionalEntityTwo");
 
                 var results = async ? await queryable.ToListAsync() : queryable.ToList();
@@ -998,13 +996,13 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>
 
                 var leftEntities = context.ChangeTracker.Entries<UnidirectionalEntityTwo>()
                     .Select(e => e.Entity)
-                    .Where(e => leftKeys.Contains(e.Id))
+                    .Where(e => leftKeys!.Contains(e.Id))
                     .OrderBy(e => e.Name)
                     .ToList();
 
                 var rightEntities = context.ChangeTracker.Entries<UnidirectionalEntityTwo>()
                     .Select(e => e.Entity)
-                    .Where(e => rightKeys.Contains(e.Id))
+                    .Where(e => rightKeys!.Contains(e.Id))
                     .OrderBy(e => e.Name)
                     .ToList();
 
@@ -1037,7 +1035,7 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>
     [Fact]
     public virtual Task Can_update_many_to_many_self_unidirectional()
     {
-        List<int> ids = null;
+        List<int> ids = null!;
 
         return ExecuteWithStrategyInTransactionAsync(
             async context =>
@@ -1150,25 +1148,25 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>
             Assert.Equal(joinCount, context.ChangeTracker.Entries<Dictionary<string, object>>().Count());
             Assert.Equal(count + joinCount, context.ChangeTracker.Entries().Count());
 
-            Assert.Contains(leftEntities[0].SelfSkipSharedRight, e => context.Entry(e).Property(e => e.Id).CurrentValue == ids[0]);
-            Assert.Contains(leftEntities[0].SelfSkipSharedRight, e => context.Entry(e).Property(e => e.Id).CurrentValue == ids[1]);
-            Assert.Contains(leftEntities[0].SelfSkipSharedRight, e => context.Entry(e).Property(e => e.Id).CurrentValue == ids[2]);
+            Assert.Contains(leftEntities[0].SelfSkipSharedRight, e => context.Entry(e).Property(e => e.Id).CurrentValue == ids![0]);
+            Assert.Contains(leftEntities[0].SelfSkipSharedRight, e => context.Entry(e).Property(e => e.Id).CurrentValue == ids![1]);
+            Assert.Contains(leftEntities[0].SelfSkipSharedRight, e => context.Entry(e).Property(e => e.Id).CurrentValue == ids![2]);
 
             var nav0 = context.Entry(rightEntities[0]).Collection<UnidirectionalEntityTwo>("UnidirectionalEntityTwo").CurrentValue!;
-            Assert.Contains(nav0, e => context.Entry(e).Property(e => e.Id).CurrentValue == ids[4]);
-            Assert.Contains(nav0, e => context.Entry(e).Property(e => e.Id).CurrentValue == ids[5]);
-            Assert.Contains(nav0, e => context.Entry(e).Property(e => e.Id).CurrentValue == ids[6]);
+            Assert.Contains(nav0, e => context.Entry(e).Property(e => e.Id).CurrentValue == ids![4]);
+            Assert.Contains(nav0, e => context.Entry(e).Property(e => e.Id).CurrentValue == ids![5]);
+            Assert.Contains(nav0, e => context.Entry(e).Property(e => e.Id).CurrentValue == ids![6]);
 
             var nav1 = context.Entry(rightEntities[1]).Collection<UnidirectionalEntityTwo>("UnidirectionalEntityTwo").CurrentValue!;
             Assert.DoesNotContain(leftEntities[0].SelfSkipSharedRight, e => e.Name == "EntityTwo 9");
             Assert.DoesNotContain(nav1, e => e.Name == "EntityTwo 1");
 
             Assert.DoesNotContain(leftEntities[4].SelfSkipSharedRight, e => e.Name == "EntityTwo 18");
-            Assert.Contains(leftEntities[4].SelfSkipSharedRight, e => context.Entry(e).Property(e => e.Id).CurrentValue == ids[3]);
+            Assert.Contains(leftEntities[4].SelfSkipSharedRight, e => context.Entry(e).Property(e => e.Id).CurrentValue == ids![3]);
 
             var nav5 = context.Entry(rightEntities[5]).Collection<UnidirectionalEntityTwo>("UnidirectionalEntityTwo").CurrentValue!;
             Assert.DoesNotContain(nav5, e => e.Name == "EntityTwo 12");
-            Assert.Contains(nav5, e => context.Entry(e).Property(e => e.Id).CurrentValue == ids[7]);
+            Assert.Contains(nav5, e => context.Entry(e).Property(e => e.Id).CurrentValue == ids![7]);
 
             var allLeft = context.ChangeTracker.Entries<UnidirectionalEntityTwo>().Select(e => e.Entity).OrderBy(e => e.Name).ToList();
             var allRight = context.ChangeTracker.Entries<UnidirectionalEntityTwo>().Select(e => e.Entity).OrderBy(e => e.Name).ToList();
@@ -1190,7 +1188,7 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>
 
                     if (rightNav?.Contains(left) == true)
                     {
-                        Assert.Contains(right, left.SelfSkipSharedRight);
+                        Assert.Contains(right, left.SelfSkipSharedRight!);
                         joins++;
                     }
                 }
@@ -1204,7 +1202,7 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>
     [Theory, InlineData(false), InlineData(true)]
     public virtual async Task Can_insert_many_to_many_with_inheritance_unidirectional(bool async)
     {
-        List<int> keys = null;
+        List<int> keys = null!;
 
         await ExecuteWithStrategyInTransactionAsync(
             async context =>
@@ -1260,7 +1258,7 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>
             },
             async context =>
             {
-                var queryable = context.Set<UnidirectionalEntityOne>().Where(e => keys.Contains(e.Id)).Include(e => e.BranchSkip);
+                var queryable = context.Set<UnidirectionalEntityOne>().Where(e => keys!.Contains(e.Id)).Include(e => e.BranchSkip);
                 var results = async ? await queryable.ToListAsync() : queryable.ToList();
                 Assert.Equal(3, results.Count);
 
@@ -1434,13 +1432,13 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>
                     var rightNav = context.Entry(right).Collection<UnidirectionalEntityOne>("UnidirectionalEntityOne").CurrentValue;
                     if (left.BranchSkip?.Contains(right) == true)
                     {
-                        Assert.Contains(left, rightNav);
+                        Assert.Contains(left, rightNav!);
                         count++;
                     }
 
                     if (rightNav?.Contains(left) == true)
                     {
-                        Assert.Contains(right, left.BranchSkip);
+                        Assert.Contains(right, left.BranchSkip!);
                         count++;
                     }
                 }
@@ -1454,8 +1452,8 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>
     [Theory, InlineData(false), InlineData(true)]
     public virtual async Task Can_insert_many_to_many_self_with_payload_unidirectional(bool async)
     {
-        List<int> leftKeys = null;
-        List<int> rightKeys = null;
+        List<int> leftKeys = null!;
+        List<int> rightKeys = null!;
 
         await ExecuteWithStrategyInTransactionAsync(
             async context =>
@@ -1516,7 +1514,7 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>
             async context =>
             {
                 var queryable = context.Set<UnidirectionalEntityOne>()
-                    .Where(e => leftKeys.Contains(e.Id) || rightKeys.Contains(e.Id))
+                    .Where(e => leftKeys!.Contains(e.Id) || rightKeys!.Contains(e.Id))
                     .Include(e => e.SelfSkipPayloadLeft);
 
                 var results = async ? await queryable.ToListAsync() : queryable.ToList();
@@ -1524,13 +1522,13 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>
 
                 var leftEntities = context.ChangeTracker.Entries<UnidirectionalEntityOne>()
                     .Select(e => e.Entity)
-                    .Where(e => leftKeys.Contains(e.Id))
+                    .Where(e => leftKeys!.Contains(e.Id))
                     .OrderBy(e => e.Name)
                     .ToList();
 
                 var rightEntities = context.ChangeTracker.Entries<UnidirectionalEntityOne>()
                     .Select(e => e.Entity)
-                    .Where(e => rightKeys.Contains(e.Id))
+                    .Where(e => rightKeys!.Contains(e.Id))
                     .OrderBy(e => e.Name)
                     .ToList();
 
@@ -1584,7 +1582,7 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>
     [Fact]
     public virtual Task Can_update_many_to_many_self_with_payload_unidirectional()
     {
-        List<int> keys = null;
+        List<int> keys = null!;
 
         return ExecuteWithStrategyInTransactionAsync(
             async context =>
@@ -1672,14 +1670,14 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>
                 context.Find<UnidirectionalJoinOneSelfPayload>(
                         keys[5],
                         context.Entry(context.UnidirectionalEntityOnes.Local.Single(e => e.Name == "EntityOne 1")).Property(e => e.Id)
-                            .CurrentValue)
+                            .CurrentValue)!
                     .Payload = new DateTime(1973, 9, 3);
 
                 context.Find<UnidirectionalJoinOneSelfPayload>(
                         context.Entry(context.UnidirectionalEntityOnes.Local.Single(e => e.Name == "EntityOne 20")).Property(e => e.Id)
                             .CurrentValue,
                         context.Entry(context.UnidirectionalEntityOnes.Local.Single(e => e.Name == "EntityOne 16")).Property(e => e.Id)
-                            .CurrentValue)
+                            .CurrentValue)!
                     .Payload = new DateTime(1969, 8, 3);
 
                 ValidateFixup(context, leftEntities, rightEntities, 28, 37, postSave: false);
@@ -1713,13 +1711,13 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>
             Assert.Equal(count + joinCount, context.ChangeTracker.Entries().Count());
 
             var leftNav0 = context.Entry(leftEntities[0]).Collection<UnidirectionalEntityOne>("UnidirectionalEntityOne").CurrentValue!;
-            Assert.Contains(leftNav0, e => context.Entry(e).Property(e => e.Id).CurrentValue == keys[0]);
-            Assert.Contains(leftNav0, e => context.Entry(e).Property(e => e.Id).CurrentValue == keys[1]);
-            Assert.Contains(leftNav0, e => context.Entry(e).Property(e => e.Id).CurrentValue == keys[2]);
+            Assert.Contains(leftNav0, e => context.Entry(e).Property(e => e.Id).CurrentValue == keys![0]);
+            Assert.Contains(leftNav0, e => context.Entry(e).Property(e => e.Id).CurrentValue == keys![1]);
+            Assert.Contains(leftNav0, e => context.Entry(e).Property(e => e.Id).CurrentValue == keys![2]);
 
-            Assert.Contains(rightEntities[0].SelfSkipPayloadLeft, e => context.Entry(e).Property(e => e.Id).CurrentValue == keys[4]);
-            Assert.Contains(rightEntities[0].SelfSkipPayloadLeft, e => context.Entry(e).Property(e => e.Id).CurrentValue == keys[5]);
-            Assert.Contains(rightEntities[0].SelfSkipPayloadLeft, e => context.Entry(e).Property(e => e.Id).CurrentValue == keys[6]);
+            Assert.Contains(rightEntities[0].SelfSkipPayloadLeft, e => context.Entry(e).Property(e => e.Id).CurrentValue == keys![4]);
+            Assert.Contains(rightEntities[0].SelfSkipPayloadLeft, e => context.Entry(e).Property(e => e.Id).CurrentValue == keys![5]);
+            Assert.Contains(rightEntities[0].SelfSkipPayloadLeft, e => context.Entry(e).Property(e => e.Id).CurrentValue == keys![6]);
 
             var leftNav7 = context.Entry(leftEntities[7]).Collection<UnidirectionalEntityOne>("UnidirectionalEntityOne").CurrentValue!;
             Assert.DoesNotContain(leftNav7, e => e.Name == "EntityOne 6");
@@ -1727,10 +1725,10 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>
 
             var leftNav4 = context.Entry(leftEntities[4]).Collection<UnidirectionalEntityOne>("UnidirectionalEntityOne").CurrentValue!;
             Assert.DoesNotContain(leftNav4, e => e.Name == "EntityOne 2");
-            Assert.Contains(leftNav4, e => context.Entry(e).Property(e => e.Id).CurrentValue == keys[3]);
+            Assert.Contains(leftNav4, e => context.Entry(e).Property(e => e.Id).CurrentValue == keys![3]);
 
             Assert.DoesNotContain(rightEntities[4].SelfSkipPayloadLeft, e => e.Name == "EntityOne 6");
-            Assert.Contains(rightEntities[4].SelfSkipPayloadLeft, e => context.Entry(e).Property(e => e.Id).CurrentValue == keys[7]);
+            Assert.Contains(rightEntities[4].SelfSkipPayloadLeft, e => context.Entry(e).Property(e => e.Id).CurrentValue == keys![7]);
 
             var joinEntries = context.ChangeTracker.Entries<UnidirectionalJoinOneSelfPayload>().ToList();
             foreach (var joinEntry in joinEntries)
@@ -1741,7 +1739,7 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>
                 Assert.Contains(joinEntity, joinEntity.Left.JoinSelfPayloadLeft);
                 Assert.Contains(joinEntity, joinEntity.Right.JoinSelfPayloadRight);
 
-                if (joinEntity.LeftId == keys[5]
+                if (joinEntity.LeftId == keys![5]
                     && joinEntity.RightId == 1)
                 {
                     Assert.Equal(postSave ? EntityState.Unchanged : EntityState.Added, joinEntry.State);
@@ -1771,7 +1769,7 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>
                 {
                     if (leftNav?.Contains(right) == true)
                     {
-                        Assert.Contains(left, right.SelfSkipPayloadLeft);
+                        Assert.Contains(left, right.SelfSkipPayloadLeft!);
                         joins++;
                     }
 
@@ -1791,7 +1789,7 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>
     [Theory, InlineData(false), InlineData(true)]
     public virtual async Task Can_insert_many_to_many_shared_with_payload_unidirectional(bool async)
     {
-        List<int> keys = null;
+        List<int> keys = null!;
 
         await ExecuteWithStrategyInTransactionAsync(
             async context =>
@@ -1849,7 +1847,7 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>
             },
             async context =>
             {
-                var queryable = context.Set<UnidirectionalEntityOne>().Where(e => keys.Contains(e.Id))
+                var queryable = context.Set<UnidirectionalEntityOne>().Where(e => keys!.Contains(e.Id))
                     .Include(e => e.ThreeSkipPayloadFullShared);
                 var results = async ? await queryable.ToListAsync() : queryable.ToList();
                 Assert.Equal(3, results.Count);
@@ -2089,7 +2087,7 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>
 
                     if (rightNav?.Contains(left) == true)
                     {
-                        Assert.Contains(right, left.ThreeSkipPayloadFullShared);
+                        Assert.Contains(right, left.ThreeSkipPayloadFullShared!);
                         count++;
                     }
                 }
@@ -2103,7 +2101,7 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>
     [Theory, InlineData(false), InlineData(true)]
     public virtual async Task Can_insert_many_to_many_shared_unidirectional(bool async)
     {
-        List<int> keys = null;
+        List<int> keys = null!;
 
         await ExecuteWithStrategyInTransactionAsync(
             async context =>
@@ -2159,7 +2157,7 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>
             },
             async context =>
             {
-                var queryable = context.Set<UnidirectionalEntityOne>().Where(e => keys.Contains(e.Id)).Include(e => e.TwoSkipShared);
+                var queryable = context.Set<UnidirectionalEntityOne>().Where(e => keys!.Contains(e.Id)).Include(e => e.TwoSkipShared);
                 var results = async ? await queryable.ToListAsync() : queryable.ToList();
                 Assert.Equal(3, results.Count);
 
@@ -2351,7 +2349,7 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>
 
                     if (oneSkipNav?.Contains(left) == true)
                     {
-                        Assert.Contains(right, left.TwoSkipShared);
+                        Assert.Contains(right, left.TwoSkipShared!);
                         count++;
                     }
                 }
@@ -2370,7 +2368,7 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>
         bool useTrackGraph,
         bool useDetectChanges)
     {
-        List<int> keys = null;
+        List<int> keys = null!;
 
         await ExecuteWithStrategyInTransactionAsync(
             async context =>
@@ -2489,7 +2487,7 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>
             async context =>
             {
                 var queryable = context.Set<UnidirectionalEntityOne>()
-                    .Where(e => keys.Contains(e.Id))
+                    .Where(e => keys!.Contains(e.Id))
                     .Include(e => e.TwoSkip)
                     .ThenInclude(e => e.Extra);
 
@@ -2547,7 +2545,7 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>
         bool useTrackGraph,
         bool useDetectChanges)
     {
-        List<int> keys = null;
+        List<int> keys = null!;
 
         await ExecuteWithStrategyInTransactionAsync(
             async context =>
@@ -2628,7 +2626,7 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>
             async context =>
             {
                 var queryable = context.Set<UnidirectionalEntityOne>()
-                    .Where(e => keys.Contains(e.Id))
+                    .Where(e => keys!.Contains(e.Id))
                     .Include(e => e.TwoSkip)
                     .ThenInclude(e => e.Extra);
 
@@ -2695,13 +2693,13 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>
 
                 await context.SaveChangesAsync();
 
-                id = (int)entity["Id"];
+                id = (int)entity["Id"]!;
             },
             async context =>
             {
-                var entity = await context.Set<ProxyableSharedType>("PST").SingleAsync(e => (int)e["Id"] == id);
+                var entity = await context.Set<ProxyableSharedType>("PST").SingleAsync(e => (int)e["Id"]! == id);
 
-                Assert.Equal("NewlyAdded", (string)entity["Payload"]);
+                Assert.Equal("NewlyAdded", (string)entity["Payload"]!);
 
                 entity["Payload"] = "AlreadyUpdated";
 
@@ -2714,15 +2712,15 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>
             },
             async context =>
             {
-                var entity = await context.Set<ProxyableSharedType>("PST").SingleAsync(e => (int)e["Id"] == id);
+                var entity = await context.Set<ProxyableSharedType>("PST").SingleAsync(e => (int)e["Id"]! == id);
 
-                Assert.Equal("AlreadyUpdated", (string)entity["Payload"]);
+                Assert.Equal("AlreadyUpdated", (string)entity["Payload"]!);
 
                 context.Set<ProxyableSharedType>("PST").Remove(entity);
 
                 await context.SaveChangesAsync();
 
-                Assert.False(await context.Set<ProxyableSharedType>("PST").AnyAsync(e => (int)e["Id"] == id));
+                Assert.False(await context.Set<ProxyableSharedType>("PST").AnyAsync(e => (int)e["Id"]! == id));
             });
     }
 
@@ -2823,7 +2821,7 @@ public abstract partial class ManyToManyTrackingTestBase<TFixture>
             async context =>
             {
                 var queryable = context.Set<UnidirectionalEntityTwo>()
-                    .Where(e => e.Name.StartsWith("Z"))
+                    .Where(e => e.Name!.StartsWith("Z"))
                     .OrderBy(e => e.Name)
                     .Include("UnidirectionalEntityThree");
 

--- a/test/EFCore.Specification.Tests/WithConstructorsTestBase.cs
+++ b/test/EFCore.Specification.Tests/WithConstructorsTestBase.cs
@@ -12,8 +12,6 @@ using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 #pragma warning disable IDE0052 // Remove unread private members
 namespace Microsoft.EntityFrameworkCore;
 
-#nullable disable
-
 public abstract class WithConstructorsTestBase<TFixture>(TFixture fixture) : IClassFixture<TFixture>
     where TFixture : WithConstructorsTestBase<TFixture>.WithConstructorsFixtureBase, new()
 {
@@ -795,7 +793,7 @@ public abstract class WithConstructorsTestBase<TFixture>(TFixture fixture) : ICl
         public Post(
             string title,
             string content,
-            Blog blog = null)
+            Blog? blog = null)
             : this(0, title, content)
             => Blog = blog;
 
@@ -803,7 +801,7 @@ public abstract class WithConstructorsTestBase<TFixture>(TFixture fixture) : ICl
         public string Content { get; set; }
 
         // ReSharper disable once AutoPropertyCanBeMadeGetOnly.Local
-        public Blog Blog { get; private set; }
+        public Blog? Blog { get; private set; }
     }
 
     protected class HasContext<TContext>
@@ -825,7 +823,7 @@ public abstract class WithConstructorsTestBase<TFixture>(TFixture fixture) : ICl
         // ReSharper disable once AutoPropertyCanBeMadeGetOnly.Local
         public bool Filler { get; private set; }
 
-        public TContext Context { get; }
+        public TContext Context { get; } = null!;
     }
 
     protected class HasContextProperty<TContext>
@@ -836,13 +834,13 @@ public abstract class WithConstructorsTestBase<TFixture>(TFixture fixture) : ICl
         // ReSharper disable once AutoPropertyCanBeMadeGetOnly.Local
         public bool Filler { get; private set; }
 
-        public TContext Context { get; private set; }
+        public TContext Context { get; private set; } = null!;
     }
 
     protected class HasContextPc<TContext>
         where TContext : DbContext
     {
-        private TContext _context;
+        private TContext _context = null!;
         private bool _setterCalled;
 
         public HasContextPc()
@@ -881,7 +879,7 @@ public abstract class WithConstructorsTestBase<TFixture>(TFixture fixture) : ICl
 
     protected class HasEntityType
     {
-        private readonly IEntityType _entityType;
+        private readonly IEntityType _entityType = null!;
 
         public HasEntityType()
         {
@@ -904,12 +902,12 @@ public abstract class WithConstructorsTestBase<TFixture>(TFixture fixture) : ICl
 
         public bool Filler { get; set; }
 
-        public IEntityType EntityType { get; set; }
+        public IEntityType EntityType { get; set; } = null!;
     }
 
     protected class HasEntityTypePc
     {
-        private IEntityType _entityType;
+        private IEntityType _entityType = null!;
         private bool _setterCalled;
 
         public HasEntityTypePc()
@@ -943,7 +941,7 @@ public abstract class WithConstructorsTestBase<TFixture>(TFixture fixture) : ICl
 
     protected class HasStateManager
     {
-        private readonly IStateManager _stateManager;
+        private readonly IStateManager _stateManager = null!;
 
         public HasStateManager()
         {
@@ -966,12 +964,12 @@ public abstract class WithConstructorsTestBase<TFixture>(TFixture fixture) : ICl
 
         public bool Filler { get; set; }
 
-        public IStateManager StateManager { get; set; }
+        public IStateManager StateManager { get; set; } = null!;
     }
 
     protected class HasStateManagerPc
     {
-        private IStateManager _stateManager;
+        private IStateManager _stateManager = null!;
         private bool _setterCalled;
         // ReSharper disable once ConvertToAutoProperty
 
@@ -1006,7 +1004,7 @@ public abstract class WithConstructorsTestBase<TFixture>(TFixture fixture) : ICl
 
     protected class LazyBlog
     {
-        private readonly ILazyLoader _loader;
+        private readonly ILazyLoader _loader = null!;
         private ICollection<LazyPost> _lazyPosts = new List<LazyPost>();
 
         public LazyBlog()
@@ -1024,13 +1022,13 @@ public abstract class WithConstructorsTestBase<TFixture>(TFixture fixture) : ICl
             => _lazyPosts.Add(post);
 
         public IEnumerable<LazyPost> LazyPosts
-            => _loader.Load(this, ref _lazyPosts);
+            => _loader.Load(this, ref _lazyPosts!)!;
     }
 
     protected class LazyPost
     {
-        private readonly ILazyLoader _loader;
-        private LazyBlog _lazyBlog;
+        private readonly ILazyLoader _loader = null!;
+        private LazyBlog _lazyBlog = null!;
 
         public LazyPost()
         {
@@ -1045,7 +1043,7 @@ public abstract class WithConstructorsTestBase<TFixture>(TFixture fixture) : ICl
 
         public LazyBlog LazyBlog
         {
-            get => _loader.Load(this, ref _lazyBlog);
+            get => _loader.Load(this, ref _lazyBlog!)!;
             set => _lazyBlog = value;
         }
     }
@@ -1054,7 +1052,7 @@ public abstract class WithConstructorsTestBase<TFixture>(TFixture fixture) : ICl
     {
         private ICollection<LazyPropertyPost> _lazyPropertyPosts = new List<LazyPropertyPost>();
 
-        private ILazyLoader Loader { get; set; }
+        private ILazyLoader Loader { get; set; } = null!;
 
         public int Id { get; set; }
 
@@ -1064,14 +1062,14 @@ public abstract class WithConstructorsTestBase<TFixture>(TFixture fixture) : ICl
             => _lazyPropertyPosts.Add(post);
 
         public IEnumerable<LazyPropertyPost> LazyPropertyPosts
-            => Loader.Load(this, ref _lazyPropertyPosts);
+            => Loader.Load(this, ref _lazyPropertyPosts!)!;
     }
 
     protected class LazyPropertyPost
     {
-        private LazyPropertyBlog _lazyPropertyBlog;
+        private LazyPropertyBlog _lazyPropertyBlog = null!;
 
-        private ILazyLoader Loader { get; set; }
+        private ILazyLoader Loader { get; set; } = null!;
 
         public int Id { get; set; }
         public bool Filler { get; set; }
@@ -1079,7 +1077,7 @@ public abstract class WithConstructorsTestBase<TFixture>(TFixture fixture) : ICl
 
         public LazyPropertyBlog LazyPropertyBlog
         {
-            get => Loader.Load(this, ref _lazyPropertyBlog);
+            get => Loader.Load(this, ref _lazyPropertyBlog!)!;
             set => _lazyPropertyBlog = value;
         }
 
@@ -1093,7 +1091,7 @@ public abstract class WithConstructorsTestBase<TFixture>(TFixture fixture) : ICl
 
 #pragma warning disable 649
 #pragma warning disable IDE0044 // Add readonly modifier
-        private ILazyLoader _loader;
+        private ILazyLoader _loader = null!;
 #pragma warning restore IDE0044 // Add readonly modifier
 #pragma warning restore 649
 
@@ -1105,16 +1103,16 @@ public abstract class WithConstructorsTestBase<TFixture>(TFixture fixture) : ICl
             => _lazyFieldPosts.Add(post);
 
         public IEnumerable<LazyFieldPost> LazyFieldPosts
-            => _loader.Load(this, ref _lazyFieldPosts);
+            => _loader.Load(this, ref _lazyFieldPosts!)!;
     }
 
     protected class LazyFieldPost
     {
-        private LazyFieldBlog _lazyFieldBlog;
+        private LazyFieldBlog _lazyFieldBlog = null!;
 
 #pragma warning disable 649
 #pragma warning disable IDE0044 // Add readonly modifier
-        private ILazyLoader _loader;
+        private ILazyLoader _loader = null!;
 #pragma warning restore IDE0044 // Add readonly modifier
 #pragma warning restore 649
 
@@ -1124,7 +1122,7 @@ public abstract class WithConstructorsTestBase<TFixture>(TFixture fixture) : ICl
 
         public LazyFieldBlog LazyFieldBlog
         {
-            get => _loader.Load(this, ref _lazyFieldBlog);
+            get => _loader.Load(this, ref _lazyFieldBlog!)!;
             set => _lazyFieldBlog = value;
         }
 
@@ -1136,7 +1134,7 @@ public abstract class WithConstructorsTestBase<TFixture>(TFixture fixture) : ICl
     {
         private ICollection<LazyPsPost> _lazyPsPosts = new List<LazyPsPost>();
 
-        private Action<object, string> LazyLoader { get; set; }
+        private Action<object, string> LazyLoader { get; set; } = null!;
 
         public int Id { get; set; }
 
@@ -1151,9 +1149,9 @@ public abstract class WithConstructorsTestBase<TFixture>(TFixture fixture) : ICl
 
     protected class LazyPsPost
     {
-        private LazyPsBlog _lazyPsBlog;
+        private LazyPsBlog _lazyPsBlog = null!;
 
-        private Action<object, string> LazyLoader { get; set; }
+        private Action<object, string> LazyLoader { get; set; } = null!;
 
         public int Id { get; set; }
 
@@ -1170,7 +1168,7 @@ public abstract class WithConstructorsTestBase<TFixture>(TFixture fixture) : ICl
     {
         private readonly ICollection<LazyAsyncPsPost> _lazyAsyncPsPosts = new List<LazyAsyncPsPost>();
 
-        private Func<object, CancellationToken, string, Task> LazyLoader { get; set; }
+        private Func<object, CancellationToken, string, Task> LazyLoader { get; set; } = null!;
 
         public int Id { get; set; }
 
@@ -1192,7 +1190,7 @@ public abstract class WithConstructorsTestBase<TFixture>(TFixture fixture) : ICl
 
     protected class LazyAsyncPsPost
     {
-        private Func<object, CancellationToken, string, Task> LazyLoader { get; set; }
+        private Func<object, CancellationToken, string, Task> LazyLoader { get; set; } = null!;
 
         public int Id { get; set; }
         public bool Filler { get; set; }
@@ -1204,13 +1202,13 @@ public abstract class WithConstructorsTestBase<TFixture>(TFixture fixture) : ICl
             return LazyAsyncPsBlog;
         }
 
-        public LazyAsyncPsBlog LazyAsyncPsBlog { get; set; }
+        public LazyAsyncPsBlog LazyAsyncPsBlog { get; set; } = null!;
     }
 
     protected class LazyPcBlog
     {
         private ICollection<LazyPcPost> _lazyPcPosts = new List<LazyPcPost>();
-        private ILazyLoader _loader;
+        private ILazyLoader _loader = null!;
 
         public LazyPcBlog()
         {
@@ -1241,13 +1239,13 @@ public abstract class WithConstructorsTestBase<TFixture>(TFixture fixture) : ICl
             => _lazyPcPosts.Add(post);
 
         public IEnumerable<LazyPcPost> LazyPcPosts
-            => Loader.Load(this, ref _lazyPcPosts);
+            => Loader.Load(this, ref _lazyPcPosts!)!;
     }
 
     protected class LazyPcPost
     {
-        private LazyPcBlog _lazyPcBlog;
-        private ILazyLoader _loader;
+        private LazyPcBlog _lazyPcBlog = null!;
+        private ILazyLoader _loader = null!;
 
         public LazyPcPost()
         {
@@ -1276,7 +1274,7 @@ public abstract class WithConstructorsTestBase<TFixture>(TFixture fixture) : ICl
 
         public LazyPcBlog LazyPcBlog
         {
-            get => Loader.Load(this, ref _lazyPcBlog);
+            get => Loader.Load(this, ref _lazyPcBlog!)!;
             set => _lazyPcBlog = value;
         }
     }
@@ -1284,7 +1282,7 @@ public abstract class WithConstructorsTestBase<TFixture>(TFixture fixture) : ICl
     protected class LazyPcsBlog
     {
         private ICollection<LazyPcsPost> _lazyPcsPosts = new List<LazyPcsPost>();
-        private Action<object, string> _loader;
+        private Action<object, string> _loader = null!;
 
         public LazyPcsBlog()
         {
@@ -1320,8 +1318,8 @@ public abstract class WithConstructorsTestBase<TFixture>(TFixture fixture) : ICl
 
     protected class LazyPcsPost
     {
-        private LazyPcsBlog _lazyPcsBlog;
-        private Action<object, string> _loader;
+        private LazyPcsBlog _lazyPcsBlog = null!;
+        private Action<object, string> _loader = null!;
 
         public LazyPcsPost()
         {
@@ -1360,7 +1358,7 @@ public abstract class WithConstructorsTestBase<TFixture>(TFixture fixture) : ICl
 
     protected class LazyPocoBlog
     {
-        private readonly Action<object, string> _loader;
+        private readonly Action<object, string> _loader = null!;
         private ICollection<LazyPocoPost> _lazyPocoPosts = new List<LazyPocoPost>();
 
         public LazyPocoBlog()
@@ -1383,8 +1381,8 @@ public abstract class WithConstructorsTestBase<TFixture>(TFixture fixture) : ICl
 
     protected class LazyPocoPost
     {
-        private readonly Action<object, string> _loader;
-        private LazyPocoBlog _lazyPocoBlog;
+        private readonly Action<object, string> _loader = null!;
+        private LazyPocoBlog _lazyPocoBlog = null!;
 
         public LazyPocoPost()
         {
@@ -1406,7 +1404,7 @@ public abstract class WithConstructorsTestBase<TFixture>(TFixture fixture) : ICl
 
     protected class LazyAsyncPocoBlog
     {
-        private readonly Func<object, CancellationToken, string, Task> _loader;
+        private readonly Func<object, CancellationToken, string, Task> _loader = null!;
         private readonly ICollection<LazyAsyncPocoPost> _lazyAsyncPocoPosts = new List<LazyAsyncPocoPost>();
 
         public LazyAsyncPocoBlog()
@@ -1436,7 +1434,7 @@ public abstract class WithConstructorsTestBase<TFixture>(TFixture fixture) : ICl
 
     protected class LazyAsyncPocoPost
     {
-        private readonly Func<object, CancellationToken, string, Task> _loader;
+        private readonly Func<object, CancellationToken, string, Task> _loader = null!;
 
         public LazyAsyncPocoPost()
         {
@@ -1456,12 +1454,12 @@ public abstract class WithConstructorsTestBase<TFixture>(TFixture fixture) : ICl
             return LazyAsyncPocoBlog;
         }
 
-        public LazyAsyncPocoBlog LazyAsyncPocoBlog { get; set; }
+        public LazyAsyncPocoBlog LazyAsyncPocoBlog { get; set; } = null!;
     }
 
     protected class LazyAsyncBlog
     {
-        private readonly ILazyLoader _loader;
+        private readonly ILazyLoader _loader = null!;
         private readonly ICollection<LazyAsyncPost> _lazyAsyncPosts = new List<LazyAsyncPost>();
 
         public LazyAsyncBlog()
@@ -1491,7 +1489,7 @@ public abstract class WithConstructorsTestBase<TFixture>(TFixture fixture) : ICl
 
     protected class LazyAsyncPost
     {
-        private readonly ILazyLoader _loader;
+        private readonly ILazyLoader _loader = null!;
 
         public LazyAsyncPost()
         {
@@ -1511,7 +1509,7 @@ public abstract class WithConstructorsTestBase<TFixture>(TFixture fixture) : ICl
             return LazyAsyncBlog;
         }
 
-        public LazyAsyncBlog LazyAsyncBlog { get; set; }
+        public LazyAsyncBlog LazyAsyncBlog { get; set; } = null!;
     }
 
     protected record BlogAsImmutableRecord


### PR DESCRIPTION
Part 4 of 5 for #24427. Based on #38790.

## Summary

- Enables nullable analysis throughout shared model, query, update, and test utility infrastructure.
- Enables NRT in InMemory functional and ASP.NET specification/functional projects.
- Annotates optional CLR properties and navigations so provider behavior remains unchanged.
- Keeps all pre-existing assertion invocations semantically intact.

## Stack

1. #38788
2. #38789
3. #38790
4. **#38791** (this PR)
5. #38792

## Validation

- Full `EFCore.slnx` build at this tip: 0 warnings, 0 errors.
- InMemory functional tests: 28,258 total, 0 failed.
- Final Roslyn assertion audit: 1,503 changed C# files, 0 missing assertions, 0 parse errors.

<!--
Please check whether the PR fulfills these requirements
-->

- [ ] I've read the guidelines for [contributing](https://github.com/dotnet/efcore/blob/main/.github/CONTRIBUTING.md) and seen the [walkthrough](https://youtu.be/9OMxy1s?t=1869)
- [ ] I've posted a comment on an issue with a detailed description of how I am planning to contribute and got approval from a member of the team
- [x] The code builds and tests pass locally (also verified by our automated build checks)
- [x] Commit messages follow the required format
- [x] Tests for the changes have been added or existing coverage validates the migration
- [x] Code follows the same patterns and style as existing code in this repo