### PR TITLE
Fix typos in build documentation

### DIFF
--- a/docs/DailyBuilds.md
+++ b/docs/DailyBuilds.md
@@ -44,7 +44,7 @@ For EF 11 daily builds, `NuGet.config` should contain:
 
 ### The EF command-line tool
 
-`dotnet ef` is the [the EF command-line tool](https://learn.microsoft.com/ef/core/cli/dotnet), used to perform various design-time tasks such as creating and applying migrations. Stable versions of `dotnet ef` usually work fine with daily build versions of EF; but in some situations you must also update to daily builds of the CLI tool. To use a daily build version of `dotnet ef`, do the following:
+`dotnet ef` is the [EF command-line tool](https://learn.microsoft.com/ef/core/cli/dotnet), used to perform various design-time tasks such as creating and applying migrations. Stable versions of `dotnet ef` usually work fine with daily build versions of EF; but in some situations you must also update to daily builds of the CLI tool. To use a daily build version of `dotnet ef`, do the following:
 
 ```sh
 dotnet tool install -g dotnet-ef --version 11.0.0-* --add-source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet11/nuget/v3/index.json

--- a/docs/getting-and-building-the-code.md
+++ b/docs/getting-and-building-the-code.md
@@ -13,7 +13,7 @@ EF Core does not generally need any prerequisites installed to build the code. H
   * The Cosmos tests are optional and will be skipped if the emulator is not available. If you are not making Cosmos changes, then you may choose to skip installing the emulator and let the continuous integration system handle Cosmos testing.
   * Tip: Turn off "Rate Limiting" in the emulator to make the Cosmos tests run faster.<br>
     ![Switch off Cosmos Rate Limiting](rate_limiting.png)
-* While not strictly necessary, since EF will download an SDK locally if needed, it is recommended to always have tha [latest public preview of the .NET SDK](https://dotnet.microsoft.com/download) installed.
+* While not strictly necessary, since EF will download an SDK locally if needed, it is recommended to always have the [latest public preview of the .NET SDK](https://dotnet.microsoft.com/download) installed.
 
 ## Fork the repository
 


### PR DESCRIPTION
Two small typo fixes in the build documentation:

- `docs/getting-and-building-the-code.md`: `tha` → `the`
- `docs/DailyBuilds.md`: remove duplicate `the` before "EF command-line tool"

Per [CONTRIBUTING.md](.github/CONTRIBUTING.md#fixing-typos), no issue is required for simple non-code changes like fixing typos in documentation. No behavior change.