### PR TITLE
Whitelist Any() and All() for GroupBy aggregate navigation lifting

### DIFF
--- a/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.cs
+++ b/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.cs
@@ -1871,7 +1871,7 @@ public partial class NavigationExpandingExpressionVisitor : ExpressionVisitor
             [nameof(Enumerable.Sum), nameof(Enumerable.Min), nameof(Enumerable.Max), nameof(Enumerable.Average)];
 
         private static readonly string[] PredicateAggregateMethodNames =
-            [nameof(Enumerable.Count), nameof(Enumerable.LongCount)];
+            [nameof(Enumerable.Any), nameof(Enumerable.All), nameof(Enumerable.Count), nameof(Enumerable.LongCount)];
 
         public List<GroupingAggregateCall> Aggregates { get; } = [];
         public bool HasUnsupportedUsage { get; private set; }

--- a/test/EFCore.Specification.Tests/Query/NorthwindGroupByQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindGroupByQueryTestBase.cs
@@ -387,6 +387,117 @@ public abstract class NorthwindGroupByQueryTestBase<TFixture>(TFixture fixture) 
             elementSorter: e => e.Key);
 
     [Theory, MemberData(nameof(IsAsyncData))]
+    public virtual Task GroupBy_Any_with_predicate_through_navigation_property(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<Order>()
+                .GroupBy(o => o.EmployeeID)
+                .Select(g => new { g.Key, Londons = g.Any(o => o.Customer!.City == "London") }),
+            elementSorter: e => e.Key);
+
+    [Theory, MemberData(nameof(IsAsyncData))]
+    public virtual Task GroupBy_All_with_predicate_through_navigation_property(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<Order>()
+                .GroupBy(o => o.EmployeeID)
+                .Select(g => new { g.Key, Londons = g.All(o => o.Customer!.City == "London") }),
+            elementSorter: e => e.Key);
+
+    [Theory, MemberData(nameof(IsAsyncData))]
+    public virtual Task GroupBy_Queryable_Any_with_predicate_through_navigation_property(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<Order>()
+                .GroupBy(o => o.EmployeeID)
+                .Select(g => new { g.Key, Londons = g.AsQueryable().Any(o => o.Customer!.City == "London") }),
+            elementSorter: e => e.Key);
+
+    [Theory, MemberData(nameof(IsAsyncData))]
+    public virtual Task GroupBy_Queryable_All_with_predicate_through_navigation_property(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<Order>()
+                .GroupBy(o => o.EmployeeID)
+                .Select(g => new { g.Key, Londons = g.AsQueryable().All(o => o.Customer!.City == "London") }),
+            elementSorter: e => e.Key);
+
+    [Theory, MemberData(nameof(IsAsyncData))]
+    public virtual Task GroupBy_Any_and_aggregate_through_navigation_property(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<Order>()
+                .GroupBy(o => o.EmployeeID)
+                .Select(
+                    g => new
+                    {
+                        g.Key,
+                        HasOrders = g.Any(),
+                        Londons = g.Count(o => o.Customer!.City == "London")
+                    }),
+            elementSorter: e => e.Key);
+
+    [Theory, MemberData(nameof(IsAsyncData))]
+    public virtual Task GroupBy_All_and_aggregate_through_navigation_property(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<Order>()
+                .GroupBy(o => o.EmployeeID)
+                .Select(
+                    g => new
+                    {
+                        g.Key,
+                        AllLate = g.All(o => o.OrderID > 10250),
+                        Londons = g.Count(o => o.Customer!.City == "London")
+                    }),
+            elementSorter: e => e.Key);
+
+    [Theory, MemberData(nameof(IsAsyncData))]
+    public virtual Task GroupBy_multiple_aggregates_with_Any_and_All_sharing_same_navigation(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<Order>()
+                .GroupBy(o => o.EmployeeID)
+                .Select(
+                    g => new
+                    {
+                        g.Key,
+                        Region = g.Max(o => o.Customer!.Region),
+                        AnyLondon = g.Any(o => o.Customer!.City == "London"),
+                        AllLondon = g.All(o => o.Customer!.City == "London"),
+                        Count = g.Count()
+                    }),
+            elementSorter: e => e.Key);
+
+    [Theory, MemberData(nameof(IsAsyncData))]
+    public virtual Task GroupBy_Any_through_two_level_navigation(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<OrderDetail>()
+                .GroupBy(od => od.ProductID)
+                .Select(g => new { g.Key, Londons = g.Any(od => od.Order!.Customer!.City == "London") }),
+            elementSorter: e => e.Key);
+
+    [Theory, MemberData(nameof(IsAsyncData))]
+    public virtual Task GroupBy_key_and_Any_through_same_navigation(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<Order>()
+                .GroupBy(o => o.Customer!.City)
+                .Select(g => new { g.Key, Londons = g.Any(o => o.Customer!.City == "London") }),
+            elementSorter: e => e.Key);
+
+    [Theory, MemberData(nameof(IsAsyncData))]
+    public virtual Task GroupBy_Any_through_navigation_in_intermediate_projection(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<Order>()
+                .Select(o => new { o.EmployeeID, o.Customer!.City })
+                .GroupBy(x => x.EmployeeID)
+                .Select(g => new { g.Key, Londons = g.Any(x => x.City == "London") }),
+            elementSorter: e => e.Key);
+
+    [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task GroupBy_key_and_aggregate_through_same_navigation(bool async)
         => AssertQuery(
             async,

--- a/test/EFCore.Specification.Tests/Query/NorthwindQueryFiltersQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindQueryFiltersQueryTestBase.cs
@@ -163,6 +163,40 @@ public abstract class NorthwindQueryFiltersQueryTestBase<TFixture>(TFixture fixt
             elementSorter: e => e.Key.GetValueOrDefault());
 
     [Theory, MemberData(nameof(IsAsyncData))]
+    public virtual Task GroupBy_Any_through_filtered_navigation(bool async)
+        => AssertFilteredQuery(
+            async,
+            ss => ss.Set<Order>()
+                .GroupBy(o => o.EmployeeID)
+                .Select(g => new { g.Key, Londons = g.Any(o => o.Customer!.City == "London") }),
+            elementSorter: e => e.Key.GetValueOrDefault());
+
+    [Theory, MemberData(nameof(IsAsyncData))]
+    public virtual Task GroupBy_Any_through_filtered_navigation_with_total(bool async)
+        => AssertFilteredQuery(
+            async,
+            ss => ss.Set<Order>()
+                .GroupBy(o => o.EmployeeID)
+                .Select(
+                    g => new
+                    {
+                        g.Key,
+                        Total = g.Count(),
+                        Londons = g.Any(o => o.Customer!.City == "London")
+                    }),
+            elementSorter: e => e.Key.GetValueOrDefault());
+
+    [Theory, MemberData(nameof(IsAsyncData))]
+    public virtual Task GroupBy_Any_through_filtered_navigation_ignore_query_filters(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<Order>()
+                .IgnoreQueryFilters()
+                .GroupBy(o => o.EmployeeID)
+                .Select(g => new { g.Key, Londons = g.Any(o => o.Customer!.City == "London") }),
+            elementSorter: e => e.Key.GetValueOrDefault());
+
+    [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Included_many_to_one_query2(bool async)
         => AssertFilteredQuery(
             async,

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindGroupByQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindGroupByQuerySqlServerTest.cs
@@ -2422,6 +2422,210 @@ GROUP BY [o].[EmployeeID]
 """);
     }
 
+    public override async Task GroupBy_Any_with_predicate_through_navigation_property(bool async)
+    {
+        await base.GroupBy_Any_with_predicate_through_navigation_property(async);
+
+        AssertSql(
+            """
+SELECT [o].[EmployeeID] AS [Key], CASE
+    WHEN EXISTS (
+        SELECT 1
+        FROM [Orders] AS [o0]
+        LEFT JOIN [Customers] AS [c] ON [o0].[CustomerID] = [c].[CustomerID]
+        WHERE ([o].[EmployeeID] = [o0].[EmployeeID] OR ([o].[EmployeeID] IS NULL AND [o0].[EmployeeID] IS NULL)) AND [c].[City] = N'London') THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END AS [Londons]
+FROM [Orders] AS [o]
+GROUP BY [o].[EmployeeID]
+""");
+    }
+
+    public override async Task GroupBy_All_with_predicate_through_navigation_property(bool async)
+    {
+        await base.GroupBy_All_with_predicate_through_navigation_property(async);
+
+        AssertSql(
+            """
+SELECT [o].[EmployeeID] AS [Key], CASE
+    WHEN NOT EXISTS (
+        SELECT 1
+        FROM [Orders] AS [o0]
+        LEFT JOIN [Customers] AS [c] ON [o0].[CustomerID] = [c].[CustomerID]
+        WHERE ([o].[EmployeeID] = [o0].[EmployeeID] OR ([o].[EmployeeID] IS NULL AND [o0].[EmployeeID] IS NULL)) AND ([c].[City] <> N'London' OR [c].[City] IS NULL)) THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END AS [Londons]
+FROM [Orders] AS [o]
+GROUP BY [o].[EmployeeID]
+""");
+    }
+
+    public override async Task GroupBy_Queryable_Any_with_predicate_through_navigation_property(bool async)
+    {
+        await base.GroupBy_Queryable_Any_with_predicate_through_navigation_property(async);
+
+        AssertSql(
+            """
+SELECT [o].[EmployeeID] AS [Key], CASE
+    WHEN EXISTS (
+        SELECT 1
+        FROM [Orders] AS [o0]
+        LEFT JOIN [Customers] AS [c] ON [o0].[CustomerID] = [c].[CustomerID]
+        WHERE ([o].[EmployeeID] = [o0].[EmployeeID] OR ([o].[EmployeeID] IS NULL AND [o0].[EmployeeID] IS NULL)) AND [c].[City] = N'London') THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END AS [Londons]
+FROM [Orders] AS [o]
+GROUP BY [o].[EmployeeID]
+""");
+    }
+
+    public override async Task GroupBy_Queryable_All_with_predicate_through_navigation_property(bool async)
+    {
+        await base.GroupBy_Queryable_All_with_predicate_through_navigation_property(async);
+
+        AssertSql(
+            """
+SELECT [o].[EmployeeID] AS [Key], CASE
+    WHEN NOT EXISTS (
+        SELECT 1
+        FROM [Orders] AS [o0]
+        LEFT JOIN [Customers] AS [c] ON [o0].[CustomerID] = [c].[CustomerID]
+        WHERE ([o].[EmployeeID] = [o0].[EmployeeID] OR ([o].[EmployeeID] IS NULL AND [o0].[EmployeeID] IS NULL)) AND ([c].[City] <> N'London' OR [c].[City] IS NULL)) THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END AS [Londons]
+FROM [Orders] AS [o]
+GROUP BY [o].[EmployeeID]
+""");
+    }
+
+    public override async Task GroupBy_Any_and_aggregate_through_navigation_property(bool async)
+    {
+        await base.GroupBy_Any_and_aggregate_through_navigation_property(async);
+
+        AssertSql(
+            """
+SELECT [o].[EmployeeID] AS [Key], CASE
+    WHEN EXISTS (
+        SELECT 1
+        FROM [Orders] AS [o0]
+        WHERE [o].[EmployeeID] = [o0].[EmployeeID] OR ([o].[EmployeeID] IS NULL AND [o0].[EmployeeID] IS NULL)) THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END AS [HasOrders], COUNT(CASE
+    WHEN [c].[City] = N'London' THEN 1
+END) AS [Londons]
+FROM [Orders] AS [o]
+LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
+GROUP BY [o].[EmployeeID]
+""");
+    }
+
+    public override async Task GroupBy_All_and_aggregate_through_navigation_property(bool async)
+    {
+        await base.GroupBy_All_and_aggregate_through_navigation_property(async);
+
+        AssertSql(
+            """
+SELECT [o].[EmployeeID] AS [Key], CASE
+    WHEN NOT EXISTS (
+        SELECT 1
+        FROM [Orders] AS [o0]
+        WHERE ([o].[EmployeeID] = [o0].[EmployeeID] OR ([o].[EmployeeID] IS NULL AND [o0].[EmployeeID] IS NULL)) AND [o0].[OrderID] <= 10250) THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END AS [AllLate], COUNT(CASE
+    WHEN [c].[City] = N'London' THEN 1
+END) AS [Londons]
+FROM [Orders] AS [o]
+LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
+GROUP BY [o].[EmployeeID]
+""");
+    }
+
+    public override async Task GroupBy_multiple_aggregates_with_Any_and_All_sharing_same_navigation(bool async)
+    {
+        await base.GroupBy_multiple_aggregates_with_Any_and_All_sharing_same_navigation(async);
+
+        AssertSql(
+            """
+SELECT [o].[EmployeeID] AS [Key], MAX([c].[Region]) AS [Region], CASE
+    WHEN EXISTS (
+        SELECT 1
+        FROM [Orders] AS [o0]
+        LEFT JOIN [Customers] AS [c0] ON [o0].[CustomerID] = [c0].[CustomerID]
+        WHERE ([o].[EmployeeID] = [o0].[EmployeeID] OR ([o].[EmployeeID] IS NULL AND [o0].[EmployeeID] IS NULL)) AND [c0].[City] = N'London') THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END AS [AnyLondon], CASE
+    WHEN NOT EXISTS (
+        SELECT 1
+        FROM [Orders] AS [o1]
+        LEFT JOIN [Customers] AS [c1] ON [o1].[CustomerID] = [c1].[CustomerID]
+        WHERE ([o].[EmployeeID] = [o1].[EmployeeID] OR ([o].[EmployeeID] IS NULL AND [o1].[EmployeeID] IS NULL)) AND ([c1].[City] <> N'London' OR [c1].[City] IS NULL)) THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END AS [AllLondon], COUNT(*) AS [Count]
+FROM [Orders] AS [o]
+LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
+GROUP BY [o].[EmployeeID]
+""");
+    }
+
+    public override async Task GroupBy_Any_through_two_level_navigation(bool async)
+    {
+        await base.GroupBy_Any_through_two_level_navigation(async);
+
+        AssertSql(
+            """
+SELECT [o].[ProductID] AS [Key], CASE
+    WHEN EXISTS (
+        SELECT 1
+        FROM [Order Details] AS [o0]
+        INNER JOIN [Orders] AS [o1] ON [o0].[OrderID] = [o1].[OrderID]
+        LEFT JOIN [Customers] AS [c] ON [o1].[CustomerID] = [c].[CustomerID]
+        WHERE [o].[ProductID] = [o0].[ProductID] AND [c].[City] = N'London') THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END AS [Londons]
+FROM [Order Details] AS [o]
+GROUP BY [o].[ProductID]
+""");
+    }
+
+    public override async Task GroupBy_key_and_Any_through_same_navigation(bool async)
+    {
+        await base.GroupBy_key_and_Any_through_same_navigation(async);
+
+        AssertSql(
+            """
+SELECT [c].[City] AS [Key], CASE
+    WHEN EXISTS (
+        SELECT 1
+        FROM [Orders] AS [o0]
+        LEFT JOIN [Customers] AS [c0] ON [o0].[CustomerID] = [c0].[CustomerID]
+        WHERE ([c].[City] = [c0].[City] OR ([c].[City] IS NULL AND [c0].[City] IS NULL)) AND [c0].[City] = N'London') THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END AS [Londons]
+FROM [Orders] AS [o]
+LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
+GROUP BY [c].[City]
+""");
+    }
+
+    public override async Task GroupBy_Any_through_navigation_in_intermediate_projection(bool async)
+    {
+        await base.GroupBy_Any_through_navigation_in_intermediate_projection(async);
+
+        AssertSql(
+            """
+SELECT [o].[EmployeeID] AS [Key], CASE
+    WHEN EXISTS (
+        SELECT 1
+        FROM [Orders] AS [o0]
+        LEFT JOIN [Customers] AS [c] ON [o0].[CustomerID] = [c].[CustomerID]
+        WHERE ([o].[EmployeeID] = [o0].[EmployeeID] OR ([o].[EmployeeID] IS NULL AND [o0].[EmployeeID] IS NULL)) AND [c].[City] = N'London') THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END AS [Londons]
+FROM [Orders] AS [o]
+GROUP BY [o].[EmployeeID]
+""");
+    }
+
     public override async Task GroupBy_key_and_aggregate_through_same_navigation(bool async)
     {
         await base.GroupBy_key_and_aggregate_through_same_navigation(async);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindQueryFiltersQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindQueryFiltersQuerySqlServerTest.cs
@@ -408,6 +408,87 @@ GROUP BY [o].[EmployeeID]
 """);
     }
 
+    public override async Task GroupBy_Any_through_filtered_navigation(bool async)
+    {
+        await base.GroupBy_Any_through_filtered_navigation(async);
+
+        AssertSql(
+            """
+@ef_filter__TenantPrefix_startswith='B%' (Size = 40)
+
+SELECT [o].[EmployeeID] AS [Key], CASE
+    WHEN EXISTS (
+        SELECT 1
+        FROM [Orders] AS [o0]
+        LEFT JOIN (
+            SELECT [c2].[CustomerID], [c2].[City], [c2].[CompanyName]
+            FROM [Customers] AS [c2]
+            WHERE [c2].[CompanyName] LIKE @ef_filter__TenantPrefix_startswith ESCAPE N'\'
+        ) AS [c1] ON [o0].[CustomerID] = [c1].[CustomerID]
+        WHERE [c1].[CustomerID] IS NOT NULL AND [c1].[CompanyName] IS NOT NULL AND ([o].[EmployeeID] = [o0].[EmployeeID] OR ([o].[EmployeeID] IS NULL AND [o0].[EmployeeID] IS NULL)) AND [c1].[City] = N'London') THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END AS [Londons]
+FROM [Orders] AS [o]
+LEFT JOIN (
+    SELECT [c].[CustomerID], [c].[CompanyName]
+    FROM [Customers] AS [c]
+    WHERE [c].[CompanyName] LIKE @ef_filter__TenantPrefix_startswith ESCAPE N'\'
+) AS [c0] ON [o].[CustomerID] = [c0].[CustomerID]
+WHERE [c0].[CustomerID] IS NOT NULL AND [c0].[CompanyName] IS NOT NULL
+GROUP BY [o].[EmployeeID]
+""");
+    }
+
+    public override async Task GroupBy_Any_through_filtered_navigation_with_total(bool async)
+    {
+        await base.GroupBy_Any_through_filtered_navigation_with_total(async);
+
+        AssertSql(
+            """
+@ef_filter__TenantPrefix_startswith='B%' (Size = 40)
+
+SELECT [o].[EmployeeID] AS [Key], COUNT(*) AS [Total], CASE
+    WHEN EXISTS (
+        SELECT 1
+        FROM [Orders] AS [o0]
+        LEFT JOIN (
+            SELECT [c2].[CustomerID], [c2].[City], [c2].[CompanyName]
+            FROM [Customers] AS [c2]
+            WHERE [c2].[CompanyName] LIKE @ef_filter__TenantPrefix_startswith ESCAPE N'\'
+        ) AS [c1] ON [o0].[CustomerID] = [c1].[CustomerID]
+        WHERE [c1].[CustomerID] IS NOT NULL AND [c1].[CompanyName] IS NOT NULL AND ([o].[EmployeeID] = [o0].[EmployeeID] OR ([o].[EmployeeID] IS NULL AND [o0].[EmployeeID] IS NULL)) AND [c1].[City] = N'London') THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END AS [Londons]
+FROM [Orders] AS [o]
+LEFT JOIN (
+    SELECT [c].[CustomerID], [c].[CompanyName]
+    FROM [Customers] AS [c]
+    WHERE [c].[CompanyName] LIKE @ef_filter__TenantPrefix_startswith ESCAPE N'\'
+) AS [c0] ON [o].[CustomerID] = [c0].[CustomerID]
+WHERE [c0].[CustomerID] IS NOT NULL AND [c0].[CompanyName] IS NOT NULL
+GROUP BY [o].[EmployeeID]
+""");
+    }
+
+    public override async Task GroupBy_Any_through_filtered_navigation_ignore_query_filters(bool async)
+    {
+        await base.GroupBy_Any_through_filtered_navigation_ignore_query_filters(async);
+
+        AssertSql(
+            """
+SELECT [o].[EmployeeID] AS [Key], CASE
+    WHEN EXISTS (
+        SELECT 1
+        FROM [Orders] AS [o0]
+        LEFT JOIN [Customers] AS [c] ON [o0].[CustomerID] = [c].[CustomerID]
+        WHERE ([o].[EmployeeID] = [o0].[EmployeeID] OR ([o].[EmployeeID] IS NULL AND [o0].[EmployeeID] IS NULL)) AND [c].[City] = N'London') THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END AS [Londons]
+FROM [Orders] AS [o]
+GROUP BY [o].[EmployeeID]
+""");
+    }
+
     public override async Task Included_many_to_one_query2(bool async)
     {
         await base.Included_many_to_one_query2(async);


### PR DESCRIPTION
Fixes #38816

- [x] I've read the guidelines for [contributing](https://github.com/dotnet/efcore/blob/main/.github/CONTRIBUTING.md) and seen the [walkthrough](https://youtu.be/9OMxy1wal1s?t=1869)
- [x] I've posted a comment on an issue with a detailed description of how I am planning to contribute and got approval from a member of the team
- [x] The code builds and tests pass locally (also verified by our automated build checks)
- [x] Commit messages follow this format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Code follows the same patterns and style as existing code in this repo

## Summary

#38668 lifts `GroupBy` aggregates whose selectors traverse a reference navigation onto a shared pre-`GroupBy` join. `GroupingAggregateScanner` only allows the grouping parameter to appear as `g.Key` or as the source of a whitelisted aggregate; `Any` and `All` were not on that whitelist, so any quantifier in the result selector marked the grouping parameter as an unsupported usage and disabled the lift **for every aggregate in the group**, not just for itself.

The trigger is the presence of the quantifier, not anything it reads — a bare `g.Any()` or an `All` whose predicate touches no navigation demotes its siblings just the same. The workaround was to write `g.Count(...) > 0` instead of `g.Any(...)`, which shows the shape is otherwise handled.

This PR adds `Any` and `All` to `PredicateAggregateMethodNames`.

```csharp
ctx.Orders
    .GroupBy(o => o.EmployeeID)
    .Select(g => new
    {
        g.Key,
        Region = g.Max(o => o.Customer.Region),
        AnyLondon = g.Any(o => o.Customer.City == "London"),
        Count = g.Count()
    });
```

```sql
-- before: Max over the navigation demoted to a correlated subquery
SELECT [o].[EmployeeID] AS [Key], (
    SELECT MAX([c].[Region])
    FROM [Orders] AS [o0]
    LEFT JOIN [Customers] AS [c] ON [o0].[CustomerID] = [c].[CustomerID]
    WHERE [o].[EmployeeID] = [o0].[EmployeeID] OR ([o].[EmployeeID] IS NULL AND [o0].[EmployeeID] IS NULL)) AS [Region], CASE
    WHEN EXISTS (
        SELECT 1
        FROM [Orders] AS [o1]
        LEFT JOIN [Customers] AS [c0] ON [o1].[CustomerID] = [c0].[CustomerID]
        WHERE ([o].[EmployeeID] = [o1].[EmployeeID] OR ([o].[EmployeeID] IS NULL AND [o1].[EmployeeID] IS NULL)) AND [c0].[City] = N'London') THEN CAST(1 AS bit)
    ELSE CAST(0 AS bit)
END AS [AnyLondon], COUNT(*) AS [Count]
FROM [Orders] AS [o]
GROUP BY [o].[EmployeeID]

-- after: Max reads the shared join; Any keeps its EXISTS
SELECT [o].[EmployeeID] AS [Key], MAX([c].[Region]) AS [Region], CASE
    WHEN EXISTS (
        SELECT 1
        FROM [Orders] AS [o0]
        LEFT JOIN [Customers] AS [c0] ON [o0].[CustomerID] = [c0].[CustomerID]
        WHERE ([o].[EmployeeID] = [o0].[EmployeeID] OR ([o].[EmployeeID] IS NULL AND [o0].[EmployeeID] IS NULL)) AND [c0].[City] = N'London') THEN CAST(1 AS bit)
    ELSE CAST(0 AS bit)
END AS [AnyLondon], COUNT(*) AS [Count]
FROM [Orders] AS [o]
LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
GROUP BY [o].[EmployeeID]
```

`Any` and `All` themselves still translate to a correlated `EXISTS` / `NOT EXISTS`, which is the right shape for them; what changes is that they no longer demote their siblings.

## Implementation

One-line change: `Any` and `All` join `Count` and `LongCount` in `GroupingAggregateScanner.PredicateAggregateMethodNames`.

Everything else already works for them:

- `TryMatchAggregate` accepts 1 or 2 arguments for predicate aggregates, so both `g.Any()` and `g.Any(predicate)` match; `All` has no parameterless overload so it always takes the predicate path.
- `RebuildLiftedAggregate` rebuilds the call against the widened element type from the generic method definition, quoting the lambda for `Queryable` overloads — no per-method handling.
- The lift is unchanged in kind, so the correctness argument from #38668 carries over verbatim: the navigation join is row-preserving by construction (FK → unique principal key ⇒ at most one match per row), so the per-group rowset the quantifier sees is identical to the one inside today's correlated subquery.

## Testing

New specification tests (all providers, SQL Server baselines) mirroring the shapes #38668 added for the already-whitelisted aggregates:

| Test | Mirrors |
| --- | --- |
| `GroupBy_Any_with_predicate_through_navigation_property` | `GroupBy_Count_with_predicate_through_navigation_property` |
| `GroupBy_All_with_predicate_through_navigation_property` | ″ |
| `GroupBy_Queryable_Any_with_predicate_through_navigation_property` | `AsQueryable()` source path |
| `GroupBy_Queryable_All_with_predicate_through_navigation_property` | ″ |
| `GroupBy_Any_and_aggregate_through_navigation_property` | bare `Any()` alongside a lifted aggregate |
| `GroupBy_All_and_aggregate_through_navigation_property` | `All` predicate reading no navigation, alongside a lifted aggregate |
| `GroupBy_multiple_aggregates_with_Any_and_All_sharing_same_navigation` | `GroupBy_multiple_aggregates_sharing_same_navigation` |
| `GroupBy_Any_through_two_level_navigation` | `GroupBy_aggregate_through_two_level_navigation` |
| `GroupBy_key_and_Any_through_same_navigation` | `GroupBy_key_and_aggregate_through_same_navigation` |
| `GroupBy_Any_through_navigation_in_intermediate_projection` | `GroupBy_aggregate_through_navigation_in_intermediate_projection` |
| `GroupBy_Any_through_filtered_navigation` | `GroupBy_aggregate_through_filtered_navigation` |
| `GroupBy_Any_through_filtered_navigation_with_total` | `GroupBy_aggregate_through_filtered_navigation_with_total` |
| `GroupBy_Any_through_filtered_navigation_ignore_query_filters` | `GroupBy_aggregate_through_filtered_navigation_ignore_query_filters` |