### PR TITLE
Fix null dereference build errors in the scaffolding tests

### DIFF
--- a/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpDbContextGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpDbContextGeneratorTest.cs
@@ -409,7 +409,7 @@ optionsBuilder
                 code => Assert.Contains("IsRowVersion()", code.ContextFile.Code),
                 model =>
                 {
-                    var property = model.FindEntityType("TestNamespace.Entity").GetProperty("Version");
+                    var property = model.FindEntityType("TestNamespace.Entity")!.GetProperty("Version");
                     Assert.True(property.IsConcurrencyToken);
                     Assert.Equal(ValueGenerated.OnAddOrUpdate, property.ValueGenerated);
                 });
@@ -432,7 +432,7 @@ optionsBuilder
                 },
                 model =>
                 {
-                    var property = model.FindEntityType("TestNamespace.Entity").GetProperty("Token");
+                    var property = model.FindEntityType("TestNamespace.Entity")!.GetProperty("Token");
                     Assert.True(property.IsConcurrencyToken);
                     Assert.NotEqual(ValueGenerated.OnAddOrUpdate, property.ValueGenerated);
                 });

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpEntityTypeGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpEntityTypeGeneratorTest.cs
@@ -1237,7 +1237,7 @@ public partial class Entity
             },
             model =>
             {
-                var property = model.FindEntityType("TestNamespace.Entity").GetProperty("Version");
+                var property = model.FindEntityType("TestNamespace.Entity")!.GetProperty("Version");
                 Assert.True(property.IsConcurrencyToken);
                 Assert.Equal(ValueGenerated.OnAddOrUpdate, property.ValueGenerated);
             });


### PR DESCRIPTION
`EFCore.Design.Tests` currently fails to build on main, which takes the `Main` leg of CI down on all three platforms:

```
test/EFCore.Design.Tests/Scaffolding/Internal/CSharpDbContextGeneratorTest.cs(412,36): error CS8602: Dereference of a possibly null reference.
test/EFCore.Design.Tests/Scaffolding/Internal/CSharpDbContextGeneratorTest.cs(435,36): error CS8602: Dereference of a possibly null reference.
test/EFCore.Design.Tests/Scaffolding/Internal/CSharpEntityTypeGeneratorTest.cs(1240,32): error CS8602: Dereference of a possibly null reference.
```

`FindEntityType` returns a nullable `IEntityType`, and the three call sites added in #38795 dereference the result directly. The test projects build with warnings as errors, so this fails the build rather than just warning.

Every other `FindEntityType` call in these two files already uses the null forgiving operator for exactly this pattern (for example lines 247, 299 and 390 of `CSharpDbContextGeneratorTest.cs`), so this change just makes the new call sites consistent with the ones around them.

Verified locally on Linux: `EFCore.Design.Tests` builds clean and the three affected tests pass.
