### PR TITLE
Query: expand owned navigations in GroupBy aggregate selectors

### DIFF
--- a/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
@@ -1709,8 +1709,14 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor : Que
         return ExpandSharedTypeEntities((SelectExpression)shapedQueryExpression.QueryExpression, lambdaBody);
     }
 
-    private Expression ExpandSharedTypeEntities(SelectExpression selectExpression, Expression lambdaBody)
-        => _sharedTypeEntityExpandingExpressionVisitor.Expand(selectExpression, lambdaBody);
+    // Mutates selectExpression. allowOwnerJoin must be false once grouping has been applied to it, so that a dependent in its own
+    // table is left unexpanded rather than adding an owner join and the dependent's key as an identifier.
+    // Also called by RelationalSqlTranslatingExpressionVisitor, which remaps aggregate lambdas onto the grouping element itself.
+    internal Expression ExpandSharedTypeEntities(
+        SelectExpression selectExpression,
+        Expression lambdaBody,
+        bool allowOwnerJoin = true)
+        => _sharedTypeEntityExpandingExpressionVisitor.Expand(selectExpression, lambdaBody, allowOwnerJoin);
 
     private sealed class IncludePruner : ExpressionVisitor
     {
@@ -1730,12 +1736,24 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor : Que
         private readonly SqlAliasManager _sqlAliasManager = queryableTranslator._sqlAliasManager;
         private SelectExpression _selectExpression = null!;
         private bool _bindComplexProperties;
+        private bool _allowOwnerJoin = true;
 
-        public Expression Expand(SelectExpression selectExpression, Expression lambdaBody)
+        public Expression Expand(SelectExpression selectExpression, Expression lambdaBody, bool allowOwnerJoin = true)
         {
-            _selectExpression = selectExpression;
+            // Expansion can re-enter SQL translation, which can re-enter expansion for a different SelectExpression.
+            var (parentSelect, parentAllowOwnerJoin, parentBindComplex) =
+                (_selectExpression, _allowOwnerJoin, _bindComplexProperties);
+            (_selectExpression, _allowOwnerJoin, _bindComplexProperties) = (selectExpression, allowOwnerJoin, false);
 
-            return Visit(lambdaBody);
+            try
+            {
+                return Visit(lambdaBody);
+            }
+            finally
+            {
+                (_selectExpression, _allowOwnerJoin, _bindComplexProperties) =
+                    (parentSelect, parentAllowOwnerJoin, parentBindComplex);
+            }
         }
 
         protected override Expression VisitMember(MemberExpression memberExpression)
@@ -1984,7 +2002,7 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor : Que
                     ? ExpandOwnedNavigation(navigation)
                     : null;
 
-            Expression ExpandOwnedNavigation(INavigation navigation)
+            Expression? ExpandOwnedNavigation(INavigation navigation)
             {
                 var targetEntityType = navigation.TargetEntityType;
 
@@ -2076,7 +2094,8 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor : Que
 
                 return entityProjectionExpression.BindNavigation(navigation)
                     ?? _selectExpression.GenerateOwnedReferenceEntityProjectionExpression(
-                        entityProjectionExpression, navigation, queryableTranslator._sqlExpressionFactory, _sqlAliasManager);
+                        entityProjectionExpression, navigation, queryableTranslator._sqlExpressionFactory, _sqlAliasManager,
+                        _allowOwnerJoin);
             }
 
             static TableExpressionBase FindRootTableExpressionForColumn(SelectExpression select, ColumnExpression column)

--- a/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
@@ -1709,8 +1709,8 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor : Que
         return ExpandSharedTypeEntities((SelectExpression)shapedQueryExpression.QueryExpression, lambdaBody);
     }
 
-    // Mutates selectExpression. allowOwnerJoin must be false once grouping has been applied to it, so that a dependent in its own
-    // table is left unexpanded rather than adding an owner join and the dependent's key as an identifier.
+    // Mutates selectExpression. When expanding over a grouped SelectExpression (e.g. aggregate lambdas remapped onto a grouping element),
+    // allowOwnerJoin should be false so that own-table owned types are left unexpanded (avoiding appending owner joins and dependent key identifiers).
     // Also called by RelationalSqlTranslatingExpressionVisitor, which remaps aggregate lambdas onto the grouping element itself.
     internal Expression ExpandSharedTypeEntities(
         SelectExpression selectExpression,

--- a/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
@@ -1709,8 +1709,9 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor : Que
         return ExpandSharedTypeEntities((SelectExpression)shapedQueryExpression.QueryExpression, lambdaBody);
     }
 
-    // Mutates selectExpression. When expanding over a grouped SelectExpression (e.g. aggregate lambdas remapped onto a grouping element),
-    // allowOwnerJoin should be false so that own-table owned types are left unexpanded (avoiding appending owner joins and dependent key identifiers).
+    // Mutates selectExpression. When expanding over a grouped SelectExpression, such as an aggregate lambda remapped onto a
+    // grouping element, allowOwnerJoin should be false so that a dependent in its own table is left unexpanded rather than
+    // appending an owner join and the dependent's key as an identifier.
     // Also called by RelationalSqlTranslatingExpressionVisitor, which remaps aggregate lambdas onto the grouping element itself.
     internal Expression ExpandSharedTypeEntities(
         SelectExpression selectExpression,

--- a/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
@@ -50,6 +50,7 @@ public partial class RelationalSqlTranslatingExpressionVisitor : ExpressionVisit
     private readonly IModel _model;
     private readonly ISqlExpressionFactory _sqlExpressionFactory;
     private readonly QueryableMethodTranslatingExpressionVisitor _queryableMethodTranslatingExpressionVisitor;
+    private readonly RelationalQueryableMethodTranslatingExpressionVisitor? _relationalQueryableTranslator;
 
     private bool _throwForNotTranslatedEfProperty;
 
@@ -69,6 +70,8 @@ public partial class RelationalSqlTranslatingExpressionVisitor : ExpressionVisit
         _queryCompilationContext = queryCompilationContext;
         _model = queryCompilationContext.Model;
         _queryableMethodTranslatingExpressionVisitor = queryableMethodTranslatingExpressionVisitor;
+        _relationalQueryableTranslator =
+            queryableMethodTranslatingExpressionVisitor as RelationalQueryableMethodTranslatingExpressionVisitor;
         _throwForNotTranslatedEfProperty = true;
     }
 
@@ -1621,10 +1624,66 @@ public partial class RelationalSqlTranslatingExpressionVisitor : ExpressionVisit
             _model, method, enumerableExpression, scalarArguments, _queryCompilationContext.Logger);
     }
 
-    private static Expression RemapLambda(EnumerableExpression enumerableExpression, LambdaExpression lambdaExpression)
-        => ReplacingExpressionVisitor.Replace(lambdaExpression.Parameters[0], enumerableExpression.Selector, lambdaExpression.Body);
+    private Expression RemapLambda(EnumerableExpression enumerableExpression, LambdaExpression lambdaExpression)
+    {
+        var body = ReplacingExpressionVisitor.Replace(
+            lambdaExpression.Parameters[0], enumerableExpression.Selector, lambdaExpression.Body);
 
-    private static EnumerableExpression ProcessSelector(EnumerableExpression enumerableExpression, LambdaExpression lambdaExpression)
+        // Lambdas remapped onto a query source get their owned navigations expanded by the queryable translator, but lambdas over a
+        // grouping element are remapped here instead, so expand them now. Without this the navigation fails to bind and the aggregate
+        // falls back to a correlated subquery, or throws. Grouping has already been applied to the source, so a dependent that would
+        // need a join added to it is left unexpanded.
+        return _relationalQueryableTranslator is not null
+            && FindSourceSelectExpression(enumerableExpression.Selector) is { } selectExpression
+                ? _relationalQueryableTranslator.ExpandSharedTypeEntities(selectExpression, body, allowOwnerJoin: false)
+                : body;
+    }
+
+    // The grouping element is an entity shaper, or a transparent identifier over several of them when navigation expansion added
+    // joins to the grouped source. Anything else yields null and the lambda is left unexpanded.
+    private static SelectExpression? FindSourceSelectExpression(Expression selector)
+    {
+        SelectExpression? result = null;
+        var conflicting = false;
+        Find(selector);
+        return conflicting ? null : result;
+
+        void Find(Expression expression)
+        {
+            switch (expression)
+            {
+                case StructuralTypeShaperExpression
+                {
+                    ValueBufferExpression: ProjectionBindingExpression { QueryExpression: SelectExpression selectExpression }
+                }:
+                    conflicting |= result is not null && !ReferenceEquals(result, selectExpression);
+                    result ??= selectExpression;
+                    break;
+
+                case NewExpression newExpression:
+                    foreach (var argument in newExpression.Arguments)
+                    {
+                        Find(argument);
+                    }
+
+                    break;
+
+                case MemberInitExpression memberInitExpression:
+                    Find(memberInitExpression.NewExpression);
+                    foreach (var binding in memberInitExpression.Bindings)
+                    {
+                        if (binding is MemberAssignment memberAssignment)
+                        {
+                            Find(memberAssignment.Expression);
+                        }
+                    }
+
+                    break;
+            }
+        }
+    }
+
+    private EnumerableExpression ProcessSelector(EnumerableExpression enumerableExpression, LambdaExpression lambdaExpression)
         => enumerableExpression.ApplySelector(RemapLambda(enumerableExpression, lambdaExpression));
 
     private EnumerableExpression? ProcessOrderByThenBy(

--- a/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
@@ -2615,18 +2615,24 @@ public sealed partial class SelectExpression : TableExpressionBase
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     [EntityFrameworkInternal]
-    public StructuralTypeShaperExpression GenerateOwnedReferenceEntityProjectionExpression(
+    public StructuralTypeShaperExpression? GenerateOwnedReferenceEntityProjectionExpression(
         StructuralTypeProjectionExpression principalEntityProjection,
         INavigation navigation,
         ISqlExpressionFactory sqlExpressionFactory,
-        SqlAliasManager sqlAliasManager)
+        SqlAliasManager sqlAliasManager,
+        bool allowOwnerJoin = true)
     {
         // We first find the select expression where principal tableExpressionBase is located
         // That is where we find shared tableExpressionBase to pull columns from or add joins
         var identifyingColumn = principalEntityProjection.BindProperty(
             navigation.DeclaringEntityType.FindPrimaryKey()!.Properties.First());
 
-        var expressions = GetPropertyExpressions(sqlExpressionFactory, sqlAliasManager, navigation, this, identifyingColumn);
+        var expressions = GetPropertyExpressions(
+            sqlExpressionFactory, sqlAliasManager, navigation, this, identifyingColumn, allowOwnerJoin);
+        if (expressions is null)
+        {
+            return null;
+        }
 
         // TODO: support for complex types on owned entity types, #33170
         var complexPropertyMap = new Dictionary<IComplexProperty, Expression>();
@@ -2642,12 +2648,13 @@ public sealed partial class SelectExpression : TableExpressionBase
         // Owned types don't support inheritance See https://github.com/dotnet/efcore/issues/9630
         // So there is no handling for dependent having hierarchy
         // TODO: The following code should also handle Function and SqlQuery mappings when supported on owned type
-        static IReadOnlyDictionary<IProperty, ColumnExpression> GetPropertyExpressions(
+        static IReadOnlyDictionary<IProperty, ColumnExpression>? GetPropertyExpressions(
             ISqlExpressionFactory sqlExpressionFactory,
             SqlAliasManager sqlAliasManager,
             INavigation navigation,
             SelectExpression selectExpression,
-            ColumnExpression identifyingColumn)
+            ColumnExpression identifyingColumn,
+            bool allowOwnerJoin)
         {
             var propertyExpressions = new Dictionary<IProperty, ColumnExpression>();
             var tableExpressionBase = selectExpression.GetTable(identifyingColumn).UnwrapJoin();
@@ -2661,7 +2668,12 @@ public sealed partial class SelectExpression : TableExpressionBase
                     .Expression;
 
                 var subqueryPropertyExpressions = GetPropertyExpressions(
-                    sqlExpressionFactory, sqlAliasManager, navigation, subquery, subqueryIdentifyingColumn);
+                    sqlExpressionFactory, sqlAliasManager, navigation, subquery, subqueryIdentifyingColumn, allowOwnerJoin);
+                if (subqueryPropertyExpressions is null)
+                {
+                    return null;
+                }
+
                 var changeNullability = identifyingColumn.IsNullable && !subqueryIdentifyingColumn.IsNullable;
                 foreach (var (property, columnExpression) in subqueryPropertyExpressions)
                 {
@@ -2758,6 +2770,8 @@ public sealed partial class SelectExpression : TableExpressionBase
                                     .Zip(innerColumns, sqlExpressionFactory.Equal)
                                     .Aggregate(sqlExpressionFactory.AndAlso);
 
+                                // Safe to append even after grouping: the fragment is joined on the dependent's own key,
+                                // so it matches at most one row and adds no identifier.
                                 selectExpression._tables.Add(new LeftJoinExpression(tableExpression, joinPredicate, prunable: true));
                             }
                         }
@@ -2784,7 +2798,13 @@ public sealed partial class SelectExpression : TableExpressionBase
             }
 
             // Either we encountered a custom table source or dependent is not sharing table
-            // In either case we need to generate join to owner
+            // In either case we need to generate join to owner. The join and the identifier below are appended directly rather
+            // than going through AddJoin, so the caller has to know that the select can still take them.
+            if (!allowOwnerJoin)
+            {
+                return null;
+            }
+
             var ownerJoinColumns = new List<ColumnExpression>();
             foreach (var property in navigation.ForeignKey.PrincipalKey.Properties)
             {

--- a/test/EFCore.Cosmos.FunctionalTests/Query/JsonQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/JsonQueryCosmosTest.cs
@@ -430,6 +430,10 @@ WHERE (c["$type"] = "CustomNaming")
         => base.Group_by_on_json_scalar_using_collection_indexer(async);
 
     [Theory(Skip = "issue #17313")]
+    public override Task Group_by_on_json_scalar_with_multiple_aggregates(bool async)
+        => base.Group_by_on_json_scalar_with_multiple_aggregates(async);
+
+    [Theory(Skip = "issue #17313")]
     public override Task Group_by_Skip_Take_on_json_scalar(bool async)
         => base.Group_by_Skip_Take_on_json_scalar(async);
 

--- a/test/EFCore.Cosmos.FunctionalTests/Query/OwnedQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/OwnedQueryCosmosTest.cs
@@ -940,6 +940,30 @@ WHERE (c["Terminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND (o["Cl
     public override Task GroupBy_aggregate_on_owned_navigation_in_aggregate_selector(bool async)
         => AssertTranslationFailed(() => base.GroupBy_aggregate_on_owned_navigation_in_aggregate_selector(async));
 
+    // TODO: GroupBy, #17313
+    public override Task GroupBy_multiple_aggregates_on_owned_navigation(bool async)
+        => AssertTranslationFailed(() => base.GroupBy_multiple_aggregates_on_owned_navigation(async));
+
+    // TODO: GroupBy, #17313
+    public override Task GroupBy_count_with_predicate_on_owned_navigation(bool async)
+        => AssertTranslationFailed(() => base.GroupBy_count_with_predicate_on_owned_navigation(async));
+
+    // TODO: GroupBy, #17313
+    public override Task GroupBy_aggregate_on_owned_navigation_over_filtered_grouping(bool async)
+        => AssertTranslationFailed(() => base.GroupBy_aggregate_on_owned_navigation_over_filtered_grouping(async));
+
+    // TODO: GroupBy, #17313
+    public override Task GroupBy_ordered_aggregate_on_owned_navigation(bool async)
+        => AssertTranslationFailed(() => base.GroupBy_ordered_aggregate_on_owned_navigation(async));
+
+    // TODO: GroupBy, #17313
+    public override Task GroupBy_aggregate_on_owned_navigation_in_having(bool async)
+        => AssertTranslationFailed(() => base.GroupBy_aggregate_on_owned_navigation_in_having(async));
+
+    // TODO: GroupBy, #17313
+    public override Task GroupBy_aggregate_on_owned_collection_navigation(bool async)
+        => AssertTranslationFailed(() => base.GroupBy_aggregate_on_owned_collection_navigation(async));
+
     public override Task Filter_on_indexer_using_closure(bool async)
         => CosmosTestHelpers.Instance.NoSyncTest(
             async, async a =>

--- a/test/EFCore.Cosmos.FunctionalTests/Query/OwnedQueryCosmosTest.cs
+++ b/test/EFCore.Cosmos.FunctionalTests/Query/OwnedQueryCosmosTest.cs
@@ -957,6 +957,10 @@ WHERE (c["Terminator"] IN ("OwnedPerson", "Branch", "LeafB", "LeafA") AND (o["Cl
         => AssertTranslationFailed(() => base.GroupBy_ordered_aggregate_on_owned_navigation(async));
 
     // TODO: GroupBy, #17313
+    public override Task GroupBy_first_entity_ordered_by_owned_navigation(bool async)
+        => AssertTranslationFailed(() => base.GroupBy_first_entity_ordered_by_owned_navigation(async));
+
+    // TODO: GroupBy, #17313
     public override Task GroupBy_aggregate_on_owned_navigation_in_having(bool async)
         => AssertTranslationFailed(() => base.GroupBy_aggregate_on_owned_navigation_in_having(async));
 

--- a/test/EFCore.Relational.Specification.Tests/Query/OwnedEntityQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/OwnedEntityQueryRelationalTestBase.cs
@@ -670,6 +670,103 @@ public abstract class OwnedEntityQueryRelationalTestBase(NonSharedFixture fixtur
 
     #endregion
 
+    #region 29593
+
+    // The dependent lives in its own table, so expanding it into the grouped query would need a join added to a query that has
+    // already been grouped. It keeps the correlated subquery it translates to today.
+    [Theory, MemberData(nameof(IsAsyncData))]
+    public virtual async Task GroupBy_aggregate_on_owned_navigation_mapped_to_its_own_table(bool async)
+    {
+        var contextFactory = await InitializeNonSharedTest<Context29593>(seed: c => c.SeedAsync());
+        using var context = contextFactory.CreateDbContext();
+        ClearLog();
+
+        var query = context.Set<Context29593.Invoice>()
+            .GroupBy(e => e.Region)
+            .Select(g => new { g.Key, Total = g.Sum(e => e.Summary!.Amount) });
+
+        var result = async ? await query.ToListAsync() : query.ToList();
+
+        Assert.Equal(2, result.Count);
+        Assert.Equal(3, result.Single(e => e.Key == "east").Total);
+        Assert.Equal(12, result.Single(e => e.Key == "west").Total);
+    }
+
+    // The dependent's main fragment shares the owner's table, so it is expanded into the grouped query; the fragment holding
+    // Tax is reached through a join that the grouped query can carry.
+    [Theory, MemberData(nameof(IsAsyncData))]
+    public virtual async Task GroupBy_aggregate_on_owned_navigation_split_over_two_tables(bool async)
+    {
+        var contextFactory = await InitializeNonSharedTest<Context29593>(seed: c => c.SeedAsync());
+        using var context = contextFactory.CreateDbContext();
+        ClearLog();
+
+        var query = context.Set<Context29593.Order>()
+            .GroupBy(e => e.Region)
+            .Select(g => new { g.Key, Total = g.Sum(e => e.Total!.Net), Tax = g.Sum(e => e.Total!.Tax) });
+
+        var result = async ? await query.ToListAsync() : query.ToList();
+
+        Assert.Equal(2, result.Count);
+        Assert.Equal(3, result.Single(e => e.Key == "east").Total);
+        Assert.Equal(30, result.Single(e => e.Key == "east").Tax);
+        Assert.Equal(12, result.Single(e => e.Key == "west").Total);
+        Assert.Equal(120, result.Single(e => e.Key == "west").Tax);
+    }
+
+    // Protected so that it can be used by inheriting tests, and so that things like unused setters are not removed.
+    protected class Context29593(DbContextOptions options) : DbContext(options)
+    {
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Invoice>().OwnsOne(e => e.Summary, b => b.ToTable("Summaries"));
+            modelBuilder.Entity<Order>().OwnsOne(
+                e => e.Total, b => b.SplitToTable("OrderTotalTax", t => t.Property(p => p.Tax)));
+        }
+
+        public Task SeedAsync()
+        {
+            AddRange(
+                new Invoice { Region = "east", Summary = new Summary { Amount = 1 } },
+                new Invoice { Region = "east", Summary = new Summary { Amount = 2 } },
+                new Invoice { Region = "west", Summary = new Summary { Amount = 12 } });
+
+            AddRange(
+                new Order { Region = "east", Total = new Total { Net = 1, Tax = 10 } },
+                new Order { Region = "east", Total = new Total { Net = 2, Tax = 20 } },
+                new Order { Region = "west", Total = new Total { Net = 12, Tax = 120 } });
+
+            return SaveChangesAsync();
+        }
+
+        public class Invoice
+        {
+            public int Id { get; set; }
+            public string Region { get; set; } = null!;
+            public Summary? Summary { get; set; }
+        }
+
+        public class Summary
+        {
+            public int Amount { get; set; }
+        }
+
+        public class Order
+        {
+            public int Id { get; set; }
+            public string Region { get; set; } = null!;
+            public Total? Total { get; set; }
+        }
+
+        public class Total
+        {
+            public int Net { get; set; }
+            public int Tax { get; set; }
+        }
+    }
+
+    #endregion
+
     protected override DbContextOptionsBuilder AddNonSharedOptions(DbContextOptionsBuilder builder)
         => base.AddNonSharedOptions(builder).ConfigureWarnings(c => c
             .Log(RelationalEventId.OptionalDependentWithoutIdentifyingPropertyWarning)

--- a/test/EFCore.Relational.Specification.Tests/Query/OwnedQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/OwnedQueryRelationalTestBase.cs
@@ -26,6 +26,45 @@ public abstract class OwnedQueryRelationalTestBase<TFixture>(TFixture fixture) :
     public override Task FirstOrDefault_over_owned_collection(bool async)
         => Task.CompletedTask;
 
+    // Relational only: the in-memory provider throws reading the missing dependent's value instead of treating it as absent.
+    // Both Bartons land in one group, so the aggregates run over a present and an absent dependent together.
+    [Theory, MemberData(nameof(IsAsyncData))]
+    public virtual Task GroupBy_aggregate_on_optional_owned_navigation(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<Barton>()
+                .GroupBy(e => e.Simple != null)
+                .Select(g => new
+                {
+                    g.Key,
+                    Sum = g.Sum(e => e.Throned!.Value),
+                    Above = g.Count(e => e.Throned!.Value > 40)
+                }),
+            ss => ss.Set<Barton>()
+                .GroupBy(e => e.Simple != null)
+                .Select(g => new
+                {
+                    g.Key,
+                    Sum = g.Sum(e => e.Throned == null ? 0 : e.Throned.Value),
+                    Above = g.Count(e => e.Throned != null && e.Throned.Value > 40)
+                }),
+            elementSorter: e => e.Key);
+
+    // Relational only: Cosmos cannot reference a second root entity type in one query.
+    [Theory, MemberData(nameof(IsAsyncData))]
+    public virtual Task GroupBy_aggregate_on_navigation_reached_through_owned_navigation(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<OwnedPerson>()
+                .GroupBy(e => (int)e.PersonAddress!["ZipCode"] > 20000)
+                .Select(g => new
+                {
+                    g.Key,
+                    Sum = g.Sum(e => (int)e.PersonAddress!["ZipCode"]),
+                    Planet = g.Max(e => e.PersonAddress!.Country!.Planet!.Name)
+                }),
+            elementSorter: e => e.Key);
+
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Query_for_base_type_loads_all_owned_navs_split(bool async)
         => AssertQuery(

--- a/test/EFCore.Specification.Tests/Query/JsonQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/JsonQueryTestBase.cs
@@ -1536,6 +1536,21 @@ public abstract class JsonQueryTestBase<TFixture>(TFixture fixture) : QueryTestB
                 .GroupBy(x => x.OwnedReferenceRoot.Name).Select(x => new { x.Key, Count = x.Count() }));
 
     [Theory, MemberData(nameof(IsAsyncData))]
+    public virtual Task Group_by_on_json_scalar_with_multiple_aggregates(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<JsonEntityBasic>()
+                .GroupBy(x => x.OwnedReferenceRoot.Name)
+                .Select(g => new
+                {
+                    g.Key,
+                    Sum = g.Sum(x => x.OwnedReferenceRoot.Number),
+                    Max = g.Max(x => x.OwnedReferenceRoot.OwnedReferenceBranch!.Fraction),
+                    Above = g.Count(x => x.OwnedReferenceRoot.Number > 5)
+                }),
+            elementSorter: e => e.Key);
+
+    [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Group_by_on_json_scalar_using_collection_indexer(bool async)
         => AssertQuery(
             async,

--- a/test/EFCore.Specification.Tests/Query/OwnedQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/OwnedQueryTestBase.cs
@@ -824,6 +824,79 @@ public abstract class OwnedQueryTestBase<TFixture> : QueryTestBase<TFixture>
             });
 
     [Theory, MemberData(nameof(IsAsyncData))]
+    public virtual Task GroupBy_multiple_aggregates_on_owned_navigation(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<OwnedPerson>()
+                .GroupBy(e => (int)e.PersonAddress!["ZipCode"] > 20000)
+                .Select(g => new
+                {
+                    g.Key,
+                    Sum = g.Sum(e => (int)e.PersonAddress!["ZipCode"]),
+                    Min = g.Min(e => (int)e.PersonAddress!["ZipCode"]),
+                    Max = g.Max(e => (int)e.PersonAddress!["ZipCode"]),
+                    Average = g.Average(e => (int)e.PersonAddress!["ZipCode"]),
+                    Nested = g.Sum(e => e.PersonAddress!.Country!.PlanetId)
+                }),
+            elementSorter: e => e.Key);
+
+    [Theory, MemberData(nameof(IsAsyncData))]
+    public virtual Task GroupBy_count_with_predicate_on_owned_navigation(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<OwnedPerson>()
+                .GroupBy(e => (int)e.PersonAddress!["ZipCode"] > 20000)
+                .Select(g => new
+                {
+                    g.Key,
+                    Total = g.Count(),
+                    Filtered = g.Count(e => (int)e.PersonAddress!["ZipCode"] > 19000)
+                }),
+            elementSorter: e => e.Key);
+
+    [Theory, MemberData(nameof(IsAsyncData))]
+    public virtual Task GroupBy_aggregate_on_owned_navigation_over_filtered_grouping(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<OwnedPerson>()
+                .GroupBy(e => (int)e.PersonAddress!["ZipCode"] > 20000)
+                .Select(g => new
+                {
+                    g.Key,
+                    Sum = g.Where(e => (int)e.PersonAddress!["ZipCode"] > 19000).Sum(e => (int)e.PersonAddress!["ZipCode"])
+                }),
+            elementSorter: e => e.Key);
+
+    // First over a grouping is translated as a subquery either way; what this pins is that ordering the grouping by an owned
+    // property translates at all.
+    [Theory, MemberData(nameof(IsAsyncData))]
+    public virtual Task GroupBy_ordered_aggregate_on_owned_navigation(bool async)
+        => AssertQueryScalar(
+            async,
+            ss => ss.Set<OwnedPerson>()
+                .GroupBy(e => (int)e.PersonAddress!["ZipCode"] > 20000)
+                .Select(g => g.OrderByDescending(e => (int)e.PersonAddress!["ZipCode"]).Select(e => e.Id).First()));
+
+    [Theory, MemberData(nameof(IsAsyncData))]
+    public virtual Task GroupBy_aggregate_on_owned_navigation_in_having(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<OwnedPerson>()
+                .GroupBy(e => (int)e.PersonAddress!["ZipCode"] > 20000)
+                .Where(g => g.Sum(e => (int)e.PersonAddress!["ZipCode"]) > 50000)
+                .Select(g => new { g.Key, Count = g.Count() }),
+            elementSorter: e => e.Key);
+
+    [Theory, MemberData(nameof(IsAsyncData))]
+    public virtual Task GroupBy_aggregate_on_owned_collection_navigation(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<OwnedPerson>()
+                .GroupBy(e => (int)e.PersonAddress!["ZipCode"] > 20000)
+                .Select(g => new { g.Key, Sum = g.Sum(e => e.Orders.Count) }),
+            elementSorter: e => e.Key);
+
+    [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Count_over_owned_collection(bool async)
         => AssertQuery(
             async,

--- a/test/EFCore.Specification.Tests/Query/OwnedQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/OwnedQueryTestBase.cs
@@ -878,6 +878,14 @@ public abstract class OwnedQueryTestBase<TFixture> : QueryTestBase<TFixture>
                 .Select(g => g.OrderByDescending(e => (int)e.PersonAddress!["ZipCode"]).Select(e => e.Id).First()));
 
     [Theory, MemberData(nameof(IsAsyncData))]
+    public virtual Task GroupBy_first_entity_ordered_by_owned_navigation(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<OwnedPerson>()
+                .GroupBy(e => (int)e.PersonAddress!["ZipCode"] > 20000)
+                .Select(g => g.OrderByDescending(e => (int)e.PersonAddress!["ZipCode"]).First()));
+
+    [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task GroupBy_aggregate_on_owned_navigation_in_having(bool async)
         => AssertQuery(
             async,

--- a/test/EFCore.SqlServer.FunctionalTests/Query/JsonQueryJsonTypeSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/JsonQueryJsonTypeSqlServerTest.cs
@@ -2254,6 +2254,23 @@ GROUP BY [j0].[Key]
 """);
     }
 
+    public override async Task Group_by_on_json_scalar_with_multiple_aggregates(bool async)
+    {
+        await base.Group_by_on_json_scalar_with_multiple_aggregates(async);
+
+        AssertSql(
+            """
+SELECT [j0].[Key], ISNULL(SUM(JSON_VALUE([j0].[c0], '$.Number' RETURNING int)), 0) AS [Sum], MAX(JSON_VALUE([j0].[c0], '$.OwnedReferenceBranch.Fraction' RETURNING decimal(18,2))) AS [Max], COUNT(CASE
+    WHEN JSON_VALUE([j0].[c0], '$.Number' RETURNING int) > 5 THEN 1
+END) AS [Above]
+FROM (
+    SELECT [j].[OwnedReferenceRoot] AS [c0], JSON_VALUE([j].[OwnedReferenceRoot], '$.Name' RETURNING nvarchar(max)) AS [Key]
+    FROM [JsonEntitiesBasic] AS [j]
+) AS [j0]
+GROUP BY [j0].[Key]
+""");
+    }
+
     public override async Task Group_by_on_json_scalar_using_collection_indexer(bool async)
     {
         await base.Group_by_on_json_scalar_using_collection_indexer(async);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/JsonQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/JsonQuerySqlServerTest.cs
@@ -2044,6 +2044,23 @@ GROUP BY [j0].[Key]
 """);
     }
 
+    public override async Task Group_by_on_json_scalar_with_multiple_aggregates(bool async)
+    {
+        await base.Group_by_on_json_scalar_with_multiple_aggregates(async);
+
+        AssertSql(
+            """
+SELECT [j0].[Key], ISNULL(SUM(CAST(JSON_VALUE([j0].[c0], '$.Number') AS int)), 0) AS [Sum], MAX(CAST(JSON_VALUE([j0].[c0], '$.OwnedReferenceBranch.Fraction') AS decimal(18,2))) AS [Max], COUNT(CASE
+    WHEN CAST(JSON_VALUE([j0].[c0], '$.Number') AS int) > 5 THEN 1
+END) AS [Above]
+FROM (
+    SELECT [j].[OwnedReferenceRoot] AS [c0], JSON_VALUE([j].[OwnedReferenceRoot], '$.Name') AS [Key]
+    FROM [JsonEntitiesBasic] AS [j]
+) AS [j0]
+GROUP BY [j0].[Key]
+""");
+    }
+
     public override async Task Group_by_on_json_scalar_using_collection_indexer(bool async)
     {
         await base.Group_by_on_json_scalar_using_collection_indexer(async);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/OwnedEntityQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/OwnedEntityQuerySqlServerTest.cs
@@ -712,4 +712,35 @@ INNER JOIN (
 ) AS [m1] ON [m].[RulerOf] = [m1].[Affiliation]
 """);
     }
+
+    public override async Task GroupBy_aggregate_on_owned_navigation_mapped_to_its_own_table(bool async)
+    {
+        await base.GroupBy_aggregate_on_owned_navigation_mapped_to_its_own_table(async);
+
+        AssertSql(
+            """
+SELECT [i].[Region] AS [Key], (
+    SELECT ISNULL(SUM([s].[Amount]), 0)
+    FROM [Invoice] AS [i0]
+    LEFT JOIN [Summaries] AS [s] ON [i0].[Id] = [s].[InvoiceId]
+    WHERE [i].[Region] = [i0].[Region]) AS [Total]
+FROM [Invoice] AS [i]
+GROUP BY [i].[Region]
+""");
+    }
+
+    public override async Task GroupBy_aggregate_on_owned_navigation_split_over_two_tables(bool async)
+    {
+        await base.GroupBy_aggregate_on_owned_navigation_split_over_two_tables(async);
+
+        AssertSql(
+            """
+SELECT [o].[Region] AS [Key], ISNULL(SUM([o].[Total_Net]), 0) AS [Total], ISNULL(SUM(CASE
+    WHEN [o].[Total_Net] IS NOT NULL THEN [o0].[Tax]
+END), 0) AS [Tax]
+FROM [Order] AS [o]
+LEFT JOIN [OrderTotalTax] AS [o0] ON [o].[Id] = [o0].[OrderId]
+GROUP BY [o].[Region]
+""");
+    }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/OwnedQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/OwnedQuerySqlServerTest.cs
@@ -1494,12 +1494,176 @@ ORDER BY [p].[Id], [s].[Id], [s0].[ClientId], [s0].[Id], [s0].[OrderClientId], [
 
         AssertSql(
             """
-SELECT [o].[Id] AS [Key], (
-    SELECT ISNULL(SUM([o0].[PersonAddress_Country_PlanetId]), 0)
-    FROM [OwnedPerson] AS [o0]
-    WHERE [o].[Id] = [o0].[Id]) AS [Sum]
+SELECT [o].[Id] AS [Key], ISNULL(SUM([o].[PersonAddress_Country_PlanetId]), 0) AS [Sum]
 FROM [OwnedPerson] AS [o]
 GROUP BY [o].[Id]
+""");
+    }
+
+    public override async Task GroupBy_multiple_aggregates_on_owned_navigation(bool async)
+    {
+        await base.GroupBy_multiple_aggregates_on_owned_navigation(async);
+
+        AssertSql(
+            """
+SELECT [o0].[Key], ISNULL(SUM([o0].[PersonAddress_ZipCode]), 0) AS [Sum], MIN([o0].[PersonAddress_ZipCode]) AS [Min], MAX([o0].[PersonAddress_ZipCode]) AS [Max], AVG(CAST([o0].[PersonAddress_ZipCode] AS float)) AS [Average], ISNULL(SUM([o0].[PersonAddress_Country_PlanetId]), 0) AS [Nested]
+FROM (
+    SELECT [o].[PersonAddress_ZipCode], CASE
+        WHEN [o].[PersonAddress_ZipCode] > 20000 THEN CAST(1 AS bit)
+        ELSE CAST(0 AS bit)
+    END AS [Key], [o].[PersonAddress_Country_PlanetId]
+    FROM [OwnedPerson] AS [o]
+) AS [o0]
+GROUP BY [o0].[Key]
+""");
+    }
+
+    public override async Task GroupBy_count_with_predicate_on_owned_navigation(bool async)
+    {
+        await base.GroupBy_count_with_predicate_on_owned_navigation(async);
+
+        AssertSql(
+            """
+SELECT [o0].[Key], COUNT(*) AS [Total], COUNT(CASE
+    WHEN [o0].[PersonAddress_ZipCode] > 19000 THEN 1
+END) AS [Filtered]
+FROM (
+    SELECT [o].[PersonAddress_ZipCode], CASE
+        WHEN [o].[PersonAddress_ZipCode] > 20000 THEN CAST(1 AS bit)
+        ELSE CAST(0 AS bit)
+    END AS [Key]
+    FROM [OwnedPerson] AS [o]
+) AS [o0]
+GROUP BY [o0].[Key]
+""");
+    }
+
+    public override async Task GroupBy_aggregate_on_owned_navigation_over_filtered_grouping(bool async)
+    {
+        await base.GroupBy_aggregate_on_owned_navigation_over_filtered_grouping(async);
+
+        AssertSql(
+            """
+SELECT [o0].[Key], ISNULL(SUM(CASE
+    WHEN [o0].[PersonAddress_ZipCode] > 19000 THEN [o0].[PersonAddress_ZipCode]
+END), 0) AS [Sum]
+FROM (
+    SELECT [o].[PersonAddress_ZipCode], CASE
+        WHEN [o].[PersonAddress_ZipCode] > 20000 THEN CAST(1 AS bit)
+        ELSE CAST(0 AS bit)
+    END AS [Key]
+    FROM [OwnedPerson] AS [o]
+) AS [o0]
+GROUP BY [o0].[Key]
+""");
+    }
+
+    public override async Task GroupBy_ordered_aggregate_on_owned_navigation(bool async)
+    {
+        await base.GroupBy_ordered_aggregate_on_owned_navigation(async);
+
+        AssertSql(
+            """
+SELECT (
+    SELECT TOP(1) [o1].[Id]
+    FROM (
+        SELECT [o2].[Id], [o2].[PersonAddress_ZipCode], CASE
+            WHEN [o2].[PersonAddress_ZipCode] > 20000 THEN CAST(1 AS bit)
+            ELSE CAST(0 AS bit)
+        END AS [Key]
+        FROM [OwnedPerson] AS [o2]
+    ) AS [o1]
+    WHERE [o0].[Key] = [o1].[Key] OR ([o0].[Key] IS NULL AND [o1].[Key] IS NULL)
+    ORDER BY [o1].[PersonAddress_ZipCode] DESC)
+FROM (
+    SELECT CASE
+        WHEN [o].[PersonAddress_ZipCode] > 20000 THEN CAST(1 AS bit)
+        ELSE CAST(0 AS bit)
+    END AS [Key]
+    FROM [OwnedPerson] AS [o]
+) AS [o0]
+GROUP BY [o0].[Key]
+""");
+    }
+
+    public override async Task GroupBy_aggregate_on_navigation_reached_through_owned_navigation(bool async)
+    {
+        await base.GroupBy_aggregate_on_navigation_reached_through_owned_navigation(async);
+
+        AssertSql(
+            """
+SELECT [s].[Key], ISNULL(SUM([s].[PersonAddress_ZipCode]), 0) AS [Sum], MAX([s].[Name0]) AS [Planet]
+FROM (
+    SELECT [o].[PersonAddress_ZipCode], [p].[Name] AS [Name0], CASE
+        WHEN [o].[PersonAddress_ZipCode] > 20000 THEN CAST(1 AS bit)
+        ELSE CAST(0 AS bit)
+    END AS [Key]
+    FROM [OwnedPerson] AS [o]
+    LEFT JOIN [Planet] AS [p] ON [o].[PersonAddress_Country_PlanetId] = [p].[Id]
+) AS [s]
+GROUP BY [s].[Key]
+""");
+    }
+
+    public override async Task GroupBy_aggregate_on_owned_navigation_in_having(bool async)
+    {
+        await base.GroupBy_aggregate_on_owned_navigation_in_having(async);
+
+        AssertSql(
+            """
+SELECT [o0].[Key], COUNT(*) AS [Count]
+FROM (
+    SELECT [o].[PersonAddress_ZipCode], CASE
+        WHEN [o].[PersonAddress_ZipCode] > 20000 THEN CAST(1 AS bit)
+        ELSE CAST(0 AS bit)
+    END AS [Key]
+    FROM [OwnedPerson] AS [o]
+) AS [o0]
+GROUP BY [o0].[Key]
+HAVING ISNULL(SUM([o0].[PersonAddress_ZipCode]), 0) > 50000
+""");
+    }
+
+    public override async Task GroupBy_aggregate_on_owned_collection_navigation(bool async)
+    {
+        await base.GroupBy_aggregate_on_owned_collection_navigation(async);
+
+        AssertSql(
+            """
+SELECT [o0].[Key], ISNULL(SUM([s].[value]), 0) AS [Sum]
+FROM (
+    SELECT [o].[Id], CASE
+        WHEN [o].[PersonAddress_ZipCode] > 20000 THEN CAST(1 AS bit)
+        ELSE CAST(0 AS bit)
+    END AS [Key]
+    FROM [OwnedPerson] AS [o]
+) AS [o0]
+OUTER APPLY (
+    SELECT COUNT(*) AS [value]
+    FROM [Order] AS [o1]
+    WHERE [o0].[Id] = [o1].[ClientId]
+) AS [s]
+GROUP BY [o0].[Key]
+""");
+    }
+
+    public override async Task GroupBy_aggregate_on_optional_owned_navigation(bool async)
+    {
+        await base.GroupBy_aggregate_on_optional_owned_navigation(async);
+
+        AssertSql(
+            """
+SELECT [b0].[Key], ISNULL(SUM([b0].[Throned_Value]), 0) AS [Sum], COUNT(CASE
+    WHEN [b0].[Throned_Value] > 40 THEN 1
+END) AS [Above]
+FROM (
+    SELECT CASE
+        WHEN [b].[Simple] IS NOT NULL THEN CAST(1 AS bit)
+        ELSE CAST(0 AS bit)
+    END AS [Key], [b].[Throned_Value]
+    FROM [Barton] AS [b]
+) AS [b0]
+GROUP BY [b0].[Key]
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/OwnedQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/OwnedQuerySqlServerTest.cs
@@ -1605,6 +1605,47 @@ GROUP BY [s].[Key]
 """);
     }
 
+    public override async Task GroupBy_first_entity_ordered_by_owned_navigation(bool async)
+    {
+        await base.GroupBy_first_entity_ordered_by_owned_navigation(async);
+
+        AssertSql(
+            """
+SELECT [o7].[Id], [o7].[Discriminator], [o7].[Name], [o5].[Key], [s].[ClientId], [s].[Id], [s].[OrderDate], [s].[OrderClientId], [s].[OrderId], [s].[Id0], [s].[Detail], [o7].[PersonAddress_AddressLine], [o7].[PersonAddress_PlaceType], [o7].[PersonAddress_ZipCode], [o7].[PersonAddress_Country_Name], [o7].[PersonAddress_Country_PlanetId], [o7].[BranchAddress_BranchName], [o7].[BranchAddress_PlaceType], [o7].[BranchAddress_Country_Name], [o7].[BranchAddress_Country_PlanetId], [o7].[LeafBAddress_LeafBType], [o7].[LeafBAddress_PlaceType], [o7].[LeafBAddress_Country_Name], [o7].[LeafBAddress_Country_PlanetId], [o7].[LeafAAddress_LeafType], [o7].[LeafAAddress_PlaceType], [o7].[LeafAAddress_Country_Name], [o7].[LeafAAddress_Country_PlanetId]
+FROM (
+    SELECT [o0].[Key]
+    FROM (
+        SELECT CASE
+            WHEN [o].[PersonAddress_ZipCode] > 20000 THEN CAST(1 AS bit)
+            ELSE CAST(0 AS bit)
+        END AS [Key]
+        FROM [OwnedPerson] AS [o]
+    ) AS [o0]
+    GROUP BY [o0].[Key]
+) AS [o5]
+LEFT JOIN (
+    SELECT [o6].[Id], [o6].[Discriminator], [o6].[Name], [o6].[PersonAddress_AddressLine], [o6].[PersonAddress_PlaceType], [o6].[PersonAddress_ZipCode], [o6].[PersonAddress_Country_Name], [o6].[PersonAddress_Country_PlanetId], [o6].[BranchAddress_BranchName], [o6].[BranchAddress_PlaceType], [o6].[BranchAddress_Country_Name], [o6].[BranchAddress_Country_PlanetId], [o6].[LeafBAddress_LeafBType], [o6].[LeafBAddress_PlaceType], [o6].[LeafBAddress_Country_Name], [o6].[LeafBAddress_Country_PlanetId], [o6].[LeafAAddress_LeafType], [o6].[LeafAAddress_PlaceType], [o6].[LeafAAddress_Country_Name], [o6].[LeafAAddress_Country_PlanetId], [o6].[Key]
+    FROM (
+        SELECT [o1].[Id], [o1].[Discriminator], [o1].[Name], [o1].[PersonAddress_AddressLine], [o1].[PersonAddress_PlaceType], [o1].[PersonAddress_ZipCode], [o1].[PersonAddress_Country_Name], [o1].[PersonAddress_Country_PlanetId], [o1].[BranchAddress_BranchName], [o1].[BranchAddress_PlaceType], [o1].[BranchAddress_Country_Name], [o1].[BranchAddress_Country_PlanetId], [o1].[LeafBAddress_LeafBType], [o1].[LeafBAddress_PlaceType], [o1].[LeafBAddress_Country_Name], [o1].[LeafBAddress_Country_PlanetId], [o1].[LeafAAddress_LeafType], [o1].[LeafAAddress_PlaceType], [o1].[LeafAAddress_Country_Name], [o1].[LeafAAddress_Country_PlanetId], [o1].[Key], ROW_NUMBER() OVER(PARTITION BY [o1].[Key] ORDER BY [o1].[PersonAddress_ZipCode] DESC) AS [row]
+        FROM (
+            SELECT [o2].[Id], [o2].[Discriminator], [o2].[Name], [o2].[PersonAddress_AddressLine], [o2].[PersonAddress_PlaceType], [o2].[PersonAddress_ZipCode], CASE
+                WHEN [o2].[PersonAddress_ZipCode] > 20000 THEN CAST(1 AS bit)
+                ELSE CAST(0 AS bit)
+            END AS [Key], [o2].[PersonAddress_Country_Name], [o2].[PersonAddress_Country_PlanetId], [o2].[BranchAddress_BranchName], [o2].[BranchAddress_PlaceType], [o2].[BranchAddress_Country_Name], [o2].[BranchAddress_Country_PlanetId], [o2].[LeafBAddress_LeafBType], [o2].[LeafBAddress_PlaceType], [o2].[LeafBAddress_Country_Name], [o2].[LeafBAddress_Country_PlanetId], [o2].[LeafAAddress_LeafType], [o2].[LeafAAddress_PlaceType], [o2].[LeafAAddress_Country_Name], [o2].[LeafAAddress_Country_PlanetId]
+            FROM [OwnedPerson] AS [o2]
+        ) AS [o1]
+    ) AS [o6]
+    WHERE [o6].[row] <= 1
+) AS [o7] ON [o5].[Key] = [o7].[Key]
+LEFT JOIN (
+    SELECT [o3].[ClientId], [o3].[Id], [o3].[OrderDate], [o4].[OrderClientId], [o4].[OrderId], [o4].[Id] AS [Id0], [o4].[Detail]
+    FROM [Order] AS [o3]
+    LEFT JOIN [OrderDetail] AS [o4] ON [o3].[ClientId] = [o4].[OrderClientId] AND [o3].[Id] = [o4].[OrderId]
+) AS [s] ON [o7].[Id] = [s].[ClientId]
+ORDER BY [o5].[Key], [s].[ClientId], [s].[Id], [s].[OrderClientId], [s].[OrderId], [s].[Id0]
+""");
+    }
+
     public override async Task GroupBy_aggregate_on_owned_navigation_in_having(bool async)
     {
         await base.GroupBy_aggregate_on_owned_navigation_in_having(async);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TemporalOwnedQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TemporalOwnedQuerySqlServerTest.cs
@@ -1464,12 +1464,176 @@ ORDER BY [p].[Id], [s].[Id], [s0].[ClientId], [s0].[Id], [s0].[OrderClientId], [
 
         AssertSql(
             """
-SELECT [o].[Id] AS [Key], (
-    SELECT ISNULL(SUM([o0].[PersonAddress_Country_PlanetId]), 0)
-    FROM [OwnedPerson] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [o0]
-    WHERE [o].[Id] = [o0].[Id]) AS [Sum]
+SELECT [o].[Id] AS [Key], ISNULL(SUM([o].[PersonAddress_Country_PlanetId]), 0) AS [Sum]
 FROM [OwnedPerson] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [o]
 GROUP BY [o].[Id]
+""");
+    }
+
+    public override async Task GroupBy_multiple_aggregates_on_owned_navigation(bool async)
+    {
+        await base.GroupBy_multiple_aggregates_on_owned_navigation(async);
+
+        AssertSql(
+            """
+SELECT [o0].[Key], ISNULL(SUM([o0].[PersonAddress_ZipCode]), 0) AS [Sum], MIN([o0].[PersonAddress_ZipCode]) AS [Min], MAX([o0].[PersonAddress_ZipCode]) AS [Max], AVG(CAST([o0].[PersonAddress_ZipCode] AS float)) AS [Average], ISNULL(SUM([o0].[PersonAddress_Country_PlanetId]), 0) AS [Nested]
+FROM (
+    SELECT [o].[PersonAddress_ZipCode], CASE
+        WHEN [o].[PersonAddress_ZipCode] > 20000 THEN CAST(1 AS bit)
+        ELSE CAST(0 AS bit)
+    END AS [Key], [o].[PersonAddress_Country_PlanetId]
+    FROM [OwnedPerson] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [o]
+) AS [o0]
+GROUP BY [o0].[Key]
+""");
+    }
+
+    public override async Task GroupBy_count_with_predicate_on_owned_navigation(bool async)
+    {
+        await base.GroupBy_count_with_predicate_on_owned_navigation(async);
+
+        AssertSql(
+            """
+SELECT [o0].[Key], COUNT(*) AS [Total], COUNT(CASE
+    WHEN [o0].[PersonAddress_ZipCode] > 19000 THEN 1
+END) AS [Filtered]
+FROM (
+    SELECT [o].[PersonAddress_ZipCode], CASE
+        WHEN [o].[PersonAddress_ZipCode] > 20000 THEN CAST(1 AS bit)
+        ELSE CAST(0 AS bit)
+    END AS [Key]
+    FROM [OwnedPerson] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [o]
+) AS [o0]
+GROUP BY [o0].[Key]
+""");
+    }
+
+    public override async Task GroupBy_aggregate_on_owned_navigation_over_filtered_grouping(bool async)
+    {
+        await base.GroupBy_aggregate_on_owned_navigation_over_filtered_grouping(async);
+
+        AssertSql(
+            """
+SELECT [o0].[Key], ISNULL(SUM(CASE
+    WHEN [o0].[PersonAddress_ZipCode] > 19000 THEN [o0].[PersonAddress_ZipCode]
+END), 0) AS [Sum]
+FROM (
+    SELECT [o].[PersonAddress_ZipCode], CASE
+        WHEN [o].[PersonAddress_ZipCode] > 20000 THEN CAST(1 AS bit)
+        ELSE CAST(0 AS bit)
+    END AS [Key]
+    FROM [OwnedPerson] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [o]
+) AS [o0]
+GROUP BY [o0].[Key]
+""");
+    }
+
+    public override async Task GroupBy_ordered_aggregate_on_owned_navigation(bool async)
+    {
+        await base.GroupBy_ordered_aggregate_on_owned_navigation(async);
+
+        AssertSql(
+            """
+SELECT (
+    SELECT TOP(1) [o1].[Id]
+    FROM (
+        SELECT [o2].[Id], [o2].[PersonAddress_ZipCode], CASE
+            WHEN [o2].[PersonAddress_ZipCode] > 20000 THEN CAST(1 AS bit)
+            ELSE CAST(0 AS bit)
+        END AS [Key]
+        FROM [OwnedPerson] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [o2]
+    ) AS [o1]
+    WHERE [o0].[Key] = [o1].[Key] OR ([o0].[Key] IS NULL AND [o1].[Key] IS NULL)
+    ORDER BY [o1].[PersonAddress_ZipCode] DESC)
+FROM (
+    SELECT CASE
+        WHEN [o].[PersonAddress_ZipCode] > 20000 THEN CAST(1 AS bit)
+        ELSE CAST(0 AS bit)
+    END AS [Key]
+    FROM [OwnedPerson] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [o]
+) AS [o0]
+GROUP BY [o0].[Key]
+""");
+    }
+
+    public override async Task GroupBy_aggregate_on_navigation_reached_through_owned_navigation(bool async)
+    {
+        await base.GroupBy_aggregate_on_navigation_reached_through_owned_navigation(async);
+
+        AssertSql(
+            """
+SELECT [s].[Key], ISNULL(SUM([s].[PersonAddress_ZipCode]), 0) AS [Sum], MAX([s].[Name0]) AS [Planet]
+FROM (
+    SELECT [o].[PersonAddress_ZipCode], [p].[Name] AS [Name0], CASE
+        WHEN [o].[PersonAddress_ZipCode] > 20000 THEN CAST(1 AS bit)
+        ELSE CAST(0 AS bit)
+    END AS [Key]
+    FROM [OwnedPerson] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [o]
+    LEFT JOIN [Planet] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [p] ON [o].[PersonAddress_Country_PlanetId] = [p].[Id]
+) AS [s]
+GROUP BY [s].[Key]
+""");
+    }
+
+    public override async Task GroupBy_aggregate_on_owned_navigation_in_having(bool async)
+    {
+        await base.GroupBy_aggregate_on_owned_navigation_in_having(async);
+
+        AssertSql(
+            """
+SELECT [o0].[Key], COUNT(*) AS [Count]
+FROM (
+    SELECT [o].[PersonAddress_ZipCode], CASE
+        WHEN [o].[PersonAddress_ZipCode] > 20000 THEN CAST(1 AS bit)
+        ELSE CAST(0 AS bit)
+    END AS [Key]
+    FROM [OwnedPerson] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [o]
+) AS [o0]
+GROUP BY [o0].[Key]
+HAVING ISNULL(SUM([o0].[PersonAddress_ZipCode]), 0) > 50000
+""");
+    }
+
+    public override async Task GroupBy_aggregate_on_owned_collection_navigation(bool async)
+    {
+        await base.GroupBy_aggregate_on_owned_collection_navigation(async);
+
+        AssertSql(
+            """
+SELECT [o0].[Key], ISNULL(SUM([s].[value]), 0) AS [Sum]
+FROM (
+    SELECT [o].[Id], CASE
+        WHEN [o].[PersonAddress_ZipCode] > 20000 THEN CAST(1 AS bit)
+        ELSE CAST(0 AS bit)
+    END AS [Key]
+    FROM [OwnedPerson] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [o]
+) AS [o0]
+OUTER APPLY (
+    SELECT COUNT(*) AS [value]
+    FROM [Order] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [o1]
+    WHERE [o0].[Id] = [o1].[ClientId]
+) AS [s]
+GROUP BY [o0].[Key]
+""");
+    }
+
+    public override async Task GroupBy_aggregate_on_optional_owned_navigation(bool async)
+    {
+        await base.GroupBy_aggregate_on_optional_owned_navigation(async);
+
+        AssertSql(
+            """
+SELECT [b0].[Key], ISNULL(SUM([b0].[Throned_Value]), 0) AS [Sum], COUNT(CASE
+    WHEN [b0].[Throned_Value] > 40 THEN 1
+END) AS [Above]
+FROM (
+    SELECT CASE
+        WHEN [b].[Simple] IS NOT NULL THEN CAST(1 AS bit)
+        ELSE CAST(0 AS bit)
+    END AS [Key], [b].[Throned_Value]
+    FROM [Barton] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [b]
+) AS [b0]
+GROUP BY [b0].[Key]
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TemporalOwnedQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TemporalOwnedQuerySqlServerTest.cs
@@ -1575,6 +1575,47 @@ GROUP BY [s].[Key]
 """);
     }
 
+    public override async Task GroupBy_first_entity_ordered_by_owned_navigation(bool async)
+    {
+        await base.GroupBy_first_entity_ordered_by_owned_navigation(async);
+
+        AssertSql(
+            """
+SELECT [o7].[Id], [o7].[Discriminator], [o7].[Name], [o7].[PeriodEnd], [o7].[PeriodStart], [o5].[Key], [s].[ClientId], [s].[Id], [s].[OrderDate], [s].[PeriodEnd], [s].[PeriodStart], [s].[OrderClientId], [s].[OrderId], [s].[Id0], [s].[Detail], [s].[PeriodEnd0], [s].[PeriodStart0], [o7].[PersonAddress_AddressLine], [o7].[PeriodEnd0], [o7].[PeriodStart0], [o7].[PersonAddress_PlaceType], [o7].[PersonAddress_ZipCode], [o7].[PersonAddress_Country_Name], [o7].[PersonAddress_Country_PlanetId], [o7].[BranchAddress_BranchName], [o7].[BranchAddress_PlaceType], [o7].[BranchAddress_Country_Name], [o7].[BranchAddress_Country_PlanetId], [o7].[LeafBAddress_LeafBType], [o7].[LeafBAddress_PlaceType], [o7].[LeafBAddress_Country_Name], [o7].[LeafBAddress_Country_PlanetId], [o7].[LeafAAddress_LeafType], [o7].[LeafAAddress_PlaceType], [o7].[LeafAAddress_Country_Name], [o7].[LeafAAddress_Country_PlanetId]
+FROM (
+    SELECT [o0].[Key]
+    FROM (
+        SELECT CASE
+            WHEN [o].[PersonAddress_ZipCode] > 20000 THEN CAST(1 AS bit)
+            ELSE CAST(0 AS bit)
+        END AS [Key]
+        FROM [OwnedPerson] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [o]
+    ) AS [o0]
+    GROUP BY [o0].[Key]
+) AS [o5]
+LEFT JOIN (
+    SELECT [o6].[Id], [o6].[Discriminator], [o6].[Name], [o6].[PeriodEnd], [o6].[PeriodStart], [o6].[PersonAddress_AddressLine], [o6].[PeriodEnd0], [o6].[PeriodStart0], [o6].[PersonAddress_PlaceType], [o6].[PersonAddress_ZipCode], [o6].[PersonAddress_Country_Name], [o6].[PersonAddress_Country_PlanetId], [o6].[BranchAddress_BranchName], [o6].[BranchAddress_PlaceType], [o6].[BranchAddress_Country_Name], [o6].[BranchAddress_Country_PlanetId], [o6].[LeafBAddress_LeafBType], [o6].[LeafBAddress_PlaceType], [o6].[LeafBAddress_Country_Name], [o6].[LeafBAddress_Country_PlanetId], [o6].[LeafAAddress_LeafType], [o6].[LeafAAddress_PlaceType], [o6].[LeafAAddress_Country_Name], [o6].[LeafAAddress_Country_PlanetId], [o6].[Key]
+    FROM (
+        SELECT [o1].[Id], [o1].[Discriminator], [o1].[Name], [o1].[PeriodEnd], [o1].[PeriodStart], [o1].[PersonAddress_AddressLine], [o1].[PeriodEnd0], [o1].[PeriodStart0], [o1].[PersonAddress_PlaceType], [o1].[PersonAddress_ZipCode], [o1].[PersonAddress_Country_Name], [o1].[PersonAddress_Country_PlanetId], [o1].[BranchAddress_BranchName], [o1].[BranchAddress_PlaceType], [o1].[BranchAddress_Country_Name], [o1].[BranchAddress_Country_PlanetId], [o1].[LeafBAddress_LeafBType], [o1].[LeafBAddress_PlaceType], [o1].[LeafBAddress_Country_Name], [o1].[LeafBAddress_Country_PlanetId], [o1].[LeafAAddress_LeafType], [o1].[LeafAAddress_PlaceType], [o1].[LeafAAddress_Country_Name], [o1].[LeafAAddress_Country_PlanetId], [o1].[Key], ROW_NUMBER() OVER(PARTITION BY [o1].[Key] ORDER BY [o1].[PersonAddress_ZipCode] DESC) AS [row]
+        FROM (
+            SELECT [o2].[Id], [o2].[Discriminator], [o2].[Name], [o2].[PeriodEnd], [o2].[PeriodStart], [o2].[PersonAddress_AddressLine], [o2].[PeriodEnd] AS [PeriodEnd0], [o2].[PeriodStart] AS [PeriodStart0], [o2].[PersonAddress_PlaceType], [o2].[PersonAddress_ZipCode], CASE
+                WHEN [o2].[PersonAddress_ZipCode] > 20000 THEN CAST(1 AS bit)
+                ELSE CAST(0 AS bit)
+            END AS [Key], [o2].[PersonAddress_Country_Name], [o2].[PersonAddress_Country_PlanetId], [o2].[BranchAddress_BranchName], [o2].[BranchAddress_PlaceType], [o2].[BranchAddress_Country_Name], [o2].[BranchAddress_Country_PlanetId], [o2].[LeafBAddress_LeafBType], [o2].[LeafBAddress_PlaceType], [o2].[LeafBAddress_Country_Name], [o2].[LeafBAddress_Country_PlanetId], [o2].[LeafAAddress_LeafType], [o2].[LeafAAddress_PlaceType], [o2].[LeafAAddress_Country_Name], [o2].[LeafAAddress_Country_PlanetId]
+            FROM [OwnedPerson] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [o2]
+        ) AS [o1]
+    ) AS [o6]
+    WHERE [o6].[row] <= 1
+) AS [o7] ON [o5].[Key] = [o7].[Key]
+LEFT JOIN (
+    SELECT [o3].[ClientId], [o3].[Id], [o3].[OrderDate], [o3].[PeriodEnd], [o3].[PeriodStart], [o4].[OrderClientId], [o4].[OrderId], [o4].[Id] AS [Id0], [o4].[Detail], [o4].[PeriodEnd] AS [PeriodEnd0], [o4].[PeriodStart] AS [PeriodStart0]
+    FROM [Order] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [o3]
+    LEFT JOIN [OrderDetail] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [o4] ON [o3].[ClientId] = [o4].[OrderClientId] AND [o3].[Id] = [o4].[OrderId]
+) AS [s] ON [o7].[Id] = [s].[ClientId]
+ORDER BY [o5].[Key], [s].[ClientId], [s].[Id], [s].[OrderClientId], [s].[OrderId], [s].[Id0]
+""");
+    }
+
     public override async Task GroupBy_aggregate_on_owned_navigation_in_having(bool async)
     {
         await base.GroupBy_aggregate_on_owned_navigation_in_having(async);


### PR DESCRIPTION
Fixes #36990
Fixes #37778
Fixes #29593
Fixes #31062

## Summary

`GroupBy(k).Select(g => g.Sum(e => e.OwnedReference.Property))` never binds the owned navigation. `RelationalSqlTranslatingExpressionVisitor.RemapLambda` rebases the aggregate lambda onto the grouping element, but owned navigations are expanded by the queryable translator when it remaps a lambda onto a query source, and it never sees this one. #29201 made the resulting failure non-fatal for aggregate selectors, which fall back to one correlated scalar subquery per aggregate. `Count` with a predicate and orderings over the grouping go through `ProcessPredicate` and `ProcessOrderByThenBy`, which still throw.

```csharp
ctx.Invoices.GroupBy(i => i.CreatedAt.Date)
    .Select(g => new { g.Key, Amount = g.Sum(i => i.Summary.TotalAmount),
                               Discount = g.Sum(i => i.Summary.TotalDiscount) })
```

before, one correlated subquery per aggregate:

```sql
SELECT [i0].[Key], (
    SELECT COALESCE(SUM(CAST(JSON_VALUE([i1].[c], '$.TotalAmount') AS bigint)), CAST(0 AS bigint))
    FROM (SELECT [i2].[Summary] AS [c], CONVERT(date, [i2].[CreatedAt]) AS [Key] FROM [Invoices] AS [i2]) AS [i1]
    WHERE [i0].[Key] = [i1].[Key] OR ([i0].[Key] IS NULL AND [i1].[Key] IS NULL)) AS [Amount], (
    SELECT COALESCE(SUM(CAST(JSON_VALUE([i3].[c], '$.TotalDiscount') AS bigint)), CAST(0 AS bigint))
    FROM (SELECT [i4].[Summary] AS [c], CONVERT(date, [i4].[CreatedAt]) AS [Key] FROM [Invoices] AS [i4]) AS [i3]
    WHERE [i0].[Key] = [i3].[Key] OR ([i0].[Key] IS NULL AND [i3].[Key] IS NULL)) AS [Discount]
FROM (SELECT CONVERT(date, [i].[CreatedAt]) AS [Key] FROM [Invoices] AS [i]) AS [i0]
GROUP BY [i0].[Key]
```

after:

```sql
SELECT [i0].[Key],
    COALESCE(SUM(CAST(JSON_VALUE([i0].[c], '$.TotalAmount') AS bigint)), CAST(0 AS bigint)) AS [Amount],
    COALESCE(SUM(CAST(JSON_VALUE([i0].[c], '$.TotalDiscount') AS bigint)), CAST(0 AS bigint)) AS [Discount]
FROM (SELECT [i].[Summary] AS [c], CONVERT(date, [i].[CreatedAt]) AS [Key] FROM [Invoices] AS [i]) AS [i0]
GROUP BY [i0].[Key]
```

## Implementation

`RemapLambda` runs `SharedTypeEntityExpandingExpressionVisitor`, the expansion the queryable translator already uses, over the remapped body. It is the single funnel for `ProcessSelector`, `ProcessPredicate` and `ProcessOrderByThenBy`, so selectors, predicates, `Where` over the grouping and orderings are covered by one call.

Only the remapped body is expanded. The original expression tree is untouched, so when the aggregate does not translate the existing fallback still builds its subquery from a clean tree.

The `SelectExpression` the grouping element is projected out of is read off the element shaper, which is an entity shaper or a transparent identifier over several of them when navigation expansion added joins to the grouped source (#38668).

## #29593 and the removed lifting pass

When #29593 was triaged, the regression was traced to 21bbb3fc36 removing `GroupByAggregateLiftingExpressionVisitor`, and the proper fix was described as very hard. That assessment was about restoring lifting, which is what #38668 has now done for reference navigations in navigation expansion.

The owned case does not need lifting. An owned type mapped into the owner's table or into JSON has no join to lift; the aggregate already had every column it needed and the navigation simply failed to bind. That is why this is a small change and why it reaches #29593 without touching the lifting machinery.

## Deliberately not expanded

A dependent mapped to its own table is reached by an owner join that `GenerateOwnedReferenceEntityProjectionExpression` appends to `_tables` directly, together with the dependent's key added to `_identifier`. Once grouping has been applied `_identifier` is the grouping key, and that column then reaches the SELECT list unaggregated. The method takes an `allowOwnerJoin` flag and returns `null` instead, so those queries keep today's translation: a correlated subquery for aggregate selectors, and the same exception for `Count` with a predicate and for orderings. I checked this holds for the plain shape and in combination with a pushed-down group key, `Distinct`, `Take`, `AsSplitQuery`, `HAVING`, a collection projection, and an aggregate that starts to translate and then bails; all thirteen are byte-identical to `main`. `GroupBy_aggregate_on_owned_navigation_mapped_to_its_own_table` pins it and fails if the flag is removed.

Entity splitting is expanded. Its extra fragment is joined on the dependent's own key, adds no identifier, and the join is prunable, so it is safe to append after grouping.

Nothing outside an aggregate chain over a grouping is affected: the expansion only runs on lambdas that `RemapLambda` rebases onto a grouping element.

## Test plan

New spec tests, each failing on `main`: multiple aggregates over one owned navigation, `Count` with a predicate, `Where` over the grouping with an owned predicate, an ordering over the grouping by an owned property, `HAVING` over an owned aggregate, an aggregate over an owned collection, an aggregate over a navigation reached through an owned navigation, an optional owned dependent where one group holds a present and an absent dependent, and the JSON equivalent. Two non-shared-model tests cover the own-table boundary and entity splitting.

The existing `GroupBy_aggregate_on_owned_navigation_in_aggregate_selector` baseline loses its correlated subquery on SQL Server and on temporal SQL Server, where `FOR SYSTEM_TIME AS OF` is carried onto the grouped query. Those are the only pre-existing baselines this changes.

For #31062, the shape this now produces is the `ROW_NUMBER() OVER(PARTITION BY ...)` translation @ajcvickers recorded on that issue as the EF Core 6 output.

## Test results

SQL Server 2025: all 368 functional test classes, 52,040 test executions, 1 failure, `MemoryOptimizedTablesTest.Can_create_memoryOptimized_table`, which fails identically on unmodified `main` in my environment (no memory-optimized filegroup).

SQLite functional 38,247 passed. InMemory functional 28,270 passed. `EFCore.Tests` 6,985, `EFCore.Relational.Tests` 1,485, `EFCore.SqlServer.Tests` 1,395, `EFCore.Sqlite.Tests` 890, `EFCore.InMemory.Tests` 39, `EFCore.ApiBaseline.Tests` 14. All passed, no baseline change.

## Known gap, not addressed here

`TranslateGroupBy` expands the result selector of the `GroupBy(key, resultSelector)` overload against an already-grouped query with `allowOwnerJoin` left at its default. For an own-table dependent read off the grouping key that emits unaggregated columns today. It is unchanged by this PR, and suppressing the join there instead drops the projection, so it needs its own fix.

## One question

#38668 handled reference navigations by lifting into pre-GroupBy joins in navigation expansion; this does the owned case in the relational translator, after grouping is applied. If you would rather the two matched, say so and I will move it. The tests transfer unchanged, and that version would likely also pick up the own-table case this one declines.

---

- [x] I've read the guidelines for [contributing](https://github.com/dotnet/efcore/blob/main/.github/CONTRIBUTING.md) and seen the [walkthrough](https://youtu.be/9OMxy1wal1s?t=1869)
- [ ] I've posted a comment on an issue with a detailed description of how I am planning to contribute and got approval from a member of the team
- [x] The code builds and tests pass locally (also verified by our automated build checks)
- [x] Commit messages follow this format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Code follows the same patterns and style as existing code in this repo

Root cause and approach were posted on #36990 before opening this; no reply yet, so the approval box is left unchecked.
