### PR TITLE
Lift GroupBy aggregates over navigations reached through an element s…

### DIFF
--- a/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.Expressions.cs
+++ b/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.Expressions.cs
@@ -304,13 +304,17 @@ public partial class NavigationExpandingExpressionVisitor
             Expression pendingSelector,
             string innerParameterName,
             NavigationExpansionExpression? parent = null,
-            LambdaExpression? originalKeySelector = null)
+            LambdaExpression? originalKeySelector = null,
+            Expression? parentShape = null,
+            LambdaExpression? originalElementSelector = null)
         {
             Source = source;
             CurrentParameter = groupingParameter;
             Type = source.Type;
             Parent = parent;
             OriginalKeySelector = originalKeySelector;
+            ParentShape = parentShape;
+            OriginalElementSelector = originalElementSelector;
             GroupingEnumerable = new NavigationExpansionExpression(
                 Call(QueryableMethods.AsQueryable.MakeGenericMethod(CurrentParameter.Type.GetGenericArguments()[1]), CurrentParameter),
                 currentTree,
@@ -335,6 +339,18 @@ public partial class NavigationExpandingExpressionVisitor
         ///     expansion is idempotent (re-expansion reuses existing joins).
         /// </summary>
         public LambdaExpression? OriginalKeySelector { get; }
+
+        /// <summary>
+        ///     The parent's pending selector as it was when the key and element selectors were written over it - i.e. before an
+        ///     element selector replaced it with the projected element shape.
+        /// </summary>
+        public Expression? ParentShape { get; }
+
+        /// <summary>
+        ///     The unprocessed element selector, if any. The lift inlines it into the aggregate selectors so they read the
+        ///     pre-GroupBy element again.
+        /// </summary>
+        public LambdaExpression? OriginalElementSelector { get; }
 
         public Type SourceElementType
             => CurrentParameter.Type;

--- a/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.cs
+++ b/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.cs
@@ -1163,6 +1163,10 @@ public partial class NavigationExpandingExpressionVisitor : ExpressionVisitor
         var originalKeySelector = keySelector;
         var keySelectorBody = ExpandNavigationsForSource(source, RemapLambdaExpression(source, keySelector));
 
+        // The shape the key and element selectors were written over. ProcessSelect below swaps the pending selector for the
+        // projected element shape, so the aggregate lift needs this stashed to remap those lambdas onto the pre-GroupBy source.
+        var parentShape = source.PendingSelector;
+
         // Need to generate lambda after processing element/result selector
         if (elementSelector != null)
         {
@@ -1184,9 +1188,9 @@ public partial class NavigationExpandingExpressionVisitor : ExpressionVisitor
 
             return new GroupByNavigationExpansionExpression(
                 innerSource, groupingParameter, source.CurrentTree, source.PendingSelector, innerParameterName,
-                // Lift state — an element selector reshapes the source, so no lift in that case.
-                elementSelector == null ? source : null,
-                elementSelector == null ? originalKeySelector : null);
+                // Lift state. An element selector reshapes the grouping element, but the lift inlines it into the aggregate
+                // selectors to get lambdas over the pre-GroupBy source back (#38775).
+                source, originalKeySelector, parentShape, elementSelector);
         }
 
         var enumerableParameter = Expression.Parameter(
@@ -1670,9 +1674,15 @@ public partial class NavigationExpandingExpressionVisitor : ExpressionVisitor
         // Lift aggregates over reference navigations into the grouped query instead of a
         // correlated subquery per group (#27933).
         if (_extensibilityHelper.SupportsNavigationExpansionJoins
-            && groupBySource is { Parent: NavigationExpansionExpression parent, OriginalKeySelector: LambdaExpression originalKeySelector })
+            && groupBySource is
+            {
+                Parent: NavigationExpansionExpression parent,
+                OriginalKeySelector: LambdaExpression originalKeySelector,
+                ParentShape: Expression parentShape
+            })
         {
-            var lifted = TryLiftAggregatesOverNavigations(parent, originalKeySelector, selector);
+            var lifted = TryLiftAggregatesOverNavigations(
+                parent, parentShape, originalKeySelector, groupBySource.OriginalElementSelector, selector);
             if (lifted != null)
             {
                 return lifted;
@@ -1725,7 +1735,9 @@ public partial class NavigationExpandingExpressionVisitor : ExpressionVisitor
     /// </summary>
     private NavigationExpansionExpression? TryLiftAggregatesOverNavigations(
         NavigationExpansionExpression parent,
+        Expression parentShape,
         LambdaExpression originalKeySelector,
+        LambdaExpression? originalElementSelector,
         LambdaExpression selector)
     {
         var scanner = new GroupingAggregateScanner(selector.Parameters[0]);
@@ -1736,12 +1748,42 @@ public partial class NavigationExpandingExpressionVisitor : ExpressionVisitor
             return null;
         }
 
+        // With an element selector the aggregate selectors are written over the projected element, so inline the element
+        // selector into each of them to get lambdas over the pre-GroupBy element back (#38775). Both are evaluated per source
+        // row, so the composition sees exactly the values the aggregate would have seen over the projected group.
+        var elementShape = originalElementSelector == null
+            ? null
+            : RemapLambdaExpression(parentShape, originalElementSelector);
+
+        var aggregateBodies = new Expression?[scanner.Aggregates.Count];
+        for (var i = 0; i < scanner.Aggregates.Count; i++)
+        {
+            var aggregateSelector = scanner.Aggregates[i].Selector;
+            if (aggregateSelector == null)
+            {
+                continue;
+            }
+
+            var aggregateBody = RemapLambdaExpression(elementShape ?? parentShape, aggregateSelector);
+
+            // A member the inlining could not bind back to what the element selector projects (a projection into a type whose
+            // members don't map onto its constructor arguments) would be left reading a member the pre-GroupBy element does
+            // not have. Those shapes keep the translation they have today.
+            if (elementShape != null
+                && ContainsUnboundProjectionMemberAccess(aggregateBody))
+            {
+                return null;
+            }
+
+            aggregateBodies[i] = aggregateBody;
+        }
+
         // Flat-aggregate queries keep the existing translation unchanged.
         var traversesNavigation = false;
-        foreach (var aggregate in scanner.Aggregates)
+        foreach (var aggregateBody in aggregateBodies)
         {
-            if (aggregate.Selector != null
-                && ContainsReferenceNavigationAccess(RemapLambdaExpression(parent, aggregate.Selector)))
+            if (aggregateBody != null
+                && ContainsReferenceNavigationAccess(aggregateBody))
             {
                 traversesNavigation = true;
                 break;
@@ -1756,14 +1798,13 @@ public partial class NavigationExpandingExpressionVisitor : ExpressionVisitor
         // Expand every body on the parent first (this applies the joins and may widen the parent's
         // element shape), then generate all lambdas over the final parameter. Re-expanding the key
         // selector is idempotent with respect to joins already applied by ProcessGroupBy.
-        var keyBody = ExpandNavigationsForSource(parent, RemapLambdaExpression(parent, originalKeySelector));
-        var aggregateBodies = new Expression?[scanner.Aggregates.Count];
-        for (var i = 0; i < scanner.Aggregates.Count; i++)
+        var keyBody = ExpandNavigationsForSource(parent, RemapLambdaExpression(parentShape, originalKeySelector));
+        for (var i = 0; i < aggregateBodies.Length; i++)
         {
-            var aggregateSelector = scanner.Aggregates[i].Selector;
-            aggregateBodies[i] = aggregateSelector == null
-                ? null
-                : ExpandNavigationsForSource(parent, RemapLambdaExpression(parent, aggregateSelector));
+            if (aggregateBodies[i] is Expression aggregateBody)
+            {
+                aggregateBodies[i] = ExpandNavigationsForSource(parent, aggregateBody);
+            }
         }
 
         var keySelector = GenerateLambda(keyBody, parent.CurrentParameter);
@@ -1836,6 +1877,34 @@ public partial class NavigationExpandingExpressionVisitor : ExpressionVisitor
         }
     }
 
+    /// <summary>
+    ///     Detects a member access left standing over an inlined projection, i.e. one that could not be bound to the member the
+    ///     element selector projects.
+    /// </summary>
+    private static bool ContainsUnboundProjectionMemberAccess(Expression body)
+    {
+        var detector = new UnboundProjectionMemberAccessDetector();
+        detector.Visit(body);
+        return detector.Found;
+    }
+
+    private sealed class UnboundProjectionMemberAccessDetector : ExpressionVisitor
+    {
+        public bool Found { get; private set; }
+
+        protected override Expression VisitMember(MemberExpression memberExpression)
+        {
+            if (memberExpression.Expression is NewExpression or MemberInitExpression)
+            {
+                Found = true;
+
+                return memberExpression;
+            }
+
+            return base.VisitMember(memberExpression);
+        }
+    }
+
     private sealed record GroupingAggregateCall(MethodCallExpression Call, LambdaExpression? Selector, bool SourceAsQueryable);
 
     private static MethodCallExpression RebuildLiftedAggregate(
@@ -1846,8 +1915,15 @@ public partial class NavigationExpandingExpressionVisitor : ExpressionVisitor
         LambdaExpression? newSelector)
     {
         var method = aggregate.Call.Method;
-        var newMethod = method.GetGenericMethodDefinition().MakeGenericMethod(
-            method.GetGenericArguments().Select(t => t == originalElementType ? newElementType : t).ToArray());
+
+        // The grouping element is always the first generic argument of these overloads; the others (Min/Max's TResult) keep
+        // their own type, which with an element selector can coincide with the element type - g.Max(x => x) over a grouping
+        // whose element selector projects a scalar.
+        var genericArguments = method.GetGenericArguments();
+        Check.DebugAssert(
+            genericArguments[0] == originalElementType, "Aggregate source is not typed as the grouping element");
+        genericArguments[0] = newElementType;
+        var newMethod = method.GetGenericMethodDefinition().MakeGenericMethod(genericArguments);
 
         Expression newSource = aggregate.SourceAsQueryable
             ? Expression.Call(QueryableMethods.AsQueryable.MakeGenericMethod(newElementType), groupingParameter)
@@ -2420,7 +2496,10 @@ public partial class NavigationExpandingExpressionVisitor : ExpressionVisitor
     }
 
     private static Expression RemapLambdaExpression(NavigationExpansionExpression source, LambdaExpression lambdaExpression)
-        => ReplacingExpressionVisitor.Replace(lambdaExpression.Parameters[0], source.PendingSelector, lambdaExpression.Body);
+        => RemapLambdaExpression(source.PendingSelector, lambdaExpression);
+
+    private static Expression RemapLambdaExpression(Expression shape, LambdaExpression lambdaExpression)
+        => ReplacingExpressionVisitor.Replace(lambdaExpression.Parameters[0], shape, lambdaExpression.Body);
 
     private LambdaExpression ProcessLambdaExpression(NavigationExpansionExpression source, LambdaExpression lambdaExpression)
         => GenerateLambda(ExpandNavigationsForSource(source, RemapLambdaExpression(source, lambdaExpression)), source.CurrentParameter);

--- a/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.cs
+++ b/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.cs
@@ -1795,15 +1795,22 @@ public partial class NavigationExpandingExpressionVisitor : ExpressionVisitor
             return null;
         }
 
+        // An aggregate selector may capture the grouping parameter as g.Key, which the scanner allows. The lifted aggregate
+        // becomes a lambda over the pre-GroupBy source, where that parameter is out of scope, so rebind g.Key to the key
+        // expression itself: evaluated per source row it yields that row's group key, which is exactly what g.Key means
+        // inside the aggregate.
+        var keyBody = RemapLambdaExpression(parentShape, originalKeySelector);
+        var capturedKeyRebinder = new CapturedGroupingKeyRebinder(selector.Parameters[0], keyBody);
+
         // Expand every body on the parent first (this applies the joins and may widen the parent's
         // element shape), then generate all lambdas over the final parameter. Re-expanding the key
         // selector is idempotent with respect to joins already applied by ProcessGroupBy.
-        var keyBody = ExpandNavigationsForSource(parent, RemapLambdaExpression(parentShape, originalKeySelector));
+        keyBody = ExpandNavigationsForSource(parent, keyBody);
         for (var i = 0; i < aggregateBodies.Length; i++)
         {
             if (aggregateBodies[i] is Expression aggregateBody)
             {
-                aggregateBodies[i] = ExpandNavigationsForSource(parent, aggregateBody);
+                aggregateBodies[i] = ExpandNavigationsForSource(parent, capturedKeyRebinder.Visit(aggregateBody));
             }
         }
 
@@ -1903,6 +1910,20 @@ public partial class NavigationExpandingExpressionVisitor : ExpressionVisitor
 
             return base.VisitMember(memberExpression);
         }
+    }
+
+    /// <summary>
+    ///     Replaces g.Key captured inside a lifted aggregate's selector with the key expression, which reads the same value
+    ///     from the source row the aggregate is now evaluated over.
+    /// </summary>
+    private sealed class CapturedGroupingKeyRebinder(ParameterExpression groupingParameter, Expression keyBody)
+        : ExpressionVisitor
+    {
+        protected override Expression VisitMember(MemberExpression memberExpression)
+            => memberExpression.Expression == groupingParameter
+                && memberExpression.Member.Name == nameof(IGrouping<object, object>.Key)
+                    ? keyBody
+                    : base.VisitMember(memberExpression);
     }
 
     private sealed record GroupingAggregateCall(MethodCallExpression Call, LambdaExpression? Selector, bool SourceAsQueryable);

--- a/test/EFCore.Relational.Specification.Tests/Query/NorthwindGroupByQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/NorthwindGroupByQueryRelationalTestBase.cs
@@ -1,7 +1,29 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.EntityFrameworkCore.TestModels.Northwind;
+
 namespace Microsoft.EntityFrameworkCore.Query;
 
 public abstract class NorthwindGroupByQueryRelationalTestBase<TFixture>(TFixture fixture) : NorthwindGroupByQueryTestBase<TFixture>(fixture)
-    where TFixture : NorthwindQueryFixtureBase<NoopModelCustomizer>, new();
+    where TFixture : NorthwindQueryFixtureBase<NoopModelCustomizer>, new()
+{
+    // A projection into a type whose members do not map onto its constructor arguments cannot be folded back into the
+    // aggregate selector, so the GroupBy aggregate lift is abandoned and the query fails to translate exactly as it
+    // does without it.
+    [Theory, MemberData(nameof(IsAsyncData))]
+    public virtual Task GroupBy_element_selector_projecting_constructor_bound_type_with_aggregate(bool async)
+        => AssertTranslationFailed(() => AssertQuery(async, ConstructorBoundElementSelectorQuery));
+
+    private static IQueryable<string?> ConstructorBoundElementSelectorQuery(ISetSource ss)
+        => ss.Set<Order>()
+            .GroupBy(o => o.EmployeeID, o => new OrderRegion(o.Customer!.Region, o.OrderID))
+            .Select(g => g.Max(x => x.Region));
+
+    private class OrderRegion(string? region, int orderID)
+    {
+        public string? Region { get; } = region;
+
+        public int OrderID { get; } = orderID;
+    }
+}

--- a/test/EFCore.Specification.Tests/Query/NorthwindGroupByQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindGroupByQueryTestBase.cs
@@ -650,6 +650,67 @@ public abstract class NorthwindGroupByQueryTestBase<TFixture>(TFixture fixture) 
             elementSorter: e => e.Key);
 
     [Theory, MemberData(nameof(IsAsyncData))]
+    public virtual Task GroupBy_element_selector_with_aggregates_through_navigation_property(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<Order>()
+                .GroupBy(o => o.EmployeeID, o => new { o.Customer!.Region, o.Customer!.City, o.OrderID })
+                .Select(g => new
+                {
+                    g.Key,
+                    Region = g.Max(x => x.Region),
+                    Londons = g.Sum(x => x.City == "London" ? 1 : 0),
+                    Total = g.Sum(x => x.OrderID),
+                    Count = g.Count()
+                }),
+            elementSorter: e => e.Key);
+
+    [Theory, MemberData(nameof(IsAsyncData))]
+    public virtual Task GroupBy_element_selector_projecting_navigation_with_aggregate(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<Order>()
+                .GroupBy(o => o.EmployeeID, o => o.Customer)
+                .Select(g => new { g.Key, Region = g.Max(c => c!.Region) }),
+            elementSorter: e => e.Key);
+
+    [Theory, MemberData(nameof(IsAsyncData))]
+    public virtual Task GroupBy_element_selector_with_aggregate_through_two_level_navigation(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<OrderDetail>()
+                .GroupBy(od => od.ProductID, od => new { od.Order!.Customer!.City, od.Quantity })
+                .Select(g => new { g.Key, Londons = g.Sum(x => x.City == "London" ? 1 : 0) }),
+            elementSorter: e => e.Key);
+
+    [Theory, MemberData(nameof(IsAsyncData))]
+    public virtual Task GroupBy_element_selector_with_predicate_aggregate_through_navigation(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<Order>()
+                .GroupBy(o => o.EmployeeID, o => new { o.Customer!.City, o.OrderID })
+                .Select(g => new { g.Key, Londons = g.Count(x => x.City == "London") }),
+            elementSorter: e => e.Key);
+
+    [Theory, MemberData(nameof(IsAsyncData))]
+    public virtual Task GroupBy_element_selector_without_aggregate_selector_through_navigation(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<Order>()
+                .GroupBy(o => o.EmployeeID, o => o.Customer!.City!.Length)
+                .Select(g => new { g.Key, Max = g.Max() }),
+            elementSorter: e => e.Key);
+
+    [Theory, MemberData(nameof(IsAsyncData))]
+    public virtual Task GroupBy_element_selector_with_identity_aggregate_selector_through_navigation(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<Order>()
+                .GroupBy(o => o.EmployeeID, o => o.Customer!.City!.Length)
+                .Select(g => new { g.Key, Max = g.Max(x => x) }),
+            elementSorter: e => e.Key);
+
+    [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task GroupBy_with_aggregate_containing_complex_where(bool async)
         => AssertQuery(
             async,

--- a/test/EFCore.Specification.Tests/Query/NorthwindGroupByQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindGroupByQueryTestBase.cs
@@ -711,6 +711,24 @@ public abstract class NorthwindGroupByQueryTestBase<TFixture>(TFixture fixture) 
             elementSorter: e => e.Key);
 
     [Theory, MemberData(nameof(IsAsyncData))]
+    public virtual Task GroupBy_aggregate_capturing_key_through_navigation(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<Order>()
+                .GroupBy(o => o.EmployeeID)
+                .Select(g => new { g.Key, Max = g.Max(o => o.Customer!.Region == null ? 0 : (int)(g.Key ?? 0)) }),
+            elementSorter: e => e.Key);
+
+    [Theory, MemberData(nameof(IsAsyncData))]
+    public virtual Task GroupBy_element_selector_with_aggregate_capturing_key_through_navigation(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<Order>()
+                .GroupBy(o => o.EmployeeID, o => new { o.Customer!.Region, o.OrderID })
+                .Select(g => new { g.Key, Max = g.Max(x => x.Region == null ? 0 : (int)(g.Key ?? 0)) }),
+            elementSorter: e => e.Key);
+
+    [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task GroupBy_with_aggregate_containing_complex_where(bool async)
         => AssertQuery(
             async,

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindGroupByQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindGroupByQuerySqlServerTest.cs
@@ -2905,6 +2905,38 @@ GROUP BY [o].[EmployeeID]
         AssertSql();
     }
 
+    public override async Task GroupBy_aggregate_capturing_key_through_navigation(bool async)
+    {
+        await base.GroupBy_aggregate_capturing_key_through_navigation(async);
+
+        AssertSql(
+            """
+SELECT [o].[EmployeeID] AS [Key], MAX(CASE
+    WHEN [c].[Region] IS NULL THEN 0
+    ELSE COALESCE([o].[EmployeeID], 0)
+END) AS [Max]
+FROM [Orders] AS [o]
+LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
+GROUP BY [o].[EmployeeID]
+""");
+    }
+
+    public override async Task GroupBy_element_selector_with_aggregate_capturing_key_through_navigation(bool async)
+    {
+        await base.GroupBy_element_selector_with_aggregate_capturing_key_through_navigation(async);
+
+        AssertSql(
+            """
+SELECT [o].[EmployeeID] AS [Key], MAX(CASE
+    WHEN [c].[Region] IS NULL THEN 0
+    ELSE COALESCE([o].[EmployeeID], 0)
+END) AS [Max]
+FROM [Orders] AS [o]
+LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
+GROUP BY [o].[EmployeeID]
+""");
+    }
+
     public override async Task GroupBy_with_aggregate_containing_complex_where(bool async)
     {
         await base.GroupBy_with_aggregate_containing_complex_where(async);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindGroupByQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindGroupByQuerySqlServerTest.cs
@@ -2808,6 +2808,103 @@ GROUP BY [o].[EmployeeID]
 """);
     }
 
+    public override async Task GroupBy_element_selector_with_aggregates_through_navigation_property(bool async)
+    {
+        await base.GroupBy_element_selector_with_aggregates_through_navigation_property(async);
+
+        AssertSql(
+            """
+SELECT [o].[EmployeeID] AS [Key], MAX([c].[Region]) AS [Region], ISNULL(SUM(CASE
+    WHEN [c].[City] = N'London' THEN 1
+    ELSE 0
+END), 0) AS [Londons], ISNULL(SUM([o].[OrderID]), 0) AS [Total], COUNT(*) AS [Count]
+FROM [Orders] AS [o]
+LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
+GROUP BY [o].[EmployeeID]
+""");
+    }
+
+    public override async Task GroupBy_element_selector_projecting_navigation_with_aggregate(bool async)
+    {
+        await base.GroupBy_element_selector_projecting_navigation_with_aggregate(async);
+
+        AssertSql(
+            """
+SELECT [o].[EmployeeID] AS [Key], MAX([c].[Region]) AS [Region]
+FROM [Orders] AS [o]
+LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
+GROUP BY [o].[EmployeeID]
+""");
+    }
+
+    public override async Task GroupBy_element_selector_with_aggregate_through_two_level_navigation(bool async)
+    {
+        await base.GroupBy_element_selector_with_aggregate_through_two_level_navigation(async);
+
+        AssertSql(
+            """
+SELECT [o].[ProductID] AS [Key], ISNULL(SUM(CASE
+    WHEN [c].[City] = N'London' THEN 1
+    ELSE 0
+END), 0) AS [Londons]
+FROM [Order Details] AS [o]
+INNER JOIN [Orders] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+LEFT JOIN [Customers] AS [c] ON [o0].[CustomerID] = [c].[CustomerID]
+GROUP BY [o].[ProductID]
+""");
+    }
+
+    public override async Task GroupBy_element_selector_with_predicate_aggregate_through_navigation(bool async)
+    {
+        await base.GroupBy_element_selector_with_predicate_aggregate_through_navigation(async);
+
+        AssertSql(
+            """
+SELECT [o].[EmployeeID] AS [Key], COUNT(CASE
+    WHEN [c].[City] = N'London' THEN 1
+END) AS [Londons]
+FROM [Orders] AS [o]
+LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
+GROUP BY [o].[EmployeeID]
+""");
+    }
+
+    public override async Task GroupBy_element_selector_without_aggregate_selector_through_navigation(bool async)
+    {
+        await base.GroupBy_element_selector_without_aggregate_selector_through_navigation(async);
+
+        AssertSql(
+            """
+SELECT [o].[EmployeeID] AS [Key], (
+    SELECT MAX(CAST(LEN([c].[City]) AS int))
+    FROM [Orders] AS [o0]
+    LEFT JOIN [Customers] AS [c] ON [o0].[CustomerID] = [c].[CustomerID]
+    WHERE [o].[EmployeeID] = [o0].[EmployeeID] OR ([o].[EmployeeID] IS NULL AND [o0].[EmployeeID] IS NULL)) AS [Max]
+FROM [Orders] AS [o]
+GROUP BY [o].[EmployeeID]
+""");
+    }
+
+    public override async Task GroupBy_element_selector_with_identity_aggregate_selector_through_navigation(bool async)
+    {
+        await base.GroupBy_element_selector_with_identity_aggregate_selector_through_navigation(async);
+
+        AssertSql(
+            """
+SELECT [o].[EmployeeID] AS [Key], MAX(CAST(LEN([c].[City]) AS int)) AS [Max]
+FROM [Orders] AS [o]
+LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
+GROUP BY [o].[EmployeeID]
+""");
+    }
+
+    public override async Task GroupBy_element_selector_projecting_constructor_bound_type_with_aggregate(bool async)
+    {
+        await base.GroupBy_element_selector_projecting_constructor_bound_type_with_aggregate(async);
+
+        AssertSql();
+    }
+
     public override async Task GroupBy_with_aggregate_containing_complex_where(bool async)
     {
         await base.GroupBy_with_aggregate_containing_complex_where(async);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/OwnedQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/OwnedQuerySqlServerTest.cs
@@ -1306,36 +1306,14 @@ ORDER BY [o].[Id], [o1].[ClientId], [o1].[Id]
 
         AssertSql(
             """
-SELECT (
-    SELECT AVG(CAST([s].[Id] AS float))
-    FROM (
-        SELECT 1 AS [Key], [o2].[PersonAddress_Country_PlanetId]
-        FROM [OwnedPerson] AS [o2]
-    ) AS [o1]
-    LEFT JOIN [Planet] AS [p] ON [o1].[PersonAddress_Country_PlanetId] = [p].[Id]
-    LEFT JOIN [Star] AS [s] ON [p].[StarId] = [s].[Id]
-    WHERE [o0].[Key] = [o1].[Key]) AS [p1], (
-    SELECT ISNULL(SUM([s0].[Id]), 0)
-    FROM (
-        SELECT 1 AS [Key], [o4].[PersonAddress_Country_PlanetId]
-        FROM [OwnedPerson] AS [o4]
-    ) AS [o3]
-    LEFT JOIN [Planet] AS [p0] ON [o3].[PersonAddress_Country_PlanetId] = [p0].[Id]
-    LEFT JOIN [Star] AS [s0] ON [p0].[StarId] = [s0].[Id]
-    WHERE [o0].[Key] = [o3].[Key]) AS [p2], (
-    SELECT MAX(CAST(LEN([s1].[Name]) AS int))
-    FROM (
-        SELECT 1 AS [Key], [o6].[PersonAddress_Country_PlanetId]
-        FROM [OwnedPerson] AS [o6]
-    ) AS [o5]
-    LEFT JOIN [Planet] AS [p1] ON [o5].[PersonAddress_Country_PlanetId] = [p1].[Id]
-    LEFT JOIN [Star] AS [s1] ON [p1].[StarId] = [s1].[Id]
-    WHERE [o0].[Key] = [o5].[Key]) AS [p3]
+SELECT AVG(CAST([s0].[Id1] AS float)) AS [p1], ISNULL(SUM([s0].[Id1]), 0) AS [p2], MAX(CAST(LEN([s0].[Name1]) AS int)) AS [p3]
 FROM (
-    SELECT 1 AS [Key]
+    SELECT [s].[Id] AS [Id1], [s].[Name] AS [Name1], 1 AS [Key]
     FROM [OwnedPerson] AS [o]
-) AS [o0]
-GROUP BY [o0].[Key]
+    LEFT JOIN [Planet] AS [p] ON [o].[PersonAddress_Country_PlanetId] = [p].[Id]
+    LEFT JOIN [Star] AS [s] ON [p].[StarId] = [s].[Id]
+) AS [s0]
+GROUP BY [s0].[Key]
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TemporalOwnedQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TemporalOwnedQuerySqlServerTest.cs
@@ -1282,36 +1282,14 @@ ORDER BY [o].[Id], [o1].[ClientId], [o1].[Id]
 
         AssertSql(
             """
-SELECT (
-    SELECT AVG(CAST([s].[Id] AS float))
-    FROM (
-        SELECT 1 AS [Key], [o2].[PersonAddress_Country_PlanetId]
-        FROM [OwnedPerson] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [o2]
-    ) AS [o1]
-    LEFT JOIN [Planet] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [p] ON [o1].[PersonAddress_Country_PlanetId] = [p].[Id]
-    LEFT JOIN [Star] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [s] ON [p].[StarId] = [s].[Id]
-    WHERE [o0].[Key] = [o1].[Key]) AS [p1], (
-    SELECT ISNULL(SUM([s0].[Id]), 0)
-    FROM (
-        SELECT 1 AS [Key], [o4].[PersonAddress_Country_PlanetId]
-        FROM [OwnedPerson] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [o4]
-    ) AS [o3]
-    LEFT JOIN [Planet] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [p0] ON [o3].[PersonAddress_Country_PlanetId] = [p0].[Id]
-    LEFT JOIN [Star] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [s0] ON [p0].[StarId] = [s0].[Id]
-    WHERE [o0].[Key] = [o3].[Key]) AS [p2], (
-    SELECT MAX(CAST(LEN([s1].[Name]) AS int))
-    FROM (
-        SELECT 1 AS [Key], [o6].[PersonAddress_Country_PlanetId]
-        FROM [OwnedPerson] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [o6]
-    ) AS [o5]
-    LEFT JOIN [Planet] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [p1] ON [o5].[PersonAddress_Country_PlanetId] = [p1].[Id]
-    LEFT JOIN [Star] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [s1] ON [p1].[StarId] = [s1].[Id]
-    WHERE [o0].[Key] = [o5].[Key]) AS [p3]
+SELECT AVG(CAST([s0].[Id1] AS float)) AS [p1], ISNULL(SUM([s0].[Id1]), 0) AS [p2], MAX(CAST(LEN([s0].[Name1]) AS int)) AS [p3]
 FROM (
-    SELECT 1 AS [Key]
+    SELECT [s].[Id] AS [Id1], [s].[Name] AS [Name1], 1 AS [Key]
     FROM [OwnedPerson] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [o]
-) AS [o0]
-GROUP BY [o0].[Key]
+    LEFT JOIN [Planet] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [p] ON [o].[PersonAddress_Country_PlanetId] = [p].[Id]
+    LEFT JOIN [Star] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [s] ON [p].[StarId] = [s].[Id]
+) AS [s0]
+GROUP BY [s0].[Key]
 """);
     }
 


### PR DESCRIPTION
Fixes #38775

- [x] I've read the guidelines for [contributing](https://github.com/dotnet/efcore/blob/main/.github/CONTRIBUTING.md) and seen the [walkthrough](https://youtu.be/9OMxy1wal1s?t=1869)
- [ ] I've posted a comment on an issue with a detailed description of how I am planning to contribute and got approval from a member of the team
- [x] The code builds and tests pass locally (also verified by our automated build checks)
- [x] Commit messages follow this format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Code follows the same patterns and style as existing code in this repo

## Summary

#38668 lifts `GroupBy` aggregates whose selectors traverse a reference navigation onto a shared pre-`GroupBy` join, so they read one join instead of a correlated subquery per aggregate. `ProcessGroupBy` throws that lift state away as soon as there is an element selector: `GroupBy(key, elementSelector)` runs the element selector through `ProcessSelect`, which swaps the source's pending selector for the projected element shape, and the `GroupByNavigationExpansionExpression` is then built with `Parent`/`OriginalKeySelector` set to `null`, so `TryLiftAggregatesOverNavigations` never runs.

Nothing else about the shape disqualifies it. The aggregates are the same aggregates — they are just written over the projected element rather than over the entity.

```csharp
ss.Set<Order>()
    .GroupBy(o => o.EmployeeID, o => new { o.Customer.Region, o.Customer.City, o.OrderID })
    .Select(g => new
    {
        g.Key,
        Region = g.Max(x => x.Region),
        Londons = g.Sum(x => x.City == "London" ? 1 : 0),
        Total = g.Sum(x => x.OrderID),
        Count = g.Count()
    })
```

```sql
-- before: one correlated subquery per aggregate that reaches the navigation,
-- each re-deriving [Orders] and re-joining [Customers]
SELECT [o].[EmployeeID] AS [Key], (
    SELECT MAX([c].[Region])
    FROM [Orders] AS [o0]
    LEFT JOIN [Customers] AS [c] ON [o0].[CustomerID] = [c].[CustomerID]
    WHERE [o].[EmployeeID] = [o0].[EmployeeID] OR ([o].[EmployeeID] IS NULL AND [o0].[EmployeeID] IS NULL)) AS [Region], (
    SELECT ISNULL(SUM(CASE
        WHEN [c0].[City] = N'London' THEN 1
        ELSE 0
    END), 0)
    FROM [Orders] AS [o1]
    LEFT JOIN [Customers] AS [c0] ON [o1].[CustomerID] = [c0].[CustomerID]
    WHERE [o].[EmployeeID] = [o1].[EmployeeID] OR ([o].[EmployeeID] IS NULL AND [o1].[EmployeeID] IS NULL)) AS [Londons], ISNULL(SUM([o].[OrderID]), 0) AS [Total], COUNT(*) AS [Count]
FROM [Orders] AS [o]
GROUP BY [o].[EmployeeID]

-- after: every aggregate reads the shared join
SELECT [o].[EmployeeID] AS [Key], MAX([c].[Region]) AS [Region], ISNULL(SUM(CASE
    WHEN [c].[City] = N'London' THEN 1
    ELSE 0
END), 0) AS [Londons], ISNULL(SUM([o].[OrderID]), 0) AS [Total], COUNT(*) AS [Count]
FROM [Orders] AS [o]
LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
GROUP BY [o].[EmployeeID]
```

This is the same translation the no-element-selector form of the query already gets; writing the aggregates over a projected element no longer changes the SQL.

## Implementation

`GroupByNavigationExpansionExpression` gains two members, and `Parent`/`OriginalKeySelector` now stay set in the element-selector case:

- **`ParentShape`** — the parent's pending selector as it was when the key and element selectors were written over it, captured before `ProcessSelect` replaces it with the projected element shape.
- **`OriginalElementSelector`** — the unprocessed element selector.

`TryLiftAggregatesOverNavigations` remaps the element selector onto `ParentShape` once, then remaps each aggregate selector onto the *result* rather than onto the parent's (now element-shaped) pending selector. `ReplacingExpressionVisitor` binds the member access back to the member the projection assigns, so `g.Max(x => x.Region)` over `o => new { o.Customer.Region, ... }` comes back as `Max(o => o.Customer.Region)` over the pre-`GroupBy` source. That is exactly the shape the existing lift already handles, so the join expansion, the rebuild and the result-selector rebinding are all unchanged. The key selector is remapped onto `ParentShape` for the same reason.

Inlining is valid because the element selector and the aggregate selector are both evaluated per source row. A `GroupBy` element selector is a projection: it cannot add, remove or reorder rows, so each aggregate sees exactly the values it saw over the projected group.

### Aggregates with no selector

`g.Count()`, `g.LongCount()` and `g.Any()` carry no selector, so there is nothing to inline. They are rebuilt over the widened element type and count the same rows, because the projection is one-to-one with the source rows.

`Sum`/`Min`/`Max`/`Average` have no parameterless overload that `TryMatchAggregate` accepts, so a bare `g.Max()` over a projected element is not matched as an aggregate at all; the grouping parameter is then seen as an unsupported usage and the whole lift is skipped. `GroupBy_element_selector_without_aggregate_selector_through_navigation` pins that as a negative case, with its correlated subquery deliberately unchanged.

### Generic arguments

`RebuildLiftedAggregate` previously rebuilt the aggregate by replacing *every* generic argument equal to the original element type. With an element selector the element type can coincide with `Min`/`Max`'s `TResult` — `g.Max(x => x)` over a grouping whose element selector projects a scalar — which would rewrite the result type as well. The grouping element is always the first generic argument of these overloads, so it is now the only one substituted, under a `Check.DebugAssert`.

### Aggregate selectors that capture `g.Key`

`GroupingAggregateScanner` permits `g.Key` inside an aggregate selector, but the lifted aggregate becomes a lambda over the pre-`GroupBy` source, where the grouping parameter is out of scope. `CapturedGroupingKeyRebinder` rebinds it to the key expression: evaluated per source row it yields that row's group key, which is what `g.Key` means inside the aggregate.

This also closes the same gap in the lift added by #38668 — `GroupBy(key).Select(g => g.Max(o => … g.Key …))` over a navigation fails to translate on `main` with `The LINQ expression 'g' could not be translated`, and `GroupBy_aggregate_capturing_key_through_navigation` covers it. This is not a regression from #38668: before it, the same shape translated but failed at execution with SQL Server error 8124 (addressed later by #38855). The shape has never worked, so this makes it work rather than restoring anything.

### Shapes deliberately left alone

A projection into a type whose members do not map onto its constructor arguments (a positional record, or any constructor-bound class) cannot be folded back by `ReplacingExpressionVisitor`, which leaves the member access standing over the `NewExpression`. `ContainsUnboundProjectionMemberAccess` detects that and abandons the lift, so those shapes keep the behaviour they have on `main` — they fail to translate, loudly, rather than being rewritten to read a member the pre-`GroupBy` element does not have.

Operators between the `GroupBy` and the `Select`, non-aggregate uses of the grouping parameter, and `g.Distinct()`/`g.Where(...)` as an aggregate source are all still rejected upstream by `GroupingAggregateScanner`, unchanged by this PR.

## Testing

Specification tests with SQL Server baselines; they also run on SQLite and the in-memory provider through the shared base.

| Test | Shape |
| --- | --- |
| `GroupBy_element_selector_with_aggregates_through_navigation_property` | the reported shape — several aggregates over the same navigation, alongside `Sum` over a plain column and `Count()` |
| `GroupBy_element_selector_projecting_navigation_with_aggregate` | the element selector projects the navigation itself (`o => o.Customer`) |
| `GroupBy_element_selector_with_aggregate_through_two_level_navigation` | two-level navigation reached through the element selector |
| `GroupBy_element_selector_with_predicate_aggregate_through_navigation` | a predicate aggregate (`g.Count(x => ...)`) rather than a selector aggregate |
| `GroupBy_element_selector_with_identity_aggregate_selector_through_navigation` | `g.Max(x => x)` over a scalar element selector — the case where the element type coincides with `Max`'s `TResult` |
| `GroupBy_element_selector_without_aggregate_selector_through_navigation` | negative case: `g.Max()` with no selector, SQL deliberately unchanged |
| `GroupBy_aggregate_capturing_key_through_navigation` | an aggregate selector capturing `g.Key`, with no element selector — fails to translate on `main` |
| `GroupBy_element_selector_with_aggregate_capturing_key_through_navigation` | the same capture reached through an element selector |

One test lives in `NorthwindGroupByQueryRelationalTestBase` rather than the shared base, because it asserts a translation failure and the in-memory provider client-evaluates instead:

| Test | Why there |
| --- | --- |
| `GroupBy_element_selector_projecting_constructor_bound_type_with_aggregate` | the element selector projects a constructor-bound type, so the lift is abandoned. Verified to fail identically on `main`, i.e. the guard preserves today's behaviour rather than introducing the failure. |

Each of the five lifting tests fails against `main` with the old correlated-subquery SQL and passes with this change.

### Existing baselines

`GroupBy_with_multiple_aggregates_on_owned_navigation_properties` in `OwnedQuerySqlServerTest` and `TemporalOwnedQuerySqlServerTest` is an existing test that the same shape covers: an owned navigation reached through a `GroupBy` with an element selector. Its three correlated subqueries collapse into a single grouped `SELECT` over one join — results unchanged, each baseline going from 30 lines of SQL to 8.
