### PR TITLE
Fix failing Cosmos tests

### DIFF
--- a/test/EFCore.Cosmos.FunctionalTests/AddHocFullTextSearchCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/AddHocFullTextSearchCosmosTest.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Net;
 using Microsoft.Azure.Cosmos;
 using Microsoft.EntityFrameworkCore.Cosmos.Internal;
 
@@ -149,10 +150,7 @@ public class AdHocFullTextSearchCosmosTest(NonSharedFixture fixture) : NonShared
         var exception =
             await Assert.ThrowsAsync<CosmosException>(() => InitializeNonSharedTest<ContextSettingDefaultFullTextSearchLanguage>());
 
-        Assert.Contains(
-            CosmosTestEnvironment.IsEmulator
-                ? "The Full Text Policy contains an unsupported language xx-YY."
-                : "The language specified in the full-text policy, 'xx-YY', is invalid.", exception.Message);
+        Assert.Equal(HttpStatusCode.BadRequest, exception.StatusCode);
     }
 
     protected class ContextSettingDefaultFullTextSearchLanguage(DbContextOptions options) : DbContext(options)
@@ -239,11 +237,7 @@ public class AdHocFullTextSearchCosmosTest(NonSharedFixture fixture) : NonShared
             await Assert.ThrowsAsync<CosmosException>(()
                 => InitializeNonSharedTest<ContextDefaultFullTextSearchLanguageNoMismatchWhenNotSpecified>());
 
-        Assert.Contains(
-            CosmosTestEnvironment.IsEmulator
-                ? "The Full Text Policy contains an unsupported language xx-YY."
-                : "The language specified in the full-text policy, 'xx-YY', is invalid.",
-            exception.Message);
+        Assert.Equal(HttpStatusCode.BadRequest, exception.StatusCode);
     }
 
     protected class ContextDefaultFullTextSearchLanguageNoMismatchWhenNotSpecified(DbContextOptions options) : DbContext(options)
@@ -316,11 +310,7 @@ public class AdHocFullTextSearchCosmosTest(NonSharedFixture fixture) : NonShared
         var exception = await Assert.ThrowsAsync<CosmosException>(()
             => InitializeNonSharedTest<ContextDefaultFullTextSearchLanguageUsedWhenPropertyDoesntSpecifyOneExplicitly>());
 
-        Assert.Contains(
-            CosmosTestEnvironment.IsEmulator
-                ? "The Full Text Policy contains an unsupported language xx-YY."
-                : "The language specified in the full-text policy, 'xx-YY', is invalid.",
-            exception.Message);
+        Assert.Equal(HttpStatusCode.BadRequest, exception.StatusCode);
     }
 
     protected class ContextDefaultFullTextSearchLanguageUsedWhenPropertyDoesntSpecifyOneExplicitly(DbContextOptions options)
@@ -360,11 +350,7 @@ public class AdHocFullTextSearchCosmosTest(NonSharedFixture fixture) : NonShared
         var exception =
             await Assert.ThrowsAsync<CosmosException>(() => InitializeNonSharedTest<ContextExplicitFullTextLanguageOverridesTheDefault>());
 
-        Assert.Contains(
-            CosmosTestEnvironment.IsEmulator
-                ? "The Full Text Policy contains an unsupported language xx-YY."
-                : "The language specified in the full-text policy, 'xx-YY', is invalid.",
-            exception.Message);
+        Assert.Equal(HttpStatusCode.BadRequest, exception.StatusCode);
     }
 
     protected class ContextExplicitFullTextLanguageOverridesTheDefault(DbContextOptions options) : DbContext(options)

--- a/test/EFCore.Cosmos.FunctionalTests/CosmosConcurrencyTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/CosmosConcurrencyTest.cs
@@ -4,13 +4,9 @@
 namespace Microsoft.EntityFrameworkCore;
 
 public class CosmosConcurrencyTest(CosmosConcurrencyTest.CosmosFixture fixture)
-    : IClassFixture<CosmosConcurrencyTest.CosmosFixture>, IAsyncLifetime
+    : IClassFixture<CosmosConcurrencyTest.CosmosFixture>
 {
     private const string DatabaseName = "CosmosConcurrencyTest";
-
-    protected ServiceProvider ServiceProvider { get; } = new ServiceCollection()
-        .AddEntityFrameworkCosmos()
-        .BuildServiceProvider();
 
     protected CosmosFixture Fixture { get; } = fixture;
 
@@ -72,7 +68,7 @@ public class CosmosConcurrencyTest(CosmosConcurrencyTest.CosmosFixture fixture)
 #pragma warning restore CS0618 // Type or member is obsolete
                             }
                         })))
-            .UseInternalServiceProvider(ServiceProvider)
+            .EnableServiceProviderCaching(false)
             .Options;
 
         var customer = new Customer
@@ -125,6 +121,9 @@ public class CosmosConcurrencyTest(CosmosConcurrencyTest.CosmosFixture fixture)
     [Theory, InlineData(null), InlineData(true), InlineData(false)]
     public async Task Etag_is_updated_in_derived_entity_after_SaveChanges(bool? contentResponseOnWriteEnabled)
     {
+        await using var serviceProvider = new ServiceCollection()
+            .AddEntityFrameworkCosmos()
+            .BuildServiceProvider();
         var options = Fixture.TestStore.AddProviderOptions(
                 Fixture.AddOptions(
                     new DbContextOptionsBuilder()
@@ -137,7 +136,7 @@ public class CosmosConcurrencyTest(CosmosConcurrencyTest.CosmosFixture fixture)
 #pragma warning restore CS0618 // Type or member is obsolete
                             }
                         })))
-            .UseInternalServiceProvider(ServiceProvider)
+            .EnableServiceProviderCaching(false)
             .Options;
 
         var customer = new PremiumCustomer
@@ -253,12 +252,6 @@ public class CosmosConcurrencyTest(CosmosConcurrencyTest.CosmosFixture fixture)
 
     protected virtual ConcurrencyContext CreateContext(DbContextOptions options)
         => new(options);
-
-    public virtual ValueTask InitializeAsync()
-        => ValueTask.CompletedTask;
-
-    public virtual async ValueTask DisposeAsync()
-        => await ServiceProvider.DisposeAsync();
 
     public class CosmosFixture : SharedStoreFixtureBase<ConcurrencyContext>
     {

--- a/test/EFCore.Cosmos.FunctionalTests/CosmosTransactionalBatchTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/CosmosTransactionalBatchTest.cs
@@ -316,15 +316,7 @@ public class CosmosTransactionalBatchTest(CosmosTransactionalBatchTest.CosmosFix
             Body = @"function trigger() {}"
         };
 
-        try
-        {
-            await container.Scripts.CreateTriggerAsync(preInsertTriggerDefinition);
-        }
-        catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.Conflict)
-        {
-            // Trigger already exists, replace it
-            await container.Scripts.ReplaceTriggerAsync(preInsertTriggerDefinition);
-        }
+        await CosmosTestHelpers.CreateOrReplaceTriggerAsync(context, container, preInsertTriggerDefinition);
 
         context.Database.AutoTransactionBehavior = AutoTransactionBehavior.Always;
 
@@ -388,7 +380,8 @@ public class CosmosTransactionalBatchTest(CosmosTransactionalBatchTest.CosmosFix
         Assert.Equal(3, customersCount);
     }
 
-    [Fact]
+    // Linux emulator times out instead of rejecting oversized requests.
+    [ConditionalFact(typeof(CosmosTestEnvironment), nameof(CosmosTestEnvironment.IsNotLinuxEmulator))]
     public virtual async Task SaveChanges_entity_too_large_throws()
     {
         using var context = Fixture.CreateContext();
@@ -439,7 +432,8 @@ public class CosmosTransactionalBatchTest(CosmosTransactionalBatchTest.CosmosFix
         Assert.Equal("1", (await assertContext.Customers.FirstAsync()).Id);
     }
 
-    [Fact]
+    // Linux emulator times out instead of rejecting oversized transactional batches.
+    [ConditionalFact(typeof(CosmosTestEnvironment), nameof(CosmosTestEnvironment.IsNotLinuxEmulator))]
     public virtual async Task SaveChanges_transaction_behavior_always_payload_larger_than_cosmos_limit_throws()
     {
         using var context = Fixture.CreateContext();

--- a/test/EFCore.Cosmos.FunctionalTests/CosmosTriggersTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/CosmosTriggersTest.cs
@@ -109,15 +109,7 @@ function preInsertTrigger() {
 }"
         };
 
-        try
-        {
-            await container.Scripts.CreateTriggerAsync(preInsertTriggerDefinition);
-        }
-        catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.Conflict)
-        {
-            // Trigger already exists, replace it
-            await container.Scripts.ReplaceTriggerAsync(preInsertTriggerDefinition);
-        }
+        await CosmosTestHelpers.CreateOrReplaceTriggerAsync(context, container, preInsertTriggerDefinition);
 
         var postDeleteTriggerDefinition = new TriggerProperties
         {
@@ -147,15 +139,7 @@ function postDeleteTrigger() {
 }"
         };
 
-        try
-        {
-            await container.Scripts.CreateTriggerAsync(postDeleteTriggerDefinition);
-        }
-        catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.Conflict)
-        {
-            // Trigger already exists, replace it
-            await container.Scripts.ReplaceTriggerAsync(postDeleteTriggerDefinition);
-        }
+        await CosmosTestHelpers.CreateOrReplaceTriggerAsync(context, container, postDeleteTriggerDefinition);
 
         var updateTriggerDefinition = new TriggerProperties
         {
@@ -186,15 +170,7 @@ function updateTrigger() {
 }"
         };
 
-        try
-        {
-            await container.Scripts.CreateTriggerAsync(updateTriggerDefinition);
-        }
-        catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.Conflict)
-        {
-            // Trigger already exists, replace it
-            await container.Scripts.ReplaceTriggerAsync(updateTriggerDefinition);
-        }
+        await CosmosTestHelpers.CreateOrReplaceTriggerAsync(context, container, updateTriggerDefinition);
     }
 
     protected class TriggersContext(DbContextOptions options) : DbContext(options)

--- a/test/EFCore.Cosmos.FunctionalTests/TestUtilities/CosmosTestHelpers.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/TestUtilities/CosmosTestHelpers.cs
@@ -1,6 +1,9 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Net;
+using Microsoft.Azure.Cosmos;
+using Microsoft.Azure.Cosmos.Scripts;
 using Microsoft.EntityFrameworkCore.Cosmos.Diagnostics.Internal;
 using Microsoft.EntityFrameworkCore.Cosmos.Internal;
 
@@ -33,6 +36,22 @@ public class CosmosTestHelpers : TestHelpers
                 "UnitTests");
 
     public override LoggingDefinitions LoggingDefinitions { get; } = new CosmosLoggingDefinitions();
+
+    public static Task CreateOrReplaceTriggerAsync(
+        DbContext context,
+        Container container,
+        TriggerProperties triggerDefinition)
+        => context.Database.CreateExecutionStrategy().ExecuteAsync(async () =>
+        {
+            try
+            {
+                await container.Scripts.CreateTriggerAsync(triggerDefinition);
+            }
+            catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.Conflict)
+            {
+                await container.Scripts.ReplaceTriggerAsync(triggerDefinition);
+            }
+        });
 
     public async Task NoSyncTest(bool async, Func<bool, Task> testCode)
     {

--- a/test/EFCore.Cosmos.FunctionalTests/TestUtilities/CosmosTestStore.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/TestUtilities/CosmosTestStore.cs
@@ -5,6 +5,7 @@ using System.Collections.Concurrent;
 using System.Net;
 using System.Net.Sockets;
 using System.Runtime.CompilerServices;
+using System.Text.Json;
 using Azure;
 using Azure.Core;
 using Azure.ResourceManager;
@@ -317,18 +318,30 @@ public class CosmosTestStore : TestStore
     {
         var created = await EnsureCreatedAsync(context).ConfigureAwait(false);
 
-        // Containers are deleted and recreated below only when the database already existed. A freshly-created
-        // database has brand-new containers whose metadata cannot be stale.
-        var containersRecreated = !created;
+        var cleanDocuments = !created && createTables && Shared;
+        var containersRecreated = !created && !cleanDocuments;
         try
         {
             if (!created)
             {
-                await DeleteContainersAsync(context).ConfigureAwait(false);
+                if (cleanDocuments)
+                {
+                    await DeleteDocumentsAsync(context).ConfigureAwait(false);
+                }
+                else
+                {
+                    await DeleteContainersAsync(context).ConfigureAwait(false);
+                }
             }
 
             if (!createTables)
             {
+                return;
+            }
+
+            if (cleanDocuments)
+            {
+                await SeedAsync(context).ConfigureAwait(false);
                 return;
             }
 
@@ -369,6 +382,69 @@ public class CosmosTestStore : TestStore
 
             throw;
         }
+    }
+
+    private async Task DeleteDocumentsAsync(DbContext context)
+    {
+        var database = context.Database.GetCosmosClient().GetDatabase(Name);
+        var model = context.GetService<IDesignTimeModel>().Model;
+
+        foreach (var containerProperties in GetContainersToCreate(model))
+        {
+            var container = database.GetContainer(containerProperties.Id);
+            var documents = new List<(string Id, PartitionKey PartitionKey)>();
+            using var iterator = container.GetItemQueryIterator<JsonElement>("SELECT VALUE c FROM c");
+
+            while (iterator.HasMoreResults)
+            {
+                foreach (var document in await iterator.ReadNextAsync().ConfigureAwait(false))
+                {
+                    documents.Add(
+                        (document.GetProperty("id").GetString()!,
+                            CreatePartitionKey(document, containerProperties.PartitionKeyStoreNames)));
+                }
+            }
+
+            foreach (var document in documents)
+            {
+                using var response = await container.DeleteItemStreamAsync(document.Id, document.PartitionKey).ConfigureAwait(false);
+                response.EnsureSuccessStatusCode();
+            }
+        }
+    }
+
+    private static PartitionKey CreatePartitionKey(JsonElement document, IReadOnlyList<string> partitionKeyStoreNames)
+    {
+        var builder = new PartitionKeyBuilder();
+        foreach (var partitionKeyStoreName in partitionKeyStoreNames)
+        {
+            if (!document.TryGetProperty(partitionKeyStoreName, out var value))
+            {
+                builder.AddNoneType();
+                continue;
+            }
+
+            switch (value.ValueKind)
+            {
+                case JsonValueKind.String:
+                    builder.Add(value.GetString()!);
+                    break;
+                case JsonValueKind.Number:
+                    builder.Add(value.GetDouble());
+                    break;
+                case JsonValueKind.True:
+                case JsonValueKind.False:
+                    builder.Add(value.GetBoolean());
+                    break;
+                case JsonValueKind.Null:
+                    builder.AddNullValue();
+                    break;
+                default:
+                    throw new InvalidOperationException($"Unsupported partition key value: {value}.");
+            }
+        }
+
+        return builder.Build();
     }
 
     // Deleting and recreating a container gives it a new resource id (_rid), but the shared CosmosClient caches each

--- a/test/EFCore.Relational.Specification.Tests/Query/UdfDbFunctionTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/UdfDbFunctionTestBase.cs
@@ -1057,22 +1057,25 @@ public abstract class UdfDbFunctionTestBase<TFixture>(TFixture fixture) : IClass
         Assert.Equal(4, query.Count);
     }
 
-#if RELEASE
     [Fact]
     public virtual void Scalar_Function_with_nullable_value_return_type_throws()
     {
         using var context = CreateContext();
 
+#if RELEASE
         var exception = Assert.Throws<InvalidOperationException>(
             () => context.Customers.Where(c => c.Id == UDFSqlContext.NullableValueReturnType()).ToList());
 
         Assert.Equal(
             RelationalStrings.DbFunctionNullableValueReturnType(
-                context.Model.FindDbFunction(typeof(UDFSqlContext).GetMethod(nameof(UDFSqlContext.NullableValueReturnType)))!.ModelName,
+                context.Model.FindDbFunction(typeof(UDFSqlContext).GetMethod(nameof(UDFSqlContext.NullableValueReturnType))!)!.ModelName,
                 "int?"),
             exception.Message);
-    }
+#else
+        Assert.Throws<UnreachableException>(
+            () => context.Customers.Where(c => c.Id == UDFSqlContext.NullableValueReturnType()).ToList());
 #endif
+    }
 
     #endregion
 

--- a/test/EFCore.Specification.Tests/SharedStoreFixtureBase.cs
+++ b/test/EFCore.Specification.Tests/SharedStoreFixtureBase.cs
@@ -10,12 +10,14 @@ public abstract class SharedStoreFixtureBase<TContext> : FixtureBase, IAsyncLife
 {
     protected virtual Type ContextType { get; } = typeof(TContext);
 
+    private IServiceProvider? _serviceProvider;
+
     public IServiceProvider ServiceProvider
     {
-        get => field
+        get => _serviceProvider
             ?? throw new InvalidOperationException(
                 $"You must override the {nameof(InitializeAsync)} method and call `await base.{nameof(InitializeAsync)}();`. At this point the {nameof(ServiceProvider)} property will be available.");
-        private set;
+        private set => _serviceProvider = value;
     }
 
     protected abstract string StoreName { get; }
@@ -112,5 +114,21 @@ public abstract class SharedStoreFixtureBase<TContext> : FixtureBase, IAsyncLife
     }
 
     public virtual async ValueTask DisposeAsync()
-        => await TestStore.DisposeAsync();
+    {
+        try
+        {
+            await TestStore.DisposeAsync();
+        }
+        finally
+        {
+            if (_serviceProvider is IAsyncDisposable asyncDisposable)
+            {
+                await asyncDisposable.DisposeAsync();
+            }
+            else if (_serviceProvider is IDisposable disposable)
+            {
+                disposable.Dispose();
+            }
+        }
+    }
 }


### PR DESCRIPTION
- Some of the flakiness is caused by CosmosClient caching container RIDs internally, making the next query after a container is recreated to fail. The workaround is to clean the databases by deleting the documents without recreating the containers.
- Cleanup service providers proactively in tests to release resources held by CosmosClient faster
- Update asserts in some tests due to new Cosmos behavior in negative cases
- Skip tests consistently failing on Linux Cosmos emulator
- Create triggers inside an ExecutionStrategy