### PR TITLE
Parse scaffolded date and time default literals with the invariant culture

### DIFF
--- a/src/EFCore.SqlServer/Scaffolding/Internal/SqlServerDatabaseModelFactory.cs
+++ b/src/EFCore.SqlServer/Scaffolding/Internal/SqlServerDatabaseModelFactory.cs
@@ -933,25 +933,25 @@ LEFT JOIN [sys].[default_constraints] AS [dc] ON [c].[object_id] = [dc].[parent_
             }
 
             if (type == typeof(DateTime)
-                && DateTime.TryParse(defaultValueSql, out var dateTime))
+                && DateTime.TryParse(defaultValueSql, CultureInfo.InvariantCulture, out var dateTime))
             {
                 return dateTime;
             }
 
             if (type == typeof(DateOnly)
-                && DateOnly.TryParse(defaultValueSql, out var dateOnly))
+                && DateOnly.TryParse(defaultValueSql, CultureInfo.InvariantCulture, out var dateOnly))
             {
                 return dateOnly;
             }
 
             if (type == typeof(TimeOnly)
-                && TimeOnly.TryParse(defaultValueSql, out var timeOnly))
+                && TimeOnly.TryParse(defaultValueSql, CultureInfo.InvariantCulture, out var timeOnly))
             {
                 return timeOnly;
             }
 
             if (type == typeof(DateTimeOffset)
-                && DateTimeOffset.TryParse(defaultValueSql, out var dateTimeOffset))
+                && DateTimeOffset.TryParse(defaultValueSql, CultureInfo.InvariantCulture, out var dateTimeOffset))
             {
                 return dateTimeOffset;
             }

--- a/src/EFCore.Sqlite.Core/Scaffolding/Internal/SqliteDatabaseModelFactory.cs
+++ b/src/EFCore.Sqlite.Core/Scaffolding/Internal/SqliteDatabaseModelFactory.cs
@@ -469,22 +469,22 @@ ORDER BY "cid"
                     column.DefaultValue = guid;
                 }
                 else if (type == typeof(DateTime)
-                         && DateTime.TryParse(defaultValueSql, out var dateTime))
+                         && DateTime.TryParse(defaultValueSql, CultureInfo.InvariantCulture, out var dateTime))
                 {
                     column.DefaultValue = dateTime;
                 }
                 else if (type == typeof(DateOnly)
-                         && DateOnly.TryParse(defaultValueSql, out var dateOnly))
+                         && DateOnly.TryParse(defaultValueSql, CultureInfo.InvariantCulture, out var dateOnly))
                 {
                     column.DefaultValue = dateOnly;
                 }
                 else if (type == typeof(TimeOnly)
-                         && TimeOnly.TryParse(defaultValueSql, out var timeOnly))
+                         && TimeOnly.TryParse(defaultValueSql, CultureInfo.InvariantCulture, out var timeOnly))
                 {
                     column.DefaultValue = timeOnly;
                 }
                 else if (type == typeof(DateTimeOffset)
-                         && DateTimeOffset.TryParse(defaultValueSql, out var dateTimeOffset))
+                         && DateTimeOffset.TryParse(defaultValueSql, CultureInfo.InvariantCulture, out var dateTimeOffset))
                 {
                     column.DefaultValue = dateTimeOffset;
                 }

--- a/test/EFCore.SqlServer.FunctionalTests/Scaffolding/SqlServerDatabaseModelFactoryTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Scaffolding/SqlServerDatabaseModelFactoryTest.cs
@@ -4483,6 +4483,43 @@ CREATE TABLE MyTable (
             "DROP TABLE MyTable;");
 
     [Fact]
+    public void Simple_date_literals_are_parsed_for_HasDefaultValue_with_Persian_locale()
+    {
+        var currentCulture = CultureInfo.CurrentCulture;
+
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo("fa-IR");
+            Test(
+                @"
+CREATE TABLE MyTable (
+    Id int,
+    A datetime2 DEFAULT (1968-10-23),
+    B date DEFAULT (1968-10-23),
+);",
+                [],
+                [],
+                (dbModel, scaffoldingFactory) =>
+                {
+                    var columns = dbModel.Tables.Single().Columns;
+
+                    var column = columns.Single(c => c.Name == "A");
+                    Assert.Equal("(1968-10-23)", column.DefaultValueSql);
+                    Assert.Equal(new DateTime(1968, 10, 23, 0, 0, 0, 0, DateTimeKind.Unspecified), column.DefaultValue);
+
+                    column = columns.Single(c => c.Name == "B");
+                    Assert.Equal("(1968-10-23)", column.DefaultValueSql);
+                    Assert.Equal(new DateOnly(1968, 10, 23), column.DefaultValue);
+                },
+                "DROP TABLE MyTable;");
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = currentCulture;
+        }
+    }
+
+    [Fact]
     public void Simple_Guid_literals_are_parsed_for_HasDefaultValue()
         => Test(
             @"

--- a/test/EFCore.Sqlite.FunctionalTests/Scaffolding/SqliteDatabaseModelFactoryTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Scaffolding/SqliteDatabaseModelFactoryTest.cs
@@ -991,6 +991,52 @@ INSERT INTO MyTable VALUES (1, '1973-09-03 12:00:01.0000000+10:00');",
             "DROP TABLE MyTable;");
 
     [Fact]
+    public void Simple_date_and_time_literals_are_parsed_for_HasDefaultValue_with_Persian_locale()
+    {
+        var culture = CultureInfo.CurrentCulture;
+
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo("fa-IR");
+
+            Test(
+                @"
+CREATE TABLE MyTable (
+    Id int,
+    A datetime DEFAULT (1968-10-23 12:00:01),
+    B date DEFAULT (1968-10-23),
+    C datetimeoffset DEFAULT (1973-09-03 12:00:01+10:00));
+
+INSERT INTO MyTable VALUES (1, 2023-01-20 13:37:00, 2023-01-20, 1973-09-03 12:00:01+10:00);",
+                [],
+                [],
+                dbModel =>
+                {
+                    var columns = dbModel.Tables.Single().Columns;
+
+                    var column = columns.Single(c => c.Name == "A");
+                    Assert.Equal("1968-10-23 12:00:01", column.DefaultValueSql);
+                    Assert.Equal(new DateTime(1968, 10, 23, 12, 0, 1, 0, DateTimeKind.Unspecified), column.DefaultValue);
+
+                    column = columns.Single(c => c.Name == "B");
+                    Assert.Equal("1968-10-23", column.DefaultValueSql);
+                    Assert.Equal(new DateOnly(1968, 10, 23), column.DefaultValue);
+
+                    column = columns.Single(c => c.Name == "C");
+                    Assert.Equal("1973-09-03 12:00:01+10:00", column.DefaultValueSql);
+                    Assert.Equal(
+                        new DateTimeOffset(new DateTime(1973, 9, 3, 12, 0, 1, 0, DateTimeKind.Unspecified), new TimeSpan(0, 10, 0, 0, 0)),
+                        column.DefaultValue);
+                },
+                "DROP TABLE MyTable;");
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = culture;
+        }
+    }
+
+    [Fact]
     public void Simple_Guid_literals_are_parsed_for_HasDefaultValue()
         => Test(
             @"


### PR DESCRIPTION
<!--
Please check whether the PR fulfills these requirements
-->

- [x] I've read the guidelines for [contributing](https://github.com/dotnet/efcore/blob/main/.github/CONTRIBUTING.md) and seen the [walkthrough](https://youtu.be/9OMxy1wal1s?t=1869)
- [ ] I've posted a comment on an issue with a detailed description of how I am planning to contribute and got approval from a member of the team
- [ ] The code builds and tests pass locally (also verified by our automated build checks)
- [x] Commit messages follow this format:
```
        Summary of the changes
        - Detail 1
        - Detail 2

        Fixes #bugnumber
```
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Code follows the same patterns and style as existing code in this repo

While reading #35675, which made the scaffolders parse decimal and numeric default literals with `CultureInfo.InvariantCulture` (the da-DK report in #35654), I noticed that the date and time branches right next to it in `SqliteDatabaseModelFactory.ParseClrDefaults` and `SqlServerDatabaseModelFactory.ParseClrDefault` still call `DateTime`/`DateOnly`/`TimeOnly`/`DateTimeOffset.TryParse(defaultValueSql, out ...)` with the current culture.

With Gregorian cultures this goes unnoticed, but the current culture also brings its calendar. Under `fa-IR` (Persian calendar) the literal `'1968-10-23'` is read as year 1968 of that calendar, and the database model silently gets `DefaultValue = 2590-01-12`. Under `ar-SA` (Um Al-Qura) the parse fails and the default value is dropped, only `DefaultValueSql` remains. Literals in the `T` round-trip form such as `'1973-09-03T12:00:01'` parse the same way in every culture, so the existing tests would not catch it even on such a machine.

I ran the released SQLite scaffolder (EF Core 9.0.8, which has the same lines) against a database created with the SQL of the new test:

```
inv    A datetime        '1968-10-23 12:00:01'          -> DateTime 1968-10-23T12:00:01.0000000
inv    B date            '1968-10-23'                   -> DateOnly 1968-10-23
inv    C datetimeoffset  '1973-09-03 12:00:01+10:00'    -> DateTimeOffset 1973-09-03T12:00:01.0000000+10:00
fa-IR  A datetime        '1968-10-23 12:00:01'          -> DateTime 2590-01-12T12:00:01.0000000
fa-IR  B date            '1968-10-23'                   -> DateOnly 2590-01-12
fa-IR  C datetimeoffset  '1973-09-03 12:00:01+10:00'    -> DateTimeOffset 2594-11-23T12:00:01.0000000+10:00
ar-SA  A datetime        '1968-10-23 12:00:01'          -> null
ar-SA  B date            '1968-10-23'                   -> null
ar-SA  C datetimeoffset  '1973-09-03 12:00:01+10:00'    -> null
```

The change passes `CultureInfo.InvariantCulture` to those four calls in both factories, the same way the decimal branch already does. A literal that the invariant culture cannot parse keeps taking the existing path: no `DefaultValue`, the SQL stays in `DefaultValueSql`. I could not find a culture where the `TimeOnly` parse differs, I changed it anyway so the four branches stay consistent.

About the two unchecked boxes. There is no issue for this; it is the same class of bug as #35654, so I went straight to a PR, but I'm happy to open one if you prefer. And I don't have the .NET 11 SDK on my machines, so I could not run the test projects. What I did instead was compile the parsing branches taken verbatim from both files, before and after the change, into a .NET 8 harness, and run them under invariant, en-US, da-DK, fa-IR and ar-SA with the literals used by the tests: 16 wrong results before (all under fa-IR and ar-SA), none after. The SQLite run above used a real database. I have not run the SQL Server test against a server; its literals and `DefaultValueSql` expectations are the ones already asserted in `Simple_DateTime_literals_are_parsed_for_HasDefaultValue` and `Simple_DateOnly_literals_are_parsed_for_HasDefaultValue`.

AI tools used
