### PR TITLE
[release/11.0] Remove internal xUnit dependency from specification tests

### DIFF
--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -29,6 +29,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(IsTestProject)' != 'false'">
+    <PackageReference Include="Microsoft.DotNet.XUnitV3Extensions" />
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
   </ItemGroup>
 

--- a/test/EFCore.Specification.Tests/EFCore.Specification.Tests.csproj
+++ b/test/EFCore.Specification.Tests/EFCore.Specification.Tests.csproj
@@ -68,7 +68,6 @@
          auto-inject the v3 packages. -->
     <PackageReference Include="xunit.v3.extensibility.core" VersionOverride="$(XUnitV3Version)" />
     <PackageReference Include="xunit.v3.assert" VersionOverride="$(XUnitV3Version)" />
-    <PackageReference Include="Microsoft.DotNet.XUnitV3Extensions" />
     <PackageReference Include="Newtonsoft.Json" />
   </ItemGroup>
 

--- a/test/EFCore.Specification.Tests/TestUtilities/TestHelpers.cs
+++ b/test/EFCore.Specification.Tests/TestUtilities/TestHelpers.cs
@@ -316,9 +316,7 @@ public abstract class TestHelpers
             .GetRuntimeMethods()
             .Where(m => m.DeclaringType != testClass
                 && (Attribute.IsDefined(m, typeof(FactAttribute))
-                    || Attribute.IsDefined(m, typeof(TheoryAttribute))
-                    || Attribute.IsDefined(m, typeof(ConditionalFactAttribute))
-                    || Attribute.IsDefined(m, typeof(ConditionalTheoryAttribute))))
+                    || Attribute.IsDefined(m, typeof(TheoryAttribute))))
             .ToList();
 
         var methodCalls = new StringBuilder();

--- a/test/Microsoft.Data.Sqlite.Tests/Microsoft.Data.Sqlite.Tests.csproj
+++ b/test/Microsoft.Data.Sqlite.Tests/Microsoft.Data.Sqlite.Tests.csproj
@@ -17,7 +17,6 @@
 
   <ItemGroup>
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" />
-    <PackageReference Include="Microsoft.DotNet.XUnitV3Extensions" />
   </ItemGroup>
 
 </Project>

--- a/test/Microsoft.Data.Sqlite.Tests/Microsoft.Data.Sqlite.sqlite3.Tests.csproj
+++ b/test/Microsoft.Data.Sqlite.Tests/Microsoft.Data.Sqlite.sqlite3.Tests.csproj
@@ -20,7 +20,6 @@
   <ItemGroup>
     <PackageReference Include="SQLitePCLRaw.core" />
     <PackageReference Include="SQLitePCLRaw.provider.sqlite3" />
-    <PackageReference Include="Microsoft.DotNet.XUnitV3Extensions" />
   </ItemGroup>
 
 </Project>

--- a/test/Microsoft.Data.Sqlite.Tests/Microsoft.Data.Sqlite.sqlite3mc.Tests.csproj
+++ b/test/Microsoft.Data.Sqlite.Tests/Microsoft.Data.Sqlite.sqlite3mc.Tests.csproj
@@ -16,7 +16,6 @@
 
   <ItemGroup>
     <PackageReference Include="SQLite3MC.PCLRaw.bundle" />
-    <PackageReference Include="Microsoft.DotNet.XUnitV3Extensions" />
   </ItemGroup>
 
 </Project>

--- a/test/Microsoft.Data.Sqlite.Tests/Microsoft.Data.Sqlite.winsqlite3.Tests.csproj
+++ b/test/Microsoft.Data.Sqlite.Tests/Microsoft.Data.Sqlite.winsqlite3.Tests.csproj
@@ -18,7 +18,6 @@
   <ItemGroup>
     <PackageReference Include="SQLitePCLRaw.core" />
     <PackageReference Include="SQLitePCLRaw.provider.winsqlite3" />
-    <PackageReference Include="Microsoft.DotNet.XUnitV3Extensions" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Fixes: #38952

**Description**
`Microsoft.EntityFrameworkCore.Specification.Tests` referenced `Microsoft.DotNet.XUnitV3Extensions`, an internal package that is not available on NuGet.org. NuGet emitted that reference into the public specification-test package and transitively into the relational specification-test package.

This moves the extension dependency to executable test projects only. `AssertAllMethodsOverridden` now relies on `FactAttribute` and `TheoryAttribute`, which also match the derived `ConditionalFactAttribute` and `ConditionalTheoryAttribute` types used by concrete provider tests.

**Customer impact**
Third-party EF Core providers cannot restore the matching EF Core 11 specification-test packages from NuGet.org:

```xml
<PackageReference
    Include="Microsoft.EntityFrameworkCore.Specification.Tests"
    Version="11.0.0-rc.1.26425.128" />
```

Restore fails with `NU1101` for `Microsoft.DotNet.XUnitV3Extensions`. The workaround is to use the older preview 5 specification-test package, which introduces version skew during provider compatibility testing.

**How found**
User reported on EF Core 11.0 RC1. The issue currently has one reporter, no additional commenters, and no reactions.

**Regression**
Yes. The dependency first appeared in EF Core 11 preview 6 as part of the xUnit v3 upgrade in #38277; preview 5 restores successfully.

**Testing**
Verified manually.

**Risk**
Extremely low. This changes specification test-project dependencies, does not affect runtime product code or public APIs, and leaves the extension dependency on executable test projects.