### PR TITLE
[release/11.0] Preserve GroupBy groups through filtered required navigations

### DIFF
--- a/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.cs
+++ b/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.cs
@@ -1737,18 +1737,24 @@ public partial class NavigationExpandingExpressionVisitor : ExpressionVisitor
         }
 
         // Flat-aggregate queries keep the existing translation unchanged.
-        var traversesNavigation = false;
+        var navigationAccessDetector = new ReferenceNavigationAccessDetector(
+            entityType => GetApplicableQueryFilters(entityType.GetRootType()).Count > 0);
         foreach (var aggregate in scanner.Aggregates)
         {
-            if (aggregate.Selector != null
-                && ContainsReferenceNavigationAccess(RemapLambdaExpression(parent, aggregate.Selector)))
+            if (aggregate.Selector == null)
             {
-                traversesNavigation = true;
-                break;
+                continue;
+            }
+
+            navigationAccessDetector.Visit(RemapLambdaExpression(parent, aggregate.Selector));
+            if (navigationAccessDetector.FoundFilteredRequiredNavigation)
+            {
+                // The required navigation's inner join would allow its query filter to remove grouping elements.
+                return null;
             }
         }
 
-        if (!traversesNavigation)
+        if (!navigationAccessDetector.Found)
         {
             return null;
         }
@@ -1803,16 +1809,10 @@ public partial class NavigationExpandingExpressionVisitor : ExpressionVisitor
     ///     Detects member chains rooted at an entity navigation tree node whose first member is a
     ///     non-collection navigation — accesses that would otherwise translate as a correlated subquery.
     /// </summary>
-    private static bool ContainsReferenceNavigationAccess(Expression body)
-    {
-        var detector = new ReferenceNavigationAccessDetector();
-        detector.Visit(body);
-        return detector.Found;
-    }
-
-    private sealed class ReferenceNavigationAccessDetector : ExpressionVisitor
+    private sealed class ReferenceNavigationAccessDetector(Func<IEntityType, bool> hasApplicableQueryFilter) : ExpressionVisitor
     {
         public bool Found { get; private set; }
+        public bool FoundFilteredRequiredNavigation { get; private set; }
 
         protected override Expression VisitMember(MemberExpression memberExpression)
         {
@@ -1825,11 +1825,36 @@ public partial class NavigationExpandingExpressionVisitor : ExpressionVisitor
             }
 
             if (current is NavigationTreeExpression { Value: EntityReference entityReference }
-                && chain.Count > 1
-                && entityReference.EntityType.FindNavigation(chain[0].Name) is INavigation { IsCollection: false })
+                && chain.Count > 1)
             {
-                Found = true;
-                return memberExpression;
+                var entityType = entityReference.EntityType;
+                var requiredPath = !entityReference.IsOptional;
+
+                foreach (var member in chain)
+                {
+                    if (entityType.FindNavigation(member) is not { IsCollection: false } navigation)
+                    {
+                        break;
+                    }
+
+                    Found = true;
+                    requiredPath = requiredPath
+                        && navigation.IsOnDependent
+                        && navigation.ForeignKey.IsEffectivelyRequired();
+                    entityType = navigation.TargetEntityType;
+
+                    if (requiredPath
+                        && hasApplicableQueryFilter(entityType))
+                    {
+                        FoundFilteredRequiredNavigation = true;
+                        break;
+                    }
+                }
+
+                if (Found)
+                {
+                    return memberExpression;
+                }
             }
 
             return base.VisitMember(memberExpression);

--- a/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.cs
+++ b/src/EFCore/Query/Internal/NavigationExpandingExpressionVisitor.cs
@@ -19,6 +19,9 @@ public partial class NavigationExpandingExpressionVisitor : ExpressionVisitor
     private static readonly PropertyInfo QueryContextContextPropertyInfo
         = typeof(QueryContext).GetTypeInfo().GetDeclaredProperty(nameof(QueryContext.Context))!;
 
+    private static readonly bool UseOldBehavior38965
+        = AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue38965", out var enabled) && enabled;
+
     private static readonly Dictionary<MethodInfo, MethodInfo> PredicateLessMethodInfo = new()
     {
         { QueryableMethods.FirstWithPredicate, QueryableMethods.FirstWithoutPredicate },
@@ -1747,7 +1750,8 @@ public partial class NavigationExpandingExpressionVisitor : ExpressionVisitor
             }
 
             navigationAccessDetector.Visit(RemapLambdaExpression(parent, aggregate.Selector));
-            if (navigationAccessDetector.FoundFilteredRequiredNavigation)
+            if (!UseOldBehavior38965
+                && navigationAccessDetector.FoundFilteredRequiredNavigation)
             {
                 // The required navigation's inner join would allow its query filter to remove grouping elements.
                 return null;

--- a/test/EFCore.Relational.Specification.Tests/Query/AdHocQueryFiltersQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/AdHocQueryFiltersQueryRelationalTestBase.cs
@@ -13,4 +13,131 @@ public abstract class AdHocQueryFiltersQueryRelationalTestBase(NonSharedFixture 
 
     protected void AssertSql(params string[] expected)
         => TestSqlLoggerFactory.AssertBaseline(expected);
+
+    #region 38965
+
+    [Theory, MemberData(nameof(IsAsyncData))]
+    public virtual async Task GroupBy_aggregate_over_required_navigation_with_query_filter(bool async)
+    {
+        var contextFactory = await InitializeNonSharedTest<Context38965>(
+            onConfiguring: b => b.ConfigureWarnings(
+                w => w.Ignore(CoreEventId.PossibleIncorrectRequiredNavigationWithQueryFilterInteractionWarning)),
+            seed: c => c.SeedAsync());
+        using var context = contextFactory.CreateDbContext();
+
+        var query = context.Dependents
+            .GroupBy(d => d.GroupId)
+            .Select(g => new
+            {
+                g.Key,
+                Count = g.Count(),
+                MaxValue = g.Max(d => (int?)d.Principal.Value)
+            });
+
+        var results = async
+            ? await query.ToListAsync()
+            : query.ToList();
+
+        Assert.Collection(
+            results.OrderBy(e => e.Key),
+            result =>
+            {
+                Assert.Equal(1, result.Key);
+                Assert.Equal(1, result.Count);
+                Assert.Equal(10, result.MaxValue);
+            },
+            result =>
+            {
+                Assert.Equal(2, result.Key);
+                Assert.Equal(1, result.Count);
+                Assert.Null(result.MaxValue);
+            });
+
+        var queryWithoutFilters = context.Dependents
+            .IgnoreQueryFilters()
+            .GroupBy(d => d.GroupId)
+            .Select(g => new
+            {
+                g.Key,
+                Count = g.Count(),
+                MaxValue = g.Max(d => (int?)d.Principal.Value)
+            });
+
+        var resultsWithoutFilters = async
+            ? await queryWithoutFilters.ToListAsync()
+            : queryWithoutFilters.ToList();
+
+        Assert.Collection(
+            resultsWithoutFilters.OrderBy(e => e.Key),
+            result =>
+            {
+                Assert.Equal(1, result.Key);
+                Assert.Equal(1, result.Count);
+                Assert.Equal(10, result.MaxValue);
+            },
+            result =>
+            {
+                Assert.Equal(2, result.Key);
+                Assert.Equal(1, result.Count);
+                Assert.Equal(20, result.MaxValue);
+            });
+    }
+
+    protected class Context38965(DbContextOptions options) : DbContext(options)
+    {
+        public DbSet<Principal38965> Principals
+            => Set<Principal38965>();
+
+        public DbSet<Dependent38965> Dependents
+            => Set<Dependent38965>();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Principal38965>().HasQueryFilter(p => !p.Filtered);
+
+            modelBuilder.Entity<Dependent38965>()
+                .HasOne(d => d.Principal)
+                .WithMany()
+                .HasForeignKey(d => d.PrincipalId)
+                .IsRequired();
+        }
+
+        public Task SeedAsync()
+        {
+            Dependents.AddRange(
+                new Dependent38965
+                {
+                    GroupId = 1,
+                    Principal = new Principal38965 { Value = 10 }
+                },
+                new Dependent38965
+                {
+                    GroupId = 2,
+                    Principal = new Principal38965
+                    {
+                        Value = 20,
+                        Filtered = true
+                    }
+                });
+
+            return SaveChangesAsync();
+        }
+    }
+
+    protected class Principal38965
+    {
+        public int Id { get; set; }
+        public int Value { get; set; }
+        public bool Filtered { get; set; }
+    }
+
+    protected class Dependent38965
+    {
+        public int Id { get; set; }
+        public int GroupId { get; set; }
+        public int PrincipalId { get; set; }
+        public Principal38965 Principal { get; set; } = null!;
+    }
+    #endregion
+    #endregion
 }

--- a/test/EFCore.Relational.Specification.Tests/Query/AdHocQueryFiltersQueryRelationalTestBase.cs
+++ b/test/EFCore.Relational.Specification.Tests/Query/AdHocQueryFiltersQueryRelationalTestBase.cs
@@ -138,6 +138,6 @@ public abstract class AdHocQueryFiltersQueryRelationalTestBase(NonSharedFixture 
         public int PrincipalId { get; set; }
         public Principal38965 Principal { get; set; } = null!;
     }
-    #endregion
+
     #endregion
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/AdHocQueryFiltersQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/AdHocQueryFiltersQuerySqlServerTest.cs
@@ -520,6 +520,33 @@ WHERE [e].[IsDraft] = CAST(0 AS bit)
         AssertSql();
     }
 
+    public override async Task GroupBy_aggregate_over_required_navigation_with_query_filter(bool async)
+    {
+        await base.GroupBy_aggregate_over_required_navigation_with_query_filter(async);
+
+        AssertSql(
+            """
+SELECT [d].[GroupId] AS [Key], COUNT(*) AS [Count], (
+    SELECT MAX([p0].[Value])
+    FROM [Dependents] AS [d0]
+    INNER JOIN (
+        SELECT [p].[Id], [p].[Value]
+        FROM [Principals] AS [p]
+        WHERE [p].[Filtered] = CAST(0 AS bit)
+    ) AS [p0] ON [d0].[PrincipalId] = [p0].[Id]
+    WHERE [d].[GroupId] = [d0].[GroupId]) AS [MaxValue]
+FROM [Dependents] AS [d]
+GROUP BY [d].[GroupId]
+""",
+            //
+            """
+SELECT [d].[GroupId] AS [Key], COUNT(*) AS [Count], MAX([p].[Value]) AS [MaxValue]
+FROM [Dependents] AS [d]
+INNER JOIN [Principals] AS [p] ON [d].[PrincipalId] = [p].[Id]
+GROUP BY [d].[GroupId]
+""");
+    }
+
     [Fact]
     public virtual void Check_all_tests_overridden()
         => TestHelpers.AssertAllMethodsOverridden(GetType());

--- a/test/EFCore.Sqlite.FunctionalTests/Query/AdHocQueryFiltersQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/AdHocQueryFiltersQuerySqliteTest.cs
@@ -15,9 +15,13 @@ public class AdHocQueryFiltersQuerySqliteTest(NonSharedFixture fixture) : AdHocQ
         AssertSql(
             """
 SELECT "d"."GroupId" AS "Key", COUNT(*) AS "Count", (
-    SELECT MAX("p"."Value")
+    SELECT MAX("p0"."Value")
     FROM "Dependents" AS "d0"
-    INNER JOIN "Principals" AS "p" ON "d0"."PrincipalId" = "p"."Id" AND NOT ("p"."Filtered")
+    INNER JOIN (
+        SELECT "p"."Id", "p"."Value"
+        FROM "Principals" AS "p"
+        WHERE NOT ("p"."Filtered")
+    ) AS "p0" ON "d0"."PrincipalId" = "p0"."Id"
     WHERE "d"."GroupId" = "d0"."GroupId") AS "MaxValue"
 FROM "Dependents" AS "d"
 GROUP BY "d"."GroupId"

--- a/test/EFCore.Sqlite.FunctionalTests/Query/AdHocQueryFiltersQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/AdHocQueryFiltersQuerySqliteTest.cs
@@ -7,4 +7,27 @@ public class AdHocQueryFiltersQuerySqliteTest(NonSharedFixture fixture) : AdHocQ
 {
     protected override ITestStoreFactory NonSharedTestStoreFactory
         => SqliteTestStoreFactory.Instance;
+
+    public override async Task GroupBy_aggregate_over_required_navigation_with_query_filter(bool async)
+    {
+        await base.GroupBy_aggregate_over_required_navigation_with_query_filter(async);
+
+        AssertSql(
+            """
+SELECT "d"."GroupId" AS "Key", COUNT(*) AS "Count", (
+    SELECT MAX("p"."Value")
+    FROM "Dependents" AS "d0"
+    INNER JOIN "Principals" AS "p" ON "d0"."PrincipalId" = "p"."Id" AND NOT ("p"."Filtered")
+    WHERE "d"."GroupId" = "d0"."GroupId") AS "MaxValue"
+FROM "Dependents" AS "d"
+GROUP BY "d"."GroupId"
+""",
+            //
+            """
+SELECT "d"."GroupId" AS "Key", COUNT(*) AS "Count", MAX("p"."Value") AS "MaxValue"
+FROM "Dependents" AS "d"
+INNER JOIN "Principals" AS "p" ON "d"."PrincipalId" = "p"."Id"
+GROUP BY "d"."GroupId"
+""");
+    }
 }


### PR DESCRIPTION
Fixes #38965

**Description**
GroupBy projections can contain both aggregates over the grouped rows and aggregates that read a value through a required navigation. When the required principal has an active query filter, the navigation aggregate was translated by joining the filtered principal before grouping. That join removed dependent rows whose principals were filtered out, so unrelated aggregates and even entire groups disappeared. This change keeps the navigation aggregate isolated when an applicable filter can make the required join non-row-preserving. Queries that ignore the filter retain the optimized joined translation.

**Customer impact**
Applications can silently receive missing groups and incorrect counts from queries such as:

```csharp
context.OrderDetails
    .GroupBy(d => d.OrderId)
    .Select(g => new { g.Key, Count = g.Count(), Max = g.Max(d => (int?)d.Product.Stock) });
```

The issue affects required principals with query filters in EF Core 11. Moving the navigation access into a pre-GroupBy element selector is a possible but non-obvious workaround.

**How found**
User reported on 11.0.0-rc.1.

**Regression**
Yes, from EF Core 10, introduced by #38668

**Testing**
Test added.

**Risk**
Low. The change is localized and just reverts to previous behavior when the condition is met. Quirk mode added.