### PR TITLE
Lift aggregate arguments that mix an outer reference with a local column

### DIFF
--- a/src/EFCore.SqlServer/Query/Internal/SqlServerAggregateArgumentPostprocessor.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerAggregateArgumentPostprocessor.cs
@@ -7,8 +7,9 @@ using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal;
 
 /// <summary>
-///     SQL Server doesn't support aggregate function invocations over subqueries, or other aggregate function invocations; this
-///     postprocessor lifts such subqueries out to an OUTER APPLY/JOIN on the SELECT to work around this limitation.
+///     SQL Server doesn't support aggregate function invocations over subqueries, or other aggregate function invocations; nor does it
+///     support aggregating an expression which references a column from an outer query alongside any other column. This postprocessor
+///     lifts such aggregate arguments out to an OUTER APPLY/JOIN on the SELECT to work around these limitations.
 /// </summary>
 /// <remarks>
 ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -16,14 +17,17 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal;
 ///     any release. You should only use it directly in your code with extreme caution and knowing that
 ///     doing so can result in application failures when updating to a new Entity Framework Core release.
 /// </remarks>
-public class SqlServerAggregateOverSubqueryPostprocessor(SqlAliasManager sqlAliasManager) : ExpressionVisitor
+public class SqlServerAggregateArgumentPostprocessor(SqlAliasManager sqlAliasManager) : ExpressionVisitor
 {
     private SelectExpression? _currentSelect;
     private bool _inAggregateInvocation;
     private bool _aggregateArgumentContainsSubquery;
+    private bool _aggregateArgumentContainsOuterReference;
+    private bool _aggregateArgumentContainsLocalReference;
     private List<JoinExpressionBase>? _joinsToAdd;
     private bool _isCorrelatedSubquery;
     private HashSet<string>? _tableAliasesInScope;
+    private HashSet<string>? _aggregatingSelectTableAliases;
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -81,18 +85,42 @@ public class SqlServerAggregateOverSubqueryPostprocessor(SqlAliasManager sqlAlia
                 var parentInAggregateInvocation = _inAggregateInvocation;
                 var parentIsCorrelatedSubquery = _isCorrelatedSubquery;
                 var parentTableAliasesInScope = _tableAliasesInScope;
+                var parentAggregatingSelectTableAliases = _aggregatingSelectTableAliases;
                 var parentAggregateArgumentContainsSubquery = _aggregateArgumentContainsSubquery;
+                var parentAggregateArgumentContainsOuterReference = _aggregateArgumentContainsOuterReference;
+                var parentAggregateArgumentContainsLocalReference = _aggregateArgumentContainsLocalReference;
                 _inAggregateInvocation = true;
                 _isCorrelatedSubquery = false;
                 _tableAliasesInScope = [];
+                // The tables of the SELECT in which the aggregate is evaluated; columns over any other table are outer references.
+                _aggregatingSelectTableAliases = _currentSelect is null
+                    ? []
+                    : new HashSet<string>(_currentSelect.Tables.Select(t => t.UnwrapJoin().Alias).Where(a => a is not null)!);
                 _aggregateArgumentContainsSubquery = false;
+                _aggregateArgumentContainsOuterReference = false;
+                _aggregateArgumentContainsLocalReference = false;
 
                 var result = base.VisitExtension(function);
 
-                if (_aggregateArgumentContainsSubquery)
+                // An outer reference on its own is fine - SQL Server evaluates such an aggregate in the outer query, which is how
+                // aggregates over an outer grouping get translated. It's only when the outer reference is combined with another column
+                // that SQL Server rejects the expression, and lifting is both needed and unambiguous.
+                var liftArgument = _aggregateArgumentContainsSubquery
+                    || (_aggregateArgumentContainsOuterReference && _aggregateArgumentContainsLocalReference);
+                var isCorrelatedSubquery = _isCorrelatedSubquery;
+
+                _inAggregateInvocation = parentInAggregateInvocation;
+                _isCorrelatedSubquery = parentIsCorrelatedSubquery;
+                _tableAliasesInScope = parentTableAliasesInScope;
+                _aggregatingSelectTableAliases = parentAggregatingSelectTableAliases;
+                _aggregateArgumentContainsSubquery = parentAggregateArgumentContainsSubquery;
+                _aggregateArgumentContainsOuterReference = parentAggregateArgumentContainsOuterReference;
+                _aggregateArgumentContainsLocalReference = parentAggregateArgumentContainsLocalReference;
+
+                if (liftArgument)
                 {
-                    // During our visitation of the aggregate function invocation, a subquery was encountered - this is our trigger to
-                    // extract out the argument to be an OUTER APPLY/CROSS JOIN.
+                    // During our visitation of the aggregate function invocation, a subquery or an outer reference was encountered - this
+                    // is our trigger to extract out the argument to be an OUTER APPLY/CROSS JOIN.
                     if (result is not SqlFunctionExpression { Instance: null, Arguments: [var argument] } visitedFunction)
                     {
                         throw new UnreachableException();
@@ -154,7 +182,7 @@ public class SqlServerAggregateOverSubqueryPostprocessor(SqlAliasManager sqlAlia
 
                     _joinsToAdd ??= [];
                     _joinsToAdd.Add(
-                        _isCorrelatedSubquery ? new OuterApplyExpression(liftedSubquery) : new CrossJoinExpression(liftedSubquery));
+                        isCorrelatedSubquery ? new OuterApplyExpression(liftedSubquery) : new CrossJoinExpression(liftedSubquery));
 
                     var projection = liftedSubquery.Projection.Single();
 
@@ -167,11 +195,6 @@ public class SqlServerAggregateOverSubqueryPostprocessor(SqlAliasManager sqlAlia
                                 nullable: true)
                         ]);
                 }
-
-                _inAggregateInvocation = parentInAggregateInvocation;
-                _isCorrelatedSubquery = parentIsCorrelatedSubquery;
-                _tableAliasesInScope = parentTableAliasesInScope;
-                _aggregateArgumentContainsSubquery = parentAggregateArgumentContainsSubquery;
 
                 return result;
             }
@@ -188,6 +211,20 @@ public class SqlServerAggregateOverSubqueryPostprocessor(SqlAliasManager sqlAlia
             // we're in a correlated subquery.
             case ColumnExpression column when _tableAliasesInScope?.Contains(column.TableAlias) == false:
                 _isCorrelatedSubquery = true;
+
+                // The column may still belong to the SELECT in which the aggregate is being evaluated (that SELECT's tables aren't in
+                // _tableAliasesInScope, since the lifted subquery must reference them via APPLY rather than via CROSS JOIN). If it doesn't,
+                // it's an outer reference, which SQL Server only tolerates inside an aggregate if it's the only column referenced there.
+                switch (_aggregatingSelectTableAliases?.Contains(column.TableAlias))
+                {
+                    case true:
+                        _aggregateArgumentContainsLocalReference = true;
+                        break;
+                    case false:
+                        _aggregateArgumentContainsOuterReference = true;
+                        break;
+                }
+
                 return base.VisitExtension(column);
 
             case ShapedQueryExpression shapedQueryExpression:

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerQueryTranslationPostprocessor.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerQueryTranslationPostprocessor.cs
@@ -20,7 +20,7 @@ public class SqlServerQueryTranslationPostprocessor(
         relationalDependencies.SqlExpressionFactory,
         queryCompilationContext.SqlAliasManager);
 
-    private readonly SqlServerAggregateOverSubqueryPostprocessor _aggregatePostprocessor = new(queryCompilationContext.SqlAliasManager);
+    private readonly SqlServerAggregateArgumentPostprocessor _aggregatePostprocessor = new(queryCompilationContext.SqlAliasManager);
     private readonly SqlServerSqlTreePruner _pruner = new();
 
     /// <summary>

--- a/test/EFCore.Relational.Specification.Tests/Query/NorthwindAggregateOperatorsQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/NorthwindAggregateOperatorsQueryRelationalTestBase.cs
@@ -48,4 +48,35 @@ public abstract class NorthwindAggregateOperatorsQueryRelationalTestBase<TFixtur
         => Assert.Equal(
             "Nullable object must have a value.",
             (await Assert.ThrowsAsync<InvalidOperationException>(() => base.Average_no_data_subquery(async))).Message);
+
+    [Theory, MemberData(nameof(IsAsyncData))]
+    public virtual Task Sum_over_expression_with_outer_reference(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<Order>()
+                .Select(o => new { o.OrderID, Total = o.OrderDetails.Sum(od => od.ProductID * o.OrderID) }),
+            elementSorter: e => e.OrderID);
+
+    [Theory, MemberData(nameof(IsAsyncData))]
+    public virtual Task Sum_over_members_of_single_result_subquery_with_outer_reference(bool async)
+        => AssertQuery(
+            async,
+            ss => from c in ss.Set<Customer>()
+                  let projected = from o in c.Orders
+                                  let d = o.OrderDetails
+                                      .OrderBy(od => od.ProductID)
+                                      .Select(od => new { od.ProductID, od.OrderID })
+                                      .FirstOrDefault()
+                                  select new
+                                  {
+                                      Products = d!.ProductID * c.CustomerID.Length,
+                                      Orders = d.OrderID * c.CustomerID.Length
+                                  }
+                  select new
+                  {
+                      c.CustomerID,
+                      TotalProducts = projected.Sum(x => x.Products),
+                      TotalOrders = projected.Sum(x => x.Orders)
+                  },
+            elementSorter: e => e.CustomerID);
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindAggregateOperatorsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindAggregateOperatorsQuerySqlServerTest.cs
@@ -3482,6 +3482,62 @@ FROM [Order Details] AS [o]
 """);
     }
 
+    public override async Task Sum_over_expression_with_outer_reference(bool async)
+    {
+        await base.Sum_over_expression_with_outer_reference(async);
+
+        AssertSql(
+            """
+SELECT [o].[OrderID], (
+    SELECT ISNULL(SUM([s].[value]), 0)
+    FROM [Order Details] AS [o0]
+    OUTER APPLY (
+        SELECT [o0].[ProductID] * [o].[OrderID] AS [value]
+    ) AS [s]
+    WHERE [o].[OrderID] = [o0].[OrderID]) AS [Total]
+FROM [Orders] AS [o]
+""");
+    }
+
+    public override async Task Sum_over_members_of_single_result_subquery_with_outer_reference(bool async)
+    {
+        await base.Sum_over_members_of_single_result_subquery_with_outer_reference(async);
+
+        AssertSql(
+            """
+SELECT [c].[CustomerID], (
+    SELECT ISNULL(SUM([s].[value]), 0)
+    FROM [Orders] AS [o]
+    LEFT JOIN (
+        SELECT [o1].[ProductID], [o1].[OrderID0]
+        FROM (
+            SELECT [o0].[ProductID], [o0].[OrderID] AS [OrderID0], ROW_NUMBER() OVER(PARTITION BY [o0].[OrderID] ORDER BY [o0].[ProductID]) AS [row]
+            FROM [Order Details] AS [o0]
+        ) AS [o1]
+        WHERE [o1].[row] <= 1
+    ) AS [o2] ON [o].[OrderID] = [o2].[OrderID0]
+    OUTER APPLY (
+        SELECT [o2].[ProductID] * CAST(LEN([c].[CustomerID]) AS int) AS [value]
+    ) AS [s]
+    WHERE [c].[CustomerID] = [o].[CustomerID]) AS [TotalProducts], (
+    SELECT ISNULL(SUM([s0].[value]), 0)
+    FROM [Orders] AS [o3]
+    LEFT JOIN (
+        SELECT [o5].[OrderID], [o5].[OrderID0]
+        FROM (
+            SELECT [o4].[OrderID], [o4].[OrderID] AS [OrderID0], ROW_NUMBER() OVER(PARTITION BY [o4].[OrderID] ORDER BY [o4].[ProductID]) AS [row]
+            FROM [Order Details] AS [o4]
+        ) AS [o5]
+        WHERE [o5].[row] <= 1
+    ) AS [o6] ON [o3].[OrderID] = [o6].[OrderID0]
+    OUTER APPLY (
+        SELECT [o6].[OrderID] * CAST(LEN([c].[CustomerID]) AS int) AS [value]
+    ) AS [s0]
+    WHERE [c].[CustomerID] = [o3].[CustomerID]) AS [TotalOrders]
+FROM [Customers] AS [c]
+""");
+    }
+
     private void AssertSql(params string[] expected)
         => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 


### PR DESCRIPTION
Fixes #38834

- [x] I've read the guidelines for [contributing](https://github.com/dotnet/efcore/blob/main/.github/CONTRIBUTING.md) and seen the [walkthrough](https://youtu.be/9OMxy1wal1s?t=1869)
- [x] I've posted a comment on an issue with a detailed description of how I am planning to contribute and got approval from a member of the team
- [x] The code builds and tests pass locally (also verified by our automated build checks)
- [x] Commit messages follow this format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Code follows the same patterns and style as existing code in this repo

## Summary

`SqlServerAggregateArgumentPostprocessor` (renamed from `SqlServerAggregateOverSubqueryPostprocessor` in this PR) works around SQL Server's refusal to aggregate over a subquery by lifting the aggregate's argument out to an `OUTER APPLY`/`CROSS JOIN` and aggregating the resulting column. SQL Server has a second restriction on aggregates which the postprocessor didn't cover:

> Msg 8124: Multiple columns are specified in an aggregated expression containing an outer reference. If an expression being aggregated contains an outer reference, then that outer reference must be the only column referenced in the expression.

An aggregate argument that combines a column of the `SELECT` the aggregate is evaluated in with a column from further out runs into this. The postprocessor only lifted arguments in which a *subquery* was found, so such an expression reached the server unchanged and the query failed at execution.

The reported shape sums, per customer, a value that multiplies a column read from a single-result subquery by a column on the outer entity:

```csharp
from c in ss.Set<Customer>()
let projected = from o in c.Orders
                let d = o.OrderDetails.OrderBy(od => od.ProductID)
                    .Select(od => new { od.ProductID, od.OrderID })
                    .FirstOrDefault()
                select new
                {
                    Products = d!.ProductID * c.CustomerID.Length,
                    Orders = d.OrderID * c.CustomerID.Length
                }
select new
{
    c.CustomerID,
    TotalProducts = projected.Sum(x => x.Products),
    TotalOrders = projected.Sum(x => x.Orders)
}
```

```sql
-- before: [c].[CustomerID] is an outer reference and [o2].[ProductID] is a second
-- column in the same aggregated expression; SQL Server rejects this with error 8124
SELECT [c].[CustomerID], (
    SELECT ISNULL(SUM([o2].[ProductID] * CAST(LEN([c].[CustomerID]) AS int)), 0)
    FROM [Orders] AS [o]
    LEFT JOIN (
        SELECT [o1].[ProductID], [o1].[OrderID0]
        FROM (
            SELECT [o0].[ProductID], [o0].[OrderID] AS [OrderID0], ROW_NUMBER() OVER(PARTITION BY [o0].[OrderID] ORDER BY [o0].[ProductID]) AS [row]
            FROM [Order Details] AS [o0]
        ) AS [o1]
        WHERE [o1].[row] <= 1
    ) AS [o2] ON [o].[OrderID] = [o2].[OrderID0]
    WHERE [c].[CustomerID] = [o].[CustomerID]) AS [TotalProducts], ...

-- after: the multiplication is lifted into an OUTER APPLY, so the SUM sees one column
SELECT [c].[CustomerID], (
    SELECT ISNULL(SUM([s].[value]), 0)
    FROM [Orders] AS [o]
    LEFT JOIN (
        SELECT [o1].[ProductID], [o1].[OrderID0]
        FROM (
            SELECT [o0].[ProductID], [o0].[OrderID] AS [OrderID0], ROW_NUMBER() OVER(PARTITION BY [o0].[OrderID] ORDER BY [o0].[ProductID]) AS [row]
            FROM [Order Details] AS [o0]
        ) AS [o1]
        WHERE [o1].[row] <= 1
    ) AS [o2] ON [o].[OrderID] = [o2].[OrderID0]
    OUTER APPLY (
        SELECT [o2].[ProductID] * CAST(LEN([c].[CustomerID]) AS int) AS [value]
    ) AS [s]
    WHERE [c].[CustomerID] = [o].[CustomerID]) AS [TotalProducts], ...
```

This is a regression in 11.0 rc.1 relative to preview.6, but the bug is older than that and isn't in the postprocessor — what changed is the shape of the argument reaching it. Before #38502, a single-result subquery projecting two or more members was repeated once per member, so the aggregate argument still contained a `ScalarSubqueryExpression` and the existing subquery trigger fired, lifting the outer reference out along with it. #38502 replaces those repeated subqueries with a single join; with no subquery left in the argument, nothing triggers the lift and the outer reference stays inside the aggregate. That's also why the workaround in the issue — projecting a single member — keeps the query working.

The same failure is reachable without any subquery at all, e.g. `o.OrderDetails.Sum(od => od.ProductID * o.OrderID)`, which is the second test added here.

## Implementation

The class is renamed from `SqlServerAggregateOverSubqueryPostprocessor` to `SqlServerAggregateArgumentPostprocessor`, since a subquery in the argument is no longer the only thing that makes it lift. It's an internal-API type under `Query/Internal`, and `SqlServerQueryTranslationPostprocessor` is its only reference.

`SqlServerAggregateArgumentPostprocessor` now tracks two more facts per aggregate invocation, alongside the existing "argument contains a subquery":

- **local reference** — the argument references a column of the `SELECT` the aggregate is evaluated in
- **outer reference** — the argument references a column from further out

and lifts the argument when both are present, in addition to the existing subquery trigger. Everything downstream of the trigger — building the lifted subquery, choosing `OUTER APPLY` vs `CROSS JOIN`, rewriting the aggregate to read the lifted projection — is reused unchanged.

Both facts are recorded in the existing `ColumnExpression` case, which already fires for exactly the columns of interest: those not in `_tableAliasesInScope`. Classification compares against the aggregating `SELECT`'s own table aliases (`_currentSelect.Tables`) rather than `_tableAliasesInScope`; that set deliberately excludes those tables, since a lifted subquery has to reach them through `APPLY` rather than `CROSS JOIN`, so it can't tell "column of the aggregating SELECT" from "column of an enclosing one".

An argument that is *purely* an outer reference is deliberately left alone: SQL Server accepts it and evaluates the aggregate in the outer query, which is how aggregates over an outer grouping are meant to translate. Only the mixed case is rejected by the server, and only there is lifting both necessary and unambiguous.

One pre-existing bug surfaced along the way: the parent visitor state was restored *after* the lifted subquery was built, so a nested aggregate clobbered the state saved by an enclosing one, and `_isCorrelatedSubquery` — read to choose between `OUTER APPLY` and `CROSS JOIN` — could reflect the wrong invocation. The restore now happens before the lift, with the flag captured into a local first.

## Testing

Two new specification tests in `NorthwindAggregateOperatorsQueryRelationalTestBase`, with SQL Server baselines:

| Test | Shape |
| --- | --- |
| `Sum_over_expression_with_outer_reference` | `Sum` over an expression multiplying a column of the aggregated collection by a column of the outer entity — the minimal form, no subquery involved |
| `Sum_over_members_of_single_result_subquery_with_outer_reference` | the reported shape: two `Sum`s over members of a `FirstOrDefault()` subquery, each combined with an outer column |

Both fail against `main` with SQL Server error 8124 and pass with this change; both also run green on SQLite through the shared base.
