### PR TITLE
Stream GroupBy elements instead of joining the source back to itself

### DIFF
--- a/src/EFCore.Relational/EFCore.Relational.baseline.json
+++ b/src/EFCore.Relational/EFCore.Relational.baseline.json
@@ -13147,6 +13147,9 @@
           "Member": "RelationalGroupByResultExpression(System.Linq.Expressions.Expression keyIdentifier, System.Collections.Generic.IReadOnlyList<Microsoft.EntityFrameworkCore.ChangeTracking.ValueComparer> keyIdentifierValueComparers, System.Linq.Expressions.Expression keyShaper, System.Linq.Expressions.Expression elementShaper);"
         },
         {
+          "Member": "RelationalGroupByResultExpression(System.Linq.Expressions.Expression keyIdentifier, System.Collections.Generic.IReadOnlyList<Microsoft.EntityFrameworkCore.ChangeTracking.ValueComparer> keyIdentifierValueComparers, System.Linq.Expressions.Expression keyShaper, System.Linq.Expressions.Expression elementShaper, System.Linq.Expressions.LambdaExpression? resultSelector);"
+        },
+        {
           "Member": "virtual Microsoft.EntityFrameworkCore.Query.RelationalGroupByResultExpression Update(System.Linq.Expressions.Expression keyIdentifier, System.Linq.Expressions.Expression keyShaper, System.Linq.Expressions.Expression elementShaper);"
         },
         {
@@ -13170,6 +13173,9 @@
           "Member": "sealed override System.Linq.Expressions.ExpressionType NodeType { get; }"
         },
         {
+          "Member": "virtual System.Linq.Expressions.LambdaExpression? ResultSelector { get; }"
+        },
+        {
           "Member": "override System.Type Type { get; }"
         }
       ]
@@ -13181,6 +13187,9 @@
           "Member": "RelationalGroupByShaperExpression(System.Linq.Expressions.Expression keySelector, System.Linq.Expressions.Expression elementSelector, Microsoft.EntityFrameworkCore.Query.ShapedQueryExpression groupingEnumerable);"
         },
         {
+          "Member": "RelationalGroupByShaperExpression(System.Linq.Expressions.Expression keySelector, System.Linq.Expressions.Expression elementSelector, Microsoft.EntityFrameworkCore.Query.ShapedQueryExpression groupingEnumerable, System.Linq.Expressions.LambdaExpression? resultSelector);"
+        },
+        {
           "Member": "override void Print(Microsoft.EntityFrameworkCore.Query.ExpressionPrinter expressionPrinter);"
         },
         {
@@ -13190,6 +13199,12 @@
       "Properties": [
         {
           "Member": "virtual System.Linq.Expressions.Expression ElementSelector { get; }"
+        },
+        {
+          "Member": "virtual System.Linq.Expressions.LambdaExpression? ResultSelector { get; }"
+        },
+        {
+          "Member": "override System.Type Type { get; }"
         }
       ]
     },
@@ -15454,6 +15469,9 @@
         },
         {
           "Member": "virtual Microsoft.EntityFrameworkCore.Query.ShapedQueryExpression? TransformJsonQueryToTable(Microsoft.EntityFrameworkCore.Query.JsonQueryExpression jsonQueryExpression);"
+        },
+        {
+          "Member": "override System.Linq.Expressions.Expression Translate(System.Linq.Expressions.Expression expression);"
         },
         {
           "Member": "override Microsoft.EntityFrameworkCore.Query.ShapedQueryExpression? TranslateAll(Microsoft.EntityFrameworkCore.Query.ShapedQueryExpression source, System.Linq.Expressions.LambdaExpression predicate);"

--- a/src/EFCore.Relational/Query/Internal/ProjectedQueryingEnumerable.cs
+++ b/src/EFCore.Relational/Query/Internal/ProjectedQueryingEnumerable.cs
@@ -1,0 +1,113 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections;
+
+namespace Microsoft.EntityFrameworkCore.Query.Internal;
+
+/// <summary>
+///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+///     any release. You should only use it directly in your code with extreme caution and knowing that
+///     doing so can result in application failures when updating to a new Entity Framework Core release.
+/// </summary>
+public static class ProjectedQueryingEnumerable
+{
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public static ProjectedQueryingEnumerable<TSource, TResult> Create<TSource, TResult>(
+        IRelationalQueryingEnumerable source,
+        Func<TSource, TResult> selector)
+        => new(source, selector);
+}
+
+/// <summary>
+///     <para>
+///         Applies a client-side projection to each element produced by another querying enumerable.
+///     </para>
+///     <para>
+///         This is used for queries which project out of a grouping without aggregating it; the groupings are materialized as usual and
+///         the projection is then applied to each of them.
+///     </para>
+///     <para>
+///         This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+///         the same compatibility standards as public APIs. It may be changed or removed without notice in
+///         any release. You should only use it directly in your code with extreme caution and knowing that
+///         doing so can result in application failures when updating to a new Entity Framework Core release.
+///     </para>
+/// </summary>
+public class ProjectedQueryingEnumerable<TSource, TResult>
+    : IEnumerable<TResult>, IAsyncEnumerable<TResult>, IRelationalQueryingEnumerable
+{
+    private readonly IRelationalQueryingEnumerable _source;
+    private readonly Func<TSource, TResult> _selector;
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public ProjectedQueryingEnumerable(IRelationalQueryingEnumerable source, Func<TSource, TResult> selector)
+    {
+        _source = source;
+        _selector = selector;
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public virtual IEnumerator<TResult> GetEnumerator()
+    {
+        foreach (var element in (IEnumerable<TSource>)_source)
+        {
+            yield return _selector(element);
+        }
+    }
+
+    IEnumerator IEnumerable.GetEnumerator()
+        => GetEnumerator();
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public virtual async IAsyncEnumerator<TResult> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+    {
+        var enumerator = ((IAsyncEnumerable<TSource>)_source).GetAsyncEnumerator(cancellationToken);
+        await using (enumerator.ConfigureAwait(false))
+        {
+            while (await enumerator.MoveNextAsync().ConfigureAwait(false))
+            {
+                yield return _selector(enumerator.Current);
+            }
+        }
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public virtual DbCommand CreateDbCommand()
+        => _source.CreateDbCommand();
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public virtual string ToQueryString()
+        => _source.ToQueryString();
+}

--- a/src/EFCore.Relational/Query/RelationalGroupByResultExpression.cs
+++ b/src/EFCore.Relational/Query/RelationalGroupByResultExpression.cs
@@ -27,12 +27,34 @@ public class RelationalGroupByResultExpression : Expression, IPrintableExpressio
         IReadOnlyList<ValueComparer> keyIdentifierValueComparers,
         Expression keyShaper,
         Expression elementShaper)
+        : this(keyIdentifier, keyIdentifierValueComparers, keyShaper, elementShaper, resultSelector: null)
+    {
+    }
+
+    /// <summary>
+    ///     Creates a new instance of the <see cref="RelationalGroupByResultExpression" /> class.
+    /// </summary>
+    /// <param name="keyIdentifier">An identifier for the parent element.</param>
+    /// <param name="keyIdentifierValueComparers">A list of value comparers to compare parent identifier.</param>
+    /// <param name="keyShaper">An expression used to create individual elements of the collection.</param>
+    /// <param name="elementShaper">An expression used to create individual elements of the collection.</param>
+    /// <param name="resultSelector">
+    ///     A client-side projection applied to each materialized grouping, or <see langword="null" /> if the groupings themselves are
+    ///     the result of the query.
+    /// </param>
+    public RelationalGroupByResultExpression(
+        Expression keyIdentifier,
+        IReadOnlyList<ValueComparer> keyIdentifierValueComparers,
+        Expression keyShaper,
+        Expression elementShaper,
+        LambdaExpression? resultSelector)
     {
         KeyIdentifier = keyIdentifier;
         KeyIdentifierValueComparers = keyIdentifierValueComparers;
         KeyShaper = keyShaper;
         ElementShaper = elementShaper;
-        Type = typeof(IGrouping<,>).MakeGenericType(keyShaper.Type, elementShaper.Type);
+        ResultSelector = resultSelector;
+        Type = resultSelector?.ReturnType ?? typeof(IGrouping<,>).MakeGenericType(keyShaper.Type, elementShaper.Type);
     }
 
     /// <summary>
@@ -54,6 +76,18 @@ public class RelationalGroupByResultExpression : Expression, IPrintableExpressio
     ///     The expression to create elements in the group.
     /// </summary>
     public virtual Expression ElementShaper { get; }
+
+    /// <summary>
+    ///     <para>
+    ///         A projection applied on the client to each grouping produced by this expression, or <see langword="null" /> when the
+    ///         groupings are themselves the result of the query.
+    ///     </para>
+    ///     <para>
+    ///         Since this is applied outside of the shaper, on already materialized groupings, it is deliberately not visited as a child
+    ///         of this expression.
+    ///     </para>
+    /// </summary>
+    public virtual LambdaExpression? ResultSelector { get; }
 
     /// <inheritdoc />
     public override Type Type { get; }
@@ -87,7 +121,8 @@ public class RelationalGroupByResultExpression : Expression, IPrintableExpressio
         => keyIdentifier != KeyIdentifier
             || keyShaper != KeyShaper
             || elementShaper != ElementShaper
-                ? new RelationalGroupByResultExpression(keyIdentifier, KeyIdentifierValueComparers, keyShaper, elementShaper)
+                ? new RelationalGroupByResultExpression(
+                    keyIdentifier, KeyIdentifierValueComparers, keyShaper, elementShaper, ResultSelector)
                 : this;
 
     /// <inheritdoc />

--- a/src/EFCore.Relational/Query/RelationalGroupByShaperExpression.cs
+++ b/src/EFCore.Relational/Query/RelationalGroupByShaperExpression.cs
@@ -25,13 +25,52 @@ public class RelationalGroupByShaperExpression : GroupByShaperExpression
         Expression keySelector,
         Expression elementSelector,
         ShapedQueryExpression groupingEnumerable)
+        : this(keySelector, elementSelector, groupingEnumerable, resultSelector: null)
+    {
+    }
+
+    /// <summary>
+    ///     Creates a new instance of the <see cref="RelationalGroupByShaperExpression" /> class.
+    /// </summary>
+    /// <param name="keySelector">An expression representing key selector for the grouping result.</param>
+    /// <param name="elementSelector">An expression representing element selector for the grouping result.</param>
+    /// <param name="groupingEnumerable">An expression representing subquery for enumerable over the grouping result.</param>
+    /// <param name="resultSelector">
+    ///     A client-side projection applied to each materialized grouping, or <see langword="null" /> if the groupings themselves are
+    ///     the result of the query.
+    /// </param>
+    public RelationalGroupByShaperExpression(
+        Expression keySelector,
+        Expression elementSelector,
+        ShapedQueryExpression groupingEnumerable,
+        LambdaExpression? resultSelector)
         : base(keySelector, groupingEnumerable)
-        => ElementSelector = elementSelector;
+    {
+        ElementSelector = elementSelector;
+        ResultSelector = resultSelector;
+    }
 
     /// <summary>
     ///     The expression representing the element selector for this grouping result.
     /// </summary>
     public virtual Expression ElementSelector { get; }
+
+    /// <summary>
+    ///     <para>
+    ///         A projection applied on the client to each grouping produced by this expression, or <see langword="null" /> when the
+    ///         groupings are themselves the result of the query.
+    ///     </para>
+    ///     <para>
+    ///         This is used when the query projects out of the grouping without aggregating it (e.g. <c>g => g.Select(e => e.Id)</c>);
+    ///         such a projection needs no aggregation on the server, so the elements are streamed in key order and the projection is
+    ///         applied to each grouping once it has been materialized.
+    ///     </para>
+    /// </summary>
+    public virtual LambdaExpression? ResultSelector { get; }
+
+    /// <inheritdoc />
+    public override Type Type
+        => ResultSelector?.ReturnType ?? base.Type;
 
     /// <inheritdoc />
     protected override Expression VisitChildren(ExpressionVisitor visitor)
@@ -50,6 +89,13 @@ public class RelationalGroupByShaperExpression : GroupByShaperExpression
         expressionPrinter.AppendLine(", ");
         expressionPrinter.Append("GroupingEnumerable:");
         expressionPrinter.Visit(GroupingEnumerable);
+        if (ResultSelector != null)
+        {
+            expressionPrinter.AppendLine(", ");
+            expressionPrinter.Append("ResultSelector: ");
+            expressionPrinter.Visit(ResultSelector);
+        }
+
         expressionPrinter.AppendLine();
     }
 }

--- a/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs
@@ -22,6 +22,9 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor : Que
     private readonly bool _subquery;
     private readonly ParameterTranslationMode _collectionParameterTranslationMode;
 
+    private Expression? _rootExpression;
+    private bool _isRootOperator;
+
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
     ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
@@ -260,6 +263,23 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor : Que
 
     /// <inheritdoc />
     protected override Expression VisitMethodCall(MethodCallExpression methodCallExpression)
+    {
+        // Operators are translated after their source has been visited, so this needs restoring rather than just clearing: by the time
+        // the query's last operator is translated, the ones nested inside it have already had their turn.
+        var parentIsRootOperator = _isRootOperator;
+        _isRootOperator = ReferenceEquals(methodCallExpression, _rootExpression);
+
+        try
+        {
+            return VisitMethodCallCore(methodCallExpression);
+        }
+        finally
+        {
+            _isRootOperator = parentIsRootOperator;
+        }
+    }
+
+    private Expression VisitMethodCallCore(MethodCallExpression methodCallExpression)
     {
         var method = methodCallExpression.Method;
 
@@ -815,8 +835,88 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor : Que
 
         newResultSelectorBody = ExpandSharedTypeEntities(selectExpression, newResultSelectorBody);
 
+        if (TryTranslateGroupingElementProjection(source, groupByShaper, newResultSelectorBody) is { } liftedGroupBy)
+        {
+            return liftedGroupBy;
+        }
+
         return source.UpdateShaperExpression(
             _projectionBindingExpressionVisitor.Translate(selectExpression, newResultSelectorBody));
+    }
+
+    /// <summary>
+    ///     Attempts to translate a projection over a grouping which doesn't aggregate the grouping, but only enumerates its elements
+    ///     (e.g. <c>GroupBy(e => e.Key).Select(g => g.Select(e => e.Id).ToList())</c>).
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Such a projection needs no GROUP BY on the server: the same rows the grouping was computed from are the rows being
+    ///         projected. Translating it as a correlated collection over the grouping would instead group on the server and then join the
+    ///         source back to itself to get the elements back, reading everything twice (see issue #35991).
+    ///     </para>
+    ///     <para>
+    ///         So instead the element projection is pushed into the grouping's element selector - where it composes over the very same
+    ///         rows - and the rest of the projection is recorded as a selector applied on the client to each grouping, once it has been
+    ///         materialized. This leaves the shaper a <see cref="RelationalGroupByShaperExpression" />, which makes
+    ///         <see
+    ///             cref="SelectExpression.ApplyProjection(Expression, ResultCardinality, QuerySplittingBehavior)" />
+    ///         stream the source rows in key order rather than aggregate them.
+    ///     </para>
+    /// </remarks>
+    private ShapedQueryExpression? TryTranslateGroupingElementProjection(
+        ShapedQueryExpression source,
+        RelationalGroupByShaperExpression groupByShaper,
+        Expression projection)
+    {
+        if (groupByShaper.ResultSelector != null)
+        {
+            // Already projected out of the grouping once; the shaper is a client-side projection which can't be composed over.
+            return null;
+        }
+
+        if (_subquery || !_isRootOperator)
+        {
+            // Anything composing over the projection - another operator, or an outer query - would compose over the rows rather than
+            // over the groupings, since the GROUP BY is what's being traded away here. So only the query's last operator is lifted.
+            return null;
+        }
+
+        var selectExpression = (SelectExpression)source.QueryExpression;
+        if (selectExpression.Limit != null
+            || selectExpression.Offset != null
+            || selectExpression.IsDistinct
+            || selectExpression.Having != null
+            || selectExpression.Orderings.Any(o => !selectExpression.GroupBy.Contains(o.Expression)))
+        {
+            // Operators between the GroupBy and the projection have already left state on the SelectExpression which counts groups
+            // rather than rows: a limit, an offset, a HAVING, an ordering over an aggregate. Dropping the GROUP BY out from under any
+            // of those would silently reinterpret them as being about the source rows.
+            return null;
+        }
+
+        var analyzer = new GroupingElementProjectionAnalyzer(groupByShaper);
+        if (!analyzer.Analyze(projection))
+        {
+            return null;
+        }
+
+        // Build the client-side selector before anything gets composed into the SelectExpression: composing mutates it, and there's no
+        // way back to the correlated subquery translation afterwards.
+        var groupingParameter = Expression.Parameter(
+            typeof(IGrouping<,>).MakeGenericType(
+                groupByShaper.KeySelector.Type,
+                analyzer.ElementSelector?.ReturnType ?? groupByShaper.ElementSelector.Type),
+            "g");
+
+        var resultSelector = Expression.Lambda(analyzer.Rewrite(projection, groupingParameter), groupingParameter);
+
+        var elementShaper = analyzer.ElementSelector is { } elementSelector
+            ? TranslateSelect(source.UpdateShaperExpression(groupByShaper.ElementSelector), elementSelector).ShaperExpression
+            : groupByShaper.ElementSelector;
+
+        return source.UpdateShaperExpression(
+            new RelationalGroupByShaperExpression(
+                groupByShaper.KeySelector, elementShaper, groupByShaper.GroupingEnumerable, resultSelector));
     }
 
     private Expression? TranslateGroupingKey(Expression expression)
@@ -1275,6 +1375,14 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor : Que
     }
 
     /// <inheritdoc />
+    public override Expression Translate(Expression expression)
+    {
+        _rootExpression ??= expression;
+        return base.Translate(expression);
+    }
+
+    /// <inheritdoc />
+    /// <inheritdoc />
     protected override ShapedQueryExpression TranslateSelect(ShapedQueryExpression source, LambdaExpression selector)
     {
         if (selector.Body == selector.Parameters[0])
@@ -1289,6 +1397,12 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor : Que
         }
 
         var newSelectorBody = RemapLambdaBody(source, selector);
+
+        if (source.ShaperExpression is RelationalGroupByShaperExpression groupByShaper
+            && TryTranslateGroupingElementProjection(source, groupByShaper, newSelectorBody) is { } liftedGroupBy)
+        {
+            return liftedGroupBy;
+        }
 
         return source.UpdateShaperExpression(_projectionBindingExpressionVisitor.Translate(selectExpression, newSelectorBody));
     }
@@ -1336,6 +1450,221 @@ public partial class RelationalQueryableMethodTranslatingExpressionVisitor : Que
         }
 
         return null;
+    }
+
+    /// <summary>
+    ///     Recognizes projections which use a grouping only through its key and a single, unfiltered enumeration of its elements, and
+    ///     splits them into the element projection (which gets composed into the grouping's element selector, server-side) and the rest
+    ///     of the projection (which gets applied on the client to each materialized grouping).
+    /// </summary>
+    private sealed class GroupingElementProjectionAnalyzer(RelationalGroupByShaperExpression groupByShaper) : ExpressionVisitor
+    {
+        private static readonly MethodInfo[] ElementEnumerationMethods =
+            [EnumerableMethods.ToList, EnumerableMethods.ToArray, EnumerableMethods.AsEnumerable];
+
+        private List<MethodInfo> _enumerationMethods = [];
+        private Expression? _elements;
+        private ParameterExpression? _groupingParameter;
+        private bool _unsupported;
+
+        /// <summary>
+        ///     The projection applied to the elements of the grouping, or <see langword="null" /> if they're enumerated as-is.
+        /// </summary>
+        public LambdaExpression? ElementSelector { get; private set; }
+
+        /// <summary>
+        ///     Checks whether the given projection over the grouping can be applied on the client, over materialized groupings.
+        /// </summary>
+        public bool Analyze(Expression projection)
+        {
+            Visit(projection);
+
+            // Projections which don't enumerate the elements at all (aggregates, or just the key) are better off translated as usual,
+            // on the server.
+            return !_unsupported && _elements != null;
+        }
+
+        /// <summary>
+        ///     Rewrites the projection into one over a materialized <see cref="IGrouping{TKey,TElement}" />, with the element projection
+        ///     taken out of it (it gets applied on the server instead).
+        /// </summary>
+        public Expression Rewrite(Expression projection, ParameterExpression groupingParameter)
+        {
+            _groupingParameter = groupingParameter;
+
+            return Visit(projection);
+        }
+
+        [return: NotNullIfNotNull(nameof(expression))]
+        public override Expression? Visit(Expression? expression)
+        {
+            if (expression is null || _unsupported)
+            {
+                return expression;
+            }
+
+            // g.Key was replaced by the grouping's key selector when the lambda body was remapped; the materialized grouping exposes
+            // the same value as its key.
+            if (ReferenceEquals(expression, groupByShaper.KeySelector))
+            {
+                return _groupingParameter is null
+                    ? expression
+                    : Expression.MakeMemberAccess(
+                        _groupingParameter, _groupingParameter.Type.GetProperty(nameof(IGrouping<object, object>.Key))!);
+            }
+
+            if (_elements is null)
+            {
+                if (TryMatchElements(expression, out var elementSelector, out var enumerationMethods))
+                {
+                    _elements = expression;
+                    ElementSelector = elementSelector;
+                    _enumerationMethods = enumerationMethods;
+
+                    return _groupingParameter is null ? expression : RewriteElements();
+                }
+            }
+            else if (ReferenceEquals(expression, _elements))
+            {
+                return _groupingParameter is null ? expression : RewriteElements();
+            }
+
+            switch (expression)
+            {
+                // Assembling the key and the elements into a result is all the client selector is allowed to do. Anything computed -
+                // g.Key.ToUpper(), EF.Functions.DateDiffDay(g.Key, ...), string.Join over the elements - has a server translation which
+                // moving it to the client would quietly replace with CLR semantics, or with a FunctionOnClient throw.
+                case NewExpression:
+                case MemberInitExpression:
+                case NewArrayExpression:
+                case ConstantExpression:
+                case ParameterExpression:
+                case UnaryExpression { NodeType: ExpressionType.Convert or ExpressionType.ConvertChecked }:
+                    return base.Visit(expression);
+
+                default:
+                    _unsupported = true;
+                    return expression;
+            }
+        }
+
+        private bool TryMatchElements(
+            Expression expression,
+            out LambdaExpression? elementSelector,
+            out List<MethodInfo> enumerationMethods)
+        {
+            enumerationMethods = [];
+            elementSelector = null;
+            var current = expression;
+
+            // g.Select(...).ToList()/.ToArray()/.AsEnumerable(), or any of those over the grouping itself. Note that the query has been
+            // preprocessed by now, so the enumeration typically reads g.AsQueryable().Select(...) rather than g.Select(...).
+            while (current is MethodCallExpression
+                   {
+                       Object: null, Method.IsGenericMethod: true, Arguments: [var enumerationSource]
+                   } enumeration
+                   && ElementEnumerationMethods.Contains(enumeration.Method.GetGenericMethodDefinition()))
+            {
+                enumerationMethods.Add(enumeration.Method.GetGenericMethodDefinition());
+                current = enumerationSource;
+            }
+
+            if (current is MethodCallExpression
+                {
+                    Object: null, Method.IsGenericMethod: true, Arguments: [var selectSource, var selectorArgument]
+                } select
+                && (select.Method.GetGenericMethodDefinition() == EnumerableMethods.Select
+                    || select.Method.GetGenericMethodDefinition() == QueryableMethods.Select)
+                && (selectorArgument is LambdaExpression
+                    or UnaryExpression { NodeType: ExpressionType.Quote, Operand: LambdaExpression })
+                && selectorArgument.UnwrapLambdaFromQuote() is { Parameters.Count: 1 } selectorLambda)
+            {
+                elementSelector = selectorLambda;
+                current = selectSource;
+            }
+
+            // The AsQueryable the preprocessor introduced is only peeled off as part of an enumeration recognized above; on its own it
+            // says nothing about what's being done with the grouping.
+            if ((enumerationMethods.Count > 0 || elementSelector != null)
+                && current is MethodCallExpression
+                {
+                    Object: null, Method.IsGenericMethod: true, Arguments: [var queryableSource]
+                } asQueryable
+                && asQueryable.Method.GetGenericMethodDefinition() == QueryableMethods.AsQueryable)
+            {
+                current = queryableSource;
+            }
+
+            if (!ReferenceEquals(current, groupByShaper)
+                || (elementSelector != null && !IsComposableElementSelector(elementSelector)))
+            {
+                elementSelector = null;
+                return false;
+            }
+
+            return true;
+        }
+
+        private Expression RewriteElements()
+        {
+            var elementType = _groupingParameter!.Type.GetGenericArguments()[1];
+            var elements = (Expression)_groupingParameter;
+
+            // The elements are enumerated as a queryable (over the grouping) rather than as a plain sequence; keep that type, the
+            // enumeration around it may well depend on it.
+            if (_elements!.Type.IsGenericType && _elements.Type.GetGenericTypeDefinition() == typeof(IQueryable<>))
+            {
+                elements = Expression.Call(QueryableMethods.AsQueryable.MakeGenericMethod(elementType), elements);
+            }
+
+            // The element projection now happens on the server, so only the materialization (ToList/ToArray/...) is left to do here.
+            for (var i = _enumerationMethods.Count - 1; i >= 0; i--)
+            {
+                elements = Expression.Call(_enumerationMethods[i].MakeGenericMethod(elementType), elements);
+            }
+
+            return elements;
+        }
+
+        /// <summary>
+        ///     Checks whether an element projection can be composed into the grouping's element selector, i.e. whether it's a projection
+        ///     of the grouping's own rows and nothing else.
+        /// </summary>
+        private bool IsComposableElementSelector(LambdaExpression elementSelector)
+        {
+            var validator = new ElementSelectorValidator(groupByShaper);
+            validator.Visit(elementSelector.Body);
+
+            return !validator.Unsupported;
+        }
+
+        private sealed class ElementSelectorValidator(RelationalGroupByShaperExpression groupByShaper) : ExpressionVisitor
+        {
+            public bool Unsupported { get; private set; }
+
+            [return: NotNullIfNotNull(nameof(expression))]
+            public override Expression? Visit(Expression? expression)
+            {
+                if (expression is null || Unsupported)
+                {
+                    return expression;
+                }
+
+                if (expression is GroupByShaperExpression
+                    || ReferenceEquals(expression, groupByShaper.KeySelector)
+                    // A collection (navigation, subquery, ...) would be translated as a correlated collection over the element; once the
+                    // GROUP BY is dropped, that correlation would be to the grouping rather than to the element.
+                    || (expression.Type != typeof(string)
+                        && expression.Type != typeof(byte[])
+                        && expression.Type.TryGetSequenceType() is not null))
+                {
+                    Unsupported = true;
+                    return expression;
+                }
+
+                return base.Visit(expression);
+            }
+        }
     }
 
     private sealed class CorrelationFindingExpressionVisitor : ExpressionVisitor

--- a/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalShapedQueryCompilingExpressionVisitor.cs
@@ -292,8 +292,40 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor : ShapedQue
                     ? relatedDataLoaders!
                     : (Expression)Constant(null, typeof(Func<QueryContext, IExecutionStrategy, SplitQueryResultCoordinator, Task>));
 
-                return Call(
-                    CreateGroupBySplitQueryingEnumerableMethodInfo.MakeGenericMethod(keySelector.ReturnType, elementSelector.ReturnType),
+                return ApplyGroupByResultSelector(
+                    relationalGroupByResultExpression,
+                    Call(
+                        CreateGroupBySplitQueryingEnumerableMethodInfo.MakeGenericMethod(
+                            keySelector.ReturnType, elementSelector.ReturnType),
+                        Convert(QueryCompilationContext.QueryContextParameter, typeof(RelationalQueryContext)),
+                        relationalCommandResolver,
+                        readerColumnsExpression,
+                        keySelector,
+                        keyIdentifier,
+                        Dependencies.LiftableConstantFactory.CreateLiftableConstant(
+                            relationalGroupByResultExpression.KeyIdentifierValueComparers.Select(x => (Func<object, object, bool>)x.Equals)
+                                .ToArray(),
+                            Lambda<Func<MaterializerLiftableConstantContext, object>>(
+                                NewArrayInit(
+                                    typeof(Func<object, object, bool>),
+                                    relationalGroupByResultExpression.KeyIdentifierValueComparers.Select(vc => vc.ObjectEqualsExpression)),
+                                Parameter(typeof(MaterializerLiftableConstantContext), "_")),
+                            "keyIdentifierValueComparers",
+                            typeof(Func<object, object, bool>[])),
+                        elementSelector,
+                        relatedDataLoadersParameter,
+                        relatedDataLoadersAsyncParameter,
+                        Constant(_contextType),
+                        Constant(QueryCompilationContext.QueryTrackingBehavior == QueryTrackingBehavior.NoTrackingWithIdentityResolution),
+                        Constant(_detailedErrorsEnabled),
+                        Constant(_threadSafetyChecksEnabled)));
+            }
+
+            return ApplyGroupByResultSelector(
+                relationalGroupByResultExpression,
+                Call(
+                    CreateGroupBySingleQueryingEnumerableMethodInfo.MakeGenericMethod(
+                        keySelector.ReturnType, elementSelector.ReturnType),
                     Convert(QueryCompilationContext.QueryContextParameter, typeof(RelationalQueryContext)),
                     relationalCommandResolver,
                     readerColumnsExpression,
@@ -310,36 +342,10 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor : ShapedQue
                         "keyIdentifierValueComparers",
                         typeof(Func<object, object, bool>[])),
                     elementSelector,
-                    relatedDataLoadersParameter,
-                    relatedDataLoadersAsyncParameter,
                     Constant(_contextType),
                     Constant(QueryCompilationContext.QueryTrackingBehavior == QueryTrackingBehavior.NoTrackingWithIdentityResolution),
                     Constant(_detailedErrorsEnabled),
-                    Constant(_threadSafetyChecksEnabled));
-            }
-
-            return Call(
-                CreateGroupBySingleQueryingEnumerableMethodInfo.MakeGenericMethod(keySelector.ReturnType, elementSelector.ReturnType),
-                Convert(QueryCompilationContext.QueryContextParameter, typeof(RelationalQueryContext)),
-                relationalCommandResolver,
-                readerColumnsExpression,
-                keySelector,
-                keyIdentifier,
-                Dependencies.LiftableConstantFactory.CreateLiftableConstant(
-                    relationalGroupByResultExpression.KeyIdentifierValueComparers.Select(x => (Func<object, object, bool>)x.Equals)
-                        .ToArray(),
-                    Lambda<Func<MaterializerLiftableConstantContext, object>>(
-                        NewArrayInit(
-                            typeof(Func<object, object, bool>),
-                            relationalGroupByResultExpression.KeyIdentifierValueComparers.Select(vc => vc.ObjectEqualsExpression)),
-                        Parameter(typeof(MaterializerLiftableConstantContext), "_")),
-                    "keyIdentifierValueComparers",
-                    typeof(Func<object, object, bool>[])),
-                elementSelector,
-                Constant(_contextType),
-                Constant(QueryCompilationContext.QueryTrackingBehavior == QueryTrackingBehavior.NoTrackingWithIdentityResolution),
-                Constant(_detailedErrorsEnabled),
-                Constant(_threadSafetyChecksEnabled));
+                    Constant(_threadSafetyChecksEnabled)));
         }
         else
         {
@@ -437,6 +443,35 @@ public partial class RelationalShapedQueryCompilingExpressionVisitor : ShapedQue
     private static readonly MethodInfo CreateGroupBySplitQueryingEnumerableMethodInfo
         = typeof(GroupBySplitQueryingEnumerable)
             .GetMethod(nameof(GroupBySplitQueryingEnumerable.Create))!;
+
+    private static readonly MethodInfo CreateProjectedQueryingEnumerableMethodInfo
+        = typeof(ProjectedQueryingEnumerable)
+            .GetMethod(nameof(ProjectedQueryingEnumerable.Create))!;
+
+    /// <summary>
+    ///     Applies the client-side projection of a GroupBy which projects out of the groupings without aggregating them, by projecting
+    ///     each grouping as it comes out of the querying enumerable.
+    /// </summary>
+    private static Expression ApplyGroupByResultSelector(
+        RelationalGroupByResultExpression relationalGroupByResultExpression,
+        Expression groupingEnumerable)
+    {
+        if (relationalGroupByResultExpression.ResultSelector is not { } resultSelector)
+        {
+            return groupingEnumerable;
+        }
+
+        Check.DebugAssert(
+            resultSelector.Parameters[0].Type == groupingEnumerable.Type.GetInterfaces()
+                .Single(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IEnumerable<>)).GetGenericArguments()[0],
+            "The result selector of a GroupBy doesn't accept the grouping type produced by the querying enumerable.");
+
+        return Call(
+            CreateProjectedQueryingEnumerableMethodInfo.MakeGenericMethod(
+                resultSelector.Parameters[0].Type, resultSelector.ReturnType),
+            groupingEnumerable,
+            resultSelector);
+    }
 
     private static Expression CreateReaderColumnsExpression(
         IReadOnlyList<ReaderColumn?>? readerColumns,

--- a/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.Helper.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.Helper.cs
@@ -574,7 +574,8 @@ public sealed partial class SelectExpression
                         relationalGroupByResultExpression.KeyIdentifier,
                         relationalGroupByResultExpression.KeyIdentifierValueComparers,
                         relationalGroupByResultExpression.KeyShaper,
-                        Visit(relationalGroupByResultExpression.ElementShaper));
+                        Visit(relationalGroupByResultExpression.ElementShaper),
+                        relationalGroupByResultExpression.ResultSelector);
 
                 default:
                     return base.VisitExtension(expression);

--- a/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/SqlExpressions/SelectExpression.cs
@@ -575,7 +575,8 @@ public sealed partial class SelectExpression : TableExpressionBase
                 shaperExpression = new RelationalGroupByShaperExpression(
                     relationalGroupByShaperExpression.KeySelector,
                     innerShaperExpression,
-                    relationalGroupByShaperExpression.GroupingEnumerable);
+                    relationalGroupByShaperExpression.GroupingEnumerable,
+                    relationalGroupByShaperExpression.ResultSelector);
             }
 
             // Convert GroupBy to OrderBy
@@ -661,9 +662,14 @@ public sealed partial class SelectExpression : TableExpressionBase
                     this, newClientProjections, projectionBindingMap, groupByShaper.KeySelector);
                 var (keyIdentifier, keyIdentifierValueComparers) = GetIdentifierAccessor(
                     this, newClientProjections, projectionBindingMap, _identifier);
-                _identifier.Clear();
-                _identifier.AddRange(_preGroupByIdentifier!);
-                _preGroupByIdentifier!.Clear();
+                // ApplyGrouping only sets this aside when it replaced the identifier with the grouping terms; when the identifier was
+                // already part of the key (e.g. grouping by the primary key) it left it alone, and there's nothing to restore.
+                if (_preGroupByIdentifier is not null)
+                {
+                    _identifier.Clear();
+                    _identifier.AddRange(_preGroupByIdentifier);
+                    _preGroupByIdentifier.Clear();
+                }
 
                 Expression AddGroupByKeySelectorToProjection(
                     SelectExpression selectExpression,
@@ -791,7 +797,8 @@ public sealed partial class SelectExpression : TableExpressionBase
 
                 remappingRequired = true;
                 shaperExpression = new RelationalGroupByResultExpression(
-                    keyIdentifier, keyIdentifierValueComparers, keySelector, groupByShaper.ElementSelector);
+                    keyIdentifier, keyIdentifierValueComparers, keySelector, groupByShaper.ElementSelector,
+                    groupByShaper.ResultSelector);
             }
 
             SelectExpression? baseSelectExpression = null;

--- a/test/EFCore.InMemory.FunctionalTests/Query/NorthwindGroupByQueryInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/NorthwindGroupByQueryInMemoryTest.cs
@@ -23,6 +23,11 @@ public class NorthwindGroupByQueryInMemoryTest(NorthwindQueryInMemoryFixture<Noo
             () => base.Final_GroupBy_property_entity_non_nullable(async),
             InMemoryStrings.NonComposedGroupByNotSupported);
 
+    public override Task Final_GroupBy_property_entity_by_identifier(bool async)
+        => AssertTranslationFailedWithDetails(
+            () => base.Final_GroupBy_property_entity_by_identifier(async),
+            InMemoryStrings.NonComposedGroupByNotSupported);
+
     public override Task Final_GroupBy_property_anonymous_type(bool async)
         => AssertTranslationFailedWithDetails(
             () => base.Final_GroupBy_property_anonymous_type(async),

--- a/test/EFCore.Relational.Specification.Tests/Query/PrecompiledQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/PrecompiledQueryRelationalTestBase.cs
@@ -269,6 +269,10 @@ _ = await context.Blogs.OrderBy(b => b.Name).Take(toTake).ToListAsync();
     public virtual Task Final_GroupBy()
         => Test("""var blogs = await context.Blogs.GroupBy(b => b.Name).ToListAsync();""");
 
+    [Fact]
+    public virtual Task Final_GroupBy_projecting_grouping_elements()
+        => Test("""var blogs = await context.Blogs.GroupBy(b => b.Name).Select(g => g.Select(b => b.Id).ToList()).ToListAsync();""");
+
     #endregion Regular operators
 
     #region Terminating operators

--- a/test/EFCore.Specification.Tests/Query/NorthwindGroupByQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindGroupByQueryTestBase.cs
@@ -2735,6 +2735,14 @@ public abstract class NorthwindGroupByQueryTestBase<TFixture>(TFixture fixture) 
             elementAsserter: (e, a) => AssertGrouping(e, a));
 
     [Theory, MemberData(nameof(IsAsyncData))]
+    public virtual Task Final_GroupBy_property_entity_by_identifier(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<Order>().Where(e => e.OrderID < 10300).GroupBy(o => o.OrderID),
+            elementSorter: e => e.Key,
+            elementAsserter: (e, a) => AssertGrouping(e, a));
+
+    [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task Final_GroupBy_property_anonymous_type(bool async)
         => AssertQuery(
             async,
@@ -2973,6 +2981,122 @@ public abstract class NorthwindGroupByQueryTestBase<TFixture>(TFixture fixture) 
             {
                 Assert.Equal(e.Key, a.Key);
                 AssertCollection(e.Data, a.Data);
+            });
+
+    [Theory, MemberData(nameof(IsAsyncData))]
+    public virtual Task GroupBy_selecting_grouping_element_list(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<Order>().GroupBy(o => o.CustomerID).Select(g => g.Select(e => e.OrderID).ToList()),
+            elementSorter: e => string.Join(",", e.OrderBy(id => id)),
+            elementAsserter: (e, a) => AssertCollection(e, a));
+
+    [Theory, MemberData(nameof(IsAsyncData))]
+    public virtual Task GroupBy_selecting_grouping_element_array_with_key(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<Order>().GroupBy(o => o.CustomerID).Select(g => new { g.Key, Orders = g.Select(e => e.OrderID).ToArray() }),
+            elementSorter: e => e.Key,
+            elementAsserter: (e, a) =>
+            {
+                Assert.Equal(e.Key, a.Key);
+                AssertCollection(e.Orders, a.Orders);
+            });
+
+    [Theory, MemberData(nameof(IsAsyncData))]
+    public virtual Task GroupBy_with_element_selector_selecting_grouping_element_list(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<Order>().GroupBy(o => o.CustomerID, o => o.OrderID).Select(g => g.ToList()),
+            elementSorter: e => string.Join(",", e.OrderBy(id => id)),
+            elementAsserter: (e, a) => AssertCollection(e, a));
+
+    [Theory, MemberData(nameof(IsAsyncData))]
+    public virtual Task GroupBy_selecting_grouping_element_list_with_aggregate(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<Order>().GroupBy(o => o.CustomerID)
+                .Select(g => new
+                {
+                    g.Key,
+                    Count = g.Count(),
+                    Orders = g.Select(e => e.OrderID).ToList()
+                }),
+            elementSorter: e => e.Key,
+            elementAsserter: (e, a) =>
+            {
+                Assert.Equal(e.Key, a.Key);
+                Assert.Equal(e.Count, a.Count);
+                AssertCollection(e.Orders, a.Orders);
+            });
+
+    [Theory, MemberData(nameof(IsAsyncData))]
+    public virtual Task GroupBy_selecting_filtered_grouping_element_list(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<Order>().GroupBy(o => o.CustomerID)
+                .Select(g => g.Where(e => e.OrderID > 10500).Select(e => e.OrderID).ToList()),
+            elementSorter: e => string.Join(",", e.OrderBy(id => id)),
+            elementAsserter: (e, a) => AssertCollection(e, a));
+
+    [Theory, MemberData(nameof(IsAsyncData))]
+    public virtual Task GroupBy_selecting_grouping_element_list_with_Take(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<Order>().GroupBy(o => o.CustomerID).OrderBy(g => g.Key)
+                .Select(g => g.Select(e => e.OrderID).ToList())
+                .Take(5),
+            elementAsserter: (e, a) => AssertCollection(e, a),
+            assertOrder: true);
+
+    [Theory, MemberData(nameof(IsAsyncData))]
+    public virtual Task GroupBy_Take_selecting_grouping_element_list(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<Order>().GroupBy(o => o.CustomerID).OrderBy(g => g.Key).Take(5)
+                .Select(g => g.Select(e => e.OrderID).ToList()),
+            elementAsserter: (e, a) => AssertCollection(e, a),
+            assertOrder: true);
+
+    [Theory, MemberData(nameof(IsAsyncData))]
+    public virtual Task GroupBy_Skip_selecting_grouping_element_list(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<Order>().GroupBy(o => o.CustomerID).OrderBy(g => g.Key).Skip(85)
+                .Select(g => g.Select(e => e.OrderID).ToList()),
+            elementAsserter: (e, a) => AssertCollection(e, a),
+            assertOrder: true);
+
+    [Theory, MemberData(nameof(IsAsyncData))]
+    public virtual Task GroupBy_Where_aggregate_selecting_grouping_element_list(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<Order>().GroupBy(o => o.CustomerID).Where(g => g.Count() > 10)
+                .Select(g => g.Select(e => e.OrderID).ToList()),
+            elementSorter: e => string.Join(",", e.OrderBy(id => id)),
+            elementAsserter: (e, a) => AssertCollection(e, a));
+
+    [Theory, MemberData(nameof(IsAsyncData))]
+    public virtual Task GroupBy_OrderBy_aggregate_selecting_grouping_element_list(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<Order>().Where(o => o.CustomerID!.StartsWith("A")).GroupBy(o => o.CustomerID)
+                .OrderBy(g => g.Count()).ThenBy(g => g.Key)
+                .Select(g => g.Select(e => e.OrderID).ToList()),
+            elementAsserter: (e, a) => AssertCollection(e, a),
+            assertOrder: true);
+
+    [Theory, MemberData(nameof(IsAsyncData))]
+    public virtual Task GroupBy_selecting_grouping_element_list_with_translated_key(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<Order>().GroupBy(o => o.CustomerID)
+                .Select(g => new { Key = g.Key!.ToUpper(), Orders = g.Select(e => e.OrderID).ToList() }),
+            elementSorter: e => e.Key,
+            elementAsserter: (e, a) =>
+            {
+                Assert.Equal(e.Key, a.Key);
+                AssertCollection(e.Orders, a.Orders);
             });
 
     [Theory, MemberData(nameof(IsAsyncData))]

--- a/test/EFCore.Specification.Tests/Query/NorthwindGroupByQueryTestBase.cs
+++ b/test/EFCore.Specification.Tests/Query/NorthwindGroupByQueryTestBase.cs
@@ -3050,6 +3050,20 @@ public abstract class NorthwindGroupByQueryTestBase<TFixture>(TFixture fixture) 
             assertOrder: true);
 
     [Theory, MemberData(nameof(IsAsyncData))]
+    public virtual Task GroupBy_with_result_selector_selecting_grouping_element_list(bool async)
+        => AssertQuery(
+            async,
+            ss => ss.Set<Order>().GroupBy(
+                o => o.CustomerID,
+                (key, elements) => new { Key = key, Orders = elements.Select(e => e.OrderID).ToList() }),
+            elementSorter: e => e.Key,
+            elementAsserter: (e, a) =>
+            {
+                Assert.Equal(e.Key, a.Key);
+                AssertCollection(e.Orders, a.Orders);
+            });
+
+    [Theory, MemberData(nameof(IsAsyncData))]
     public virtual Task GroupBy_Take_selecting_grouping_element_list(bool async)
         => AssertQuery(
             async,

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsCollectionsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsCollectionsQuerySqlServerTest.cs
@@ -2331,19 +2331,10 @@ ORDER BY [l].[Id], [s].[Date], [s].[Date0], [s].[Name]
 @validIds1='L1 01' (Size = 4000)
 @validIds2='L1 02' (Size = 4000)
 
-SELECT [l1].[Date], [l2].[Id]
-FROM (
-    SELECT [l].[Date]
-    FROM [LevelOne] AS [l]
-    WHERE [l].[Name] IN (@validIds1, @validIds2)
-    GROUP BY [l].[Date]
-) AS [l1]
-LEFT JOIN (
-    SELECT [l0].[Id], [l0].[Date]
-    FROM [LevelOne] AS [l0]
-    WHERE [l0].[Name] IN (@validIds1, @validIds2)
-) AS [l2] ON [l1].[Date] = [l2].[Date]
-ORDER BY [l1].[Date]
+SELECT [l].[Date], [l].[Id]
+FROM [LevelOne] AS [l]
+WHERE [l].[Name] IN (@validIds1, @validIds2)
+ORDER BY [l].[Date]
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsCollectionsSharedTypeQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsCollectionsSharedTypeQuerySqlServerTest.cs
@@ -3011,19 +3011,10 @@ ORDER BY [l].[Id], [s].[Date], [s].[Date0], [s].[Name]
 @validIds1='L1 01' (Size = 4000)
 @validIds2='L1 02' (Size = 4000)
 
-SELECT [l1].[Date], [l2].[Id]
-FROM (
-    SELECT [l].[Date]
-    FROM [Level1] AS [l]
-    WHERE [l].[Name] IN (@validIds1, @validIds2)
-    GROUP BY [l].[Date]
-) AS [l1]
-LEFT JOIN (
-    SELECT [l0].[Id], [l0].[Date]
-    FROM [Level1] AS [l0]
-    WHERE [l0].[Name] IN (@validIds1, @validIds2)
-) AS [l2] ON [l1].[Date] = [l2].[Date]
-ORDER BY [l1].[Date]
+SELECT [l].[Date], [l].[Id]
+FROM [Level1] AS [l]
+WHERE [l].[Name] IN (@validIds1, @validIds2)
+ORDER BY [l].[Date]
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsCollectionsSplitQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsCollectionsSplitQuerySqlServerTest.cs
@@ -3719,30 +3719,10 @@ ORDER BY [l].[Id], [l15].[Date], [l17].[Name], [l17].[Date]
 @validIds1='L1 01' (Size = 4000)
 @validIds2='L1 02' (Size = 4000)
 
-SELECT [l].[Date]
+SELECT [l].[Date], [l].[Id]
 FROM [LevelOne] AS [l]
 WHERE [l].[Name] IN (@validIds1, @validIds2)
-GROUP BY [l].[Date]
 ORDER BY [l].[Date]
-""",
-            //
-            """
-@validIds3='L1 01' (Size = 4000)
-@validIds4='L1 02' (Size = 4000)
-
-SELECT [l5].[Id], [l4].[Date]
-FROM (
-    SELECT [l].[Date]
-    FROM [LevelOne] AS [l]
-    WHERE [l].[Name] IN (@validIds3, @validIds4)
-    GROUP BY [l].[Date]
-) AS [l4]
-INNER JOIN (
-    SELECT [l3].[Id], [l3].[Date]
-    FROM [LevelOne] AS [l3]
-    WHERE [l3].[Name] IN (@validIds3, @validIds4)
-) AS [l5] ON [l4].[Date] = [l5].[Date]
-ORDER BY [l4].[Date]
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindGroupByQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindGroupByQuerySqlServerTest.cs
@@ -3981,6 +3981,18 @@ WHERE [o0].[OrderID] = [t].[c]
 """);
     }
 
+    public override async Task GroupBy_with_result_selector_selecting_grouping_element_list(bool async)
+    {
+        await base.GroupBy_with_result_selector_selecting_grouping_element_list(async);
+
+        AssertSql(
+            """
+SELECT [o].[CustomerID], [o].[OrderID]
+FROM [Orders] AS [o]
+ORDER BY [o].[CustomerID]
+""");
+    }
+
     public override async Task GroupBy_Take_selecting_grouping_element_list(bool async)
     {
         await base.GroupBy_Take_selecting_grouping_element_list(async);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindGroupByQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindGroupByQuerySqlServerTest.cs
@@ -2886,14 +2886,9 @@ GROUP BY [e].[EmployeeID]
 
         AssertSql(
             """
-SELECT [c1].[City], [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
-FROM (
-    SELECT [c].[City]
-    FROM [Customers] AS [c]
-    GROUP BY [c].[City]
-) AS [c1]
-LEFT JOIN [Customers] AS [c0] ON [c1].[City] = [c0].[City]
-ORDER BY [c1].[City]
+SELECT [c].[City], [c].[CustomerID], [c].[Address], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+ORDER BY [c].[City]
 """);
     }
 
@@ -2903,14 +2898,9 @@ ORDER BY [c1].[City]
 
         AssertSql(
             """
-SELECT [c1].[City], [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
-FROM (
-    SELECT [c].[City]
-    FROM [Customers] AS [c]
-    GROUP BY [c].[City]
-) AS [c1]
-LEFT JOIN [Customers] AS [c0] ON [c1].[City] = [c0].[City]
-ORDER BY [c1].[City]
+SELECT [c].[City], [c].[CustomerID], [c].[Address], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+ORDER BY [c].[City]
 """);
     }
 
@@ -3991,20 +3981,207 @@ WHERE [o0].[OrderID] = [t].[c]
 """);
     }
 
+    public override async Task GroupBy_Take_selecting_grouping_element_list(bool async)
+    {
+        await base.GroupBy_Take_selecting_grouping_element_list(async);
+
+        AssertSql(
+            """
+@p='5'
+
+SELECT [o1].[CustomerID], [o0].[OrderID]
+FROM (
+    SELECT TOP(@p) [o].[CustomerID]
+    FROM [Orders] AS [o]
+    GROUP BY [o].[CustomerID]
+    ORDER BY [o].[CustomerID]
+) AS [o1]
+LEFT JOIN [Orders] AS [o0] ON [o1].[CustomerID] = [o0].[CustomerID]
+ORDER BY [o1].[CustomerID]
+""");
+    }
+
+    public override async Task GroupBy_Skip_selecting_grouping_element_list(bool async)
+    {
+        await base.GroupBy_Skip_selecting_grouping_element_list(async);
+
+        AssertSql(
+            """
+@p='85'
+
+SELECT [o1].[CustomerID], [o0].[OrderID]
+FROM (
+    SELECT [o].[CustomerID]
+    FROM [Orders] AS [o]
+    GROUP BY [o].[CustomerID]
+    ORDER BY [o].[CustomerID]
+    OFFSET @p ROWS
+) AS [o1]
+LEFT JOIN [Orders] AS [o0] ON [o1].[CustomerID] = [o0].[CustomerID]
+ORDER BY [o1].[CustomerID]
+""");
+    }
+
+    public override async Task GroupBy_Where_aggregate_selecting_grouping_element_list(bool async)
+    {
+        await base.GroupBy_Where_aggregate_selecting_grouping_element_list(async);
+
+        AssertSql(
+            """
+SELECT [o1].[CustomerID], [o0].[OrderID]
+FROM (
+    SELECT [o].[CustomerID]
+    FROM [Orders] AS [o]
+    GROUP BY [o].[CustomerID]
+    HAVING COUNT(*) > 10
+) AS [o1]
+LEFT JOIN [Orders] AS [o0] ON [o1].[CustomerID] = [o0].[CustomerID]
+ORDER BY [o1].[CustomerID]
+""");
+    }
+
+    public override async Task GroupBy_OrderBy_aggregate_selecting_grouping_element_list(bool async)
+    {
+        await base.GroupBy_OrderBy_aggregate_selecting_grouping_element_list(async);
+
+        AssertSql(
+            """
+SELECT [o1].[CustomerID], [o2].[OrderID]
+FROM (
+    SELECT [o].[CustomerID], COUNT(*) AS [c]
+    FROM [Orders] AS [o]
+    WHERE [o].[CustomerID] LIKE N'A%'
+    GROUP BY [o].[CustomerID]
+) AS [o1]
+LEFT JOIN (
+    SELECT [o0].[OrderID], [o0].[CustomerID]
+    FROM [Orders] AS [o0]
+    WHERE [o0].[CustomerID] LIKE N'A%'
+) AS [o2] ON [o1].[CustomerID] = [o2].[CustomerID]
+ORDER BY [o1].[c], [o1].[CustomerID]
+""");
+    }
+
+    public override async Task GroupBy_selecting_grouping_element_list_with_translated_key(bool async)
+    {
+        await base.GroupBy_selecting_grouping_element_list_with_translated_key(async);
+
+        AssertSql(
+            """
+SELECT [o1].[c], [o1].[CustomerID], [o0].[OrderID]
+FROM (
+    SELECT UPPER([o].[CustomerID]) AS [c], [o].[CustomerID]
+    FROM [Orders] AS [o]
+    GROUP BY [o].[CustomerID]
+) AS [o1]
+LEFT JOIN [Orders] AS [o0] ON [o1].[CustomerID] = [o0].[CustomerID]
+ORDER BY [o1].[CustomerID]
+""");
+    }
+
+    public override async Task GroupBy_selecting_grouping_element_list(bool async)
+    {
+        await base.GroupBy_selecting_grouping_element_list(async);
+
+        AssertSql(
+            """
+SELECT [o].[CustomerID], [o].[OrderID]
+FROM [Orders] AS [o]
+ORDER BY [o].[CustomerID]
+""");
+    }
+
+    public override async Task GroupBy_selecting_grouping_element_array_with_key(bool async)
+    {
+        await base.GroupBy_selecting_grouping_element_array_with_key(async);
+
+        AssertSql(
+            """
+SELECT [o].[CustomerID], [o].[OrderID]
+FROM [Orders] AS [o]
+ORDER BY [o].[CustomerID]
+""");
+    }
+
+    public override async Task GroupBy_with_element_selector_selecting_grouping_element_list(bool async)
+    {
+        await base.GroupBy_with_element_selector_selecting_grouping_element_list(async);
+
+        AssertSql(
+            """
+SELECT [o].[CustomerID], [o].[OrderID]
+FROM [Orders] AS [o]
+ORDER BY [o].[CustomerID]
+""");
+    }
+
+    public override async Task GroupBy_selecting_grouping_element_list_with_aggregate(bool async)
+    {
+        await base.GroupBy_selecting_grouping_element_list_with_aggregate(async);
+
+        AssertSql(
+            """
+SELECT [o1].[CustomerID], [o1].[c], [o0].[OrderID]
+FROM (
+    SELECT [o].[CustomerID], COUNT(*) AS [c]
+    FROM [Orders] AS [o]
+    GROUP BY [o].[CustomerID]
+) AS [o1]
+LEFT JOIN [Orders] AS [o0] ON [o1].[CustomerID] = [o0].[CustomerID]
+ORDER BY [o1].[CustomerID]
+""");
+    }
+
+    public override async Task GroupBy_selecting_filtered_grouping_element_list(bool async)
+    {
+        await base.GroupBy_selecting_filtered_grouping_element_list(async);
+
+        AssertSql(
+            """
+SELECT [o1].[CustomerID], [o2].[OrderID]
+FROM (
+    SELECT [o].[CustomerID]
+    FROM [Orders] AS [o]
+    GROUP BY [o].[CustomerID]
+) AS [o1]
+LEFT JOIN (
+    SELECT [o0].[OrderID], [o0].[CustomerID]
+    FROM [Orders] AS [o0]
+    WHERE [o0].[OrderID] > 10500
+) AS [o2] ON [o1].[CustomerID] = [o2].[CustomerID]
+ORDER BY [o1].[CustomerID]
+""");
+    }
+
+    public override async Task GroupBy_selecting_grouping_element_list_with_Take(bool async)
+    {
+        await base.GroupBy_selecting_grouping_element_list_with_Take(async);
+
+        AssertSql(
+            """
+@p='5'
+
+SELECT [o1].[CustomerID], [o0].[OrderID]
+FROM (
+    SELECT TOP(@p) [o].[CustomerID]
+    FROM [Orders] AS [o]
+    GROUP BY [o].[CustomerID]
+    ORDER BY [o].[CustomerID]
+) AS [o1]
+LEFT JOIN [Orders] AS [o0] ON [o1].[CustomerID] = [o0].[CustomerID]
+ORDER BY [o1].[CustomerID]
+""");
+    }
+
     public override async Task GroupBy_selecting_grouping_key_list(bool async)
     {
         await base.GroupBy_selecting_grouping_key_list(async);
 
         AssertSql(
             """
-SELECT [o1].[CustomerID], [o0].[CustomerID], [o0].[OrderID]
-FROM (
-    SELECT [o].[CustomerID]
-    FROM [Orders] AS [o]
-    GROUP BY [o].[CustomerID]
-) AS [o1]
-LEFT JOIN [Orders] AS [o0] ON [o1].[CustomerID] = [o0].[CustomerID]
-ORDER BY [o1].[CustomerID]
+SELECT [o].[CustomerID]
+FROM [Orders] AS [o]
+ORDER BY [o].[CustomerID]
 """);
     }
 
@@ -4463,6 +4640,19 @@ ORDER BY [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[Co
 SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice]
 FROM [Order Details] AS [o]
 WHERE [o].[OrderID] < 10500
+ORDER BY [o].[OrderID]
+""");
+    }
+
+    public override async Task Final_GroupBy_property_entity_by_identifier(bool async)
+    {
+        await base.Final_GroupBy_property_entity_by_identifier(async);
+
+        AssertSql(
+            """
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE [o].[OrderID] < 10300
 ORDER BY [o].[OrderID]
 """);
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/PrecompiledQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/PrecompiledQuerySqlServerTest.cs
@@ -421,6 +421,18 @@ ORDER BY [b].[Name]
 """);
     }
 
+    public override async Task Final_GroupBy_projecting_grouping_elements()
+    {
+        await base.Final_GroupBy_projecting_grouping_elements();
+
+        AssertSql(
+            """
+SELECT [b].[Name], [b].[Id]
+FROM [Blogs] AS [b]
+ORDER BY [b].[Name]
+""");
+    }
+
     #endregion Regular operators
 
     #region Terminating operators

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TemporalComplexNavigationsCollectionsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TemporalComplexNavigationsCollectionsQuerySqlServerTest.cs
@@ -2304,19 +2304,10 @@ ORDER BY [l].[Id], [s].[Date], [s].[Date0], [s].[Name]
 @validIds1='L1 01' (Size = 4000)
 @validIds2='L1 02' (Size = 4000)
 
-SELECT [l1].[Date], [l2].[Id]
-FROM (
-    SELECT [l].[Date]
-    FROM [LevelOne] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [l]
-    WHERE [l].[Name] IN (@validIds1, @validIds2)
-    GROUP BY [l].[Date]
-) AS [l1]
-LEFT JOIN (
-    SELECT [l0].[Id], [l0].[Date]
-    FROM [LevelOne] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [l0]
-    WHERE [l0].[Name] IN (@validIds1, @validIds2)
-) AS [l2] ON [l1].[Date] = [l2].[Date]
-ORDER BY [l1].[Date]
+SELECT [l].[Date], [l].[Id]
+FROM [LevelOne] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [l]
+WHERE [l].[Name] IN (@validIds1, @validIds2)
+ORDER BY [l].[Date]
 """);
     }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/TemporalComplexNavigationsCollectionsSharedTypeQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/TemporalComplexNavigationsCollectionsSharedTypeQuerySqlServerTest.cs
@@ -3031,19 +3031,10 @@ ORDER BY [l].[Id], [s].[Date], [s].[Date0], [s].[Name]
 @validIds1='L1 01' (Size = 4000)
 @validIds2='L1 02' (Size = 4000)
 
-SELECT [l1].[Date], [l2].[Id]
-FROM (
-    SELECT [l].[Date]
-    FROM [Level1] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [l]
-    WHERE [l].[Name] IN (@validIds1, @validIds2)
-    GROUP BY [l].[Date]
-) AS [l1]
-LEFT JOIN (
-    SELECT [l0].[Id], [l0].[Date]
-    FROM [Level1] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [l0]
-    WHERE [l0].[Name] IN (@validIds1, @validIds2)
-) AS [l2] ON [l1].[Date] = [l2].[Date]
-ORDER BY [l1].[Date]
+SELECT [l].[Date], [l].[Id]
+FROM [Level1] FOR SYSTEM_TIME AS OF '2010-01-01T00:00:00.0000000' AS [l]
+WHERE [l].[Name] IN (@validIds1, @validIds2)
+ORDER BY [l].[Date]
 """);
     }
 


### PR DESCRIPTION
Fixes #35991

- [x] I've read the guidelines for [contributing](https://github.com/dotnet/efcore/blob/main/.github/CONTRIBUTING.md) and seen the [walkthrough](https://youtu.be/9OMxy1wal1s?t=1869)
- [ ] I've posted a comment on an issue with a detailed description of how I am planning to contribute and got approval from a member of the team
- [x] The code builds and tests pass locally (also verified by our automated build checks)
- [x] Commit messages follow this format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Code follows the same patterns and style as existing code in this repo

## Summary

`SelectExpression.ApplyGrouping` clones the pre-`GROUP BY` `SelectExpression` and attaches a correlation predicate on the grouping terms, carrying it on the shaper as `GroupingEnumerable` — the query to run when someone asks for a group's elements. Any projection which reaches into the grouping is translated against that clone, as a correlated collection.

That is the right translation when the elements are needed alongside an aggregate, or filtered, or ordered. It is the wrong one when the projection does nothing but enumerate them: the rows the grouping was computed from *are* the rows being projected, so the clone re-derives the source a second time and is joined back to the keys it came from. `ApplyProjection` already has the cheap translation for exactly these rows — a query whose final shaper is still a `RelationalGroupByShaperExpression` drops its `GROUP BY`, orders by the grouping terms and assembles the groupings as rows stream in — but the collection shaper produced by the projection means that path is no longer taken.

```csharp
context.Artifacts
    .Select(a => new { a.GenerationId, a.Id })
    .GroupBy(a => a.GenerationId)
    .Select(g => g.Select(a => a.Id).ToArray())
```

```sql
-- before: GROUP BY for the keys, then a join back to [Artifacts] for the rows it just grouped
SELECT [a1].[GenerationId], [a0].[ArtifactId]
FROM (
    SELECT [a].[GenerationId]
    FROM [Artifacts] AS [a]
    GROUP BY [a].[GenerationId]
) AS [a1]
LEFT JOIN [Artifacts] AS [a0] ON [a1].[GenerationId] = [a0].[GenerationId]
ORDER BY [a1].[GenerationId]

-- after: the same rows, read once, in key order
SELECT [a].[GenerationId], [a].[ArtifactId]
FROM [Artifacts] AS [a]
ORDER BY [a].[GenerationId]
```

Since the clone copies the whole query and not just the table the key came from, the cost grows with the source. The issue's second shape groups over a `SelectMany`, and the join tree appears on both sides:

```csharp
context.Operations
    .SelectMany(o => o.Generation.Artifacts)
    .Select(a => new { a.GenerationId, a.Id })
    .GroupBy(a => a.GenerationId)
    .Select(g => g.Select(a => a.Id).ToArray())
```

```sql
-- before
SELECT [s].[GenerationId], [s0].[ArtifactId], [s0].[OperationId]
FROM (
    SELECT [a].[GenerationId]
    FROM [Operations] AS [o]
    LEFT JOIN [Generations] AS [g] ON [o].[OperationId] = [g].[OperationId]
    INNER JOIN [Artifacts] AS [a] ON [g].[GenerationId] = [a].[GenerationId]
    GROUP BY [a].[GenerationId]
) AS [s]
LEFT JOIN (
    SELECT [a0].[ArtifactId], [o0].[OperationId], [a0].[GenerationId]
    FROM [Operations] AS [o0]
    LEFT JOIN [Generations] AS [g0] ON [o0].[OperationId] = [g0].[OperationId]
    INNER JOIN [Artifacts] AS [a0] ON [g0].[GenerationId] = [a0].[GenerationId]
) AS [s0] ON [s].[GenerationId] = [s0].[GenerationId0]
ORDER BY [s].[GenerationId], [s0].[OperationId]

-- after
SELECT [a].[GenerationId], [a].[ArtifactId]
FROM [Operations] AS [o]
LEFT JOIN [Generations] AS [g] ON [o].[OperationId] = [g].[OperationId]
INNER JOIN [Artifacts] AS [a] ON [g].[GenerationId] = [a].[GenerationId]
ORDER BY [a].[GenerationId]
```

`[s0].[OperationId]` goes with it: it was the inner query's identifier, projected and ordered by so the materializer could tell where one collection ended, and there is no inner query left to delimit.

An expensive `Where` before the `GroupBy` is evaluated once rather than twice, which is what the issue measures as minutes against roughly a second. A volatile one is also now sampled once — with the source derived twice, the filter deciding which keys exist and the filter deciding which rows belong to them were independent draws.

### Regenerated baselines

Eight existing tests describe this shape and their SQL Server baselines are regenerated here — results unchanged in every case, only the SQL.

| Test | Change |
| --- | --- |
| `GroupBy_select_grouping_list`, `GroupBy_select_grouping_array` | `Customers` grouped by `City` projecting the entities: 8 lines to 3, and the key column is no longer read twice |
| `GroupBy_selecting_grouping_key_list` | 8 lines to 3 |
| `Collection_projection_over_GroupBy_over_parameter` (`ComplexNavigationsCollections`, `…SharedType`, `…SplitQuery`, and the two temporal variants) | 9 lines to 4; under `AsSplitQuery` the second round-trip disappears, since the split query re-ran the filter to fetch the elements |

## Implementation

`RelationalGroupByShaperExpression` and `RelationalGroupByResultExpression` take an optional `ResultSelector`, a lambda over the materialized `IGrouping<TKey, TElement>`, and report its return type as their `Type`. It is deliberately not visited as a child: it runs outside the shaper, on groupings that are already built, so the shaper-processing visitors have no business rewriting it. That does mean the `VerifyNoClientConstant` in `VisitShapedQuery` never reaches it, so `ApplyGroupByResultSelector` runs the same verification over the selector body before building the `ProjectedQueryingEnumerable` — otherwise `g => new { Elements = g.ToList(), Instance = this }` would root the captured instance in the compiled query cache instead of reporting `ClientProjectionCapturingConstantInTree`.

`TryTranslateGroupingElementProjection` in `RelationalQueryableMethodTranslatingExpressionVisitor` splits a projection over a grouping in two. The element projection is composed into the grouping's element selector by translating it over the same `SelectExpression`, exactly as an `elementSelector` passed to `GroupBy` would have been; what remains becomes the `ResultSelector`. `GroupBy(k).Select(g => new { g.Key, Ids = g.Select(e => e.Id).ToList() })` splits into `e => e.Id` on the server and `grp => new { grp.Key, Ids = grp.ToList() }` on the client. The shaper stays a `RelationalGroupByShaperExpression`, so `ApplyProjection` takes its existing final-`GroupBy` path.

Both entry points into a projection over a grouping go through it — `TranslateSelect`, and `TranslateGroupBy` for the result-selector overload — and both fall back to the current translation when it declines, so anything unrecognized keeps today's SQL rather than failing.

Composing the element projection mutates the `SelectExpression`, and there is no way back to the correlated-subquery translation once it has, so the client selector is built first and the whole projection is validated before anything is touched.

What is recognized, and what deliberately isn't:

- **The enumeration** is the grouping, optionally through one `Select`, optionally materialized by `ToList`/`ToArray`/`AsEnumerable`. By the time the projection reaches translation it has been through preprocessing, so this is usually spelled `g.AsQueryable().Select(…).ToList()`; the `AsQueryable` is only peeled as part of an enumeration recognized around it, never on its own, so that `g.AsQueryable().Sum()` isn't mistaken for one.
- **The client selector may only assemble** — object construction, constants, conversions, the key used whole, and that enumeration. Anything computed declines, because the alternative is to quietly replace a server translation with CLR semantics: `string.Join` over the elements is `STRING_AGG` and the spatial combiners reach them the same way; `g.Key.ToUpper()` is `UPPER` under the column's collation, and `g.Key.Length` is `LEN`, which ignores trailing spaces where the CLR doesn't; and `EF.Functions.DateDiffDay(g.Key, …)` doesn't run on the client at all, it throws `FunctionOnClient`. Aggregates fall out of the same rule rather than needing one of their own.
- **The element selector** declines if any node in it has a collection type. Such a projection is translated as a correlated collection over the element, and with the `GROUP BY` dropped that correlation would be to the grouping rather than to the element.

`ProjectedQueryingEnumerable<TSource, TResult>` applies the selector to each grouping as it comes out of the group-by querying enumerable, for both the single- and split-query paths. It forwards `ToQueryString()` and `CreateDbCommand()` to the enumerable it wraps, which `RelationalQueryableExtensions.ToQueryString` needs to find on the top-level result.

Both plans return the same rows, and neither orders within a group; the elements of a group can come back in a different order than before, where previously they arrived in the order of the joined query's identifier.

### Only when nothing else is counting groups

Dropping the `GROUP BY` is what makes the streaming translation possible, so anything else in the query which counts groups rather than rows has to be accounted for. That cuts two ways.

**Operators after the projection** would compose over rows where they expect groups — `.Take(2)` would take two elements rather than two groups — so the projection is only lifted when it is the node `Translate` was handed, and never in a subquery. `VisitMethodCall` tracks whether the node being translated is the root one; operators stripped during preprocessing (`AsNoTracking`, `TagWith`, `AsSplitQuery`) don't count against it, and `.ToList()`/`.ToArray()` never reach the provider at all.

**Operators before it** have already left that state on the `SelectExpression`: `GroupBy(k).Take(2)` a `Limit`, `Skip` an `Offset`, `Where(g => g.Count() > 10)` a `HAVING`, `OrderBy(g => g.Count())` an ordering over an aggregate. Lifting regardless would reinterpret each of them as being about the source rows — `TOP(2)` over an ungrouped scan, or a `HAVING` with no `GROUP BY` left to attach to. The lift declines whenever any of them is present.

The first of those is the part of the change I'd most like a second opinion on. It means `.Take(1)` after the projection silently returns to the old SQL, and it puts two fields of mutable state on the translating visitor. Deciding in `ApplyProjection` instead would avoid both, since by then what composes over the projection is known — but composing the element projection needs the projection binder, which is only available during translation, and once the `SelectExpression` has been mutated there is no way back to the correlated-subquery form. Happy to restructure if there's a way to defer the decision that I've missed.

### Unrelated fix

`ApplyProjection` restores `_identifier` from `_preGroupByIdentifier` unconditionally after a final `GroupBy`, but `ApplyGrouping` only sets that field when it replaced the identifier with the grouping terms — grouping by the identifier itself leaves it alone. `context.Set<Order>().GroupBy(o => o.OrderID).ToList()` therefore throws a `NullReferenceException` on `main` today; no existing test groups by a complete identifier, which is how it survived. The restore is now conditional, since there is nothing to restore in that case — the identifier already is the key — and `Final_GroupBy_property_entity_by_identifier` covers it. It is here because the new translation reaches the same line through `GroupBy(o => o.OrderID).Select(g => g.ToList())`, and is easy to split out if preferred.

## Testing

Specification tests with SQL Server baselines; they also run on SQLite and the in-memory provider through the shared base. The client-constant case lives in the relational base, so it runs on SQL Server and SQLite only.

| Test | Shape |
| --- | --- |
| `GroupBy_selecting_grouping_element_list` | the reported shape — `g.Select(e => e.OrderID).ToList()` and nothing else |
| `GroupBy_selecting_grouping_element_array_with_key` | key and elements together, the common projection |
| `GroupBy_with_element_selector_selecting_grouping_element_list` | the projection already lives in `GroupBy`'s element selector; `g.ToList()` composes onto it |
| `GroupBy_selecting_grouping_element_list_with_aggregate` | `Count()` alongside the elements — asserts the aggregate-and-join plan is kept |
| `GroupBy_selecting_filtered_grouping_element_list` | `Where` inside the group — likewise kept, the elements are genuinely a different set of rows |
| `GroupBy_selecting_grouping_element_list_with_Take` | `Take` after the projection — asserts `TOP` still applies to groups, over the `GROUP BY` subquery |
| `GroupBy_Take_selecting_grouping_element_list`, `GroupBy_Skip_selecting_grouping_element_list` | a limit or offset applied to the groups before the projection — asserts `TOP`/`OFFSET` still count groups |
| `GroupBy_Where_aggregate_selecting_grouping_element_list` | a `HAVING` before the projection — asserts it keeps its `GROUP BY` |
| `GroupBy_OrderBy_aggregate_selecting_grouping_element_list` | groups ordered by an aggregate before the projection |
| `GroupBy_selecting_grouping_element_list_with_translated_key` | `g.Key.ToUpper()` alongside the elements — asserts `UPPER` stays on the server |
| `Final_GroupBy_property_entity_by_identifier` | the `NullReferenceException` above; throws on `main` |
| `Final_GroupBy_projecting_grouping_elements` | the lifted projection through a precompiled query, since the result selector has to survive the query code generator |
| `GroupBy_with_result_selector_selecting_grouping_element_list` | the projection is `GroupBy`'s own result selector rather than a separate `Select` — the second entry point into the lift |
| `GroupBy_selecting_grouping_element_list_with_captured_instance` | a captured instance in the lifted projection — asserts the result selector is still verified for client constants; fails without that verification |

The existing `GroupBy_select_grouping_list` / `_array` cover entity elements and tracking, and `Collection_projection_over_GroupBy_over_parameter` covers a grouping element enumerated without a materializer, under single and split query. `string.Join` and the spatial aggregates over a grouping element are covered by `StringTranslationsSqlServerTest` and `SpatialQuerySqlServer*Test`, which is how the first draft's narrower rule was caught.

`Final_GroupBy_property_entity_by_identifier` also needed an InMemory override, since that provider doesn't support a final composed `GroupBy`.

Beyond the GroupBy suites, the full SQL Server (49,576), SQLite (38,264) and in-memory (28,083) functional suites pass with no failures, and the `EFCore.Relational` API baseline is regenerated for the two added constructors and their properties.