### PR TITLE
Restrict SQL Server login failure retries to post-creation checks

### DIFF
--- a/src/EFCore.SqlServer/Storage/Internal/SqlServerDatabaseCreator.cs
+++ b/src/EFCore.SqlServer/Storage/Internal/SqlServerDatabaseCreator.cs
@@ -294,7 +294,7 @@ SELECT 1 ELSE SELECT 0");
         => exception.Number is 4060 or 1832 or 5120;
 
     // See Issue #985
-    private bool RetryOnExistsFailure(SqlException exception, bool retryOnNotExists)
+    private bool RetryOnExistsFailure(SqlException exception, bool retryOnLoginFailure)
     {
         // This is to handle the case where Open throws (Number 233):
         //   Microsoft.Data.SqlClient.SqlException: A connection was successfully established with the
@@ -314,11 +314,11 @@ SELECT 1 ELSE SELECT 0");
         //   Microsoft.Data.SqlClient.SqlException: Unable to Attach database file as database xxxxxxx.
         // And (Number 5120)
         //   Microsoft.Data.SqlClient.SqlException: Unable to open the physical file xxxxxxx.
-        // And (Number 18456)
+        // And (Number 18456) when checking whether the database exists after creation
         //   Microsoft.Data.SqlClient.SqlException: Login failed for user 'xxxxxxx'.
         if ((exception.Number is 203 && exception.InnerException is Win32Exception)
             || (exception.Number is 233 or -2 or 4060 or 1832 or 5120)
-            || (retryOnNotExists && exception.Number is 18456))
+            || (retryOnLoginFailure && exception.Number is 18456))
         {
             ClearPool();
             return true;

--- a/src/EFCore.SqlServer/Storage/Internal/SqlServerDatabaseCreator.cs
+++ b/src/EFCore.SqlServer/Storage/Internal/SqlServerDatabaseCreator.cs
@@ -205,7 +205,7 @@ SELECT 1 ELSE SELECT 0");
                         }
 
                         if (DateTime.UtcNow > giveUp
-                            || !RetryOnExistsFailure(e))
+                            || !RetryOnExistsFailure(e, retryOnNotExists))
                         {
                             throw;
                         }
@@ -270,7 +270,7 @@ SELECT 1 ELSE SELECT 0");
                         }
 
                         if (DateTime.UtcNow > giveUp
-                            || !RetryOnExistsFailure(e))
+                            || !RetryOnExistsFailure(e, retryOnNotExists))
                         {
                             throw;
                         }
@@ -294,7 +294,7 @@ SELECT 1 ELSE SELECT 0");
         => exception.Number is 4060 or 1832 or 5120;
 
     // See Issue #985
-    private bool RetryOnExistsFailure(SqlException exception)
+    private bool RetryOnExistsFailure(SqlException exception, bool retryOnNotExists)
     {
         // This is to handle the case where Open throws (Number 233):
         //   Microsoft.Data.SqlClient.SqlException: A connection was successfully established with the
@@ -317,7 +317,8 @@ SELECT 1 ELSE SELECT 0");
         // And (Number 18456)
         //   Microsoft.Data.SqlClient.SqlException: Login failed for user 'xxxxxxx'.
         if ((exception.Number is 203 && exception.InnerException is Win32Exception)
-            || (exception.Number is 233 or -2 or 4060 or 1832 or 5120 or 18456))
+            || (exception.Number is 233 or -2 or 4060 or 1832 or 5120)
+            || (retryOnNotExists && exception.Number is 18456))
         {
             ClearPool();
             return true;

--- a/test/EFCore.SqlServer.Tests/Storage/Internal/SqlServerDatabaseCreatorTest.cs
+++ b/test/EFCore.SqlServer.Tests/Storage/Internal/SqlServerDatabaseCreatorTest.cs
@@ -33,6 +33,10 @@ public class SqlServerDatabaseCreatorTest
         => Create_checks_for_existence_and_retries_until_it_passes(5120, async: false);
 
     [Fact]
+    public Task Create_checks_for_existence_and_retries_if_login_fails_until_it_passes()
+        => Create_checks_for_existence_and_retries_until_it_passes(18456, async: false);
+
+    [Fact]
     public Task CreateAsync_checks_for_existence_and_retries_if_no_proccess_until_it_passes()
         => Create_checks_for_existence_and_retries_until_it_passes(233, async: true);
 
@@ -51,6 +55,10 @@ public class SqlServerDatabaseCreatorTest
     [Fact]
     public Task CreateAsync_checks_for_existence_and_retries_if_cannot_open_file_until_it_passes()
         => Create_checks_for_existence_and_retries_until_it_passes(5120, async: true);
+
+    [Fact]
+    public Task CreateAsync_checks_for_existence_and_retries_if_login_fails_until_it_passes()
+        => Create_checks_for_existence_and_retries_until_it_passes(18456, async: true);
 
     private async Task Create_checks_for_existence_and_retries_until_it_passes(int errorNumber, bool async)
     {
@@ -119,6 +127,40 @@ public class SqlServerDatabaseCreatorTest
         {
             Assert.Throws<SqlException>(creator.Create);
         }
+    }
+
+    [Fact]
+    public Task Exists_does_not_retry_if_login_fails()
+        => Exists_does_not_retry_if_login_fails_test(async: false);
+
+    [Fact]
+    public Task ExistsAsync_does_not_retry_if_login_fails()
+        => Exists_does_not_retry_if_login_fails_test(async: true);
+
+    private async Task Exists_does_not_retry_if_login_fails_test(bool async)
+    {
+        var customServices = new ServiceCollection()
+            .AddScoped<ISqlServerConnection, FakeSqlServerConnection>()
+            .AddScoped<IRelationalCommandBuilderFactory, FakeRelationalCommandBuilderFactory>()
+            .AddScoped<IExecutionStrategyFactory, ExecutionStrategyFactory>();
+
+        var contextServices = SqlServerTestHelpers.Instance.CreateContextServices(customServices);
+        var connection = (FakeSqlServerConnection)contextServices.GetRequiredService<ISqlServerConnection>();
+        connection.ErrorNumber = 18456;
+        connection.FailureCount = 2;
+
+        var creator = (SqlServerDatabaseCreator)contextServices.GetRequiredService<IRelationalDatabaseCreator>();
+
+        if (async)
+        {
+            await Assert.ThrowsAsync<SqlException>(() => creator.ExistsAsync());
+        }
+        else
+        {
+            Assert.Throws<SqlException>(creator.Exists);
+        }
+
+        Assert.Equal(1, connection.OpenCount);
     }
 
     private class FakeSqlServerConnection(IDbContextOptions options, RelationalConnectionDependencies dependencies)

--- a/test/EFCore.SqlServer.Tests/Storage/Internal/SqlServerDatabaseCreatorTest.cs
+++ b/test/EFCore.SqlServer.Tests/Storage/Internal/SqlServerDatabaseCreatorTest.cs
@@ -157,7 +157,7 @@ public class SqlServerDatabaseCreatorTest
         }
         else
         {
-            Assert.Throws<SqlException>(creator.Exists);
+            Assert.Throws<SqlException>(() => creator.Exists());
         }
 
         Assert.Equal(1, connection.OpenCount);


### PR DESCRIPTION
Fixes #38886

SQL error 18456 is transient immediately after Azure SQL database creation,
but it should not be retried during ordinary CanConnectAsync() or migration
existence checks.

This change restricts 18456 retries to the post-creation existence check and
adds synchronous and asynchronous regression tests.
