### PR TITLE
Fix UUID suffix handling in scaffolded navigation names

### DIFF
--- a/src/EFCore.Design/Scaffolding/Internal/CandidateNamingService.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/CandidateNamingService.cs
@@ -128,7 +128,8 @@ public class CandidateNamingService : ICandidateNamingService
 
         var ignoredCharacterCount = 2;
         if (commonPrefix.Length > 4
-            && commonPrefix.EndsWith("guid", StringComparison.OrdinalIgnoreCase))
+            && (commonPrefix.EndsWith("guid", StringComparison.OrdinalIgnoreCase)
+                || commonPrefix.EndsWith("uuid", StringComparison.OrdinalIgnoreCase)))
         {
             ignoredCharacterCount = 4;
         }

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/CandidateNamingServiceTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/CandidateNamingServiceTest.cs
@@ -42,6 +42,31 @@ public class CandidateNamingServiceTest
         Assert.Equal("_Id", new CandidateNamingService().GetDependentEndCandidateNavigationPropertyName(foreignKey));
     }
 
+    [Theory]
+    [InlineData("FileUuid", "File")]
+    [InlineData("QuestionUuid", "Question")]
+    public void Dependent_end_navigation_name_strips_Uuid_suffix(
+        string foreignKeyName,
+        string expectedNavigationName)
+    {
+        var modelBuilder = FakeRelationalTestHelpers.Instance.CreateConventionBuilder();
+        modelBuilder.Entity<NamingPrincipal>();
+        modelBuilder.Entity<NamingDependent>(b =>
+        {
+            b.Property<Guid>(foreignKeyName);
+            b.HasOne<NamingPrincipal>().WithMany().HasForeignKey(foreignKeyName);
+        });
+
+        var foreignKey = modelBuilder.Model
+            .FindEntityType(typeof(NamingDependent))!
+            .GetForeignKeys()
+            .Single();
+
+        Assert.Equal(
+            expectedNavigationName,
+            new CandidateNamingService().GetDependentEndCandidateNavigationPropertyName(foreignKey));
+    }
+
     private class NamingPrincipal
     {
         public int Id { get; set; }


### PR DESCRIPTION
Fixes #38767

## Summary

- Handle `Uuid` suffixes when deriving scaffolded navigation property names.
- Add regression coverage for foreign key names such as `FileUuid` and `QuestionUuid`.

Before this change, `CandidateNamingService.StripId()` handled the `Guid` suffix specially, but `Uuid` was treated as a regular `Id` suffix, resulting in names such as `FileUu` and `QuestionUu`.

## Tests

- `CandidateNamingServiceTest`: 14/14 passed.
- The full `EFCore.Design.Tests` run has one unrelated failure in `TextTemplatingModelGeneratorTest.GenerateModel_reports_compiler_errors` on my Windows environment.
- The unrelated failure also reproduces when run in isolation.

<!--
Please check whether the PR fulfills these requirements
-->

- [x] I've read the guidelines for [contributing](https://github.com/dotnet/efcore/blob/main/.github/CONTRIBUTING.md) and seen the [walkthrough](https://youtu.be/9OMxy1wal1s?t=1869)
- [ ] I've posted a comment on an issue with a detailed description of how I am planning to contribute and got approval from a member of the team
- [ ] The code builds and tests pass locally (also verified by our automated build checks)
- [x] Commit messages follow this format:

    Summary of the changes
    - Detail 1
    - Detail 2

    Fixes #bugnumber

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Code follows the same patterns and style as existing code in this repo