### PR TITLE
Translate Any/All over a grouping element as an aggregate

### DIFF
--- a/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
@@ -1526,7 +1526,8 @@ public partial class RelationalSqlTranslatingExpressionVisitor : ExpressionVisit
     /// <summary>
     ///     Translates <see cref="Queryable.Any{TSource}(IQueryable{TSource})" />,
     ///     <see cref="Queryable.Any{TSource}(IQueryable{TSource}, Expression{Func{TSource, bool}})" /> and
-    ///     <see cref="Queryable.All{TSource}" /> over a grouping element into an aggregate over the enclosing GROUP BY.
+    ///     <see cref="Queryable.All{TSource}(IQueryable{TSource}, Expression{Func{TSource, bool}})" /> over a grouping element
+    ///     into an aggregate over the enclosing GROUP BY.
     ///     The fallback translation is a correlated EXISTS, which cannot share the outer query's FROM and so re-derives the
     ///     whole grouping source once per group.
     /// </summary>
@@ -1587,6 +1588,13 @@ public partial class RelationalSqlTranslatingExpressionVisitor : ExpressionVisit
 
         bool TryTranslateCount(EnumerableExpression source, [NotNullWhen(true)] out SqlExpression? count)
         {
+            // COUNT ignores NULL values, so counting the grouping element itself would drop every row whose element is NULL -
+            // including, for Any, the very rows a predicate such as "x == null" matched. Count the star fragment instead: the
+            // aggregate translator renders that as COUNT(*), or as COUNT(CASE WHEN <predicate> THEN 1 END) once a predicate is
+            // applied, so rows are counted rather than values. An element selector that isn't a scalar already counts that way;
+            // this makes a scalar one (from a Select over the grouping element) behave the same.
+            source = source.ApplySelector(_sqlExpressionFactory.Fragment("*"));
+
             count = TranslateAggregateMethod(
                 source,
                 QueryableMethods.CountWithoutPredicate.MakeGenericMethod(source.Selector.Type),

--- a/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
@@ -1485,6 +1485,25 @@ public partial class RelationalSqlTranslatingExpressionVisitor : ExpressionVisit
 
                         break;
 
+                    // Any/All over a grouping element are quantifiers rather than aggregates, but over a GROUP BY they can be
+                    // computed as one, which avoids a correlated EXISTS that re-derives the whole grouping source.
+                    case nameof(Queryable.Any)
+                        when genericMethod == QueryableMethods.AnyWithoutPredicate
+                        || genericMethod == QueryableMethods.AnyWithPredicate:
+                    case nameof(Queryable.All)
+                        when genericMethod == QueryableMethods.All:
+                        if (TryTranslateQuantifierOverGrouping(
+                                genericMethod,
+                                enumerableExpression,
+                                arguments.Count > 1 ? arguments[1].UnwrapLambdaFromQuote() : null,
+                                out translation))
+                        {
+                            return true;
+                        }
+
+                        abortTranslation = true;
+                        break;
+
                     default:
                         abortTranslation = true;
                         break;
@@ -1502,6 +1521,79 @@ public partial class RelationalSqlTranslatingExpressionVisitor : ExpressionVisit
 
         translation = null;
         return false;
+    }
+
+    /// <summary>
+    ///     Translates <see cref="Queryable.Any{TSource}(IQueryable{TSource})" />,
+    ///     <see cref="Queryable.Any{TSource}(IQueryable{TSource}, Expression{Func{TSource, bool}})" /> and
+    ///     <see cref="Queryable.All{TSource}" /> over a grouping element into an aggregate over the enclosing GROUP BY.
+    ///     The fallback translation is a correlated EXISTS, which cannot share the outer query's FROM and so re-derives the
+    ///     whole grouping source once per group.
+    /// </summary>
+    private bool TryTranslateQuantifierOverGrouping(
+        MethodInfo genericMethod,
+        EnumerableExpression enumerableExpression,
+        LambdaExpression? predicateLambda,
+        [NotNullWhen(true)] out SqlExpression? translation)
+    {
+        translation = null;
+
+        // DISTINCT cannot change whether any/all rows satisfy a predicate.
+        enumerableExpression = enumerableExpression.SetDistinct(false);
+
+        var isAll = genericMethod == QueryableMethods.All;
+
+        if (predicateLambda == null && enumerableExpression.Predicate == null)
+        {
+            // Any() over an unfiltered grouping element: GROUP BY never produces an empty group.
+            translation = _sqlExpressionFactory.Constant(true);
+            return true;
+        }
+
+        // COUNT over the group as it stands, before the quantifier's own predicate narrows it. Only All needs this.
+        SqlExpression? total = null;
+        if (isAll && !TryTranslateCount(enumerableExpression, out total))
+        {
+            return false;
+        }
+
+        if (predicateLambda != null)
+        {
+            if (TranslateInternal(RemapLambda(enumerableExpression, predicateLambda)) is not SqlExpression predicate)
+            {
+                return false;
+            }
+
+            enumerableExpression = enumerableExpression.ApplyPredicate(predicate);
+        }
+
+        if (!TryTranslateCount(enumerableExpression, out var matched))
+        {
+            return false;
+        }
+
+        // Any(p) is "at least one row matched". All(p) is "every row matched", expressed by comparing the match count against
+        // the size of the group rather than by negating the predicate: NOT p is NULL wherever p is, and inside the CASE that
+        // COUNT filters on, NULL reads as false - the row would go uncounted and All would wrongly come out true. Counting
+        // matches sidesteps that, since a row whose predicate is NULL simply fails to match.
+        //
+        // COUNT is also non-nullable, so no null guard is wrapped around either comparison, and both stay correct when the
+        // grouping element was already filtered down to no rows: Any is false, All is true.
+        translation = isAll
+            ? _sqlExpressionFactory.Equal(matched, total!)
+            : _sqlExpressionFactory.GreaterThan(matched, _sqlExpressionFactory.Constant(0));
+
+        return true;
+
+        bool TryTranslateCount(EnumerableExpression source, [NotNullWhen(true)] out SqlExpression? count)
+        {
+            count = TranslateAggregateMethod(
+                source,
+                QueryableMethods.CountWithoutPredicate.MakeGenericMethod(source.Selector.Type),
+                []) as SqlExpression;
+
+            return count != null;
+        }
     }
 
     /// <summary>

--- a/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
@@ -1551,12 +1551,9 @@ public partial class RelationalSqlTranslatingExpressionVisitor : ExpressionVisit
             return true;
         }
 
-        // COUNT over the group as it stands, before the quantifier's own predicate narrows it. Only All needs this.
-        SqlExpression? total = null;
-        if (isAll && !TryTranslateCount(enumerableExpression, out total))
-        {
-            return false;
-        }
+        // What each row contributes to the count. Any counts every row its predicates leave, so any non-null marker will do;
+        // All counts only the rows that fail its predicate, which the marker itself has to decide.
+        var marker = _sqlExpressionFactory.Fragment("*");
 
         if (predicateLambda != null)
         {
@@ -1565,38 +1562,50 @@ public partial class RelationalSqlTranslatingExpressionVisitor : ExpressionVisit
                 return false;
             }
 
-            enumerableExpression = enumerableExpression.ApplyPredicate(predicate);
+            if (isAll)
+            {
+                // All(p) is "no row fails p". A row fails where p is false or NULL, so the marker is NULL exactly where p
+                // holds and the count skips it - NOT p would not do, being NULL wherever p is, which the CASE would read as
+                // false and leave the row uncounted, making All wrongly come out true.
+                //
+                // Deciding it in the marker rather than by counting matches against the size of the group keeps both the
+                // grouping element's own filter and p in the SQL once each. Emitted twice, a volatile filter such as
+                // Where(o => EF.Functions.Random() > 0.5) is sampled independently per occurrence, and the counts stop
+                // describing the same rows.
+                marker = _sqlExpressionFactory.Case(
+                    [new CaseWhenClause(predicate, _sqlExpressionFactory.Constant(null, typeof(int)))],
+                    elseResult: _sqlExpressionFactory.Constant(1));
+            }
+            else
+            {
+                enumerableExpression = enumerableExpression.ApplyPredicate(predicate);
+            }
         }
 
-        if (!TryTranslateCount(enumerableExpression, out var matched))
+        if (!TryTranslateCount(enumerableExpression, marker, out var count))
         {
             return false;
         }
 
-        // Any(p) is "at least one row matched". All(p) is "every row matched", expressed by comparing the match count against
-        // the size of the group rather than by negating the predicate: NOT p is NULL wherever p is, and inside the CASE the
-        // count filters on, NULL reads as false - the row would go uncounted and All would wrongly come out true. Counting
-        // matches sidesteps that, since a row whose predicate is NULL simply fails to match.
-        //
-        // A count is also non-nullable, so no null guard is wrapped around either comparison, and both stay correct when the
-        // grouping element was already filtered down to no rows: Any is false, All is true.
+        // Any(p) is "at least one row matched"; All(p) is "no row failed". A count is non-nullable, so no null guard is
+        // wrapped around either comparison, and both stay correct when the grouping element was already filtered down to no
+        // rows: Any is false, All is true.
         translation = isAll
-            ? _sqlExpressionFactory.Equal(matched, total!)
-            : _sqlExpressionFactory.GreaterThan(matched, _sqlExpressionFactory.Constant(0));
+            ? _sqlExpressionFactory.Equal(count, _sqlExpressionFactory.Constant(0))
+            : _sqlExpressionFactory.GreaterThan(count, _sqlExpressionFactory.Constant(0));
 
         return true;
 
-        bool TryTranslateCount(EnumerableExpression source, [NotNullWhen(true)] out SqlExpression? count)
+        bool TryTranslateCount(EnumerableExpression source, SqlExpression selector, [NotNullWhen(true)] out SqlExpression? count)
         {
-            // A count ignores NULL values, so counting the grouping element itself would drop every row whose element is NULL
-            // - including, for Any, the very rows a predicate such as "x == null" matched. Count the star fragment instead:
-            // the aggregate translator renders that as a bare count over the group, or over CASE WHEN <predicate> THEN 1 END
-            // once a predicate is applied, so rows are counted rather than values. An element selector that isn't a scalar
-            // already counts that way; this makes a scalar one (from a Select over the grouping element) behave the same.
+            // Count the caller's marker rather than the grouping element: a count ignores NULL values, so counting the
+            // element would drop every row whose element is NULL - including, for Any, the very rows a predicate such as
+            // "x == null" matched. An element selector that isn't a scalar already counts rows rather than values; this
+            // makes a scalar one (from a Select over the grouping element) behave the same.
             //
             // LongCount rather than Count: the quantifier returns bool, so nothing in the query asks for a 32-bit counter,
             // and the EXISTS translation this replaces has no cardinality limit of its own.
-            source = source.ApplySelector(_sqlExpressionFactory.Fragment("*"));
+            source = source.ApplySelector(selector);
 
             count = TranslateAggregateMethod(
                 source,

--- a/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs
@@ -1574,11 +1574,11 @@ public partial class RelationalSqlTranslatingExpressionVisitor : ExpressionVisit
         }
 
         // Any(p) is "at least one row matched". All(p) is "every row matched", expressed by comparing the match count against
-        // the size of the group rather than by negating the predicate: NOT p is NULL wherever p is, and inside the CASE that
-        // COUNT filters on, NULL reads as false - the row would go uncounted and All would wrongly come out true. Counting
+        // the size of the group rather than by negating the predicate: NOT p is NULL wherever p is, and inside the CASE the
+        // count filters on, NULL reads as false - the row would go uncounted and All would wrongly come out true. Counting
         // matches sidesteps that, since a row whose predicate is NULL simply fails to match.
         //
-        // COUNT is also non-nullable, so no null guard is wrapped around either comparison, and both stay correct when the
+        // A count is also non-nullable, so no null guard is wrapped around either comparison, and both stay correct when the
         // grouping element was already filtered down to no rows: Any is false, All is true.
         translation = isAll
             ? _sqlExpressionFactory.Equal(matched, total!)
@@ -1588,16 +1588,19 @@ public partial class RelationalSqlTranslatingExpressionVisitor : ExpressionVisit
 
         bool TryTranslateCount(EnumerableExpression source, [NotNullWhen(true)] out SqlExpression? count)
         {
-            // COUNT ignores NULL values, so counting the grouping element itself would drop every row whose element is NULL -
-            // including, for Any, the very rows a predicate such as "x == null" matched. Count the star fragment instead: the
-            // aggregate translator renders that as COUNT(*), or as COUNT(CASE WHEN <predicate> THEN 1 END) once a predicate is
-            // applied, so rows are counted rather than values. An element selector that isn't a scalar already counts that way;
-            // this makes a scalar one (from a Select over the grouping element) behave the same.
+            // A count ignores NULL values, so counting the grouping element itself would drop every row whose element is NULL
+            // - including, for Any, the very rows a predicate such as "x == null" matched. Count the star fragment instead:
+            // the aggregate translator renders that as a bare count over the group, or over CASE WHEN <predicate> THEN 1 END
+            // once a predicate is applied, so rows are counted rather than values. An element selector that isn't a scalar
+            // already counts that way; this makes a scalar one (from a Select over the grouping element) behave the same.
+            //
+            // LongCount rather than Count: the quantifier returns bool, so nothing in the query asks for a 32-bit counter,
+            // and the EXISTS translation this replaces has no cardinality limit of its own.
             source = source.ApplySelector(_sqlExpressionFactory.Fragment("*"));
 
             count = TranslateAggregateMethod(
                 source,
-                QueryableMethods.CountWithoutPredicate.MakeGenericMethod(source.Selector.Type),
+                QueryableMethods.LongCountWithoutPredicate.MakeGenericMethod(source.Selector.Type),
                 []) as SqlExpression;
 
             return count != null;

--- a/test/EFCore.Relational.Specification.Tests/Query/NullSemanticsQueryTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/NullSemanticsQueryTestBase.cs
@@ -2225,6 +2225,23 @@ public abstract class NullSemanticsQueryTestBase<TFixture>(TFixture fixture) : Q
             ss => ss.Set<NullSemanticsEntity1>().GroupBy(e => e.NullableIntA)
                 .Select(g => new { g.Key, Sum = g.Sum(x => x.IntA) != g.Key }));
 
+    // Enumerable.Any and All read a predicate that evaluates to NULL as "does not satisfy": such a row is not a match for
+    // Any, and is a failure for All. NullableIntA is 0, 1 or NULL, so "greater than or equal to 0" can only fail on a NULL,
+    // and grouping by it gives a group whose rows are all NULL - neither of which the Northwind columns the GroupBy
+    // quantifier tests group over can offer, since none of those hold NULLs.
+    [Theory, MemberData(nameof(IsAsyncData))]
+    public virtual Task Quantifier_over_group_treats_null_predicate_as_not_satisfied(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<NullSemanticsEntity1>().GroupBy(e => e.NullableIntA)
+                .Select(g => new
+                {
+                    g.Key,
+                    All = g.All(e => e.NullableIntA >= 0),
+                    Any = g.Any(e => e.NullableIntA >= 0)
+                }),
+            elementSorter: e => e.Key);
+
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Nullability_is_computed_correctly_for_chained_coalesce(bool async)
         => AssertQuery(

--- a/test/EFCore.Specification.Tests/Query/NorthwindGroupByQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindGroupByQueryTestBase.cs
@@ -470,6 +470,24 @@ public abstract class NorthwindGroupByQueryTestBase<TFixture>(TFixture fixture) 
                 .Select(g => new { g.Key, AllSenior = g.All(o => o.EmployeeID > 5) }),
             elementSorter: e => e.Key);
 
+    // A Select over the grouping element keeps a scalar element selector on the aggregate, which COUNT would treat as a
+    // value to count rather than a row - dropping the NULL elements this predicate matches. GroupingAggregateScanner only
+    // lifts aggregates whose source is the grouping parameter itself, so the shape falls back to EXISTS and keeps
+    // Enumerable's semantics. Asserted here so that widening the whitelist has to revisit the counts.
+    [Theory, MemberData(nameof(IsAsyncData))]
+    public virtual Task GroupBy_Select_Distinct_Any_with_nullable_element(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<Order>()
+                .GroupBy(o => o.CustomerID)
+                .Select(g => new
+                {
+                    g.Key,
+                    Employees = g.Select(o => o.EmployeeID).Distinct().Count(),
+                    AnyUnassigned = g.Select(o => o.EmployeeID).Distinct().Any(id => id == null)
+                }),
+            elementSorter: e => e.Key);
+
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task GroupBy_Any_with_predicate_through_navigation_property(bool async)
         => AssertQuery(

--- a/test/EFCore.Specification.Tests/Query/NorthwindGroupByQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindGroupByQueryTestBase.cs
@@ -452,6 +452,10 @@ public abstract class NorthwindGroupByQueryTestBase<TFixture>(TFixture fixture) 
 
     // EmployeeID is nullable, so the predicate is NULL rather than false on a row with no employee. Enumerable.Any/All
     // treat that as "does not satisfy"; the SQL must too, so such a row has to be left out of the match count.
+    //
+    // No Northwind order actually has a NULL EmployeeID, so these two only pin the SQL shape. The behaviour itself is
+    // covered by NullSemanticsQueryTestBase.Quantifier_over_group_treats_null_predicate_as_not_satisfied, whose model
+    // does hold NULLs.
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task GroupBy_Any_with_nullable_predicate(bool async)
         => AssertQuery(

--- a/test/EFCore.Specification.Tests/Query/NorthwindGroupByQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindGroupByQueryTestBase.cs
@@ -387,6 +387,90 @@ public abstract class NorthwindGroupByQueryTestBase<TFixture>(TFixture fixture) 
             elementSorter: e => e.Key);
 
     [Theory, MemberData(nameof(IsAsyncData))]
+    public virtual Task GroupBy_Any_with_predicate(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<Order>()
+                .GroupBy(o => o.CustomerID)
+                .Select(g => new { g.Key, AnyBig = g.Any(o => o.OrderID > 10500) }),
+            elementSorter: e => e.Key);
+
+    [Theory, MemberData(nameof(IsAsyncData))]
+    public virtual Task GroupBy_All_with_predicate(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<Order>()
+                .GroupBy(o => o.CustomerID)
+                .Select(g => new { g.Key, AllBig = g.All(o => o.OrderID > 10500) }),
+            elementSorter: e => e.Key);
+
+    [Theory, MemberData(nameof(IsAsyncData))]
+    public virtual Task GroupBy_Any_without_predicate(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<Order>()
+                .GroupBy(o => o.CustomerID)
+                .Select(g => new { g.Key, HasAny = g.Any() }),
+            elementSorter: e => e.Key);
+
+    // The shape reported in #27953: a quantifier guarding an aggregate expression that would otherwise divide by zero.
+    [Theory, MemberData(nameof(IsAsyncData))]
+    public virtual Task GroupBy_Any_guarding_aggregate_expression(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<Order>()
+                .GroupBy(o => o.CustomerID)
+                .Select(g => new { g.Key, Average = !g.Any() ? 0 : g.Sum(o => o.OrderID) / g.Count() }),
+            elementSorter: e => e.Key);
+
+    [Theory, MemberData(nameof(IsAsyncData))]
+    public virtual Task GroupBy_Any_with_predicate_and_other_aggregate(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<Order>()
+                .GroupBy(o => o.CustomerID)
+                .Select(g => new
+                {
+                    g.Key,
+                    Total = g.Sum(o => o.OrderID),
+                    AnyBig = g.Any(o => o.OrderID > 10500)
+                }),
+            elementSorter: e => e.Key);
+
+    [Theory, MemberData(nameof(IsAsyncData))]
+    public virtual Task GroupBy_Any_with_predicate_guarding_nullable_Sum(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<Order>()
+                .GroupBy(o => o.CustomerID)
+                .Select(g => new
+                {
+                    g.Key,
+                    Employees = g.Any(o => o.EmployeeID != null) ? g.Sum(o => (int?)o.EmployeeID) : null
+                }),
+            elementSorter: e => e.Key);
+
+    // EmployeeID is nullable, so the predicate is NULL rather than false on a row with no employee. Enumerable.Any/All
+    // treat that as "does not satisfy"; the SQL must too, so such a row has to be left out of the match count.
+    [Theory, MemberData(nameof(IsAsyncData))]
+    public virtual Task GroupBy_Any_with_nullable_predicate(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<Order>()
+                .GroupBy(o => o.CustomerID)
+                .Select(g => new { g.Key, AnySenior = g.Any(o => o.EmployeeID > 5) }),
+            elementSorter: e => e.Key);
+
+    [Theory, MemberData(nameof(IsAsyncData))]
+    public virtual Task GroupBy_All_with_nullable_predicate(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<Order>()
+                .GroupBy(o => o.CustomerID)
+                .Select(g => new { g.Key, AllSenior = g.All(o => o.EmployeeID > 5) }),
+            elementSorter: e => e.Key);
+
+    [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task GroupBy_Any_with_predicate_through_navigation_property(bool async)
         => AssertQuery(
             async,

--- a/test/EFCore.Specification.Tests/Query/NorthwindGroupByQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindGroupByQueryTestBase.cs
@@ -488,6 +488,33 @@ public abstract class NorthwindGroupByQueryTestBase<TFixture>(TFixture fixture) 
                 }),
             elementSorter: e => e.Key);
 
+    // A grouping element filtered by Where rather than by the quantifier's own predicate: the aggregate reads the filter
+    // already on the element, so Any needs no predicate of its own to count against.
+    [Theory, MemberData(nameof(IsAsyncData))]
+    public virtual Task GroupBy_Where_Any_over_grouping_element(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<Order>()
+                .GroupBy(o => o.CustomerID)
+                .Select(g => new { g.Key, AnyBig = g.Where(o => o.OrderID > 10500).Any() }),
+            elementSorter: e => e.Key);
+
+    // The same, with a filter that leaves no rows in any group. Both counts come out 0, which has to read as Any false and
+    // All true - the Enumerable semantics for an empty sequence.
+    [Theory, MemberData(nameof(IsAsyncData))]
+    public virtual Task GroupBy_Where_quantifiers_over_empty_filtered_grouping_element(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<Order>()
+                .GroupBy(o => o.CustomerID)
+                .Select(g => new
+                {
+                    g.Key,
+                    Any = g.Where(o => o.OrderID > 999999).Any(),
+                    All = g.Where(o => o.OrderID > 999999).All(o => o.OrderID > 0)
+                }),
+            elementSorter: e => e.Key);
+
     [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task GroupBy_Any_with_predicate_through_navigation_property(bool async)
         => AssertQuery(

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindGroupByQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindGroupByQuerySqlServerTest.cs
@@ -2429,9 +2429,9 @@ GROUP BY [o].[EmployeeID]
         AssertSql(
             """
 SELECT [o].[CustomerID] AS [Key], CASE
-    WHEN COUNT(CASE
+    WHEN COUNT_BIG(CASE
         WHEN [o].[OrderID] > 10500 THEN 1
-    END) > 0 THEN CAST(1 AS bit)
+    END) > CAST(0 AS bigint) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END AS [AnyBig]
 FROM [Orders] AS [o]
@@ -2445,9 +2445,9 @@ GROUP BY [o].[CustomerID]
 
         AssertSql(
             """
-SELECT [o].[CustomerID] AS [Key], ~CAST(COUNT(CASE
+SELECT [o].[CustomerID] AS [Key], ~CAST(COUNT_BIG(CASE
     WHEN [o].[OrderID] > 10500 THEN 1
-END) ^ COUNT(*) AS bit) AS [AllBig]
+END) ^ COUNT_BIG(*) AS bit) AS [AllBig]
 FROM [Orders] AS [o]
 GROUP BY [o].[CustomerID]
 """);
@@ -2484,9 +2484,9 @@ GROUP BY [o].[CustomerID]
         AssertSql(
             """
 SELECT [o].[CustomerID] AS [Key], ISNULL(SUM([o].[OrderID]), 0) AS [Total], CASE
-    WHEN COUNT(CASE
+    WHEN COUNT_BIG(CASE
         WHEN [o].[OrderID] > 10500 THEN 1
-    END) > 0 THEN CAST(1 AS bit)
+    END) > CAST(0 AS bigint) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END AS [AnyBig]
 FROM [Orders] AS [o]
@@ -2501,9 +2501,9 @@ GROUP BY [o].[CustomerID]
         AssertSql(
             """
 SELECT [o].[CustomerID] AS [Key], CASE
-    WHEN COUNT(CASE
+    WHEN COUNT_BIG(CASE
         WHEN [o].[EmployeeID] IS NOT NULL THEN 1
-    END) > 0 THEN ISNULL(SUM([o].[EmployeeID]), 0)
+    END) > CAST(0 AS bigint) THEN ISNULL(SUM([o].[EmployeeID]), 0)
 END AS [Employees]
 FROM [Orders] AS [o]
 GROUP BY [o].[CustomerID]
@@ -2517,9 +2517,9 @@ GROUP BY [o].[CustomerID]
         AssertSql(
             """
 SELECT [o].[CustomerID] AS [Key], CASE
-    WHEN COUNT(CASE
+    WHEN COUNT_BIG(CASE
         WHEN [o].[EmployeeID] > 5 THEN 1
-    END) > 0 THEN CAST(1 AS bit)
+    END) > CAST(0 AS bigint) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END AS [AnySenior]
 FROM [Orders] AS [o]
@@ -2533,9 +2533,9 @@ GROUP BY [o].[CustomerID]
 
         AssertSql(
             """
-SELECT [o].[CustomerID] AS [Key], ~CAST(COUNT(CASE
+SELECT [o].[CustomerID] AS [Key], ~CAST(COUNT_BIG(CASE
     WHEN [o].[EmployeeID] > 5 THEN 1
-END) ^ COUNT(*) AS bit) AS [AllSenior]
+END) ^ COUNT_BIG(*) AS bit) AS [AllSenior]
 FROM [Orders] AS [o]
 GROUP BY [o].[CustomerID]
 """);
@@ -2566,9 +2566,9 @@ GROUP BY [o].[CustomerID]
         AssertSql(
             """
 SELECT [o].[CustomerID] AS [Key], CASE
-    WHEN COUNT(CASE
+    WHEN COUNT_BIG(CASE
         WHEN [o].[OrderID] > 10500 THEN 1
-    END) > 0 THEN CAST(1 AS bit)
+    END) > CAST(0 AS bigint) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END AS [AnyBig]
 FROM [Orders] AS [o]
@@ -2583,13 +2583,13 @@ GROUP BY [o].[CustomerID]
         AssertSql(
             """
 SELECT [o].[CustomerID] AS [Key], CASE
-    WHEN COUNT(CASE
+    WHEN COUNT_BIG(CASE
         WHEN [o].[OrderID] > 999999 THEN 1
-    END) > 0 THEN CAST(1 AS bit)
+    END) > CAST(0 AS bigint) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
-END AS [Any], ~CAST(COUNT(CASE
+END AS [Any], ~CAST(COUNT_BIG(CASE
     WHEN [o].[OrderID] > 999999 AND [o].[OrderID] > 0 THEN 1
-END) ^ COUNT(CASE
+END) ^ COUNT_BIG(CASE
     WHEN [o].[OrderID] > 999999 THEN 1
 END) AS bit) AS [All]
 FROM [Orders] AS [o]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindGroupByQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindGroupByQuerySqlServerTest.cs
@@ -2422,6 +2422,125 @@ GROUP BY [o].[EmployeeID]
 """);
     }
 
+    public override async Task GroupBy_Any_with_predicate(bool async)
+    {
+        await base.GroupBy_Any_with_predicate(async);
+
+        AssertSql(
+            """
+SELECT [o].[CustomerID] AS [Key], CASE
+    WHEN COUNT(CASE
+        WHEN [o].[OrderID] > 10500 THEN 1
+    END) > 0 THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END AS [AnyBig]
+FROM [Orders] AS [o]
+GROUP BY [o].[CustomerID]
+""");
+    }
+
+    public override async Task GroupBy_All_with_predicate(bool async)
+    {
+        await base.GroupBy_All_with_predicate(async);
+
+        AssertSql(
+            """
+SELECT [o].[CustomerID] AS [Key], ~CAST(COUNT(CASE
+    WHEN [o].[OrderID] > 10500 THEN 1
+END) ^ COUNT(*) AS bit) AS [AllBig]
+FROM [Orders] AS [o]
+GROUP BY [o].[CustomerID]
+""");
+    }
+
+    public override async Task GroupBy_Any_without_predicate(bool async)
+    {
+        await base.GroupBy_Any_without_predicate(async);
+
+        AssertSql(
+            """
+SELECT [o].[CustomerID] AS [Key], CAST(1 AS bit) AS [HasAny]
+FROM [Orders] AS [o]
+GROUP BY [o].[CustomerID]
+""");
+    }
+
+    public override async Task GroupBy_Any_guarding_aggregate_expression(bool async)
+    {
+        await base.GroupBy_Any_guarding_aggregate_expression(async);
+
+        AssertSql(
+            """
+SELECT [o].[CustomerID] AS [Key], ISNULL(SUM([o].[OrderID]), 0) / COUNT(*) AS [Average]
+FROM [Orders] AS [o]
+GROUP BY [o].[CustomerID]
+""");
+    }
+
+    public override async Task GroupBy_Any_with_predicate_and_other_aggregate(bool async)
+    {
+        await base.GroupBy_Any_with_predicate_and_other_aggregate(async);
+
+        AssertSql(
+            """
+SELECT [o].[CustomerID] AS [Key], ISNULL(SUM([o].[OrderID]), 0) AS [Total], CASE
+    WHEN COUNT(CASE
+        WHEN [o].[OrderID] > 10500 THEN 1
+    END) > 0 THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END AS [AnyBig]
+FROM [Orders] AS [o]
+GROUP BY [o].[CustomerID]
+""");
+    }
+
+    public override async Task GroupBy_Any_with_predicate_guarding_nullable_Sum(bool async)
+    {
+        await base.GroupBy_Any_with_predicate_guarding_nullable_Sum(async);
+
+        AssertSql(
+            """
+SELECT [o].[CustomerID] AS [Key], CASE
+    WHEN COUNT(CASE
+        WHEN [o].[EmployeeID] IS NOT NULL THEN 1
+    END) > 0 THEN ISNULL(SUM([o].[EmployeeID]), 0)
+END AS [Employees]
+FROM [Orders] AS [o]
+GROUP BY [o].[CustomerID]
+""");
+    }
+
+    public override async Task GroupBy_Any_with_nullable_predicate(bool async)
+    {
+        await base.GroupBy_Any_with_nullable_predicate(async);
+
+        AssertSql(
+            """
+SELECT [o].[CustomerID] AS [Key], CASE
+    WHEN COUNT(CASE
+        WHEN [o].[EmployeeID] > 5 THEN 1
+    END) > 0 THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END AS [AnySenior]
+FROM [Orders] AS [o]
+GROUP BY [o].[CustomerID]
+""");
+    }
+
+    public override async Task GroupBy_All_with_nullable_predicate(bool async)
+    {
+        await base.GroupBy_All_with_nullable_predicate(async);
+
+        AssertSql(
+            """
+SELECT [o].[CustomerID] AS [Key], ~CAST(COUNT(CASE
+    WHEN [o].[EmployeeID] > 5 THEN 1
+END) ^ COUNT(*) AS bit) AS [AllSenior]
+FROM [Orders] AS [o]
+GROUP BY [o].[CustomerID]
+""");
+    }
+
     public override async Task GroupBy_Any_with_predicate_through_navigation_property(bool async)
     {
         await base.GroupBy_Any_with_predicate_through_navigation_property(async);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindGroupByQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindGroupByQuerySqlServerTest.cs
@@ -2446,8 +2446,9 @@ GROUP BY [o].[CustomerID]
         AssertSql(
             """
 SELECT [o].[CustomerID] AS [Key], ~CAST(COUNT_BIG(CASE
-    WHEN [o].[OrderID] > 10500 THEN 1
-END) ^ COUNT_BIG(*) AS bit) AS [AllBig]
+    WHEN [o].[OrderID] > 10500 THEN NULL
+    ELSE 1
+END) ^ CAST(0 AS bigint) AS bit) AS [AllBig]
 FROM [Orders] AS [o]
 GROUP BY [o].[CustomerID]
 """);
@@ -2534,8 +2535,9 @@ GROUP BY [o].[CustomerID]
         AssertSql(
             """
 SELECT [o].[CustomerID] AS [Key], ~CAST(COUNT_BIG(CASE
-    WHEN [o].[EmployeeID] > 5 THEN 1
-END) ^ COUNT_BIG(*) AS bit) AS [AllSenior]
+    WHEN [o].[EmployeeID] > 5 THEN NULL
+    ELSE 1
+END) ^ CAST(0 AS bigint) AS bit) AS [AllSenior]
 FROM [Orders] AS [o]
 GROUP BY [o].[CustomerID]
 """);
@@ -2588,10 +2590,11 @@ SELECT [o].[CustomerID] AS [Key], CASE
     END) > CAST(0 AS bigint) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END AS [Any], ~CAST(COUNT_BIG(CASE
-    WHEN [o].[OrderID] > 999999 AND [o].[OrderID] > 0 THEN 1
-END) ^ COUNT_BIG(CASE
-    WHEN [o].[OrderID] > 999999 THEN 1
-END) AS bit) AS [All]
+    WHEN [o].[OrderID] > 999999 THEN CASE
+        WHEN [o].[OrderID] > 0 THEN NULL
+        ELSE 1
+    END
+END) ^ CAST(0 AS bigint) AS bit) AS [All]
 FROM [Orders] AS [o]
 GROUP BY [o].[CustomerID]
 """);
@@ -2622,8 +2625,9 @@ GROUP BY [o].[EmployeeID]
         AssertSql(
             """
 SELECT [o].[EmployeeID] AS [Key], ~CAST(COUNT_BIG(CASE
-    WHEN [c].[City] = N'London' THEN 1
-END) ^ COUNT_BIG(*) AS bit) AS [Londons]
+    WHEN [c].[City] = N'London' THEN NULL
+    ELSE 1
+END) ^ CAST(0 AS bigint) AS bit) AS [Londons]
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
 GROUP BY [o].[EmployeeID]
@@ -2655,8 +2659,9 @@ GROUP BY [o].[EmployeeID]
         AssertSql(
             """
 SELECT [o].[EmployeeID] AS [Key], ~CAST(COUNT_BIG(CASE
-    WHEN [c].[City] = N'London' THEN 1
-END) ^ COUNT_BIG(*) AS bit) AS [Londons]
+    WHEN [c].[City] = N'London' THEN NULL
+    ELSE 1
+END) ^ CAST(0 AS bigint) AS bit) AS [Londons]
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
 GROUP BY [o].[EmployeeID]
@@ -2685,8 +2690,9 @@ GROUP BY [o].[EmployeeID]
         AssertSql(
             """
 SELECT [o].[EmployeeID] AS [Key], ~CAST(COUNT_BIG(CASE
-    WHEN [o].[OrderID] > 10250 THEN 1
-END) ^ COUNT_BIG(*) AS bit) AS [AllLate], COUNT(CASE
+    WHEN [o].[OrderID] > 10250 THEN NULL
+    ELSE 1
+END) ^ CAST(0 AS bigint) AS bit) AS [AllLate], COUNT(CASE
     WHEN [c].[City] = N'London' THEN 1
 END) AS [Londons]
 FROM [Orders] AS [o]
@@ -2707,8 +2713,9 @@ SELECT [o].[EmployeeID] AS [Key], MAX([c].[Region]) AS [Region], CASE
     END) > CAST(0 AS bigint) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END AS [AnyLondon], ~CAST(COUNT_BIG(CASE
-    WHEN [c].[City] = N'London' THEN 1
-END) ^ COUNT_BIG(*) AS bit) AS [AllLondon], COUNT(*) AS [Count]
+    WHEN [c].[City] = N'London' THEN NULL
+    ELSE 1
+END) ^ CAST(0 AS bigint) AS bit) AS [AllLondon], COUNT(*) AS [Count]
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
 GROUP BY [o].[EmployeeID]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindGroupByQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindGroupByQuerySqlServerTest.cs
@@ -2541,6 +2541,24 @@ GROUP BY [o].[CustomerID]
 """);
     }
 
+    public override async Task GroupBy_Select_Distinct_Any_with_nullable_element(bool async)
+    {
+        await base.GroupBy_Select_Distinct_Any_with_nullable_element(async);
+
+        AssertSql(
+            """
+SELECT [o].[CustomerID] AS [Key], COUNT(DISTINCT ([o].[EmployeeID])) AS [Employees], CASE
+    WHEN EXISTS (
+        SELECT 1
+        FROM [Orders] AS [o0]
+        WHERE ([o].[CustomerID] = [o0].[CustomerID] OR ([o].[CustomerID] IS NULL AND [o0].[CustomerID] IS NULL)) AND [o0].[EmployeeID] IS NULL) THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END AS [AnyUnassigned]
+FROM [Orders] AS [o]
+GROUP BY [o].[CustomerID]
+""");
+    }
+
     public override async Task GroupBy_Any_with_predicate_through_navigation_property(bool async)
     {
         await base.GroupBy_Any_with_predicate_through_navigation_property(async);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindGroupByQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindGroupByQuerySqlServerTest.cs
@@ -2604,14 +2604,13 @@ GROUP BY [o].[CustomerID]
         AssertSql(
             """
 SELECT [o].[EmployeeID] AS [Key], CASE
-    WHEN EXISTS (
-        SELECT 1
-        FROM [Orders] AS [o0]
-        LEFT JOIN [Customers] AS [c] ON [o0].[CustomerID] = [c].[CustomerID]
-        WHERE ([o].[EmployeeID] = [o0].[EmployeeID] OR ([o].[EmployeeID] IS NULL AND [o0].[EmployeeID] IS NULL)) AND [c].[City] = N'London') THEN CAST(1 AS bit)
+    WHEN COUNT_BIG(CASE
+        WHEN [c].[City] = N'London' THEN 1
+    END) > CAST(0 AS bigint) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END AS [Londons]
 FROM [Orders] AS [o]
+LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
 GROUP BY [o].[EmployeeID]
 """);
     }
@@ -2622,15 +2621,11 @@ GROUP BY [o].[EmployeeID]
 
         AssertSql(
             """
-SELECT [o].[EmployeeID] AS [Key], CASE
-    WHEN NOT EXISTS (
-        SELECT 1
-        FROM [Orders] AS [o0]
-        LEFT JOIN [Customers] AS [c] ON [o0].[CustomerID] = [c].[CustomerID]
-        WHERE ([o].[EmployeeID] = [o0].[EmployeeID] OR ([o].[EmployeeID] IS NULL AND [o0].[EmployeeID] IS NULL)) AND ([c].[City] <> N'London' OR [c].[City] IS NULL)) THEN CAST(1 AS bit)
-    ELSE CAST(0 AS bit)
-END AS [Londons]
+SELECT [o].[EmployeeID] AS [Key], ~CAST(COUNT_BIG(CASE
+    WHEN [c].[City] = N'London' THEN 1
+END) ^ COUNT_BIG(*) AS bit) AS [Londons]
 FROM [Orders] AS [o]
+LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
 GROUP BY [o].[EmployeeID]
 """);
     }
@@ -2642,14 +2637,13 @@ GROUP BY [o].[EmployeeID]
         AssertSql(
             """
 SELECT [o].[EmployeeID] AS [Key], CASE
-    WHEN EXISTS (
-        SELECT 1
-        FROM [Orders] AS [o0]
-        LEFT JOIN [Customers] AS [c] ON [o0].[CustomerID] = [c].[CustomerID]
-        WHERE ([o].[EmployeeID] = [o0].[EmployeeID] OR ([o].[EmployeeID] IS NULL AND [o0].[EmployeeID] IS NULL)) AND [c].[City] = N'London') THEN CAST(1 AS bit)
+    WHEN COUNT_BIG(CASE
+        WHEN [c].[City] = N'London' THEN 1
+    END) > CAST(0 AS bigint) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END AS [Londons]
 FROM [Orders] AS [o]
+LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
 GROUP BY [o].[EmployeeID]
 """);
     }
@@ -2660,15 +2654,11 @@ GROUP BY [o].[EmployeeID]
 
         AssertSql(
             """
-SELECT [o].[EmployeeID] AS [Key], CASE
-    WHEN NOT EXISTS (
-        SELECT 1
-        FROM [Orders] AS [o0]
-        LEFT JOIN [Customers] AS [c] ON [o0].[CustomerID] = [c].[CustomerID]
-        WHERE ([o].[EmployeeID] = [o0].[EmployeeID] OR ([o].[EmployeeID] IS NULL AND [o0].[EmployeeID] IS NULL)) AND ([c].[City] <> N'London' OR [c].[City] IS NULL)) THEN CAST(1 AS bit)
-    ELSE CAST(0 AS bit)
-END AS [Londons]
+SELECT [o].[EmployeeID] AS [Key], ~CAST(COUNT_BIG(CASE
+    WHEN [c].[City] = N'London' THEN 1
+END) ^ COUNT_BIG(*) AS bit) AS [Londons]
 FROM [Orders] AS [o]
+LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
 GROUP BY [o].[EmployeeID]
 """);
     }
@@ -2679,13 +2669,7 @@ GROUP BY [o].[EmployeeID]
 
         AssertSql(
             """
-SELECT [o].[EmployeeID] AS [Key], CASE
-    WHEN EXISTS (
-        SELECT 1
-        FROM [Orders] AS [o0]
-        WHERE [o].[EmployeeID] = [o0].[EmployeeID] OR ([o].[EmployeeID] IS NULL AND [o0].[EmployeeID] IS NULL)) THEN CAST(1 AS bit)
-    ELSE CAST(0 AS bit)
-END AS [HasOrders], COUNT(CASE
+SELECT [o].[EmployeeID] AS [Key], CAST(1 AS bit) AS [HasOrders], COUNT(CASE
     WHEN [c].[City] = N'London' THEN 1
 END) AS [Londons]
 FROM [Orders] AS [o]
@@ -2700,13 +2684,9 @@ GROUP BY [o].[EmployeeID]
 
         AssertSql(
             """
-SELECT [o].[EmployeeID] AS [Key], CASE
-    WHEN NOT EXISTS (
-        SELECT 1
-        FROM [Orders] AS [o0]
-        WHERE ([o].[EmployeeID] = [o0].[EmployeeID] OR ([o].[EmployeeID] IS NULL AND [o0].[EmployeeID] IS NULL)) AND [o0].[OrderID] <= 10250) THEN CAST(1 AS bit)
-    ELSE CAST(0 AS bit)
-END AS [AllLate], COUNT(CASE
+SELECT [o].[EmployeeID] AS [Key], ~CAST(COUNT_BIG(CASE
+    WHEN [o].[OrderID] > 10250 THEN 1
+END) ^ COUNT_BIG(*) AS bit) AS [AllLate], COUNT(CASE
     WHEN [c].[City] = N'London' THEN 1
 END) AS [Londons]
 FROM [Orders] AS [o]
@@ -2722,20 +2702,13 @@ GROUP BY [o].[EmployeeID]
         AssertSql(
             """
 SELECT [o].[EmployeeID] AS [Key], MAX([c].[Region]) AS [Region], CASE
-    WHEN EXISTS (
-        SELECT 1
-        FROM [Orders] AS [o0]
-        LEFT JOIN [Customers] AS [c0] ON [o0].[CustomerID] = [c0].[CustomerID]
-        WHERE ([o].[EmployeeID] = [o0].[EmployeeID] OR ([o].[EmployeeID] IS NULL AND [o0].[EmployeeID] IS NULL)) AND [c0].[City] = N'London') THEN CAST(1 AS bit)
+    WHEN COUNT_BIG(CASE
+        WHEN [c].[City] = N'London' THEN 1
+    END) > CAST(0 AS bigint) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
-END AS [AnyLondon], CASE
-    WHEN NOT EXISTS (
-        SELECT 1
-        FROM [Orders] AS [o1]
-        LEFT JOIN [Customers] AS [c1] ON [o1].[CustomerID] = [c1].[CustomerID]
-        WHERE ([o].[EmployeeID] = [o1].[EmployeeID] OR ([o].[EmployeeID] IS NULL AND [o1].[EmployeeID] IS NULL)) AND ([c1].[City] <> N'London' OR [c1].[City] IS NULL)) THEN CAST(1 AS bit)
-    ELSE CAST(0 AS bit)
-END AS [AllLondon], COUNT(*) AS [Count]
+END AS [AnyLondon], ~CAST(COUNT_BIG(CASE
+    WHEN [c].[City] = N'London' THEN 1
+END) ^ COUNT_BIG(*) AS bit) AS [AllLondon], COUNT(*) AS [Count]
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
 GROUP BY [o].[EmployeeID]
@@ -2749,15 +2722,14 @@ GROUP BY [o].[EmployeeID]
         AssertSql(
             """
 SELECT [o].[ProductID] AS [Key], CASE
-    WHEN EXISTS (
-        SELECT 1
-        FROM [Order Details] AS [o0]
-        INNER JOIN [Orders] AS [o1] ON [o0].[OrderID] = [o1].[OrderID]
-        LEFT JOIN [Customers] AS [c] ON [o1].[CustomerID] = [c].[CustomerID]
-        WHERE [o].[ProductID] = [o0].[ProductID] AND [c].[City] = N'London') THEN CAST(1 AS bit)
+    WHEN COUNT_BIG(CASE
+        WHEN [c].[City] = N'London' THEN 1
+    END) > CAST(0 AS bigint) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END AS [Londons]
 FROM [Order Details] AS [o]
+INNER JOIN [Orders] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+LEFT JOIN [Customers] AS [c] ON [o0].[CustomerID] = [c].[CustomerID]
 GROUP BY [o].[ProductID]
 """);
     }
@@ -2769,11 +2741,9 @@ GROUP BY [o].[ProductID]
         AssertSql(
             """
 SELECT [c].[City] AS [Key], CASE
-    WHEN EXISTS (
-        SELECT 1
-        FROM [Orders] AS [o0]
-        LEFT JOIN [Customers] AS [c0] ON [o0].[CustomerID] = [c0].[CustomerID]
-        WHERE ([c].[City] = [c0].[City] OR ([c].[City] IS NULL AND [c0].[City] IS NULL)) AND [c0].[City] = N'London') THEN CAST(1 AS bit)
+    WHEN COUNT_BIG(CASE
+        WHEN [c].[City] = N'London' THEN 1
+    END) > CAST(0 AS bigint) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END AS [Londons]
 FROM [Orders] AS [o]
@@ -2789,14 +2759,13 @@ GROUP BY [c].[City]
         AssertSql(
             """
 SELECT [o].[EmployeeID] AS [Key], CASE
-    WHEN EXISTS (
-        SELECT 1
-        FROM [Orders] AS [o0]
-        LEFT JOIN [Customers] AS [c] ON [o0].[CustomerID] = [c].[CustomerID]
-        WHERE ([o].[EmployeeID] = [o0].[EmployeeID] OR ([o].[EmployeeID] IS NULL AND [o0].[EmployeeID] IS NULL)) AND [c].[City] = N'London') THEN CAST(1 AS bit)
+    WHEN COUNT_BIG(CASE
+        WHEN [c].[City] = N'London' THEN 1
+    END) > CAST(0 AS bigint) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END AS [Londons]
 FROM [Orders] AS [o]
+LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
 GROUP BY [o].[EmployeeID]
 """);
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindGroupByQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindGroupByQuerySqlServerTest.cs
@@ -2559,6 +2559,44 @@ GROUP BY [o].[CustomerID]
 """);
     }
 
+    public override async Task GroupBy_Where_Any_over_grouping_element(bool async)
+    {
+        await base.GroupBy_Where_Any_over_grouping_element(async);
+
+        AssertSql(
+            """
+SELECT [o].[CustomerID] AS [Key], CASE
+    WHEN COUNT(CASE
+        WHEN [o].[OrderID] > 10500 THEN 1
+    END) > 0 THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END AS [AnyBig]
+FROM [Orders] AS [o]
+GROUP BY [o].[CustomerID]
+""");
+    }
+
+    public override async Task GroupBy_Where_quantifiers_over_empty_filtered_grouping_element(bool async)
+    {
+        await base.GroupBy_Where_quantifiers_over_empty_filtered_grouping_element(async);
+
+        AssertSql(
+            """
+SELECT [o].[CustomerID] AS [Key], CASE
+    WHEN COUNT(CASE
+        WHEN [o].[OrderID] > 999999 THEN 1
+    END) > 0 THEN CAST(1 AS bit)
+    ELSE CAST(0 AS bit)
+END AS [Any], ~CAST(COUNT(CASE
+    WHEN [o].[OrderID] > 999999 AND [o].[OrderID] > 0 THEN 1
+END) ^ COUNT(CASE
+    WHEN [o].[OrderID] > 999999 THEN 1
+END) AS bit) AS [All]
+FROM [Orders] AS [o]
+GROUP BY [o].[CustomerID]
+""");
+    }
+
     public override async Task GroupBy_Any_with_predicate_through_navigation_property(bool async)
     {
         await base.GroupBy_Any_with_predicate_through_navigation_property(async);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindQueryFiltersQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindQueryFiltersQuerySqlServerTest.cs
@@ -417,20 +417,14 @@ GROUP BY [o].[EmployeeID]
 @ef_filter__TenantPrefix_startswith='B%' (Size = 40)
 
 SELECT [o].[EmployeeID] AS [Key], CASE
-    WHEN EXISTS (
-        SELECT 1
-        FROM [Orders] AS [o0]
-        LEFT JOIN (
-            SELECT [c2].[CustomerID], [c2].[City], [c2].[CompanyName]
-            FROM [Customers] AS [c2]
-            WHERE [c2].[CompanyName] LIKE @ef_filter__TenantPrefix_startswith ESCAPE N'\'
-        ) AS [c1] ON [o0].[CustomerID] = [c1].[CustomerID]
-        WHERE [c1].[CustomerID] IS NOT NULL AND [c1].[CompanyName] IS NOT NULL AND ([o].[EmployeeID] = [o0].[EmployeeID] OR ([o].[EmployeeID] IS NULL AND [o0].[EmployeeID] IS NULL)) AND [c1].[City] = N'London') THEN CAST(1 AS bit)
+    WHEN COUNT_BIG(CASE
+        WHEN [c0].[City] = N'London' THEN 1
+    END) > CAST(0 AS bigint) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END AS [Londons]
 FROM [Orders] AS [o]
 LEFT JOIN (
-    SELECT [c].[CustomerID], [c].[CompanyName]
+    SELECT [c].[CustomerID], [c].[City], [c].[CompanyName]
     FROM [Customers] AS [c]
     WHERE [c].[CompanyName] LIKE @ef_filter__TenantPrefix_startswith ESCAPE N'\'
 ) AS [c0] ON [o].[CustomerID] = [c0].[CustomerID]
@@ -448,20 +442,14 @@ GROUP BY [o].[EmployeeID]
 @ef_filter__TenantPrefix_startswith='B%' (Size = 40)
 
 SELECT [o].[EmployeeID] AS [Key], COUNT(*) AS [Total], CASE
-    WHEN EXISTS (
-        SELECT 1
-        FROM [Orders] AS [o0]
-        LEFT JOIN (
-            SELECT [c2].[CustomerID], [c2].[City], [c2].[CompanyName]
-            FROM [Customers] AS [c2]
-            WHERE [c2].[CompanyName] LIKE @ef_filter__TenantPrefix_startswith ESCAPE N'\'
-        ) AS [c1] ON [o0].[CustomerID] = [c1].[CustomerID]
-        WHERE [c1].[CustomerID] IS NOT NULL AND [c1].[CompanyName] IS NOT NULL AND ([o].[EmployeeID] = [o0].[EmployeeID] OR ([o].[EmployeeID] IS NULL AND [o0].[EmployeeID] IS NULL)) AND [c1].[City] = N'London') THEN CAST(1 AS bit)
+    WHEN COUNT_BIG(CASE
+        WHEN [c0].[City] = N'London' THEN 1
+    END) > CAST(0 AS bigint) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END AS [Londons]
 FROM [Orders] AS [o]
 LEFT JOIN (
-    SELECT [c].[CustomerID], [c].[CompanyName]
+    SELECT [c].[CustomerID], [c].[City], [c].[CompanyName]
     FROM [Customers] AS [c]
     WHERE [c].[CompanyName] LIKE @ef_filter__TenantPrefix_startswith ESCAPE N'\'
 ) AS [c0] ON [o].[CustomerID] = [c0].[CustomerID]
@@ -477,14 +465,13 @@ GROUP BY [o].[EmployeeID]
         AssertSql(
             """
 SELECT [o].[EmployeeID] AS [Key], CASE
-    WHEN EXISTS (
-        SELECT 1
-        FROM [Orders] AS [o0]
-        LEFT JOIN [Customers] AS [c] ON [o0].[CustomerID] = [c].[CustomerID]
-        WHERE ([o].[EmployeeID] = [o0].[EmployeeID] OR ([o].[EmployeeID] IS NULL AND [o0].[EmployeeID] IS NULL)) AND [c].[City] = N'London') THEN CAST(1 AS bit)
+    WHEN COUNT_BIG(CASE
+        WHEN [c].[City] = N'London' THEN 1
+    END) > CAST(0 AS bigint) THEN CAST(1 AS bit)
     ELSE CAST(0 AS bit)
 END AS [Londons]
 FROM [Orders] AS [o]
+LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
 GROUP BY [o].[EmployeeID]
 """);
     }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindGroupByQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/NorthwindGroupByQuerySqliteTest.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore.Sqlite.Internal;
+using Microsoft.EntityFrameworkCore.TestModels.Northwind;
 
 namespace Microsoft.EntityFrameworkCore.Query;
 
@@ -13,6 +14,36 @@ public class NorthwindGroupByQuerySqliteTest : NorthwindGroupByQueryRelationalTe
     {
         Fixture.TestSqlLoggerFactory.Clear();
         Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
+    }
+
+    // SQLite evaluates random() per row, where SQL Server's RAND() is a runtime constant - so this is the provider that
+    // can catch the grouping element's filter being emitted more than once. Every order has OrderID > 0, so All holds for
+    // every group whichever rows the filter samples, which is what the expected query asserts directly; EF.Functions.Random
+    // has no client translation, so the two queries cannot be the same one.
+    [Theory, MemberData(nameof(IsAsyncData))]
+    public virtual async Task GroupBy_All_over_volatile_filtered_grouping_element(bool async)
+    {
+        await AssertQuery(
+            async,
+            ss => ss.Set<Order>()
+                .GroupBy(o => o.CustomerID)
+                .Select(g => new { g.Key, All = g.Where(o => EF.Functions.Random() > 0.5).All(o => o.OrderID > 0) }),
+            ss => ss.Set<Order>()
+                .GroupBy(o => o.CustomerID)
+                .Select(g => new { g.Key, All = true }),
+            elementSorter: e => e.Key);
+
+        AssertSql(
+            """
+SELECT "o"."CustomerID" AS "Key", COUNT(CASE
+    WHEN abs(random() / 9.2233720368547799E+18) > 0.5 THEN CASE
+        WHEN "o"."OrderID" > 0 THEN NULL
+        ELSE 1
+    END
+END) = 0 AS "All"
+FROM "Orders" AS "o"
+GROUP BY "o"."CustomerID"
+""");
     }
 
     public override Task Select_uncorrelated_collection_with_groupby_multiple_collections_work(bool async)


### PR DESCRIPTION
Fixes #27953

- [x] I've read the guidelines for [contributing](https://github.com/dotnet/efcore/blob/main/.github/CONTRIBUTING.md) and seen the [walkthrough](https://youtu.be/9OMxy1wal1s?t=1869)
- [ ] I've posted a comment on an issue with a detailed description of how I am planning to contribute and got approval from a member of the team
- [x] The code builds and tests pass locally (also verified by our automated build checks)
- [x] Commit messages follow this format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Code follows the same patterns and style as existing code in this repo

## Summary

`TryTranslateAggregateMethodCall` folds aggregates over a grouping element into the enclosing `GROUP BY`, so `g.Count()` becomes `COUNT(*)` in the same `SELECT`. `Any` and `All` aren't in that switch, so they fall through to the general quantifier translation and become a correlated `EXISTS` that re-derives the grouping source once per group — the difference the issue reports between `g.Count() == 0` and `!g.Any()`.

```csharp
ss.Set<Order>()
    .GroupBy(o => o.CustomerID)
    .Select(g => new { g.Key, Average = !g.Any() ? 0 : g.Sum(o => o.OrderID) / g.Count() })
```

```sql
-- before: the guard re-derives [Orders] per group
SELECT [o].[CustomerID] AS [Key], CASE
    WHEN NOT EXISTS (
        SELECT 1
        FROM [Orders] AS [o0]
        WHERE [o].[CustomerID] = [o0].[CustomerID] OR ([o].[CustomerID] IS NULL AND [o0].[CustomerID] IS NULL)) THEN 0
    ELSE ISNULL(SUM([o].[OrderID]), 0) / COUNT(*)
END AS [Average]
FROM [Orders] AS [o]
GROUP BY [o].[CustomerID]

-- after: a group produced by GROUP BY is never empty, so the guard folds away
SELECT [o].[CustomerID] AS [Key], ISNULL(SUM([o].[OrderID]), 0) / COUNT(*) AS [Average]
FROM [Orders] AS [o]
GROUP BY [o].[CustomerID]
```

With a predicate, `g.Any(o => o.OrderID > 10500)` likewise drops its `EXISTS` and reads the group the surrounding aggregates already read:

```sql
CASE
    WHEN COUNT_BIG(CASE
        WHEN [o].[OrderID] > 10500 THEN 1
    END) > CAST(0 AS bigint) THEN CAST(1 AS bit)
    ELSE CAST(0 AS bit)
END AS [AnyBig]
```

### Interaction with #38829

#38829 has since merged, whitelisting `Any`/`All` for `GroupBy` aggregate navigation lifting so that a quantifier no longer demotes its siblings. On top of that, this PR removes the quantifier's own subquery, so `Any`/`All` over a reference navigation read the shared pre-`GROUP BY` join and emit no subquery at all. Thirteen SQL Server baselines from that PR are regenerated here — results unchanged, only the SQL. Across those ten the generated SQL drops from 5,010 characters to 3,212; `GroupBy_multiple_aggregates_with_Any_and_All_sharing_same_navigation` goes from 18 lines to 12, losing both correlated subqueries.

## Implementation

`Any` (both overloads) and `All` join the aggregate switch, delegating to a new `TryTranslateQuantifierOverGrouping`. Each is expressed with the existing `LongCount` translation, so nothing new is needed from providers or `SqlExpressionFactory`:

- **`Any()`** over an unfiltered grouping element is `true` — `GROUP BY` doesn't produce empty groups, so no aggregate is emitted at all.
- **`Any(p)`** (and `Any()` over an element already filtered by `Where`) is `COUNT_BIG(<matching>) > 0`.
- **`All(p)`** is `COUNT_BIG(<failing>) = 0`, with the failure decided inside the counted expression rather than by a second predicate.

For `All` the counted expression is `CASE WHEN p THEN NULL ELSE 1 END`, which does two things at once. It gives `Enumerable.All` semantics: a row whose predicate is `NULL` falls to the `ELSE` and counts as a failure, where `NOT p` would be `NULL` wherever `p` is, which the surrounding `CASE` reads as false — leaving the row uncounted and `All` wrongly true. This mirrors what the existing subquery translation of `All` already emits for its negation (`CASE WHEN p THEN 0 ELSE 1 END = 1`). It also keeps both the grouping element's own filter and `p` in the SQL once each; emitted twice, a volatile filter such as `Where(o => EF.Functions.Random() > 0.5)` is sampled independently per occurrence and the two counts stop describing the same rows.

For `Any`, the counted expression is the `*` fragment, so rows are counted rather than values — a count ignores `NULL`s, which would otherwise drop exactly the rows an `Any(x => x == null)` matched whenever the element selector is a scalar.

`LongCount` rather than `Count` because the quantifier returns `bool`: nothing in the query asks for a 32-bit counter, and the `EXISTS` translation this replaces has no cardinality limit of its own. A count is non-nullable, so neither comparison needs a null guard, and both stay correct when the grouping element was filtered down to no rows: `Any` false, `All` true.

`Distinct` is dropped before counting, since it can't change whether any or all rows satisfy a predicate.

When the count can't be translated as an aggregate over the enclosing `GROUP BY`, the method returns false and the existing `EXISTS` / `NOT EXISTS` translation applies unchanged.

## Testing

Specification tests with SQL Server baselines; they also run on SQLite and the in-memory provider through the shared base.

| Test | Shape |
| --- | --- |
| `GroupBy_Any_guarding_aggregate_expression` | the reported shape — `!g.Any()` guarding a division by `g.Count()` |
| `GroupBy_Any_without_predicate` | bare `g.Any()` over a grouping element |
| `GroupBy_Any_with_predicate` / `GroupBy_All_with_predicate` | the basic quantifier over a group |
| `GroupBy_Any_with_predicate_and_other_aggregate` | quantifier and `Sum` sharing one `GROUP BY` |
| `GroupBy_Any_with_predicate_guarding_nullable_Sum` | quantifier guarding a nullable aggregate |
| `GroupBy_Any_with_nullable_predicate` / `GroupBy_All_with_nullable_predicate` | nullable predicate — pins the SQL shape (no Northwind order has a NULL `EmployeeID`) |
| `GroupBy_Where_Any_over_grouping_element` | element filtered by `Where` rather than by the quantifier's own predicate |
| `GroupBy_Where_quantifiers_over_empty_filtered_grouping_element` | that filter leaves no rows — `Any` false, `All` true |
| `GroupBy_Select_Distinct_Any_with_nullable_element` | a `Select` over the element keeps a scalar element selector; asserts the `EXISTS` fallback, since `GroupingAggregateScanner` only lifts aggregates whose source is the grouping parameter itself |

Two tests live outside the Northwind GroupBy suite because that model can't express what they need:

| Test | Why there |
| --- | --- |
| `NullSemanticsQueryTestBase.Quantifier_over_group_treats_null_predicate_as_not_satisfied` | `NullableIntA` is `0`, `1` or `NULL`, so `>= 0` can only fail on a `NULL`, and grouping by it gives an all-`NULL` group. No Northwind column the quantifier tests group over holds `NULL`s, so this is where the `NULL` branch is actually exercised. |
| `NorthwindGroupByQuerySqliteTest.GroupBy_All_over_volatile_filtered_grouping_element` | SQLite evaluates `random()` per row, where SQL Server's `RAND()` is a runtime constant — so it is the provider that can catch the grouping element's filter being emitted more than once. |