### PR TITLE
Do not carry a named default constraint onto the temporal history table

### DIFF
--- a/src/EFCore.SqlServer/Migrations/SqlServerMigrationsSqlGenerator.cs
+++ b/src/EFCore.SqlServer/Migrations/SqlServerMigrationsSqlGenerator.cs
@@ -2770,6 +2770,9 @@ public class SqlServerMigrationsSqlGenerator : MigrationsSqlGenerator
             || (operation[SqlServerAnnotationNames.ValueGenerationStrategy] as SqlServerValueGenerationStrategy?)
             == SqlServerValueGenerationStrategy.IdentityColumn;
 
+    private static void RemoveDefaultConstraintNameAnnotation(ColumnOperation operation)
+        => operation.RemoveAnnotation(RelationalAnnotationNames.DefaultConstraintName);
+
     private static void RemoveIdentityAnnotations(ColumnOperation operation)
     {
         operation.RemoveAnnotation(SqlServerAnnotationNames.Identity);
@@ -3689,6 +3692,13 @@ public class SqlServerMigrationsSqlGenerator : MigrationsSqlGenerator
                             // identity columns are not allowed inside HistoryTables
                             RemoveIdentityAnnotations(alterHistoryTableColumn);
                             RemoveIdentityAnnotations(alterHistoryTableColumn.OldColumn);
+
+                            // a named default constraint belongs to the current table only, so
+                            // carrying the name over makes the history table drop a constraint
+                            // that was never created there. without the name the generated sql
+                            // looks the constraint up first and skips it when there is none
+                            RemoveDefaultConstraintNameAnnotation(alterHistoryTableColumn);
+                            RemoveDefaultConstraintNameAnnotation(alterHistoryTableColumn.OldColumn);
 
                             operations.Add(alterHistoryTableColumn);
                         }

--- a/src/EFCore.SqlServer/Migrations/SqlServerMigrationsSqlGenerator.cs
+++ b/src/EFCore.SqlServer/Migrations/SqlServerMigrationsSqlGenerator.cs
@@ -2770,6 +2770,8 @@ public class SqlServerMigrationsSqlGenerator : MigrationsSqlGenerator
             || (operation[SqlServerAnnotationNames.ValueGenerationStrategy] as SqlServerValueGenerationStrategy?)
             == SqlServerValueGenerationStrategy.IdentityColumn;
 
+    // Named default constraints belong to the current table, so copied history-table operations
+    // must create or look up their own constraints rather than reuse the current table's name.
     private static void RemoveDefaultConstraintNameAnnotation(ColumnOperation operation)
         => operation.RemoveAnnotation(RelationalAnnotationNames.DefaultConstraintName);
 
@@ -3528,6 +3530,8 @@ public class SqlServerMigrationsSqlGenerator : MigrationsSqlGenerator
                             // identity columns are not allowed inside HistoryTables
                             RemoveIdentityAnnotations(addHistoryTableColumnOperation);
 
+                            RemoveDefaultConstraintNameAnnotation(addHistoryTableColumnOperation);
+
                             operations.Add(addHistoryTableColumnOperation);
                         }
                     }
@@ -3693,10 +3697,6 @@ public class SqlServerMigrationsSqlGenerator : MigrationsSqlGenerator
                             RemoveIdentityAnnotations(alterHistoryTableColumn);
                             RemoveIdentityAnnotations(alterHistoryTableColumn.OldColumn);
 
-                            // a named default constraint belongs to the current table only, so
-                            // carrying the name over makes the history table drop a constraint
-                            // that was never created there. without the name the generated sql
-                            // looks the constraint up first and skips it when there is none
                             RemoveDefaultConstraintNameAnnotation(alterHistoryTableColumn);
                             RemoveDefaultConstraintNameAnnotation(alterHistoryTableColumn.OldColumn);
 

--- a/test/EFCore.SqlServer.FunctionalTests/Migrations/SqlServerMigrationsSqlGeneratorTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Migrations/SqlServerMigrationsSqlGeneratorTest.cs
@@ -156,6 +156,52 @@ ALTER TABLE [CustomersHistory] ADD [Number] int NOT NULL DEFAULT 0;
     }
 
     [Fact]
+    public virtual void AlterColumnOperation_default_constraint_name_not_propagated_to_history_table()
+    {
+        Generate(
+            modelBuilder => modelBuilder.Entity(
+                "Customer", e =>
+                {
+                    e.Property<int>("Id").ValueGeneratedOnAdd();
+                    e.Property<int>("Number");
+                    e.Property<DateTime>("PeriodStart").ValueGeneratedOnAddOrUpdate();
+                    e.Property<DateTime>("PeriodEnd").ValueGeneratedOnAddOrUpdate();
+                    e.HasKey("Id");
+                    e.ToTable(
+                        "Customers", tb => tb.IsTemporal(ttb =>
+                        {
+                            ttb.UseHistoryTable("CustomersHistory");
+                            ttb.HasPeriodStart("PeriodStart");
+                            ttb.HasPeriodEnd("PeriodEnd");
+                        }));
+                }),
+            new AlterColumnOperation
+            {
+                Table = "Customers",
+                Name = "Number",
+                ClrType = typeof(int),
+                ColumnType = "int",
+                IsNullable = false,
+                OldColumn = new AddColumnOperation
+                {
+                    Table = "Customers",
+                    Name = "Number",
+                    ClrType = typeof(int),
+                    ColumnType = "int",
+                    IsNullable = false,
+                    DefaultValue = 1,
+                    [RelationalAnnotationNames.DefaultConstraintName] = "DF_Customers_Number"
+                },
+                [SqlServerAnnotationNames.IsTemporal] = true,
+                [SqlServerAnnotationNames.TemporalHistoryTableName] = "CustomersHistory",
+                [SqlServerAnnotationNames.TemporalPeriodStartColumnName] = "PeriodStart",
+                [SqlServerAnnotationNames.TemporalPeriodEndColumnName] = "PeriodEnd"
+            });
+
+        Assert.DoesNotContain("[CustomersHistory] DROP CONSTRAINT [DF_Customers_Number]", Sql);
+    }
+
+    [Fact]
     public virtual void AddColumnOperation_identity_legacy_not_propagated_to_history_table()
     {
         var migrationBuilder = new MigrationBuilder("Microsoft.EntityFrameworkCore.SqlServer");

--- a/test/EFCore.SqlServer.FunctionalTests/Migrations/SqlServerMigrationsSqlGeneratorTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Migrations/SqlServerMigrationsSqlGeneratorTest.cs
@@ -156,6 +156,75 @@ ALTER TABLE [CustomersHistory] ADD [Number] int NOT NULL DEFAULT 0;
     }
 
     [Fact]
+    public virtual void AddColumnOperation_default_constraint_name_not_propagated_to_history_table()
+    {
+        Generate(
+            modelBuilder => modelBuilder.Entity(
+                "Customer", e =>
+                {
+                    e.Property<int>("Id").ValueGeneratedOnAdd();
+                    e.Property<int>("Number");
+                    e.Property<DateTime>("PeriodStart").ValueGeneratedOnAddOrUpdate();
+                    e.Property<DateTime>("PeriodEnd").ValueGeneratedOnAddOrUpdate();
+                    e.HasKey("Id");
+                    e.ToTable(
+                        "Customers", tb => tb.IsTemporal(ttb =>
+                        {
+                            ttb.UseHistoryTable("CustomersHistory");
+                            ttb.HasPeriodStart("PeriodStart");
+                            ttb.HasPeriodEnd("PeriodEnd");
+                        }));
+                }),
+            new DropColumnOperation
+            {
+                Table = "Customers",
+                Name = "Name"
+            },
+            new AddColumnOperation
+            {
+                Table = "Customers",
+                Name = "Number",
+                ClrType = typeof(int),
+                ColumnType = "int",
+                IsNullable = false,
+                DefaultValue = 0,
+                [RelationalAnnotationNames.DefaultConstraintName] = "DF_Customers_Number"
+            });
+
+        AssertSql(
+            """
+ALTER TABLE [Customers] SET (SYSTEM_VERSIONING = OFF)
+
+GO
+
+DECLARE @var1 nvarchar(max);
+SELECT @var1 = QUOTENAME(OBJECT_NAME([c].[default_object_id]))
+FROM [sys].[columns] [c]
+WHERE [c].[object_id] = OBJECT_ID(N'[Customers]') AND [c].[name] = N'Name';
+IF @var1 IS NOT NULL EXEC(N'ALTER TABLE [Customers] DROP CONSTRAINT ' + @var1 + ';');
+ALTER TABLE [Customers] DROP COLUMN [Name];
+GO
+
+DECLARE @var2 nvarchar(max);
+SELECT @var2 = QUOTENAME(OBJECT_NAME([c].[default_object_id]))
+FROM [sys].[columns] [c]
+WHERE [c].[object_id] = OBJECT_ID(N'[CustomersHistory]') AND [c].[name] = N'Name';
+IF @var2 IS NOT NULL EXEC(N'ALTER TABLE [CustomersHistory] DROP CONSTRAINT ' + @var2 + ';');
+ALTER TABLE [CustomersHistory] DROP COLUMN [Name];
+GO
+
+ALTER TABLE [Customers] ADD [Number] int NOT NULL CONSTRAINT [DF_Customers_Number] DEFAULT 0;
+GO
+
+ALTER TABLE [CustomersHistory] ADD [Number] int NOT NULL DEFAULT 0;
+GO
+
+DECLARE @historyTableSchema nvarchar(max) = QUOTENAME(SCHEMA_NAME())
+EXEC(N'ALTER TABLE [Customers] SET (SYSTEM_VERSIONING = ON (HISTORY_TABLE = ' + @historyTableSchema + '.[CustomersHistory]))')
+""");
+    }
+
+    [Fact]
     public virtual void AlterColumnOperation_default_constraint_name_not_propagated_to_history_table()
     {
         Generate(
@@ -198,7 +267,27 @@ ALTER TABLE [CustomersHistory] ADD [Number] int NOT NULL DEFAULT 0;
                 [SqlServerAnnotationNames.TemporalPeriodEndColumnName] = "PeriodEnd"
             });
 
-        Assert.DoesNotContain("[CustomersHistory] DROP CONSTRAINT [DF_Customers_Number]", Sql);
+        AssertSql(
+            """
+ALTER TABLE [Customers] SET (SYSTEM_VERSIONING = OFF)
+
+GO
+
+ALTER TABLE [Customers] DROP CONSTRAINT [DF_Customers_Number];
+ALTER TABLE [Customers] ALTER COLUMN [Number] int NOT NULL;
+GO
+
+DECLARE @var1 nvarchar(max);
+SELECT @var1 = QUOTENAME(OBJECT_NAME([c].[default_object_id]))
+FROM [sys].[columns] [c]
+WHERE [c].[object_id] = OBJECT_ID(N'[CustomersHistory]') AND [c].[name] = N'Number';
+IF @var1 IS NOT NULL EXEC(N'ALTER TABLE [CustomersHistory] DROP CONSTRAINT ' + @var1 + ';');
+ALTER TABLE [CustomersHistory] ALTER COLUMN [Number] int NOT NULL;
+GO
+
+DECLARE @historyTableSchema nvarchar(max) = QUOTENAME(SCHEMA_NAME())
+EXEC(N'ALTER TABLE [Customers] SET (SYSTEM_VERSIONING = ON (HISTORY_TABLE = ' + @historyTableSchema + '.[CustomersHistory]))')
+""");
     }
 
     [Fact]


### PR DESCRIPTION
Fixes #38836

## problem

removing a named default constraint from a property on a temporal table generates a drop against the history table as well, and applying the migration fails:

```
'DF_MyEntity_Seq' is not a constraint.
Could not drop constraint. See previous errors.
```

the constraint only ever existed on the current table.

## cause

when an `AlterColumnOperation` runs against a temporal table the generator makes a copy of it for the history table. `CopyColumnOperation` copies every annotation from the source, so the copy carries `Relational:DefaultConstraintName` with the current table's constraint name on it.

`DropDefaultConstraint` then has a name to work with and emits the direct form:

```sql
ALTER TABLE [MY_ENTITYHistory] DROP CONSTRAINT [DF_MyEntity_Seq];
```

which fails, because that constraint is not there.

## fix

drop the annotation from the history copy, the same way the identity annotations directly above it are already dropped and for the same reason: it describes something that belongs to the current table only.

with no name to use, `DropDefaultConstraint` falls through to its other branch, which looks the default up in `sys.columns` first and does nothing when the column has none. so the history column still gets altered, it just no longer tries to drop a constraint that was never created.

## tests

`AlterColumnOperation_default_constraint_name_not_propagated_to_history_table` in `SqlServerMigrationsSqlGeneratorTest`, sitting next to the existing `AddColumnOperation_identity_not_propagated_to_history_table` since it is the same shape of problem.

it is a generator test, so it needs no sql server. on `main` it fails with

```
Assert.DoesNotContain() Failure: Sub-string found
Found: "[CustomersHistory] DROP CONSTRAINT [DF_Customers_N"
```

and passes with the change.

whole `SqlServerMigrationsSqlGeneratorTest` class: 132 passed, 0 failed.

built with the repo's own sdk via `restore.sh`, net11.0 on macos arm64.

---

disclaimer: this contribution was prepared with the assistance of an ai agent. i reproduced the generated sql against `main` first, reviewed the change, and ran the generator test class locally before opening it.
