### PR TITLE
[release/11.0] Detect all line endings in generated C# comments

### DIFF
--- a/src/EFCore.Design/Design/Internal/CSharpHelper.cs
+++ b/src/EFCore.Design/Design/Internal/CSharpHelper.cs
@@ -1512,7 +1512,7 @@ public class CSharpHelper : ICSharpHelper
         var builder = new StringBuilder();
 
         var first = true;
-        foreach (var line in comment.Split(["\r\n", "\n", "\r"], StringSplitOptions.None))
+        foreach (var line in comment.Split(["\r\n", "\r", "\n", "\u0085", "\u2028", "\u2029"], StringSplitOptions.None))
         {
             if (!first)
             {

--- a/test/EFCore.Design.Tests/Design/Internal/CSharpHelperTest.cs
+++ b/test/EFCore.Design.Tests/Design/Internal/CSharpHelperTest.cs
@@ -540,6 +540,16 @@ public class CSharpHelperTest
 #pragma warning restore CS0618
 
     [Fact]
+    public void XmlComment_handles_all_line_terminators()
+    {
+        var result = new CSharpHelper(TypeMappingSource).XmlComment("one\r\ntwo\rthree\nfour\u0085five\u2028six\u2029seven", indent: 1);
+
+        Assert.Equal(
+            $"one{EOL}    /// two{EOL}    /// three{EOL}    /// four{EOL}    /// five{EOL}    /// six{EOL}    /// seven",
+            result);
+    }
+
+    [Fact]
     public void Really_unknown_literal_with_no_mapping_support()
     {
         var typeMapping = CreateTypeMappingSource<SimpleTestType>(null);


### PR DESCRIPTION
**Description**
Updated `XmlComment` in `CSharpHelper` to split input text on all Unicode line terminators, including `\u0085`, `\u2028`, and `\u2029`, in addition to the standard ones.

**Customer impact**
If the target database contains comments with these characters, then in the scaffolded they won't be escaped correctly

**How found**
User reported on 11.0 preview-7.

**Regression**
No

**Testing**
Tests added.

**Risk**
Very low.