### PR TITLE
SQLite: do not ask for the metadata of a column that has no table

### DIFF
--- a/src/Microsoft.Data.Sqlite.Core/SqliteDataRecord.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteDataRecord.cs
@@ -297,6 +297,14 @@ internal class SqliteDataRecord(sqlite3_stmt stmt, bool hasRows, SqliteConnectio
         var blobDatabaseName = sqlite3_column_database_name(Handle, ordinal).utf8_to_string();
         var blobTableName = sqlite3_column_table_name(Handle, ordinal).utf8_to_string();
 
+        if (blobDatabaseName == null
+            || blobTableName == null)
+        {
+            // The value came from an expression, so there is no row to open a blob on. Looking for a rowid
+            // column would also hand these nulls to sqlite3_table_column_metadata, which is misuse
+            return new MemoryStream(GetCachedBlob(ordinal), false);
+        }
+
         var rowidkey = $"{blobDatabaseName}_{blobTableName}";
         if (!RowIds.TryGetValue(rowidkey, out var rowIdForOrdinal))
         {

--- a/test/Microsoft.Data.Sqlite.Tests/SqliteDataReaderTest.cs
+++ b/test/Microsoft.Data.Sqlite.Tests/SqliteDataReaderTest.cs
@@ -414,6 +414,68 @@ public class SqliteDataReaderTest
     }
 
     [Fact]
+    public void GetStream_works_when_expression_and_a_literal_in_the_same_query()
+    {
+        using var connection = new SqliteConnection("Data Source=:memory:");
+        connection.Open();
+
+        connection.ExecuteNonQuery(
+            "CREATE TABLE DataTable (Id INTEGER PRIMARY KEY, Data BLOB); INSERT INTO DataTable VALUES (5, X'01020304');");
+
+        var selectCommand = connection.CreateCommand();
+        selectCommand.CommandText = "SELECT 42, substr(Data, 1, 3) FROM DataTable WHERE Id = 5";
+        using var reader = selectCommand.ExecuteReader();
+        Assert.True(reader.Read());
+
+        using var sourceStream = reader.GetStream(1);
+        Assert.IsType<MemoryStream>(sourceStream);
+        var buffer = new byte[3];
+        var bytesRead = sourceStream.Read(buffer, 0, 3);
+        Assert.Equal(3, bytesRead);
+        Assert.Equal([0x01, 0x02, 0x03], buffer);
+    }
+
+    [Fact]
+    public void GetTextReader_works_when_expression_and_a_literal_in_the_same_query()
+    {
+        using var connection = new SqliteConnection("Data Source=:memory:");
+        connection.Open();
+
+        connection.ExecuteNonQuery(
+            "CREATE TABLE DataTable (Id INTEGER PRIMARY KEY, Value TEXT); INSERT INTO DataTable VALUES (5, 'abcdef');");
+
+        var selectCommand = connection.CreateCommand();
+        selectCommand.CommandText = "SELECT 42, substr(Value, 1, 3) FROM DataTable WHERE Id = 5";
+        using var reader = selectCommand.ExecuteReader();
+        Assert.True(reader.Read());
+
+        using var textReader = reader.GetTextReader(1);
+        Assert.Equal("abc", textReader.ReadToEnd());
+    }
+
+    [Fact]
+    public void GetStream_Blob_works_when_a_literal_is_in_the_same_query()
+    {
+        using var connection = new SqliteConnection("Data Source=:memory:");
+        connection.Open();
+
+        connection.ExecuteNonQuery(
+            "CREATE TABLE DataTable (Id INTEGER PRIMARY KEY, Data BLOB); INSERT INTO DataTable VALUES (5, X'01020304');");
+
+        var selectCommand = connection.CreateCommand();
+        selectCommand.CommandText = "SELECT 42, Id, Data FROM DataTable WHERE Id = 5";
+        using var reader = selectCommand.ExecuteReader();
+        Assert.True(reader.Read());
+
+        using var sourceStream = reader.GetStream(2);
+        Assert.IsType<SqliteBlob>(sourceStream);
+        var buffer = new byte[4];
+        var bytesRead = sourceStream.Read(buffer, 0, 4);
+        Assert.Equal(4, bytesRead);
+        Assert.Equal([0x01, 0x02, 0x03, 0x04], buffer);
+    }
+
+    [Fact]
     public void GetStream_Blob_works_when_long_pk()
     {
         using var connection = new SqliteConnection("Data Source=:memory:");


### PR DESCRIPTION
Fixes #27776

the issue asks whether the column metadata calls in `GetStream` can be handed a null , and they can .

## what happens

`GetStream` looks for a rowid column so it can hand back a `SqliteBlob` . for a value that came from an expression there is no underlying column , so `sqlite3_column_database_name` , `sqlite3_column_table_name` and `sqlite3_column_origin_name` all answer null . i printed them for `SELECT 42, substr("Content", 1, 3) FROM "Case"` :

```
ordinal=0 name=42                         db=<null> table=<null> origin=<null>
ordinal=1 name=substr("Content", 1, 3)    db=<null> table=<null> origin=<null>
```

the search starts from a null database and table name , so the literal in column 0 matches it , and its null origin name goes into `sqlite3_table_column_metadata` . sqlite answers `SQLITE_MISUSE` and `GetStream` throws :

```
Microsoft.Data.Sqlite.SqliteException : SQLite Error 21: 'bad parameter or other API misuse'
   at Microsoft.Data.Sqlite.SqliteDataRecord.GetStream(Int32 ordinal) in SqliteDataRecord.cs:341
```

the same expression on its own is fine , because there is no second column for the search to reach . that is why the report says removing the `42` makes it work . it is also why a real column sitting next to a literal is fine , a non null table name does not match the literal's null one .

this is the ado.net repro of ericsink/SQLitePCL.raw#479 , which asked whether the bug was in the wrapper or in the caller . it is the caller .

## the fix

a column with no database or table name has no row to open a blob on , so return the `MemoryStream` , which is what already happens when no rowid column is found :

```csharp
if (blobDatabaseName == null
    || blobTableName == null)
{
    return new MemoryStream(GetCachedBlob(ordinal), false);
}
```

`GetTextReader` and `GetFieldValue<Stream>` both go through `GetStream` , so they are fixed with it .

## tests

three , next to the existing `GetStream` ones .

- `GetStream_works_when_expression_and_a_literal_in_the_same_query` , the report's shape . throws `SQLITE_MISUSE` on main , gives a `MemoryStream` with the right three bytes after
- `GetTextReader_works_when_expression_and_a_literal_in_the_same_query` , same path through the text reader . same before and after
- `GetStream_Blob_works_when_a_literal_is_in_the_same_query` , a real blob column with a literal beside it . passes on main and after , so the guard is not swallowing the blob case

on main that is 2 failures out of 714 , and both are the two above . with the change `Microsoft.Data.Sqlite.sqlite3.Tests` is 707 pass , `sqlite3mc` 708 pass , `EFCore.Sqlite.Tests` 896 pass , all 0 failed . `EFCore.Sqlite.FunctionalTests` is 38042 pass , and its 177 failures are all `mod_spatialite.dylib` not being installed on this mac , the same 177 as before the change .

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VfnFMKDUZWENKk7Vpe6GS7
