### PR TITLE
Enable nullability in shared test sources

### DIFF
--- a/src/Shared/BidirectionalDictionary.cs
+++ b/src/Shared/BidirectionalDictionary.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System.Collections;
 using System.Diagnostics.CodeAnalysis;
 

--- a/src/Shared/Check.cs
+++ b/src/Shared/Check.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using JetBrains.Annotations;

--- a/src/Shared/CodeAnnotations.cs
+++ b/src/Shared/CodeAnnotations.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 namespace JetBrains.Annotations;
 
 [AttributeUsage(AttributeTargets.Parameter)]

--- a/src/Shared/DictionaryExtensions.cs
+++ b/src/Shared/DictionaryExtensions.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.EntityFrameworkCore.Utilities;

--- a/src/Shared/DisposableExtensions.cs
+++ b/src/Shared/DisposableExtensions.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore.Utilities;
 
 internal static class DisposableExtensions

--- a/src/Shared/EnumerableExtensions.cs
+++ b/src/Shared/EnumerableExtensions.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System.Collections;
 
 // ReSharper disable once CheckNamespace

--- a/src/Shared/ExpressionExtensions.cs
+++ b/src/Shared/ExpressionExtensions.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System.Diagnostics.CodeAnalysis;
 
 // ReSharper disable once CheckNamespace

--- a/src/Shared/ExpressionVisitorExtensions.cs
+++ b/src/Shared/ExpressionVisitorExtensions.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System.Runtime.CompilerServices;
 
 // ReSharper disable once CheckNamespace

--- a/src/Shared/HashHelpers.cs
+++ b/src/Shared/HashHelpers.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore.Utilities;
 
 internal static class HashHelpers

--- a/src/Shared/IDictionaryDebugView.cs
+++ b/src/Shared/IDictionaryDebugView.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore.Utilities;
 
 internal sealed class IDictionaryDebugView<TKey, TValue>(IDictionary<TKey, TValue> dictionary)

--- a/src/Shared/MemberInfoExtensions.cs
+++ b/src/Shared/MemberInfoExtensions.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 namespace System.Reflection;
 
 internal static class EntityFrameworkMemberInfoExtensions

--- a/src/Shared/Multigraph.cs
+++ b/src/Shared/Multigraph.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 namespace Microsoft.EntityFrameworkCore.Utilities;
 
 internal class Multigraph<TVertex, TEdge> : Graph<TVertex>

--- a/src/Shared/NonCapturingLazyInitializer.cs
+++ b/src/Shared/NonCapturingLazyInitializer.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.EntityFrameworkCore.Internal;

--- a/src/Shared/OrderedDictionary.KeyCollection.cs
+++ b/src/Shared/OrderedDictionary.KeyCollection.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System.Collections;
 
 namespace Microsoft.EntityFrameworkCore.Utilities;

--- a/src/Shared/OrderedDictionary.ValueCollection.cs
+++ b/src/Shared/OrderedDictionary.ValueCollection.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System.Collections;
 
 namespace Microsoft.EntityFrameworkCore.Utilities;

--- a/src/Shared/OrderedDictionary.cs
+++ b/src/Shared/OrderedDictionary.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System.Collections;
 using System.Diagnostics.CodeAnalysis;
 

--- a/src/Shared/PropertyInfoExtensions.cs
+++ b/src/Shared/PropertyInfoExtensions.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 // ReSharper disable once CheckNamespace
 
 namespace System.Reflection;

--- a/src/Shared/SharedTypeExtensions.cs
+++ b/src/Shared/SharedTypeExtensions.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Text;


### PR DESCRIPTION
Part 5 of 5 for #24427. Based on #38791.

## Summary

- Removes nullable opt-out directives from the 18 shared source files linked into test projects.
- Completes nullable analysis coverage across benchmark and test projects.
- Retains nullable directives only in generated files and tests that intentionally exercise a specific nullable context.

## Stack

1. #38788
2. #38789
3. #38790
4. #38791
5. **#38792** (this PR)

## Validation

- Every stack tip builds `EFCore.slnx` with 0 warnings and 0 errors.
- All 28 runnable test hosts pass serially: 140,057 total, 0 failed, 138,733 passed, 1,324 skipped.
- Trimming apps publish and both return the required success code `100`.
- NativeAOT's NRT-specific generated-code error is fixed; remaining NativeAOT failures are stale compiled-model API errors already present on `main`, and that project is excluded from CI.
- Project nullable opt-outs: 0.
- Retained nullable directives: 424, all generated or targeted.
- Final tree is byte-for-byte identical to the validated snapshot.

Fixes #24427

<!--
Please check whether the PR fulfills these requirements
-->

- [ ] I've read the guidelines for [contributing](https://github.com/dotnet/efcore/blob/main/.github/CONTRIBUTING.md) and seen the [walkthrough](https://youtu.be/9OMxy1s?t=1869)
- [ ] I've posted a comment on an issue with a detailed description of how I am planning to contribute and got approval from a member of the team
- [x] The code builds and tests pass locally (also verified by our automated build checks)
- [x] Commit messages follow the required format
- [x] Tests for the changes have been added or existing coverage validates the migration
- [x] Code follows the same patterns and style as existing code in this repo